### PR TITLE
Rename main Docker Compose service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,25 @@
 tests:
 	docker-compose build
-	docker-compose run leeloo bash tests.sh
+	docker-compose run api bash tests.sh
 
 flake8:
 	docker-compose build
-	docker-compose run leeloo flake8
+	docker-compose run api flake8
 
 docker-cleanup:
 	docker rm -f `docker ps -qa` || echo
 
 migrate:
-	docker-compose run leeloo python manage.py migrate
+	docker-compose run api python manage.py migrate
 
 init-es:
-	docker-compose run leeloo python manage.py init_es
+	docker-compose run api python manage.py init_es
 
 makemigrations:
-	docker-compose run leeloo python manage.py makemigrations
+	docker-compose run api python manage.py makemigrations
 
 shellplus:
-	docker-compose run leeloo python manage.py shell_plus --ipython
+	docker-compose run api python manage.py shell_plus --ipython
 
 load-metadata:
-	docker-compose run leeloo python manage.py loadinitialmetadata
+	docker-compose run api python manage.py loadinitialmetadata

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This project uses Docker compose to setup and run all the necessary components. 
       along in the api container's logs.
     * **NOTE:**
       If you are using a linux system, the elasticsearch container may not
-      come up successfully (`data-hub-leeloo_es_1`) - it might be perpetually
+      come up successfully (`data-hub-api_es_1`) - it might be perpetually
       restarting.
       If the logs for that container mention something like
       `max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`,
@@ -175,7 +175,7 @@ Automatically-generated API documentation is served at `/docs` (requires admin s
 
 ## Local development
 
-If using Docker, prefix these commands with `docker-compose run leeloo`.
+If using Docker, prefix these commands with `docker-compose run api`.
 
 To run the tests:
 
@@ -328,7 +328,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 
 ## Management commands
 
-If using Docker, remember to run these commands inside your container by prefixing them with `docker-compose run leeloo`.
+If using Docker, remember to run these commands inside your container by prefixing them with `docker-compose run api`.
 
 ### Database
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
 
-  leeloo:
+  api:
     build:
       context: .
     ports:
@@ -23,7 +23,7 @@ services:
       context: .
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -wait tcp://leeloo:8000 -timeout 180s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -wait tcp://api:8000 -timeout 180s
     env_file: .env
     command: watchmedo auto-restart -d . -R -p '*.py' -- celery worker -A config -l info -Q celery -B
 

--- a/start-uat.sh
+++ b/start-uat.sh
@@ -3,4 +3,4 @@
 clear
 docker-compose down
 docker-compose build
-docker-compose run --publish 8000:8000 leeloo bash setup-uat.sh
+docker-compose run --publish 8000:8000 api bash setup-uat.sh


### PR DESCRIPTION
### Description of change

This updates the docker-compose service name to `api` following the renaming of the project to Data Hub API.

([Docker Compose prepends the project name to the service name](https://docs.docker.com/compose/reference/envvars/), so just `api` should be OK.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
