### PR TITLE
Optimise a couple of slow tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ job_defaults: &job_defaults
 
     - run:
         name: Run tests
-        command: python -m pytest -n 4 -p no:sugar --cov --junitxml=test-reports/junit.xml
+        command: python -m pytest -n 4 -p no:sugar --cov --junitxml=test-reports/junit.xml --durations 25
 
     - store_test_results:
         path: test-reports

--- a/datahub/activity_stream/test/test_cursor_pagination.py
+++ b/datahub/activity_stream/test/test_cursor_pagination.py
@@ -1,5 +1,4 @@
 import pytest
-from django.conf import settings
 from rest_framework import status
 
 from datahub.activity_stream.test import hawk
@@ -18,11 +17,16 @@ from datahub.omis.order.test.factories import OrderFactory
     ),
 )
 @pytest.mark.django_db
-def test_cursor_pagination(api_client, factory, endpoint):
+def test_cursor_pagination(factory, endpoint, api_client, monkeypatch):
     """
     Test if pagination behaves as expected
     """
-    page_size = settings.REST_FRAMEWORK['PAGE_SIZE']
+    page_size = 2
+    monkeypatch.setattr(
+        'datahub.activity_stream.pagination.ActivityCursorPagination.page_size',
+        page_size,
+    )
+
     interactions = factory.create_batch(page_size + 1)
     response = hawk.get(api_client, get_url(endpoint))
     assert response.status_code == status.HTTP_200_OK

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -488,18 +488,16 @@ class TestContactExportView(APITestMixin):
         orm_ordering,
     ):
         """Test export of contact search results."""
-        ArchivedContactFactory.create_batch(2)
-        ContactWithOwnAddressFactory.create_batch(2)
-        ContactFactory.create_batch(2)
-        # This is to test date of and team of latest interaction a bit more thoroughly
-        CompanyInteractionFactory.create_batch(
-            10,
-            contacts=[ContactFactory(), ContactFactory(), ContactFactory()],
-        )
-        CompanyInteractionFactory.create_batch(10)
+        ArchivedContactFactory()
+        ContactWithOwnAddressFactory()
+        ContactFactory()
+
+        # These are to test date of and team of latest interaction a bit more thoroughly
+        CompanyInteractionFactory.create_batch(2)
+        CompanyInteractionFactory(contacts=ContactFactory.create_batch(2))
         interaction_with_multiple_teams = CompanyInteractionFactory()
         InteractionDITParticipantFactory.create_batch(
-            5,
+            2,
             interaction=interaction_with_multiple_teams,
         )
 

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -564,7 +564,6 @@ class TestOrderExportView(APITestMixin):
             OrderWithoutAssigneesFactory,
             OrderWithoutLeadAssigneeFactory,
             ApprovedRefundFactory,
-            ApprovedRefundFactory,
             RequestedRefundFactory,
         )
 
@@ -583,7 +582,7 @@ class TestOrderExportView(APITestMixin):
         )
 
         for factory_ in factories:
-            factory_.create_batch(2)
+            factory_()
 
         es_with_collector.flush_and_refresh()
 


### PR DESCRIPTION
### Description of change

This:

- optimises a couple of slow tests (details in the commit messages)
- changes the pytest command line on CircleCI so that the top 25 slowest tests are identified

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
