### PR TITLE
Stop pip cache growing unbounded on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,8 +62,7 @@ job_defaults: &job_defaults
     - restore_cache:
         name: Restore pip cache
         keys:
-          - v1-leeloo-{{ checksum "requirements.txt" }}
-          - v1-leeloo-
+          - v2-<< parameters.python_image >>-{{ checksum "requirements.txt" }}
         paths:
           - ~/cache/pip
 
@@ -73,7 +72,7 @@ job_defaults: &job_defaults
 
     - save_cache:
         name: Save pip cache
-        key: v1-leeloo-{{ checksum "requirements.txt" }}
+        key: v2-<< parameters.python_image >>-{{ checksum "requirements.txt" }}
         paths:
           - ~/cache/pip
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ job_defaults: &job_defaults
 
     - run:
         name: Install dependencies
-        command: python -m pip install --cache-dir ~/cache/pip -r requirements.txt
+        command: python -m pip install --cache-dir ~/cache/pip --progress-bar off -r requirements.txt
 
     - save_cache:
         name: Save pip cache


### PR DESCRIPTION
### Description of change

The pip cache on CircleCI had grown to 1.1 GB, because packages were added to it but never removed (e.g. when updated).

This changes the configuration to only restore a cache that matches the specific set of requirements we currently have (whereas before it would fall back to the most recent cache if an exact match for the requirements wasn't found).

This stops the cache growing unbounded as a result, and gets its size down to about 40 MB.

Most builds should be about 15 seconds faster (builds where dependencies are changed will take about the same time as before).

The cache key was also changed so that it includes the Docker image name (so that it includes the Python version).

(See https://circleci.com/docs/2.0/caching/ for more details about caching on CircleCI.)

(The progress bar has also been disabled for `pip install` as it doesn't work well on CircleCI.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
