### PR TITLE
Migrate Elasticsearch mapping types automatically on deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `RESOURCE_SERVER_AUTH_TOKEN` | If SSO enabled | Access token for RFC 7662 token introspection server |
 | `RESTRICT_ADMIN` | No | Whether to restrict access to the admin site by IP address. |
 | `SENTRY_ENVIRONMENT`  | Yes | Value for the environment tag in Sentry. |
+| `SKIP_ES_MAPPING_MIGRATIONS` | No | If non-empty, skip applying Elasticsearch mapping type migrations on deployment. |
 | `SKIP_MI_DATABASE_MIGRATIONS` | No | If non-empty, skip applying MI database migrations on deployment. Used in environments without a working MI database. |
 | `SSO_ENABLED` | Yes | Whether single sign-on via RFC 7662 token introspection is enabled |
 | `STATSD_HOST` | No | StatsD host url. |

--- a/changelog/run-migrate-es-automatically.internal.md
+++ b/changelog/run-migrate-es-automatically.internal.md
@@ -1,0 +1,1 @@
+Elasticsearch mapping type migrations are now automatically run during deployments.

--- a/docs/Elasticsearch migrations.md
+++ b/docs/Elasticsearch migrations.md
@@ -26,8 +26,8 @@ mapping it returns.
 
 ## Operation during a migration
 
-A migration is triggered by running `./manage.py migrate_es`. (At the moment, this 
-is _not_ automatically triggered during deployments.)
+A migration is triggered by running `./manage.py migrate_es`. (This 
+is automatically run during deployment.)
 
 This command:
 

--- a/web.sh
+++ b/web.sh
@@ -11,4 +11,12 @@ if [ -z "$SKIP_MI_DATABASE_MIGRATIONS" ]; then
 fi
 
 ./manage.py init_es
+
+# This command schedules asynchronous Celery tasks, so this checks the app instance index to
+# avoid tasks being scheduled multiple times unnecessarilly
+# (using a similar approach to https://docs.run.pivotal.io/buildpacks/ruby/rake-config.html)
+if [ -z "$SKIP_ES_MAPPING_MIGRATIONS" ] && [ "${CF_INSTANCE_INDEX:-0}" == "0" ]; then
+  ./manage.py migrate_es
+fi
+
 gunicorn config.wsgi --config config/gunicorn.py


### PR DESCRIPTION
### Description of change

This schedules the `migrate_es` management command to run automatically on deployment.

Previously, we had to run this command manually after deploying. However, this relied on:

- the person deploying knowing it needed to be done; and
- remembering to do it in every environment

There is a slight bit of complexity in automating this in that there is a chance that, during the rolling deployment, an old Celery instance could pick up the tasks scheduled by `./manage.py migrate_es`. 

However, there is already logic to handle this in the `complete_model_migration` task and it appears to work well from testing in the UAT environment.

(Still, I added an `SKIP_ES_MAPPING_MIGRATIONS` environment variable to disable the automatic migrations just in case we do run into problems.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
