### PR TITLE
Fix occasionally failing basic search test

### DIFF
--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -126,7 +126,8 @@ class TestBasicSearch(APITestMixin):
         for obj in objects:
             obj.save()
 
-        ids = sorted(obj.id for obj in objects)
+        # Note: id is a Keyword field, so string sorting must be used
+        ids = sorted((obj.id for obj in objects), key=str)
 
         es_with_collector.flush_and_refresh()
 


### PR DESCRIPTION
### Description of change

This fixes an occasionally failing test for basic search pagination.

The test was occasionally failing because it was sorting the IDs of the created `SimpleModel` objects as numbers, when Elasticsearch was sorting them as strings (as `id` is a `Keyword` field on the search model).

(Hence, the test was sometimes failing depending on what the `id` values of the model objects created in the test were.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
