### PR TITLE
Add management command for updating investment project statuses

### DIFF
--- a/changelog/investment/update-status-command.feature.md
+++ b/changelog/investment/update-status-command.feature.md
@@ -1,0 +1,1 @@
+A management command `update_investment_project_status` was added which can update the statuses of a list of investment projects from a CSV file stored in Amazon S3.

--- a/datahub/dbmaintenance/management/commands/update_investment_project_status.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_status.py
@@ -1,0 +1,37 @@
+from logging import getLogger
+
+import reversion
+
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_choice, parse_uuid
+from datahub.investment.project.models import InvestmentProject
+
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """Command to update investment_project.status."""
+
+    help = """
+    Update the statuses of investment projects using a CSV file containing
+    'id' and 'status' columns.
+    """
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        pk = parse_uuid(row['id'])
+        investment_project = InvestmentProject.objects.get(pk=pk)
+        status = parse_choice(row['status'], InvestmentProject.STATUSES)
+
+        if investment_project.status == status:
+            return
+
+        investment_project.status = status
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            investment_project.save(update_fields=('status',))
+            reversion.set_comment('Bulk status update.')

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_status.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_status.py
@@ -1,0 +1,110 @@
+"""Tests for the update_investment_project_status management command."""
+
+from io import BytesIO
+
+import factory
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.investment.project.models import InvestmentProject
+from datahub.investment.project.test.factories import InvestmentProjectFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize('simulate', (True, False))
+def test_run(s3_stubber, caplog, simulate):
+    """
+    Test that the command:
+
+    - updates records if simulate=False
+    - doesn't update records if simulate=True
+    - ignores rows with errors
+    """
+    caplog.set_level('ERROR')
+
+    original_statuses = [
+        InvestmentProject.STATUSES.ongoing,
+        InvestmentProject.STATUSES.ongoing,
+        InvestmentProject.STATUSES.won,
+        InvestmentProject.STATUSES.abandoned,
+    ]
+    investment_projects = InvestmentProjectFactory.create_batch(
+        len(original_statuses),
+        status=factory.Iterator(original_statuses),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,status
+00000000-0000-0000-0000-000000000000,ongoing
+{investment_projects[0].pk},invalid
+{investment_projects[1].pk},ongoing
+{investment_projects[2].pk},dormant
+{investment_projects[3].pk},ongoing
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_investment_project_status', bucket, object_key, simulate=simulate)
+
+    for project in investment_projects:
+        project.refresh_from_db()
+
+    assert 'InvestmentProject matching query does not exist' in caplog.text
+    assert '"invalid" is not a valid choice.' in caplog.text
+    assert len(caplog.records) == 2
+
+    if simulate:
+        assert [project.status for project in investment_projects] == original_statuses
+    else:
+        expected_statuses = [
+            InvestmentProject.STATUSES.ongoing,  # no change as the new value wasn't valid
+            InvestmentProject.STATUSES.ongoing,
+            InvestmentProject.STATUSES.dormant,
+            InvestmentProject.STATUSES.ongoing,
+        ]
+        assert [project.status for project in investment_projects] == expected_statuses
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created for updated rows."""
+    project_without_change = InvestmentProjectFactory(status=InvestmentProject.STATUSES.ongoing)
+    project_with_change = InvestmentProjectFactory(status=InvestmentProject.STATUSES.ongoing)
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,status
+{project_without_change.pk},ongoing
+{project_with_change.pk},delayed
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_investment_project_status', bucket, object_key)
+
+    versions = Version.objects.get_for_object(project_without_change)
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(project_with_change)
+    assert versions.count() == 1
+    assert versions[0].revision.get_comment() == 'Bulk status update.'

--- a/datahub/dbmaintenance/test/test_utils.py
+++ b/datahub/dbmaintenance/test/test_utils.py
@@ -1,0 +1,32 @@
+import pytest
+from model_utils import Choices
+from rest_framework import serializers
+
+from datahub.dbmaintenance.utils import parse_choice
+
+CHOICES = Choices(
+    ('one', 'One'),
+    (2, '_2', 'Two'),
+)
+
+
+class TestParseChoiceValue:
+    """Tests for parse_choice()."""
+
+    @pytest.mark.parametrize(
+        'input_value,expected_value',
+        (
+            ('one', CHOICES.one),
+            ('2', CHOICES._2),
+        ),
+    )
+    def test_accepts_and_transforms_valid_values(self, input_value, expected_value):
+        """Test that valid values are accepted and transformed to the internal value."""
+        assert parse_choice(input_value, CHOICES) == expected_value
+
+    def test_raises_error_on_invalid_value(self):
+        """Test that an error is raised if an invalid value is passed."""
+        with pytest.raises(serializers.ValidationError) as excinfo:
+            parse_choice('invalid', CHOICES)
+
+        assert excinfo.value.detail == ['"invalid" is not a valid choice.']

--- a/datahub/dbmaintenance/utils.py
+++ b/datahub/dbmaintenance/utils.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from rest_framework.fields import (
-    BooleanField, CharField, DateField, DecimalField, EmailField, UUIDField,
+    BooleanField, CharField, ChoiceField, DateField, DecimalField, EmailField, UUIDField,
 )
 
 
@@ -37,6 +37,11 @@ def parse_uuid_list(value):
     field = UUIDField()
 
     return [field.to_internal_value(item) for item in value.split(',')]
+
+
+def parse_choice(value, choices, blank_value=''):
+    """Parses and validates a value from a list of choices."""
+    return _parse_value(value, ChoiceField(choices=choices), blank_value=blank_value)
 
 
 def parse_limited_string(value, max_length=settings.CHAR_FIELD_MAX_LENGTH):


### PR DESCRIPTION
### Description of change

This adds a new management command to the `dbmaintenance` app that can update the statuses of investment projects using a CSV file stored in Amazon S3.

(The command is similar to other `dbmaintenance` commands that are based on `CSVBaseCommand`.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
