### PR TITLE
Make company account manager endpoints set modified_by

### DIFF
--- a/changelog/company/account-manager-modified-by.bugfix.md
+++ b/changelog/company/account-manager-modified-by.bugfix.md
@@ -1,0 +1,1 @@
+The `POST /v4/company/<ID>/self-assign-account-manager` and `POST /v4/company/<ID>/remove-account-manager` endpoints now correctly update the `modified_by` field of the company (instead of leaving it unchanged).

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -404,18 +404,25 @@ class Company(ArchivableModel, BaseModel):
         group_global_headquarters = self.get_group_global_headquarters()
         return group_global_headquarters.one_list_account_owner
 
-    def assign_one_list_account_manager_and_tier(self, adviser, one_list_tier_id):
+    def assign_one_list_account_manager_and_tier(
+        self,
+        one_list_account_owner,
+        one_list_tier_id,
+        modified_by,
+    ):
         """Update the company's One List account manager and tier."""
-        self.one_list_account_owner = adviser
+        self.modified_by = modified_by
+        self.one_list_account_owner = one_list_account_owner
         self.one_list_tier_id = one_list_tier_id
         self.save()
 
-    def remove_from_one_list(self):
+    def remove_from_one_list(self, modified_by):
         """
         Remove the company from the One List.
 
         This is done by unsetting the company's One List account manager and tier.
         """
+        self.modified_by = modified_by
         self.one_list_account_owner = None
         self.one_list_tier = None
         self.save()

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -566,6 +566,7 @@ class SelfAssignAccountManagerSerializer(serializers.Serializer):
         self.instance.assign_one_list_account_manager_and_tier(
             adviser,
             self.target_one_list_tier_id,
+            adviser,
         )
         return self.instance
 
@@ -594,9 +595,9 @@ class RemoveAccountManagerSerializer(serializers.Serializer):
 
         return attrs
 
-    def save(self, adviser):
+    def save(self, by):
         """Unset the company's One List account manager and tier."""
-        self.instance.remove_from_one_list()
+        self.instance.remove_from_one_list(by)
         return self.instance
 
 

--- a/datahub/company/test/test_company_views_account_manager.py
+++ b/datahub/company/test/test_company_views_account_manager.py
@@ -105,6 +105,7 @@ class TestSelfAssignCompanyAccountManagerView(APITestMixin):
         company.refresh_from_db()
         assert company.one_list_account_owner == international_trade_adviser
         assert company.one_list_tier_id == OneListTierID.tier_d_international_trade_advisers.value
+        assert company.modified_by == international_trade_adviser
 
     @pytest.mark.parametrize(
         'company_factory,expected_errors',
@@ -225,6 +226,7 @@ class TestRemoveCompanyAccountManagerView(APITestMixin):
         company.refresh_from_db()
         assert company.one_list_account_owner is None
         assert company.one_list_tier is None
+        assert company.modified_by == international_trade_adviser
 
     @pytest.mark.django_db
     def test_cannot_remove_account_manager_for_other_tiers(self, international_trade_adviser):


### PR DESCRIPTION
### Description of change

This fixes a bug where `POST /v4/company/<ID>/self-assign-account-manager` and `POST /v4/company/<ID>/remove-account-manager` endpoints did not update `modified_by` on the company.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
