### PR TITLE
Update Elasticsearch to version 6.8.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,4 +109,4 @@ workflows:
           python_image: python:3.7
           postgres_image: postgres:10
           mi_postgres_image: postgres:9.6
-          es_image: docker.elastic.co/elasticsearch/elasticsearch:6.7.1
+          es_image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Dependencies:
 -   Python 3.7.x
 -   PostgreSQL 10 (note: PostgreSQL 9.6 is used for the MI database)
 -   redis 3.2
--   Elasticsearch 6.7
+-   Elasticsearch 6.8
 
 1.  Clone the repository:
 
@@ -124,7 +124,7 @@ Dependencies:
 9. Make sure you have Elasticsearch running locally. If you don't, you can run one in Docker:
 
     ```shell
-    docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" docker.elastic.co/elasticsearch/elasticsearch:6.8.2
     ```
 
 10. Make sure you have redis running locally and that the REDIS_BASE_URL in your `.env` is up-to-date.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,7 @@ services:
       - POSTGRES_DB=mi
 
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2
     restart: always
     ports:
       - "9200:9200"


### PR DESCRIPTION
### Description of change

We've been updated to Elasticsearch 6.8.2 in production. This updates the CircleCI build, `docker-compose.yml` and README to match this.

(There is no change to anything deployed, so I haven't added a news fragment.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
