### PR TITLE
Add function for syncing a selected list of fields for a company with DNB 

### DIFF
--- a/changelog/company/update_company_from_dnb.internal.md
+++ b/changelog/company/update_company_from_dnb.internal.md
@@ -1,0 +1,4 @@
+A helper function for the "Update from DNB" admin feature was refactored as
+a utility function `datahub.dnb_api.utils.update_company_from_dnb`.  The function
+can optionally take an iterable of fields to update so that we can partially
+update companies from DNB.

--- a/datahub/company/admin/dnb.py
+++ b/datahub/company/admin/dnb.py
@@ -216,7 +216,7 @@ def update_from_dnb(model_admin, request, object_id):
 
     try:
         handle_dnb_error(
-            lambda: update_company_from_dnb(dh_company, request.user),
+            lambda: update_company_from_dnb(dh_company, user=request.user),
             company_change_page,
         )
         return HttpResponseRedirect(company_change_page)

--- a/datahub/company/admin/dnb.py
+++ b/datahub/company/admin/dnb.py
@@ -204,7 +204,7 @@ def update_from_dnb(model_admin, request, object_id):
         )
 
     try:
-        update_company_from_dnb(dh_company, dnb_company, user=request.user)
+        update_company_from_dnb(dh_company, dnb_company, request.user)
         return HttpResponseRedirect(company_change_page)
     except serializers.ValidationError:
         message = 'Data from D&B did not pass the Data Hub validation checks.'

--- a/datahub/company/test/admin/test_update_from_dnb.py
+++ b/datahub/company/test/admin/test_update_from_dnb.py
@@ -206,7 +206,7 @@ class TestUpdateFromDNB(AdminTestMixin):
         expected_message,
     ):
         """
-        Test if we gets anything other than a single company from dnb-service,
+        Test if we get anything other than a single company from dnb-service,
         we return an error message to the user.
         """
         _, update_url = self._create_company(duns_number='123456789')

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -3,17 +3,66 @@ from uuid import UUID
 
 import pytest
 from django.conf import settings
-from rest_framework import status
+from rest_framework import serializers, status
+from reversion.models import Version
 
+from datahub.company.models import Company
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.core.serializers import AddressSerializer
 from datahub.dnb_api.utils import (
     DNBServiceError,
     DNBServiceInvalidRequest,
     DNBServiceInvalidResponse,
     get_company,
+    update_company_from_dnb,
 )
+from datahub.metadata.models import Country
+
+pytestmark = pytest.mark.django_db
 
 
 DNB_SEARCH_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/search/')
+
+REQUIRED_REGISTERED_ADDRESS_FIELDS = [
+    f'registered_address_{field}' for field in AddressSerializer.REQUIRED_FIELDS
+]
+# TODO: base these on a DRY list of fields when we add it
+ALL_DNB_UPDATED_SERIALIZER_FIELDS = [
+    'name',
+    'trading_names',
+    'address',
+    'registered_address',
+    'website',
+    'number_of_employees',
+    'is_number_of_employees_estimated',
+    'turnover',
+    'is_turnover_estimated',
+    'website',
+    'global_ultimate_duns_number',
+    'company_number',
+]
+ALL_DNB_UPDATED_FIELDS = [
+    'name',
+    'trading_names',
+    'address_1',
+    'address_2',
+    'address_county',
+    'address_country',
+    'address_postcode',
+    'registered_address_1',
+    'registered_address_2',
+    'registered_address_county',
+    'registered_address_country',
+    'registered_address_postcode',
+    'website',
+    'number_of_employees',
+    'is_number_of_employees_estimated',
+    'turnover',
+    'is_turnover_estimated',
+    'website',
+    'global_ultimate_duns_number',
+    'company_number',
+]
 
 
 @pytest.mark.parametrize(
@@ -145,3 +194,267 @@ def test_get_company_valid(
         'website': 'http://foo.com',
         'global_ultimate_duns_number': '291332174',
     }
+
+
+class TestUpdateCompanyFromDNB:
+    """
+    Test update_company_from_dnb utility function.
+    """
+
+    def _assert_company_synced_with_dnb(self, company, dnb_company, fields=None):  # NOQA: C901
+        """
+        Check whether the given DataHub company has been synced with the given
+        DNB company.
+        """
+        if not fields:
+            fields = ALL_DNB_UPDATED_SERIALIZER_FIELDS
+
+        country = Country.objects.filter(
+            iso_alpha2_code=dnb_company['address_country'],
+        ).first()
+
+        registered_country = Country.objects.filter(
+            iso_alpha2_code=dnb_company['registered_address_country'],
+        ).first() if dnb_company.get('registered_address_country') else None
+
+        company_number = (
+            dnb_company['registration_numbers'][0].get('registration_number')
+            if country.iso_alpha2_code == 'GB' else None
+        )
+
+        required_registered_address_fields_present = all(
+            field in dnb_company for field in REQUIRED_REGISTERED_ADDRESS_FIELDS
+        )
+
+        if 'name' in fields:
+            assert company.name == dnb_company['primary_name']
+
+        if 'trading_names' in fields:
+            assert company.trading_names == dnb_company['trading_names']
+
+        if 'address' in fields:
+            assert company.address_1 == dnb_company['address_line_1']
+            assert company.address_2 == dnb_company['address_line_2']
+            assert company.address_country == country
+            assert company.address_town == dnb_company['address_town']
+            assert company.address_county == dnb_company['address_county']
+            assert company.address_postcode == dnb_company['address_postcode']
+
+        if 'registered_address' in fields and required_registered_address_fields_present:
+            assert company.registered_address_1 == dnb_company['registered_address_line_1']
+            assert company.registered_address_2 == dnb_company['registered_address_line_2']
+            assert company.registered_address_country == registered_country
+            assert company.registered_address_town == dnb_company['registered_address_town']
+            assert company.registered_address_county == dnb_company['registered_address_county']
+            assert (
+                company.registered_address_postcode == dnb_company['registered_address_postcode']
+            )
+
+        if 'company_number' in fields:
+            assert company.company_number == company_number
+
+        if 'number_of_employees' in fields:
+            assert company.number_of_employees == dnb_company['employee_number']
+
+        if 'is_number_of_employees_estimated' in fields:
+            is_employees_number_estimated = dnb_company['is_employees_number_estimated']
+            assert (
+                company.is_number_of_employees_estimated == is_employees_number_estimated
+            )
+
+        if 'turnover' in fields:
+            assert company.turnover == float(dnb_company['annual_sales'])
+
+        if 'is_turnover_estimated' in fields:
+            assert company.is_turnover_estimated == dnb_company['is_annual_sales_estimated']
+
+        if 'website' in fields:
+            assert company.website == f'http://{dnb_company["domain"]}'
+
+        if 'global_ultimate_duns_number' in fields:
+            assert (
+                company.global_ultimate_duns_number == dnb_company['global_ultimate_duns_number']
+            )
+
+    def _add_address_model_fields(self, fields_set, prefix):
+        fields_set.add(f'{prefix}_1')
+        fields_set.add(f'{prefix}_2')
+        fields_set.add(f'{prefix}_postcode')
+        fields_set.add(f'{prefix}_county')
+        fields_set.add(f'{prefix}_country')
+
+    @pytest.mark.parametrize(
+        'adviser_callable',
+        (
+            lambda: None,
+            lambda: AdviserFactory(),
+        ),
+    )
+    def test_update_company_from_dnb_all_fields(
+        self,
+        requests_mock,
+        dnb_company_search_feature_flag,
+        dnb_response_uk,
+        adviser_callable,
+    ):
+        """
+        Test that update_company_from_dnb will update all fields when the fields
+        kwarg is not specified.
+        """
+        duns_number = '123456789'
+        company = CompanyFactory(duns_number=duns_number, pending_dnb_investigation=True)
+        adviser = adviser_callable()
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response_uk,
+        )
+
+        update_company_from_dnb(company, user=adviser)
+        company.refresh_from_db()
+        dnb_company = dnb_response_uk['results'][0]
+        self._assert_company_synced_with_dnb(company, dnb_company)
+        assert company.pending_dnb_investigation is False
+
+        versions = list(Version.objects.get_for_object(company))
+        assert len(versions) == 1
+        version = versions[0]
+        assert version.revision.comment == 'Updated from D&B'
+
+        if adviser:
+            assert company.modified_by == adviser
+            assert version.revision.user == adviser
+
+    @pytest.mark.parametrize(
+        'fields_to_update',
+        (
+            ['global_ultimate_duns_number'],
+            ['name', 'address'],
+        ),
+    )
+    def test_update_company_from_dnb_partial_fields(
+        self,
+        requests_mock,
+        dnb_company_search_feature_flag,
+        dnb_response_uk,
+        fields_to_update,
+    ):
+        """
+        Test that update_company_from_dnb can update a subset of fields.
+        """
+        duns_number = '123456789'
+        company = CompanyFactory(duns_number=duns_number)
+        original_company = Company.objects.get(id=company.id)
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response_uk,
+        )
+
+        update_company_from_dnb(company, fields_to_update=fields_to_update)
+        company.refresh_from_db()
+        dnb_company = dnb_response_uk['results'][0]
+        self._assert_company_synced_with_dnb(company, dnb_company, fields=fields_to_update)
+        updated_model_fields = set(fields_to_update)
+
+        if 'address' in fields_to_update:
+            updated_model_fields.remove('address')
+            self._add_address_model_fields(updated_model_fields, 'address')
+
+        if 'registered_address' in fields_to_update:
+            updated_model_fields.remove('registered_address')
+            self._add_address_model_fields(updated_model_fields, 'registered_address')
+
+        expected_unmodified_fields = set(ALL_DNB_UPDATED_FIELDS) - updated_model_fields
+        for field in expected_unmodified_fields:
+            original_value = getattr(original_company, field)
+            current_value = getattr(company, field)
+            assert current_value == original_value
+
+    @pytest.mark.parametrize(
+        'dnb_response_code',
+        (
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
+    def test_post_dnb_error(self, requests_mock, dnb_response_code):
+        """
+        Tests that DNBServiceError is raised when calling the DNB API returns a non-200
+        status.
+        """
+        company = CompanyFactory(duns_number='123456789')
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=dnb_response_code,
+        )
+        with pytest.raises(DNBServiceError):
+            update_company_from_dnb(company)
+
+    @pytest.mark.parametrize(
+        'search_results, expected_message',
+        (
+            (
+                ['foo', 'bar'],
+                'Something went wrong in an upstream service.',
+            ),
+            (
+                [{'duns_number': '012345678'}],
+                'Something went wrong in an upstream service.',
+            ),
+        ),
+    )
+    def test_post_dnb_response_invalid(
+        self,
+        requests_mock,
+        search_results,
+        expected_message,
+    ):
+        """
+        Tests that DNBServiceInvalidResponse is raised when DNB responds with an unexpected
+        response format.
+        """
+        company = CompanyFactory(duns_number='12345678')
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json={'results': search_results},
+        )
+        with pytest.raises(DNBServiceInvalidResponse) as exc:
+            update_company_from_dnb(company)
+            assert str(exc) == expected_message
+
+    def test_post_dnb_request_invalid(
+        self,
+        requests_mock,
+    ):
+        """
+        Tests that DNBServiceInvalidRequest is raised when DNB yields no results.
+        """
+        company = CompanyFactory(duns_number='12345678')
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json={'results': []},
+        )
+        with pytest.raises(DNBServiceInvalidRequest) as exc:
+            update_company_from_dnb(company)
+            assert str(exc) == 'Cannot find a company with duns_number: 12345678'
+
+    def test_post_dnb_data_invalid(
+        self,
+        requests_mock,
+        dnb_response_uk,
+    ):
+        """
+        Tests that ValidationError is raised when data returned by DNB is not valid for saving to a
+        Data Hub Company.
+        """
+        company = CompanyFactory(duns_number='123456789')
+        dnb_response_uk['results'][0]['primary_name'] = None
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response_uk,
+        )
+        with pytest.raises(serializers.ValidationError) as exc:
+            update_company_from_dnb(company)
+            assert str(exc) == 'Data from D&B did not pass the Data Hub validation checks.'

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -313,6 +313,6 @@ class TestUpdateCompanyFromDNB:
         company = CompanyFactory(duns_number='123456789')
         adviser = AdviserFactory()
         formatted_dnb_company['name'] = None
-        with pytest.raises(serializers.ValidationError) as exc:
+        with pytest.raises(serializers.ValidationError) as excinfo:
             update_company_from_dnb(company, formatted_dnb_company, adviser)
-            assert str(exc) == 'Data from D&B did not pass the Data Hub validation checks.'
+            assert str(excinfo) == 'Data from D&B did not pass the Data Hub validation checks.'

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -182,7 +182,7 @@ def format_dnb_company_investigation(data):
     return data
 
 
-def update_company_from_dnb(dh_company, dnb_company, fields_to_update=None, user=None):
+def update_company_from_dnb(dh_company, dnb_company, user, fields_to_update=None):
     """
     Updates `dh_company` with new data from `dnb_company` while setting `modified_by` to the
     given user and creating a revision.
@@ -213,9 +213,9 @@ def update_company_from_dnb(dh_company, dnb_company, fields_to_update=None, user
         raise
 
     with reversion.create_revision():
-        company_kwargs = {'pending_dnb_investigation': False}
-        if user:
-            company_kwargs['modified_by'] = user
-            reversion.set_user(user)
-        company_serializer.save(**company_kwargs)
+        company_serializer.save(
+            modified_by=user,
+            pending_dnb_investigation=False,
+        )
+        reversion.set_user(user)
         reversion.set_comment('Updated from D&B')

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -182,27 +182,22 @@ def format_dnb_company_investigation(data):
     return data
 
 
-def update_company_from_dnb(company, fields_to_update=None, user=None):
+def update_company_from_dnb(dh_company, dnb_company, fields_to_update=None, user=None):
     """
-    Updates `company` with new data from dnb while setting `modified_by` to the
+    Updates `dh_company` with new data from `dnb_company` while setting `modified_by` to the
     given user and creating a revision.
     If `fields_to_update` is specified, only the fields specified will be synced
     with DNB.  `fields_to_update` should be an iterable of strings representing
     DNBCompanySerializer field names.
 
     Raises serializers.ValidationError if data is invalid.
-    Raises DNBServiceError/DNBServiceInvalidResponse if there are problems
-    communicating with DNB.
-    Raises DNBServiceInvalidRequest if the request to DNB was invalid.
     """
-    dnb_company = get_company(company.duns_number)
-
     if fields_to_update:
         # Set dnb_company data to only include the fields in fields_to_update
         dnb_company = {field: dnb_company[field] for field in fields_to_update}
 
     company_serializer = DNBCompanySerializer(
-        company,
+        dh_company,
         data=dnb_company,
         partial=True,
     )

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -192,7 +192,7 @@ def update_company_from_dnb(dh_company, dnb_company, user, fields_to_update=None
 
     Raises serializers.ValidationError if data is invalid.
     """
-    if fields_to_update:
+    if fields_to_update is not None:
         # Set dnb_company data to only include the fields in fields_to_update
         dnb_company = {field: dnb_company[field] for field in fields_to_update}
 


### PR DESCRIPTION
### Description of change

This PR refactors `datahub.company.admin.dnb._update_from_dnb` to be a standalone utility function `datahub.dnb_api.utils.update_company_from_dnb`.  It enriches the refactored function so that a subset of fields can be specified - `fields_to_update` - enabling callers to selectively sync certain fields on the Data Hub company model with it's DNB company equivalent, instead of syncing **all** fields.

This makes the first building block for a bulk DNB syncing tool.  The next PR(s) will:
- Add a celery task to wrap `update_company_from_dnb`.
- Add a management command inheriting from `CSVBaseCommand` which will allow callers to sync selected DNB data fields for a list of Data Hub company IDs.  This will enable us to start refreshing the data for our ~80K DNB-linked records according to business needs.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
