### PR TITLE
Rename project to Data Hub API

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@
 
 ### Checklist
 
-* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
-* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
+* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
+* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
 * [ ] Have any relevant search models been updated?
 * [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
 * [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3681,11 +3681,11 @@
 
 ## Internal changes
 
-  - Moved to one Elasticsearch index per mapping type, and added a command (`./manage.py migrate_es`) to migrate Elasticsearch index mappings. See [docs/Elasticsearch migrations.md](https://github.com/uktrade/data-hub-leeloo/blob/master/docs/Elasticsearch%20migrations.md) for more detail. (After upgrading, `./manage.py init_es` must be run to update index aliases.)
+  - Moved to one Elasticsearch index per mapping type, and added a command (`./manage.py migrate_es`) to migrate Elasticsearch index mappings. See [docs/Elasticsearch migrations.md](https://github.com/uktrade/data-hub-api/blob/master/docs/Elasticsearch%20migrations.md) for more detail. (After upgrading, `./manage.py init_es` must be run to update index aliases.)
   - Fixed a random failure in the `TestListCompanies.test_sort_by_name` test
   - Added a contact for an archived company to the test data
   - Updated various dependencies
 
 # Data Hub \< 5.0.0
 
-Please check the [previous releases on GitHub](https://github.com/uktrade/data-hub-leeloo/releases).
+Please check the [previous releases on GitHub](https://github.com/uktrade/data-hub-api/releases).

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# Data Hub Leeloo
+# Data Hub API
 
 [![image](https://circleci.com/gh/uktrade/data-hub-leeloo/tree/master.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-leeloo/tree/master)
 [![image](https://codecov.io/gh/uktrade/data-hub-leeloo/branch/master/graph/badge.svg)](https://codecov.io/gh/uktrade/data-hub-leeloo)
 [![image](https://codeclimate.com/github/uktrade/data-hub-leeloo/badges/gpa.svg)](https://codeclimate.com/github/uktrade/data-hub-leeloo)
 [![Updates](https://pyup.io/repos/github/uktrade/data-hub-leeloo/shield.svg)](https://pyup.io/repos/github/uktrade/data-hub-leeloo/)
 
-Leeloo provides an API into Data Hub for Data Hub clients. Using Leeloo you can search for entities and manage companies, contacts and interactions.
+Data Hub API provides an API into Data Hub for Data Hub clients. Using Data Hub API you can search for entities and manage companies, contacts and interactions.
 
 More guides can be found in the [docs](./docs/) folder.
 
 ## Installation with Docker
 
-Leeloo uses Docker compose to setup and run all the necessary components. The docker-compose.yml file provided is meant to be used for running tests and development.
+This project uses Docker compose to setup and run all the necessary components. The docker-compose.yml file provided is meant to be used for running tests and development.
 
 1.  Clone the repository:
 
@@ -32,7 +32,7 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
     docker-compose up
     ```
 
-    * It will take time for the leeloo API container to come up - it will run
+    * It will take time for the API container to come up - it will run
       migrations on both DBs, load initial data, sync elasticsearch etc. Watch
       along in the api container's logs.
     * **NOTE:**
@@ -57,7 +57,7 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
       For more information, [see the elasticsearch docs on vm.max_map_count](https://www.elastic.co/guide/en/elasticsearch/reference/6.6/vm-max-map-count.html).
 
 4.  Optionally, you may want to run a local copy of the data hub frontend.
-    By default, you can run both leeloo and the frontend under one docker-compose
+    By default, you can run both the API and the frontend under one docker-compose
     project.  [See the instructions in the frontend readme to set it up](https://github.com/uktrade/data-hub-frontend/#setting-up-with-docker-compose).
 
 ## Native installation (without Docker)
@@ -200,7 +200,7 @@ flake8
 
 ## Granting access to the front end
 
-The [internal front end](https://github.com/uktrade/data-hub-frontend) uses single sign-on. You should configure Leeloo as follows to use with the front end:
+The [internal front end](https://github.com/uktrade/data-hub-frontend) uses single sign-on. You should configure the API as follows to use with the front end:
 
 * `SSO_ENABLED`: `True`
 * `RESOURCE_SERVER_INTROSPECTION_URL`: URL of the [RFC 7662](https://tools.ietf.org/html/rfc7662) introspection endpoint (should be the same server the front end is using). This is provided by a [Staff SSO](https://github.com/uktrade/staff-sso) instance.
@@ -229,7 +229,7 @@ The currently defined scopes can be found in [`datahub/oauth/scopes.py`](https:/
 
 ## Deployment
 
-Leeloo can run on any Heroku-style platform. Configuration is performed via the following environment variables:
+Data Hub API can run on any Heroku-style platform. Configuration is performed via the following environment variables:
 
 
 | Variable name | Required | Description |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Data Hub API
 
-[![image](https://circleci.com/gh/uktrade/data-hub-leeloo/tree/master.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-leeloo/tree/master)
-[![image](https://codecov.io/gh/uktrade/data-hub-leeloo/branch/master/graph/badge.svg)](https://codecov.io/gh/uktrade/data-hub-leeloo)
-[![image](https://codeclimate.com/github/uktrade/data-hub-leeloo/badges/gpa.svg)](https://codeclimate.com/github/uktrade/data-hub-leeloo)
-[![Updates](https://pyup.io/repos/github/uktrade/data-hub-leeloo/shield.svg)](https://pyup.io/repos/github/uktrade/data-hub-leeloo/)
+[![image](https://circleci.com/gh/uktrade/data-hub-api/tree/master.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-api/tree/master)
+[![image](https://codecov.io/gh/uktrade/data-hub-api/branch/master/graph/badge.svg)](https://codecov.io/gh/uktrade/data-hub-api)
+[![image](https://codeclimate.com/github/uktrade/data-hub-api/badges/gpa.svg)](https://codeclimate.com/github/uktrade/data-hub-api)
+[![Updates](https://pyup.io/repos/github/uktrade/data-hub-api/shield.svg)](https://pyup.io/repos/github/uktrade/data-hub-api/)
 
 Data Hub API provides an API into Data Hub for Data Hub clients. Using Data Hub API you can search for entities and manage companies, contacts and interactions.
 
@@ -16,8 +16,8 @@ This project uses Docker compose to setup and run all the necessary components. 
 1.  Clone the repository:
 
     ```shell
-    git clone https://github.com/uktrade/data-hub-leeloo
-    cd data-hub-leeloo
+    git clone https://github.com/uktrade/data-hub-api
+    cd data-hub-api
     ```
 
 2.  Create a `.env` file from `sample.env`
@@ -72,8 +72,8 @@ Dependencies:
 1.  Clone the repository:
 
     ```shell
-    git clone https://github.com/uktrade/data-hub-leeloo
-    cd data-hub-leeloo
+    git clone https://github.com/uktrade/data-hub-api
+    cd data-hub-api
     ```
 
 2.  Install Python 3.7.
@@ -223,7 +223,7 @@ page with these details:
     * Application: The application just created
     * Scope: The required scopes
 
-The currently defined scopes can be found in [`datahub/oauth/scopes.py`](https://github.com/uktrade/data-hub-leeloo/tree/develop/datahub/oauth/scopes.py).
+The currently defined scopes can be found in [`datahub/oauth/scopes.py`](https://github.com/uktrade/data-hub-api/tree/develop/datahub/oauth/scopes.py).
 
 [Further information about the available grant types can be found in the OAuthLib docs](http://oauthlib.readthedocs.io/en/stable/oauth2/grants/grants.html).
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Data Hub API
 
-[![image](https://circleci.com/gh/uktrade/data-hub-api/tree/master.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-api/tree/master)
-[![image](https://codecov.io/gh/uktrade/data-hub-api/branch/master/graph/badge.svg)](https://codecov.io/gh/uktrade/data-hub-api)
-[![image](https://codeclimate.com/github/uktrade/data-hub-api/badges/gpa.svg)](https://codeclimate.com/github/uktrade/data-hub-api)
+[![CircleCI](https://circleci.com/gh/uktrade/data-hub-api.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-api)
+[![codecov](https://codecov.io/gh/uktrade/data-hub-api/branch/develop/graph/badge.svg)](https://codecov.io/gh/uktrade/data-hub-api)
+[![Maintainability](https://api.codeclimate.com/v1/badges/853f041744da17eb32bf/maintainability)](https://codeclimate.com/github/uktrade/data-hub-api/maintainability)
 
 Data Hub API provides an API into Data Hub for Data Hub clients. Using Data Hub API you can search for entities and manage companies, contacts and interactions.
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![image](https://circleci.com/gh/uktrade/data-hub-api/tree/master.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-api/tree/master)
 [![image](https://codecov.io/gh/uktrade/data-hub-api/branch/master/graph/badge.svg)](https://codecov.io/gh/uktrade/data-hub-api)
 [![image](https://codeclimate.com/github/uktrade/data-hub-api/badges/gpa.svg)](https://codeclimate.com/github/uktrade/data-hub-api)
-[![Updates](https://pyup.io/repos/github/uktrade/data-hub-api/shield.svg)](https://pyup.io/repos/github/uktrade/data-hub-api/)
 
 Data Hub API provides an API into Data Hub for Data Hub clients. Using Data Hub API you can search for entities and manage companies, contacts and interactions.
 

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Django settings for Leeloo project.
+Django settings for the project.
 For more information on this file, see
 https://docs.djangoproject.com/en/dev/topics/settings/
 For the full list of settings and their values, see
@@ -306,7 +306,6 @@ SEARCH_APPS = [
 
 VCAP_SERVICES = env.json('VCAP_SERVICES', default={})
 
-# Leeloo stuff
 if 'elasticsearch' in VCAP_SERVICES:
     ES_URL = VCAP_SERVICES['elasticsearch'][0]['credentials']['uri']
 else:

--- a/docs/How to add a non-nullable field.md
+++ b/docs/How to add a non-nullable field.md
@@ -40,7 +40,7 @@ repo, here is a concrete example (including work to enforce defaults through the
 API) for adding a boolean field `archived` to the `interaction` model:
 
 Initial nullable PR:
-https://github.com/uktrade/data-hub-leeloo/pull/1627
+https://github.com/uktrade/data-hub-api/pull/1627
 
 Follow-up PR to set as not-nullable:
-https://github.com/uktrade/data-hub-leeloo/pull/1679
+https://github.com/uktrade/data-hub-api/pull/1679

--- a/docs/How to deprecate a field.md
+++ b/docs/How to deprecate a field.md
@@ -14,7 +14,7 @@ This is currently done by creating [newsfragments](../changelog/) with details o
 
 To do that:
 
-* Create an `.api `, `.deprecation` and, if necessary, a `.db` newsfragment announcing the change. See [example](https://github.com/uktrade/data-hub-leeloo/commit/ff5484b4331cd8a42dfd962d00438274d9edc6a6).
+* Create an `.api `, `.deprecation` and, if necessary, a `.db` newsfragment announcing the change. See [example](https://github.com/uktrade/data-hub-api/commit/ff5484b4331cd8a42dfd962d00438274d9edc6a6).
 * Open a PR and merge it into develop after it's been approved.
 * Wait for the next release; your changes will appear in the release notes.
 
@@ -40,7 +40,7 @@ We have weekly releases every Thursday so give at least one week of notice from 
 
 If you are removing a model field you might want to start [removing it from django](#how-to-remove-column) at the same time.
 
-See [example](https://github.com/uktrade/data-hub-leeloo/pull/1107/files).
+See [example](https://github.com/uktrade/data-hub-api/pull/1107/files).
 
 ### Migrate elasticsearch
 
@@ -66,27 +66,27 @@ If the field has a NOT NULL constraint you need to create a migration to change 
 
 To do this:
 * Make sure you announced the deprecation in a previous release.
-* Make the field nullable if necessary. See [example](https://github.com/uktrade/data-hub-leeloo/blob/d57e613aad6c4c033131f0b3074e6143bd4fb010/datahub/company/migrations/0036_update_contact_contactable_columns.py):
+* Make the field nullable if necessary. See [example](https://github.com/uktrade/data-hub-api/blob/d57e613aad6c4c033131f0b3074e6143bd4fb010/datahub/company/migrations/0036_update_contact_contactable_columns.py):
     * Change the django field in `models.py`.
     * Create a migration `./manage.py makemigrations <app> --name=remove_<field>_from_django`.
 * Remove the field from the django model.
 * Add the logic that removes the field from django while keeping the column:
     * Open the `xxxx_remove_<field>_from_django.py` file if you made the field nullable or create an empty one with `./manage.py makemigrations <app> --empty --name=remove_<field>_from_django` otherwise.
-    * Add a `migrations.SeparateDatabaseAndState` operation following [this example](https://github.com/uktrade/data-hub-leeloo/blob/d4b7d447cb992f71427ac56b219d4a63c73fbb2b/datahub/company/migrations/0034_remove-account-manager-from-django.py).
+    * Add a `migrations.SeparateDatabaseAndState` operation following [this example](https://github.com/uktrade/data-hub-api/blob/d4b7d447cb992f71427ac56b219d4a63c73fbb2b/datahub/company/migrations/0034_remove-account-manager-from-django.py).
     * `./manage.py migrate`.
 * Remove the field from any other part of the code including factories, admin and tests.
 * Create a `.removal` and, if necessary, a `.db` newsfragment announcing the change.
 * Open a PR and merge it into develop after it's been approved.
 * Wait for the next release; your changes will appear in the release notes.
 
-See [example](https://github.com/uktrade/data-hub-leeloo/pull/1107/files).
+See [example](https://github.com/uktrade/data-hub-api/pull/1107/files).
 
 ### Remove the column from the databse
 
 * Make sure you removed the field from the API and from django in a previous release and this has been deployed to production.
 * Remove the column from the database:
     * Create an empty migration `./manage.py makemigrations <app> --empty --name=remove_<field>_from_database`.
-    * Add the field copying the definition from a previous migration file and then immediately after remove it completely. See [example](https://github.com/uktrade/data-hub-leeloo/blob/70eb77d76f5189f9476601ca1a5f118c9b7cbe5f/datahub/company/migrations/0035_remove_account_manager_column.py).
+    * Add the field copying the definition from a previous migration file and then immediately after remove it completely. See [example](https://github.com/uktrade/data-hub-api/blob/70eb77d76f5189f9476601ca1a5f118c9b7cbe5f/datahub/company/migrations/0035_remove_account_manager_column.py).
     * `./manage.py migrate`.
 * Create a `.removal` and a `.db` newsfragment announcing the change.
 * Open a PR and merge it into develop after it's been approved.

--- a/docs/How to prepare a release.md
+++ b/docs/How to prepare a release.md
@@ -69,7 +69,7 @@ Releasing to production happens manually but after it has been announced and app
 Post in the `#data-hub` slack channel the following (replace `<version>` with the version number and `<service-manager>` with the person resposible for approvals):
 
 ```
-@here Data Hub API version <version> is ready to be deployed. Please check the release notes to know how this will affect you: https://github.com/uktrade/data-hub-leeloo/blob/master/CHANGELOG.md. @<service-manager> Are you happy for us to release?
+@here Data Hub API version <version> is ready to be deployed. Please check the release notes to know how this will affect you: https://github.com/uktrade/data-hub-api/blob/master/CHANGELOG.md. @<service-manager> Are you happy for us to release?
 ```
 
 After the approval, the release can be deployed.
@@ -84,7 +84,7 @@ Click on `build`, follow the deployment and check that everything looks fine aft
 
 ## Formalise the release
 
-In GitHub, [create a release](https://github.com/uktrade/data-hub-leeloo/releases/new) with the following values:
+In GitHub, [create a release](https://github.com/uktrade/data-hub-api/releases/new) with the following values:
 
 * **Tag version**: `v<version>` e.g. `v6.3.0`
 * **Target**: `master`

--- a/docs/Managing dependencies.md
+++ b/docs/Managing dependencies.md
@@ -62,4 +62,4 @@ have been removed which can cause problems.)
 6. Create a PR. Include links to the change logs for dependencies in `requirements.in` that 
 were updated to make it easier for other developers to have a look at them. 
 
-   [Example of such a PR.](https://github.com/uktrade/data-hub-leeloo/pull/1171)
+   [Example of such a PR.](https://github.com/uktrade/data-hub-api/pull/1171)

--- a/scripts/create_changelog.py
+++ b/scripts/create_changelog.py
@@ -28,7 +28,7 @@ from script_utils.git import any_uncommitted_changes, local_branch_exists, remot
 from script_utils.news_fragments import list_news_fragments
 from script_utils.version import Version
 
-BASE_GITHUB_REPO_URL = 'https://github.com/uktrade/data-hub-leeloo'
+BASE_GITHUB_REPO_URL = 'https://github.com/uktrade/data-hub-api'
 
 parser = argparse.ArgumentParser(description='Create and push a changelog for a new version.')
 parser.add_argument('release_type', choices=Version._fields)

--- a/scripts/create_release_pr.py
+++ b/scripts/create_release_pr.py
@@ -31,9 +31,9 @@ from script_utils.git import (
 )
 from script_utils.news_fragments import list_news_fragments
 
-GITHUB_BASE_REPO_URL = 'https://github.com/uktrade/data-hub-leeloo'
+GITHUB_BASE_REPO_URL = 'https://github.com/uktrade/data-hub-api'
 RELEASE_GUIDE_URL = (
-    'https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/'
+    'https://github.com/uktrade/data-hub-api/blob/develop/docs/'
     'How%20to%20prepare%20a%20release.md'
 )
 PR_BODY_TEMPLATE = """This is the release PR for version {version}.


### PR DESCRIPTION
### Description of change

This:

- updates any references to the project name to Data Hub API (or similar)
- updates any references to the GitHub repo name to `data-hub-api`
- removes the PyUp badge from the README (as we no longer use it) and updates the other badges to the latest versions

(It doesn't change the docker-compose project name – that will be done separately.)

Would recommend looking at the commits individually.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
