### PR TITLE
Optimise entity search tests by syncing only the app being tested

### DIFF
--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -29,10 +29,15 @@ from datahub.core.test_utils import (
 from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.metadata.models import Country, Sector
 from datahub.metadata.test.factories import TeamFactory
+from datahub.search.company import CompanySearchApp
 from datahub.search.company.models import get_suggestions
 from datahub.search.company.views import SearchCompanyExportAPIView
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.es_collector_apps.with_args(CompanySearchApp),
+]
 
 
 @pytest.fixture

--- a/datahub/search/company/test/test_public_search_view.py
+++ b/datahub/search/company/test/test_public_search_view.py
@@ -11,6 +11,10 @@ from datahub.company.models import Company
 from datahub.company.test.factories import CompanyFactory
 from datahub.core import constants
 from datahub.core.test_utils import HawkAPITestClient
+from datahub.search.company import CompanySearchApp
+
+# Index objects for this search app only
+pytestmark = pytest.mark.es_collector_apps.with_args(CompanySearchApp)
 
 
 @pytest.fixture

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -34,9 +34,14 @@ from datahub.interaction.test.factories import (
 )
 from datahub.metadata.models import Sector as SectorModel
 from datahub.metadata.test.factories import TeamFactory
+from datahub.search.contact import ContactSearchApp
 from datahub.search.contact.views import SearchContactExportAPIView
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.es_collector_apps.with_args(ContactSearchApp),
+]
 
 
 @pytest.fixture

--- a/datahub/search/event/test/test_views.py
+++ b/datahub/search/event/test/test_views.py
@@ -11,6 +11,7 @@ from datahub.core import constants
 from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.event.test.factories import EventFactory
 from datahub.metadata.test.factories import TeamFactory
+from datahub.search.event import EventSearchApp
 
 
 @pytest.fixture
@@ -19,7 +20,11 @@ def setup_data():
     EventFactory.create_batch(2)
 
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.es_collector_apps.with_args(EventSearchApp),
+]
 
 
 class TestSearch(APITestMixin):

--- a/datahub/search/interaction/test/test_views.py
+++ b/datahub/search/interaction/test/test_views.py
@@ -47,9 +47,14 @@ from datahub.interaction.test.factories import (
 from datahub.investment.project.test.factories import ActiveInvestmentProjectFactory
 from datahub.metadata.models import Sector
 from datahub.metadata.test.factories import TeamFactory
+from datahub.search.interaction import InteractionSearchApp
 from datahub.search.interaction.views import SearchInteractionExportAPIView
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.es_collector_apps.with_args(InteractionSearchApp),
+]
 
 
 @pytest.fixture

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -38,9 +38,14 @@ from datahub.investment.project.test.factories import (
 )
 from datahub.metadata.models import Sector
 from datahub.metadata.test.factories import TeamFactory
+from datahub.search.investment import InvestmentSearchApp
 from datahub.search.investment.views import SearchInvestmentExportAPIView
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.es_collector_apps.with_args(InvestmentSearchApp),
+]
 
 
 @pytest.fixture

--- a/datahub/search/large_investor_profile/test/test_views.py
+++ b/datahub/search/large_investor_profile/test/test_views.py
@@ -38,9 +38,14 @@ from datahub.investment.investor_profile.test.factories import (
     CompleteLargeCapitalInvestorProfileFactory,
     LargeCapitalInvestorProfileFactory,
 )
+from datahub.search.large_investor_profile import LargeInvestorProfileSearchApp
 from datahub.search.large_investor_profile.views import SearchLargeInvestorProfileExportAPIView
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.es_collector_apps.with_args(LargeInvestorProfileSearchApp),
+]
 
 
 @pytest.fixture

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -44,9 +44,14 @@ from datahub.omis.payment.test.factories import (
     ApprovedRefundFactory,
     RequestedRefundFactory,
 )
+from datahub.search.omis import OrderSearchApp
 from datahub.search.omis.views import SearchOrderExportAPIView
 
-pytestmark = pytest.mark.django_db
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.es_collector_apps.with_args(OrderSearchApp),
+]
 
 
 @pytest.fixture

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,6 @@ addopts = --ds=config.settings.test
 norecursedirs = env
 filterwarnings =
     ignore:`settings.OMIS_NOTIFICATION_API_KEY`
+markers =
+    es_collector_apps: used in conjunction with the es_with_collector fixture to configure which
+    search apps should be synced to Elasticsearch


### PR DESCRIPTION
### Description of change

This adds a simple optimisation to the entity search view tests so that only the search app being tested is synced to Elasticsearch.

This is done by making the `es_with_collector` fixture only sync the apps set in the `es_collector_apps` marker (if it is set).

(I went for this approach as it is easy to set a marker on a whole module.)

(This optimisation is possible as each entity search view only searches the index for a particular search app.)

This reduces the running time of `pytest -n2 --reuse-db datahub/search/` by around 13% for me (locally).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
