### PR TITLE
Handle DNB search API connection errors gracefully

### DIFF
--- a/changelog/company/dnb-api-connection-error-handling.feature.rst
+++ b/changelog/company/dnb-api-connection-error-handling.feature.rst
@@ -1,0 +1,2 @@
+Error handling was added for when a `ConnectionError` occurs when accessing the
+DNB company search API endpoint.

--- a/datahub/company/admin/dnb.py
+++ b/datahub/company/admin/dnb.py
@@ -18,6 +18,7 @@ from datahub.dnb_api.utils import (
     DNBServiceError,
     DNBServiceInvalidRequest,
     DNBServiceInvalidResponse,
+    DNBServiceTimeoutError,
     get_company,
     update_company_from_dnb,
 )
@@ -182,7 +183,12 @@ def update_from_dnb(model_admin, request, object_id):
     try:
         dnb_company = get_company(dh_company.duns_number)
 
-    except (DNBServiceError, DNBServiceConnectionError, DNBServiceInvalidResponse):
+    except (
+        DNBServiceError,
+        DNBServiceConnectionError,
+        DNBServiceTimeoutError,
+        DNBServiceInvalidResponse,
+    ):
         message = 'Something went wrong in an upstream service.'
         raise AdminException(message, company_change_page)
 

--- a/datahub/company/admin/dnb.py
+++ b/datahub/company/admin/dnb.py
@@ -14,6 +14,7 @@ from django.views.decorators.http import require_http_methods
 from rest_framework import serializers
 
 from datahub.dnb_api.utils import (
+    DNBServiceConnectionError,
     DNBServiceError,
     DNBServiceInvalidRequest,
     DNBServiceInvalidResponse,
@@ -181,7 +182,7 @@ def update_from_dnb(model_admin, request, object_id):
     try:
         dnb_company = get_company(dh_company.duns_number)
 
-    except (DNBServiceError, DNBServiceInvalidResponse):
+    except (DNBServiceError, DNBServiceConnectionError, DNBServiceInvalidResponse):
         message = 'Something went wrong in an upstream service.'
         raise AdminException(message, company_change_page)
 

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -6,6 +6,7 @@ from datahub.company.models import Company
 from datahub.dnb_api.utils import (
     DNBServiceConnectionError,
     DNBServiceError,
+    DNBServiceTimeoutError,
     get_company,
     update_company_from_dnb,
 )
@@ -22,7 +23,7 @@ def _sync_company_with_dnb(company_id, fields_to_update, task):
         if is_server_error(exc.status_code):
             raise task.retry(exc=exc, countdown=60)
         raise
-    except DNBServiceConnectionError as exc:
+    except (DNBServiceConnectionError, DNBServiceTimeoutError) as exc:
         raise task.retry(exc=exc, countdown=60)
 
     update_company_from_dnb(

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -4,6 +4,7 @@ from rest_framework.status import is_server_error
 
 from datahub.company.models import Company
 from datahub.dnb_api.utils import (
+    DNBServiceConnectionError,
     DNBServiceError,
     get_company,
     update_company_from_dnb,
@@ -21,6 +22,8 @@ def _sync_company_with_dnb(company_id, fields_to_update, task):
         if is_server_error(exc.status_code):
             raise task.retry(exc=exc, countdown=60)
         raise
+    except DNBServiceConnectionError as exc:
+        raise task.retry(exc=exc, countdown=60)
 
     update_company_from_dnb(
         dh_company,

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -12,7 +12,11 @@ from reversion.models import Version
 from datahub.company.models import Company
 from datahub.company.test.factories import CompanyFactory
 from datahub.dnb_api.tasks import sync_company_with_dnb
-from datahub.dnb_api.utils import DNBServiceConnectionError, DNBServiceError
+from datahub.dnb_api.utils import (
+    DNBServiceConnectionError,
+    DNBServiceError,
+    DNBServiceTimeoutError,
+)
 from datahub.metadata.models import Country
 
 pytestmark = pytest.mark.django_db
@@ -193,6 +197,7 @@ def test_sync_company_with_dnb_partial_fields(
         (DNBServiceError('An error occurred', status_code=403), False),
         (DNBServiceError('An error occurred', status_code=400), False),
         (DNBServiceConnectionError('An error occurred'), True),
+        (DNBServiceTimeoutError('An error occurred'), True),
     ),
 )
 def test_sync_company_with_dnb_retries_errors(monkeypatch, error, expect_retry):

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -74,6 +74,7 @@ def search_dnb(query_params):
         'POST',
         'companies/search/',
         json=query_params,
+        timeout=3.0,
     )
     statsd.incr(f'dnb.search.{response.status_code}')
     return response

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -4,6 +4,7 @@ import reversion
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.timezone import now
+from requests.exceptions import ConnectionError
 from rest_framework import serializers, status
 
 from datahub.core import statsd
@@ -48,6 +49,12 @@ class DNBServiceInvalidResponse(Exception):
     """
 
 
+class DNBServiceConnectionError(Exception):
+    """
+    Exception for when an error was encountered when connecting to DNB service.
+    """
+
+
 def search_dnb(query_params):
     """
     Queries the dnb-service with the given query_params. E.g.:
@@ -75,7 +82,12 @@ def get_company(duns_number):
     found or if the `duns_number` for the company is not the same as the one
     we searched for.
     """
-    dnb_response = search_dnb({'duns_number': duns_number})
+    try:
+        dnb_response = search_dnb({'duns_number': duns_number})
+    except ConnectionError:
+        error_message = f'Encountered an error connecting to DNB service'
+        logger.error(error_message)
+        raise DNBServiceConnectionError(error_message)
 
     if dnb_response.status_code != status.HTTP_200_OK:
         error_message = f'DNB service returned an error status: {dnb_response.status_code}'

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -23,6 +23,7 @@ from datahub.dnb_api.serializers import (
     DUNSNumberSerializer,
 )
 from datahub.dnb_api.utils import (
+    DNBServiceConnectionError,
     DNBServiceError,
     DNBServiceInvalidRequest,
     DNBServiceInvalidResponse,
@@ -171,7 +172,7 @@ class DNBCompanyCreateView(APIView):
         try:
             dnb_company = get_company(duns_number)
 
-        except (DNBServiceError, DNBServiceInvalidResponse) as exc:
+        except (DNBServiceConnectionError, DNBServiceError, DNBServiceInvalidResponse) as exc:
             raise APIUpstreamException(str(exc))
 
         except DNBServiceInvalidRequest as exc:


### PR DESCRIPTION
### Description of change

This PR ensures that we handle DNB search connection errors gracefully from several callers: the DNB company create API endpoint, the "update from DNB" admin command and the `sync_company_with_dnb` celery task.

This change was requested in a PR here: https://github.com/uktrade/data-hub-api/pull/2272#discussion_r344178926 - we deferred resolving the issue in to a separate PR; this PR!

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
