### PR TITLE
Update country names from reference data

### DIFF
--- a/changelog/rename-countries.feature.md
+++ b/changelog/rename-countries.feature.md
@@ -1,0 +1,1 @@
+The names of various countries were updated to match DIT reference data.

--- a/datahub/metadata/migrations/0039_rename_countries.yaml
+++ b/datahub/metadata/migrations/0039_rename_countries.yaml
@@ -1,0 +1,75 @@
+# From Bahamas
+- model: metadata.country
+  pk: a25f66a0-5d95-e211-a939-e4115bead28a
+  fields:
+    name: The Bahamas
+# Burkina
+- model: metadata.country
+  pk: 58af72a6-5d95-e211-a939-e4115bead28a
+  fields:
+    name: Burkina Faso
+# Burma
+- model: metadata.country
+  pk: 59af72a6-5d95-e211-a939-e4115bead28a
+  fields:
+    name: Myanmar (Burma)
+# Czech Republic
+- model: metadata.country
+  pk: 6faf72a6-5d95-e211-a939-e4115bead28a
+  fields:
+    name: Czechia
+# Gambia
+- model: metadata.country
+  pk: dff682ac-5d95-e211-a939-e4115bead28a
+  fields:
+    name: The Gambia
+#Hong Kong (SAR)
+- model: metadata.country
+  pk: f0f682ac-5d95-e211-a939-e4115bead28a
+  fields:
+    name: Hong Kong
+#Korea (North)
+- model: metadata.country
+  pk: 7b6a9ab2-5d95-e211-a939-e4115bead28a
+  fields:
+    name: North Korea
+#Korea (South)
+- model: metadata.country
+  pk: 7c6a9ab2-5d95-e211-a939-e4115bead28a
+  fields:
+    name: South Korea
+#Macao (SAR)
+- model: metadata.country
+  pk: 886a9ab2-5d95-e211-a939-e4115bead28a
+  fields:
+    name: Macao
+#Macedonia
+- model: metadata.country
+  pk: 896a9ab2-5d95-e211-a939-e4115bead28a
+  fields:
+    name: North Macedonia
+#Reunion
+- model: metadata.country
+  pk: 5761b8be-5d95-e211-a939-e4115bead28a
+  fields:
+    name: Réunion
+#Sudan, South
+- model: metadata.country
+  pk: 7e756b9a-5d95-e211-a939-e4115bead28a
+  fields:
+    name: South Sudan
+#Surinam
+- model: metadata.country
+  pk: 2d0be5c4-5d95-e211-a939-e4115bead28a
+  fields:
+    name: Suriname
+#Swaziland
+- model: metadata.country
+  pk: 2f0be5c4-5d95-e211-a939-e4115bead28a
+  fields:
+    name: Eswatini
+#Virgin Islands (US)
+- model: metadata.country
+  pk: bb6ee1ca-5d95-e211-a939-e4115bead28a
+  fields:
+    name: United States Virgin Islands

--- a/datahub/metadata/migrations/0039_update_countries_to_ref_data.py
+++ b/datahub/metadata/migrations/0039_update_countries_to_ref_data.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+def load_countries(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0039_rename_countries.yaml',
+    )
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0038_remove_service_name_from_db'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_countries, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
### Description of change
This updates a selection of country names in metadata_country as these were out of line with the Data Workspace reference data


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
