### PR TITLE
Add additional fields to contacts dataset endpoint response

### DIFF
--- a/changelog/contact/dataset-api-endpoint-additional-fields.api.md
+++ b/changelog/contact/dataset-api-endpoint-additional-fields.api.md
@@ -1,0 +1,1 @@
+`GET /v4/dataset/contacts-dataset`: The primary contact flag and contact address details were added to the contacts dataset response

--- a/datahub/dataset/contact/test/test_views.py
+++ b/datahub/dataset/contact/test/test_views.py
@@ -19,8 +19,13 @@ def get_expected_data_from_contact(contact):
     """Returns expected dictionary based on given contact"""
     return {
         'accepts_dit_email_marketing': contact.accepts_dit_email_marketing,
+        'address_1': contact.address_1,
+        'address_2': contact.address_2,
         'address_country__name': get_attr_or_none(contact, 'address_country.name'),
+        'address_county': contact.address_county,
         'address_postcode': contact.address_postcode,
+        'address_same_as_company': contact.address_same_as_company,
+        'address_town': contact.address_town,
         'company_id': str(contact.company_id) if contact.company_id is not None else None,
         'created_on': format_date_or_datetime(contact.created_on),
         'email': contact.email,
@@ -29,6 +34,7 @@ def get_expected_data_from_contact(contact):
         'job_title': contact.job_title,
         'name': contact.name,
         'notes': contact.notes,
+        'primary': contact.primary,
         'telephone_alternative': contact.telephone_alternative,
         'telephone_number': contact.telephone_number,
     }

--- a/datahub/dataset/contact/views.py
+++ b/datahub/dataset/contact/views.py
@@ -18,8 +18,13 @@ class ContactsDatasetView(BaseDatasetView):
             name=get_full_name_expression(),
         ).values(
             'accepts_dit_email_marketing',
+            'address_1',
+            'address_2',
             'address_country__name',
+            'address_county',
             'address_postcode',
+            'address_same_as_company',
+            'address_town',
             'company_id',
             'created_on',
             'email',
@@ -28,6 +33,7 @@ class ContactsDatasetView(BaseDatasetView):
             'job_title',
             'name',
             'notes',
+            'primary',
             'telephone_alternative',
             'telephone_number',
         )


### PR DESCRIPTION
Adds full address details and primary flag to response. These details are required for the service and interactions report on data workspace.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
