### PR TITLE
Remove /v3/investment/from view

### DIFF
--- a/changelog/investment/investment-from.removal.md
+++ b/changelog/investment/investment-from.removal.md
@@ -1,0 +1,1 @@
+The deprecated `GET /v3/investment/from` endpoint was removed.

--- a/datahub/investment/project/urls.py
+++ b/datahub/investment/project/urls.py
@@ -6,7 +6,6 @@ from datahub.investment.project.evidence.urls import urlpatterns as evidence_url
 from datahub.investment.project.proposition.urls import urlpatterns as proposition_urlpatterns
 from datahub.investment.project.views import (
     IProjectAuditViewSet,
-    IProjectModifiedSinceViewSet,
     IProjectTeamMembersViewSet,
     IProjectViewSet,
 )
@@ -33,10 +32,6 @@ project_team_member_item = IProjectTeamMembersViewSet.as_view({
     'delete': 'destroy',
 })
 
-project_modified_since_collection = IProjectModifiedSinceViewSet.as_view({
-    'get': 'list',
-})
-
 audit_item = IProjectAuditViewSet.as_view({
     'get': 'list',
 })
@@ -51,11 +46,6 @@ urlpatterns = [
         'investment',
         project_collection,
         name='investment-collection',
-    ),
-    path(
-        'investment/from',
-        project_modified_since_collection,
-        name='investment-modified-since-collection',
     ),
     path(
         'investment/<uuid:pk>',

--- a/datahub/investment/project/views.py
+++ b/datahub/investment/project/views.py
@@ -2,11 +2,10 @@
 from django.db import transaction
 from django.db.models import Prefetch
 from django.http import Http404
-from django_filters.rest_framework import DjangoFilterBackend, FilterSet, IsoDateTimeFilter
+from django_filters.rest_framework import DjangoFilterBackend
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework import status
 from rest_framework.filters import OrderingFilter
-from rest_framework.pagination import BasePagination
 from rest_framework.response import Response
 
 from datahub.core.audit import AuditViewSet
@@ -131,50 +130,6 @@ class IProjectViewSet(ArchivableViewSetMixin, CoreViewSet):
             **super().get_serializer_context(),
             'current_user': self.request.user if self.request else None,
         }
-
-
-class _ModifiedOnFilter(FilterSet):
-    """Filter set for the modified-since view."""
-
-    modified_on__gte = IsoDateTimeFilter(field_name='modified_on', lookup_expr='gte')
-    modified_on__lte = IsoDateTimeFilter(field_name='modified_on', lookup_expr='lte')
-
-    class Meta:
-        model = InvestmentProject
-        fields = ()
-
-
-class _SinglePagePaginator(BasePagination):
-    """Paginator that returns all items in a single page.
-
-    The purpose of this is to wrap the results in a dict with count and results keys,
-    for consistency with other endpoints.
-    """
-
-    def paginate_queryset(self, queryset, request, view=None):
-        return queryset
-
-    def get_paginated_response(self, data):
-        return Response({
-            'count': len(data),
-            'results': data,
-        })
-
-
-class IProjectModifiedSinceViewSet(IProjectViewSet):
-    """
-    View set for the modified-since endpoint (intended for use by Data Hub MI).
-
-    TODO: Remove this view following the deprecation period.
-    """
-
-    permission_classes = (IsAuthenticatedOrTokenHasScope,)
-    required_scopes = (Scope.mi,)
-    pagination_class = _SinglePagePaginator
-
-    filter_backends = (DjangoFilterBackend,)
-    filterset_fields = None
-    filterset_class = _ModifiedOnFilter
 
 
 class IProjectTeamMembersViewSet(CoreViewSet):

--- a/datahub/oauth/scopes.py
+++ b/datahub/oauth/scopes.py
@@ -8,13 +8,11 @@ from datahub.oauth.models import OAuthApplicationScope
 class Scope(StrEnum):
     """Defined OAuth scopes."""
 
-    mi = 'data-hub:mi'
     internal_front_end = 'data-hub:internal-front-end'
     public_omis_front_end = 'data-hub:public-omis-front-end'
 
 
 SCOPES_DESCS = {
-    Scope.mi.value: 'Endpoints used by Data Hub MI (machine-to-machine)',
     Scope.internal_front_end.value: 'Endpoints used by the internal front end',
     Scope.public_omis_front_end.value: 'Endpoints used by the OMIS public front end',
 }


### PR DESCRIPTION
### Description of change

This removes the deprecated `GET /v3/investment/from` endpoint and related code.

This was deprecated in #2265.

The `data-hub:mi` OAuth scope was also removed as it was only used by that endpoint.

This PR is to be merged on or after 13 November.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
