### PR TITLE
Optimise import interactions tool tests

### DIFF
--- a/datahub/interaction/test/admin_csv_import/test_file_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_file_form.py
@@ -121,12 +121,12 @@ class TestInteractionCSVForm:
     @pytest.mark.parametrize(
         'num_matching,num_unmatched,num_multiple_matches,max_returned_rows',
         (
-            (5, 6, 7, 5),
-            (5, 6, 7, 3),
-            (5, 6, 7, 10),
-            (5, 0, 0, 5),
-            (0, 5, 5, 5),
-            (0, 0, 5, 5),
+            (4, 3, 2, 4),
+            (4, 3, 2, 2),
+            (4, 3, 2, 8),
+            (4, 0, 0, 4),
+            (0, 2, 2, 4),
+            (0, 0, 2, 4),
         ),
     )
     def test_get_matching_summary(
@@ -202,12 +202,13 @@ class TestInteractionCSVForm:
         with pytest.raises(DataHubException):
             form.get_matching_summary(50)
 
-    @pytest.mark.parametrize('num_matching', (5, 10))
-    @pytest.mark.parametrize('num_unmatched', (0, 6))
-    @pytest.mark.parametrize('num_multiple_matches', (0, 6))
+    @pytest.mark.parametrize('num_unmatched', (0, 2))
+    @pytest.mark.parametrize('num_multiple_matches', (0, 2))
     @pytest.mark.usefixtures('local_memory_cache')
-    def test_save_returns_correct_counts(self, num_matching, num_unmatched, num_multiple_matches):
+    def test_save_returns_correct_counts(self, num_unmatched, num_multiple_matches):
         """Test that save() returns the expected counts for each matching status."""
+        num_matching = 1
+
         matched_rows = make_matched_rows(num_matching)
         unmatched_rows = make_unmatched_rows(num_unmatched)
         multiple_matches_rows = make_multiple_matches_rows(num_multiple_matches)
@@ -235,12 +236,13 @@ class TestInteractionCSVForm:
             ContactMatchingStatus.multiple_matches: num_multiple_matches,
         }
 
-    @pytest.mark.parametrize('num_matching', (5, 10))
-    @pytest.mark.parametrize('num_unmatched', (0, 6))
-    @pytest.mark.parametrize('num_multiple_matches', (0, 6))
+    @pytest.mark.parametrize('num_unmatched', (0, 2))
+    @pytest.mark.parametrize('num_multiple_matches', (0, 2))
     @pytest.mark.usefixtures('local_memory_cache')
-    def test_save_returns_unmatched_rows(self, num_matching, num_unmatched, num_multiple_matches):
+    def test_save_returns_unmatched_rows(self, num_unmatched, num_multiple_matches):
         """Test that save() returns an UnmatchedRowCollector with the expected rows."""
+        num_matching = 2
+
         matched_rows = make_matched_rows(num_matching)
         unmatched_rows = make_unmatched_rows(num_unmatched)
         multiple_matches_rows = make_multiple_matches_rows(num_multiple_matches)
@@ -267,11 +269,12 @@ class TestInteractionCSVForm:
             *multiple_matches_rows,
         ]
 
-    @pytest.mark.parametrize('num_matching', (5, 10))
-    @pytest.mark.parametrize('num_unmatched', (0, 6))
-    @pytest.mark.parametrize('num_multiple_matches', (0, 6))
-    def test_save_creates_interactions(self, num_matching, num_unmatched, num_multiple_matches):
+    @pytest.mark.parametrize('num_unmatched', (0, 2))
+    @pytest.mark.parametrize('num_multiple_matches', (0, 2))
+    def test_save_creates_interactions(self, num_unmatched, num_multiple_matches):
         """Test that save() creates interactions."""
+        num_matching = 3
+
         matched_rows = make_matched_rows(num_matching)
         unmatched_rows = make_unmatched_rows(num_unmatched)
         multiple_matches_rows = make_multiple_matches_rows(num_multiple_matches)


### PR DESCRIPTION
### Description of change

This reduces the running of tests for the import interactions admin site tool by:

- reducing the number of objects created
- removing unneeded parametrisations

The running time of `pytest --reuse-db datahub/interaction/test/admin_csv_import/` is reduced by about 15 seconds locally.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
