### PR TITLE
Sync company from dnb celery task

### DIFF
--- a/changelog/company/sync_company_from_dnb_task.internal.md
+++ b/changelog/company/sync_company_from_dnb_task.internal.md
@@ -1,0 +1,3 @@
+A celery task `datahub.dnb_api.tasks.sync_company_from_dnb` was added which gives
+a mechanism for syncing specified fields for a DNB-matched company with the latest
+DNB data for that company.

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -14,6 +14,33 @@ from datahub.core.validators import EqualsRule, OperatorRule, RulesBasedValidato
 from datahub.interaction.models import InteractionPermission
 
 
+# TODO: Use this as a DRY reference for all code relating to updated DNB fields in the future
+ALL_DNB_UPDATED_FIELDS = [
+    'name',
+    'trading_names',
+    'address_1',
+    'address_2',
+    'address_town',
+    'address_county',
+    'address_country',
+    'address_postcode',
+    'registered_address_1',
+    'registered_address_2',
+    'registered_address_town',
+    'registered_address_county',
+    'registered_address_country',
+    'registered_address_postcode',
+    'website',
+    'number_of_employees',
+    'is_number_of_employees_estimated',
+    'turnover',
+    'is_turnover_estimated',
+    'website',
+    'global_ultimate_duns_number',
+    'company_number',
+]
+
+
 class DNBMatchedCompanySerializer(PermittedFieldsModelSerializer):
     """
     Serialiser for data hub companies matched with a DNB entry.
@@ -115,6 +142,23 @@ class DNBCompanySerializer(CompanySerializer):
                 ),
             ),
         )
+
+    def save_dnb_fields(self, **kwargs):
+        """
+        Method to save the instance - by writing only the fields updated by DNB.
+        Takes kwargs to override the values of specific fields for the model
+        on save - these fields are not subject to the DNB-only restriction.
+
+        Note: modified_on will not be updated by this method.
+        """
+        instance = self.instance
+        validated_data = dict(
+            list(self.validated_data.items()) + list(kwargs.items()),
+        )
+        for field, value in validated_data.items():
+            setattr(instance, field, value)
+        update_fields = ALL_DNB_UPDATED_FIELDS + list(kwargs.keys())
+        instance.save(update_fields=update_fields)
 
 
 class DUNSNumberSerializer(serializers.Serializer):

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -14,6 +14,13 @@ from datahub.core.validators import EqualsRule, OperatorRule, RulesBasedValidato
 from datahub.interaction.models import InteractionPermission
 
 
+class SerializerNotPartial(Exception):
+    """
+    Exception for when some logic was called which expects a serializer object
+    to be self.partial=True.
+    """
+
+
 class DNBMatchedCompanySerializer(PermittedFieldsModelSerializer):
     """
     Serialiser for data hub companies matched with a DNB entry.
@@ -121,10 +128,14 @@ class DNBCompanySerializer(CompanySerializer):
         Method to save the instance - by writing only the fields updated by the serializer.
         Takes kwargs to override the values of specific fields for the model on save.
 
-        Note: modified_on will not be updated by this method.
+        Note: modified_on will not be updated by this method - this is the original
+        reason for this method to exist as modified_on has auto_now=True and which makes it
+        difficult to to prevent updates to this field.
         """
         if not self.partial:
-            raise Exception('partial_save() called, but serializer is not set as partial.')
+            raise SerializerNotPartial(
+                'partial_save() called, but serializer is not set as partial.',
+            )
         instance = self.instance
         validated_data = {**self.validated_data, **kwargs}
         for field, value in validated_data.items():

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -1,5 +1,4 @@
 from celery import shared_task
-from celery.exceptions import Retry
 from celery.utils.log import get_task_logger
 from rest_framework.status import is_server_error
 
@@ -44,12 +43,4 @@ def sync_company_with_dnb(self, company_id, fields_to_update=None):
     company serializer fields that should be updated - if it is None, all fields
     will be synced.
     """
-    try:
-        _sync_company_with_dnb(company_id, fields_to_update, self)
-    except Retry as exc:
-        status_code = exc.exc.status_code
-        logger.info(
-            f'DNB service responded with status {status_code}. Retrying '
-            'sync_company_with_dnb celery task',
-        )
-        raise
+    _sync_company_with_dnb(company_id, fields_to_update, self)

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -1,0 +1,59 @@
+from celery import shared_task
+from celery.exceptions import Retry
+from celery.utils.log import get_task_logger
+from rest_framework import status
+
+from datahub.company.models import Company
+from datahub.dnb_api.utils import (
+    DNBServiceError,
+    get_company,
+    update_company_from_dnb,
+)
+
+logger = get_task_logger(__name__)
+
+
+def _sync_company_with_dnb(company_id, fields_to_update, task):
+    dh_company = Company.objects.get(id=company_id)
+
+    try:
+        dnb_company = get_company(dh_company.duns_number)
+    except DNBServiceError as exc:
+        server_error_statuses = (
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status.HTTP_502_BAD_GATEWAY,
+            status.HTTP_503_SERVICE_UNAVAILABLE,
+            status.HTTP_504_GATEWAY_TIMEOUT,
+        )
+        if exc.status_code in server_error_statuses:
+            raise task.retry(exc=exc, countdown=60)
+        raise
+
+    update_company_from_dnb(
+        dh_company,
+        dnb_company,
+        fields_to_update=fields_to_update,
+        update_descriptor='celery:sync_company_with_dnb',
+    )
+
+
+@shared_task(
+    bind=True,
+    acks_late=True,
+    priority=9,
+    max_retries=3,
+)
+def sync_company_with_dnb(self, company_id, fields_to_update=None):
+    """
+    Sync a company record with data sourced from DNB. `company_id` identifies the
+    company record to sync and `fields_to_update` defines an iterable of
+    company serializer fields that should be updated - if it is None, all fields
+    will be synced.
+    """
+    try:
+        _sync_company_with_dnb(company_id, fields_to_update, self)
+    except Retry:
+        raise
+    except Exception:
+        logger.error(f'Encountered an error when syncing Company "{company_id}" with DNB')
+        raise

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -1,0 +1,210 @@
+from unittest import mock
+from urllib.parse import urljoin
+
+import pytest
+from celery.exceptions import Retry
+from django.conf import settings
+from django.forms.models import model_to_dict
+from reversion.models import Version
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.dnb_api.tasks import sync_company_with_dnb
+from datahub.dnb_api.utils import DNBServiceError
+from datahub.metadata.models import Country
+
+pytestmark = pytest.mark.django_db
+
+
+DNB_SEARCH_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/search/')
+
+
+def test_sync_company_with_dnb_all_fields(
+    dnb_company_search_feature_flag,
+    requests_mock,
+    dnb_response_uk,
+):
+    """
+    Test the sync_company_with_dnb task when all fields should be synced.
+    """
+    requests_mock.post(
+        DNB_SEARCH_URL,
+        json=dnb_response_uk,
+    )
+    company = CompanyFactory(duns_number='123456789')
+    original_company = company
+    sync_company_with_dnb.apply_async(args=[company.id])
+    company.refresh_from_db()
+    uk_country = Country.objects.get(iso_alpha2_code='GB')
+    assert model_to_dict(company) == {
+        'address_1': 'Unit 10, Ockham Drive',
+        'address_2': '',
+        'address_country': uk_country.id,
+        'address_county': '',
+        'address_postcode': 'UB6 0F2',
+        'address_town': 'GREENFORD',
+        'archived': False,
+        'archived_by': None,
+        'archived_documents_url_path': original_company.archived_documents_url_path,
+        'archived_on': None,
+        'archived_reason': None,
+        'business_type': original_company.business_type.id,
+        'company_number': '01261539',
+        'created_by': original_company.created_by.id,
+        'description': None,
+        'dnb_investigation_data': None,
+        'duns_number': '123456789',
+        'employee_range': original_company.employee_range.id,
+        'export_experience_category': original_company.export_experience_category.id,
+        'export_potential': None,
+        'export_to_countries': [],
+        'future_interest_countries': [],
+        'global_headquarters': None,
+        'global_ultimate_duns_number': '291332174',
+        'great_profile_status': None,
+        'headquarter_type': None,
+        'id': original_company.id,
+        'is_number_of_employees_estimated': True,
+        'is_turnover_estimated': None,
+        'modified_by': original_company.modified_by.id,
+        'name': 'FOO BICYCLE LIMITED',
+        'number_of_employees': 260,
+        'one_list_account_owner': None,
+        'one_list_tier': None,
+        'pending_dnb_investigation': False,
+        'reference_code': '',
+        'registered_address_1': 'C/O LONE VARY',
+        'registered_address_2': '',
+        'registered_address_country': uk_country.id,
+        'registered_address_county': '',
+        'registered_address_postcode': 'UB6 0F2',
+        'registered_address_town': 'GREENFORD',
+        'sector': original_company.sector.id,
+        'trading_names': [],
+        'transfer_reason': '',
+        'transferred_by': None,
+        'transferred_on': None,
+        'transferred_to': None,
+        'turnover': 50651895,
+        'turnover_range': original_company.turnover_range.id,
+        'uk_region': original_company.uk_region.id,
+        'vat_number': '',
+        'website': 'http://foo.com',
+    }
+
+    versions = list(Version.objects.get_for_object(company))
+    assert len(versions) == 1
+    version = versions[0]
+    assert version.revision.comment == 'Updated from D&B [celery:sync_company_with_dnb]'
+    assert version.revision.user is None
+
+
+def test_sync_company_with_dnb_partial_fields(
+    dnb_company_search_feature_flag,
+    requests_mock,
+    dnb_response_uk,
+):
+    """
+    Test the sync_company_with_dnb task when only a subset of fields should be synced.
+    """
+    requests_mock.post(
+        DNB_SEARCH_URL,
+        json=dnb_response_uk,
+    )
+    company = CompanyFactory(duns_number='123456789')
+    original_company = company
+    sync_company_with_dnb.apply_async(
+        args=[company.id],
+        kwargs={'fields_to_update': ['global_ultimate_duns_number']},
+    )
+    company.refresh_from_db()
+    assert model_to_dict(company) == {
+        'address_1': original_company.address_1,
+        'address_2': original_company.address_2,
+        'address_country': original_company.address_country.id,
+        'address_county': original_company.address_county,
+        'address_postcode': original_company.address_postcode,
+        'address_town': original_company.address_town,
+        'archived': original_company.archived,
+        'archived_by': original_company.archived_by,
+        'archived_documents_url_path': original_company.archived_documents_url_path,
+        'archived_on': original_company.archived_on,
+        'archived_reason': original_company.archived_reason,
+        'business_type': original_company.business_type.id,
+        'company_number': original_company.company_number,
+        'created_by': original_company.created_by.id,
+        'description': original_company.description,
+        'dnb_investigation_data': original_company.dnb_investigation_data,
+        'duns_number': original_company.duns_number,
+        'employee_range': original_company.employee_range.id,
+        'export_experience_category': original_company.export_experience_category.id,
+        'export_potential': original_company.export_potential,
+        'export_to_countries': [],
+        'future_interest_countries': [],
+        'global_headquarters': original_company.global_headquarters,
+        'global_ultimate_duns_number': '291332174',
+        'great_profile_status': original_company.great_profile_status,
+        'headquarter_type': original_company.headquarter_type,
+        'id': original_company.id,
+        'is_number_of_employees_estimated': original_company.is_number_of_employees_estimated,
+        'is_turnover_estimated': original_company.is_turnover_estimated,
+        'modified_by': original_company.modified_by.id,
+        'name': original_company.name,
+        'number_of_employees': original_company.number_of_employees,
+        'one_list_account_owner': original_company.one_list_account_owner,
+        'one_list_tier': original_company.one_list_tier,
+        'pending_dnb_investigation': original_company.pending_dnb_investigation,
+        'reference_code': original_company.reference_code,
+        'registered_address_1': original_company.registered_address_1,
+        'registered_address_2': original_company.registered_address_2,
+        'registered_address_country': original_company.registered_address_country.id,
+        'registered_address_county': original_company.registered_address_county,
+        'registered_address_postcode': original_company.registered_address_postcode,
+        'registered_address_town': original_company.registered_address_town,
+        'sector': original_company.sector.id,
+        'trading_names': original_company.trading_names,
+        'transfer_reason': original_company.transfer_reason,
+        'transferred_by': None,
+        'transferred_on': None,
+        'transferred_to': None,
+        'turnover': original_company.turnover,
+        'turnover_range': original_company.turnover_range.id,
+        'uk_region': original_company.uk_region.id,
+        'vat_number': original_company.vat_number,
+        'website': original_company.website,
+    }
+
+
+@pytest.mark.parametrize(
+    'error_status_code,expect_retry',
+    (
+        (504, True),
+        (503, True),
+        (502, True),
+        (500, True),
+        (403, False),
+        (400, False),
+    ),
+)
+def test_sync_company_with_dnb_retries_errors(monkeypatch, error_status_code, expect_retry):
+    """
+    Test the sync_company_with_dnb task retries server errors.
+    """
+    company = CompanyFactory(duns_number='123456789')
+
+    # Set up a DNBServiceError with the parametrized status code
+    error = DNBServiceError('An error occurred', status_code=error_status_code)
+    mocked_get_company = mock.Mock()
+    mocked_get_company.side_effect = error
+    monkeypatch.setattr('datahub.dnb_api.tasks.get_company', mocked_get_company)
+
+    # Mock the task's retry method
+    retry_mock = mock.Mock(side_effect=Retry())
+    monkeypatch.setattr('datahub.dnb_api.tasks.sync_company_with_dnb.retry', retry_mock)
+
+    if expect_retry:
+        expected_exception_class = Retry
+    else:
+        expected_exception_class = DNBServiceError
+
+    with pytest.raises(expected_exception_class):
+        sync_company_with_dnb(company.id)

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.forms.models import model_to_dict
 from reversion.models import Version
 
+from datahub.company.models import Company
 from datahub.company.test.factories import CompanyFactory
 from datahub.dnb_api.tasks import sync_company_with_dnb
 from datahub.dnb_api.utils import DNBServiceError
@@ -31,7 +32,7 @@ def test_sync_company_with_dnb_all_fields(
         json=dnb_response_uk,
     )
     company = CompanyFactory(duns_number='123456789')
-    original_company = company
+    original_company = Company.objects.get(id=company.id)
     sync_company_with_dnb.apply_async(args=[company.id])
     company.refresh_from_db()
     uk_country = Country.objects.get(iso_alpha2_code='GB')
@@ -111,7 +112,7 @@ def test_sync_company_with_dnb_partial_fields(
         json=dnb_response_uk,
     )
     company = CompanyFactory(duns_number='123456789')
-    original_company = company
+    original_company = Company.objects.get(id=company.id)
     sync_company_with_dnb.apply_async(
         args=[company.id],
         kwargs={'fields_to_update': ['global_ultimate_duns_number']},

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -33,7 +33,8 @@ def test_sync_company_with_dnb_all_fields(
     )
     company = CompanyFactory(duns_number='123456789')
     original_company = Company.objects.get(id=company.id)
-    sync_company_with_dnb.apply_async(args=[company.id])
+    task_result = sync_company_with_dnb.apply_async(args=[company.id])
+    assert task_result.successful()
     company.refresh_from_db()
     uk_country = Country.objects.get(iso_alpha2_code='GB')
     assert model_to_dict(company) == {
@@ -48,14 +49,14 @@ def test_sync_company_with_dnb_all_fields(
         'archived_documents_url_path': original_company.archived_documents_url_path,
         'archived_on': None,
         'archived_reason': None,
-        'business_type': original_company.business_type.id,
+        'business_type': original_company.business_type_id,
         'company_number': '01261539',
-        'created_by': original_company.created_by.id,
+        'created_by': original_company.created_by_id,
         'description': None,
         'dnb_investigation_data': None,
         'duns_number': '123456789',
-        'employee_range': original_company.employee_range.id,
-        'export_experience_category': original_company.export_experience_category.id,
+        'employee_range': original_company.employee_range_id,
+        'export_experience_category': original_company.export_experience_category_id,
         'export_potential': None,
         'export_to_countries': [],
         'future_interest_countries': [],
@@ -66,7 +67,7 @@ def test_sync_company_with_dnb_all_fields(
         'id': original_company.id,
         'is_number_of_employees_estimated': True,
         'is_turnover_estimated': None,
-        'modified_by': original_company.modified_by.id,
+        'modified_by': original_company.modified_by_id,
         'name': 'FOO BICYCLE LIMITED',
         'number_of_employees': 260,
         'one_list_account_owner': None,
@@ -79,15 +80,15 @@ def test_sync_company_with_dnb_all_fields(
         'registered_address_county': '',
         'registered_address_postcode': 'UB6 0F2',
         'registered_address_town': 'GREENFORD',
-        'sector': original_company.sector.id,
+        'sector': original_company.sector_id,
         'trading_names': [],
         'transfer_reason': '',
         'transferred_by': None,
         'transferred_on': None,
         'transferred_to': None,
         'turnover': 50651895,
-        'turnover_range': original_company.turnover_range.id,
-        'uk_region': original_company.uk_region.id,
+        'turnover_range': original_company.turnover_range_id,
+        'uk_region': original_company.uk_region_id,
         'vat_number': '',
         'website': 'http://foo.com',
     }
@@ -113,10 +114,11 @@ def test_sync_company_with_dnb_partial_fields(
     )
     company = CompanyFactory(duns_number='123456789')
     original_company = Company.objects.get(id=company.id)
-    sync_company_with_dnb.apply_async(
+    task_result = sync_company_with_dnb.apply_async(
         args=[company.id],
         kwargs={'fields_to_update': ['global_ultimate_duns_number']},
     )
+    assert task_result.successful()
     company.refresh_from_db()
     assert model_to_dict(company) == {
         'address_1': original_company.address_1,
@@ -130,14 +132,14 @@ def test_sync_company_with_dnb_partial_fields(
         'archived_documents_url_path': original_company.archived_documents_url_path,
         'archived_on': original_company.archived_on,
         'archived_reason': original_company.archived_reason,
-        'business_type': original_company.business_type.id,
+        'business_type': original_company.business_type_id,
         'company_number': original_company.company_number,
-        'created_by': original_company.created_by.id,
+        'created_by': original_company.created_by_id,
         'description': original_company.description,
         'dnb_investigation_data': original_company.dnb_investigation_data,
         'duns_number': original_company.duns_number,
-        'employee_range': original_company.employee_range.id,
-        'export_experience_category': original_company.export_experience_category.id,
+        'employee_range': original_company.employee_range_id,
+        'export_experience_category': original_company.export_experience_category_id,
         'export_potential': original_company.export_potential,
         'export_to_countries': [],
         'future_interest_countries': [],
@@ -148,7 +150,7 @@ def test_sync_company_with_dnb_partial_fields(
         'id': original_company.id,
         'is_number_of_employees_estimated': original_company.is_number_of_employees_estimated,
         'is_turnover_estimated': original_company.is_turnover_estimated,
-        'modified_by': original_company.modified_by.id,
+        'modified_by': original_company.modified_by_id,
         'name': original_company.name,
         'number_of_employees': original_company.number_of_employees,
         'one_list_account_owner': original_company.one_list_account_owner,
@@ -161,15 +163,15 @@ def test_sync_company_with_dnb_partial_fields(
         'registered_address_county': original_company.registered_address_county,
         'registered_address_postcode': original_company.registered_address_postcode,
         'registered_address_town': original_company.registered_address_town,
-        'sector': original_company.sector.id,
+        'sector': original_company.sector_id,
         'trading_names': original_company.trading_names,
         'transfer_reason': original_company.transfer_reason,
         'transferred_by': None,
         'transferred_on': None,
         'transferred_to': None,
         'turnover': original_company.turnover,
-        'turnover_range': original_company.turnover_range.id,
-        'uk_region': original_company.uk_region.id,
+        'turnover_range': original_company.turnover_range_id,
+        'uk_region': original_company.uk_region_id,
         'vat_number': original_company.vat_number,
         'website': original_company.website,
     }

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -121,7 +121,7 @@ def test_sync_company_with_dnb_partial_fields(
     assert model_to_dict(company) == {
         'address_1': original_company.address_1,
         'address_2': original_company.address_2,
-        'address_country': original_company.address_country.id,
+        'address_country': original_company.address_country_id,
         'address_county': original_company.address_county,
         'address_postcode': original_company.address_postcode,
         'address_town': original_company.address_town,
@@ -157,7 +157,7 @@ def test_sync_company_with_dnb_partial_fields(
         'reference_code': original_company.reference_code,
         'registered_address_1': original_company.registered_address_1,
         'registered_address_2': original_company.registered_address_2,
-        'registered_address_country': original_company.registered_address_country.id,
+        'registered_address_country': original_company.registered_address_country_id,
         'registered_address_county': original_company.registered_address_county,
         'registered_address_postcode': original_company.registered_address_postcode,
         'registered_address_town': original_company.registered_address_town,
@@ -199,7 +199,7 @@ def test_sync_company_with_dnb_retries_errors(monkeypatch, error_status_code, ex
     monkeypatch.setattr('datahub.dnb_api.tasks.get_company', mocked_get_company)
 
     # Mock the task's retry method
-    retry_mock = mock.Mock(side_effect=Retry())
+    retry_mock = mock.Mock(side_effect=Retry(exc=error))
     monkeypatch.setattr('datahub.dnb_api.tasks.sync_company_with_dnb.retry', retry_mock)
 
     if expect_retry:

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -7,6 +7,7 @@ from django.forms.models import model_to_dict
 from rest_framework import serializers, status
 from reversion.models import Version
 
+from datahub.company.models import Company
 from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.dnb_api.utils import (
     DNBServiceError,
@@ -188,7 +189,7 @@ class TestUpdateCompanyFromDNB:
         """
         duns_number = '123456789'
         company = CompanyFactory(duns_number=duns_number, pending_dnb_investigation=True)
-        original_company = company
+        original_company = Company.objects.get(id=company.id)
         adviser = adviser_callable()
         update_company_from_dnb(
             company,
@@ -277,7 +278,7 @@ class TestUpdateCompanyFromDNB:
         """
         duns_number = '123456789'
         company = CompanyFactory(duns_number=duns_number)
-        original_company = company
+        original_company = Company.objects.get(id=company.id)
         adviser = AdviserFactory()
 
         update_company_from_dnb(
@@ -303,7 +304,7 @@ class TestUpdateCompanyFromDNB:
         """
         duns_number = '123456789'
         company = CompanyFactory(duns_number=duns_number)
-        original_company = company
+        original_company = Company.objects.get(id=company.id)
         adviser = AdviserFactory()
 
         update_company_from_dnb(

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -268,10 +268,18 @@ class TestUpdateCompanyFromDNB:
         if not adviser:
             assert company.modified_on == original_company.modified_on
 
+    @pytest.mark.parametrize(
+        'adviser_callable',
+        (
+            lambda: None,
+            lambda: AdviserFactory(),
+        ),
+    )
     def test_update_company_from_dnb_partial_fields_single(
         self,
         dnb_company_search_feature_flag,
         formatted_dnb_company,
+        adviser_callable,
     ):
         """
         Test that update_company_from_dnb can update a subset of fields.
@@ -279,7 +287,7 @@ class TestUpdateCompanyFromDNB:
         duns_number = '123456789'
         company = CompanyFactory(duns_number=duns_number)
         original_company = Company.objects.get(id=company.id)
-        adviser = AdviserFactory()
+        adviser = adviser_callable()
 
         update_company_from_dnb(
             company,
@@ -294,10 +302,18 @@ class TestUpdateCompanyFromDNB:
         assert company.name == original_company.name
         assert company.number_of_employees == original_company.number_of_employees
 
+    @pytest.mark.parametrize(
+        'adviser_callable',
+        (
+            lambda: None,
+            lambda: AdviserFactory(),
+        ),
+    )
     def test_update_company_from_dnb_partial_fields_multiple(
         self,
         dnb_company_search_feature_flag,
         formatted_dnb_company,
+        adviser_callable,
     ):
         """
         Test that update_company_from_dnb can update a subset of fields.
@@ -305,7 +321,7 @@ class TestUpdateCompanyFromDNB:
         duns_number = '123456789'
         company = CompanyFactory(duns_number=duns_number)
         original_company = Company.objects.get(id=company.id)
-        adviser = AdviserFactory()
+        adviser = adviser_callable()
 
         update_company_from_dnb(
             company,

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -170,10 +170,17 @@ class TestUpdateCompanyFromDNB:
     """
 
     @pytest.mark.parametrize(
-        'adviser_callable,update_descriptor',
+        'adviser_callable',
         (
-            (lambda: None, None),
-            (lambda: AdviserFactory(), 'automatic'),
+            lambda: None,
+            lambda: AdviserFactory(),
+        ),
+    )
+    @pytest.mark.parametrize(
+        'update_descriptor',
+        (
+            None,
+            'automatic',
         ),
     )
     def test_update_company_from_dnb_all_fields(

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -63,7 +63,7 @@ def test_get_company_dnb_service_error(
     with pytest.raises(DNBServiceError) as e:
         get_company('123456789')
 
-    expected_message = f'DNB service returned: {dnb_response_status}'
+    expected_message = f'DNB service returned an error status: {dnb_response_status}'
 
     assert e.value.args[0] == expected_message
     assert len(caplog.records) == 1

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -77,7 +77,7 @@ def get_company(duns_number):
     dnb_response = search_dnb({'duns_number': duns_number})
 
     if dnb_response.status_code != status.HTTP_200_OK:
-        error_message = f'DNB service returned: {dnb_response.status_code}'
+        error_message = f'DNB service returned an error status: {dnb_response.status_code}'
         logger.error(error_message)
         raise DNBServiceError(error_message, dnb_response.status_code)
 
@@ -231,9 +231,10 @@ def update_company_from_dnb(
             reversion.set_user(user)
             company_serializer.save(**company_kwargs)
         else:
-            # Call a method to update the DNB fields only; this prevents us from modifying
-            # modified_on - which should only be set through saves initiated by a user
-            company_serializer.save_dnb_fields(**company_kwargs)
+            # Call a method to update the fields changed on the serializer only; this prevents
+            # us from modifyinh modified_on - which should only be set through saves initiated by
+            # a user
+            company_serializer.partial_save(**company_kwargs)
 
         update_comment = 'Updated from D&B'
         if update_descriptor:

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework import serializers, status
 
+from datahub.company.models import Company
 from datahub.core import statsd
 from datahub.core.api_client import APIClient, TokenAuth
 from datahub.core.serializers import AddressSerializer
@@ -225,16 +226,23 @@ def update_company_from_dnb(
         raise
 
     with reversion.create_revision():
+        original_modified_on = dh_company.modified_on
+
         company_kwargs = {'pending_dnb_investigation': False}
         if user:
             company_kwargs['modified_by'] = user
             reversion.set_user(user)
-        else:
-            # When an update is made by an automatic process, keep the modified_on field
-            # unchanged as this field should only be when a change was initiated by a user
-            company_kwargs['modified_on'] = dh_company.modified_on
 
         company_serializer.save(**company_kwargs)
+
+        # When an update is made by an automatic process, keep the modified_on field
+        # unchanged as this field should only be when a change was initiated by a user
+        # Unfortunately, we have to do this as a second update call to avoid django's
+        # `auto_now` machinery from triggering - there's no way to avoid this when
+        # saving with a serializer
+        if not user:
+            Company.objects.filter(id=dh_company.id).update(modified_on=original_modified_on)
+
         update_comment = 'Updated from D&B'
         if update_descriptor:
             update_comment = ' '.join((update_comment, f'[{update_descriptor}]'))

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -232,11 +232,11 @@ def update_company_from_dnb(
             company_serializer.save(**company_kwargs)
         else:
             # Call a method to update the fields changed on the serializer only; this prevents
-            # us from modifyinh modified_on - which should only be set through saves initiated by
+            # us from modifying modified_on - which should only be set through saves initiated by
             # a user
             company_serializer.partial_save(**company_kwargs)
 
         update_comment = 'Updated from D&B'
         if update_descriptor:
-            update_comment = ' '.join((update_comment, f'[{update_descriptor}]'))
+            update_comment = f'{update_comment} [{update_descriptor}]'
         reversion.set_comment(update_comment)


### PR DESCRIPTION
### Description of change

This PR adds a celery task to sync a company's data with DNB.  The task can optionally be called with a list of fields to sync.

Based on Reupen's suggestion in the previous PR, I've ensured that `Company.modified_on` is not changed by this task as the aspiration is for this to be initiated by a batch/automated process.

The next PR to follow will be a management command which calls this task for a batch of company IDs.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
