### PR TITLE
Deprecate POST /company

### DIFF
--- a/changelog/company/company_create.deprecation.md
+++ b/changelog/company/company_create.deprecation.md
@@ -1,0 +1,7 @@
+The following Company endpoint is deprecated and will be removed on or after 12 November 2019:
+
+- `POST /v4/company`
+
+DataHub has moved to using D&B creating new companies and so instead of the above endpoint, please use:
+
+- `POST /v4/dnb/company-create`


### PR DESCRIPTION
### Description of change

DataHub has moved to using D&B creating new companies and so instead of the above endpoint, please use:

 - `POST /v4/dnb/company-create`

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
