### PR TITLE
Add Staff SSO OAuth admin views integration

### DIFF
--- a/changelog/django-admin-staff-sso-integration.feature.md
+++ b/changelog/django-admin-staff-sso-integration.feature.md
@@ -1,0 +1,1 @@
+It is now possible to configure the application to use Staff SSO to log into the admin site.

--- a/datahub/admin_report/test/test_views.py
+++ b/datahub/admin_report/test/test_views.py
@@ -23,11 +23,11 @@ class TestReportAdmin(AdminTestMixin):
     def test_redirects_to_login_page_if_not_logged_in(self, url):
         """Test that the view redirects to the login page if the user isn't authenticated."""
         client = Client()
-        response = client.get(url, follow=True)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     @pytest.mark.parametrize(
         'url',
@@ -41,11 +41,10 @@ class TestReportAdmin(AdminTestMixin):
         user = create_test_user(is_staff=False, password=self.PASSWORD)
 
         client = self.create_client(user=user)
-        response = client.get(url, follow=True)
+        response = client.get(url)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     def test_200_if_staff(self):
         """Test that the view returns a 200 response if the user is an admin user."""

--- a/datahub/company/test/admin/merge/test_common.py
+++ b/datahub/company/test/admin/merge/test_common.py
@@ -42,11 +42,10 @@ class TestCompanyAdminPermissions(AdminTestMixin):
 
         client = Client()
         request_func = getattr(client, method)
-        response = request_func(url, follow=True)
+        response = request_func(url)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     @pytest.mark.parametrize(
         'route_name,method',
@@ -81,11 +80,10 @@ class TestCompanyAdminPermissions(AdminTestMixin):
         client = self.create_client(user=user)
         request_func = getattr(client, method)
 
-        response = request_func(url, follow=True)
+        response = request_func(url)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     @pytest.mark.parametrize(
         'route_name,method',

--- a/datahub/company/test/admin/test_contact.py
+++ b/datahub/company/test/admin/test_contact.py
@@ -67,11 +67,10 @@ class TestContactAdminOptOutForm(AdminTestMixin):
             admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
         )
         client = Client()
-        response = client.get(url, follow=True)
+        response = client.get(url)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     def test_redirects_to_login_page_if_not_staff(self):
         """Test that the view redirects to the login page if the user isn't a member of staff."""
@@ -81,11 +80,10 @@ class TestContactAdminOptOutForm(AdminTestMixin):
         user = create_test_user(is_staff=False, password=self.PASSWORD)
 
         client = self.create_client(user=user)
-        response = client.get(url, follow=True)
+        response = client.get(url)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     def test_permission_denied_if_staff_and_without_change_permission(self):
         """

--- a/datahub/core/test/test_docs.py
+++ b/datahub/core/test/test_docs.py
@@ -11,13 +11,10 @@ class TestDocsSwaggerUIView(AdminTestMixin):
     def test_redirects_to_login_page_if_not_logged_in(self, client):
         """Test that the view redirects to the login page if the user isn't authenticated."""
         url = reverse('api-docs:swagger-ui')
-        response = client.get(url, follow=True)
+        response = client.get(url)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain == [
-            (self.login_url_with_redirect(url), status.HTTP_302_FOUND),
-        ]
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     def test_returns_200_if_authenticated(self, client):
         """Test that a 200 is returned if the user is authenticated via the admin site."""

--- a/datahub/interaction/test/admin_csv_import/test_views.py
+++ b/datahub/interaction/test/admin_csv_import/test_views.py
@@ -96,28 +96,22 @@ class TestAccessRestrictions(AdminTestMixin):
     def test_redirects_to_login_page_if_not_logged_in(self, http_method, url):
         """Test that the view redirects to the login page if the user isn't authenticated."""
         client = Client()
-        # Note: Client.generic() doesn't support follow=True
         request_func = getattr(client, http_method)
-        response = request_func(url, follow=True)
+        response = request_func(url)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.redirect_chain == [
-            (self.login_url_with_redirect(url), status.HTTP_302_FOUND),
-        ]
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     def test_redirects_to_login_page_if_not_staff(self, url, http_method):
         """Test that the view redirects to the login page if the user isn't a member of staff."""
         user = create_test_user(is_staff=False, password=self.PASSWORD)
 
         client = self.create_client(user=user)
-        # Note: Client.generic() doesn't support follow=True
         request_func = getattr(client, http_method)
-        response = request_func(url, follow=True)
+        response = request_func(url)
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.redirect_chain == [
-            (self.login_url_with_redirect(url), status.HTTP_302_FOUND),
-        ]
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     def test_permission_denied_if_staff_and_without_change_permission(self, url, http_method):
         """

--- a/datahub/investment/project/report/test/test_views.py
+++ b/datahub/investment/project/report/test/test_views.py
@@ -20,10 +20,10 @@ class TestGetSPIReport(AdminTestMixin):
                 'pk': report.pk,
             },
         )
-        response = api_client.get(url, follow=True)
-        assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     def test_user_with_permission_can_get_report(self):
         """Test get report by a user with permission."""

--- a/datahub/oauth/admin/admin.py
+++ b/datahub/oauth/admin/admin.py
@@ -1,0 +1,18 @@
+from django.contrib import admin
+from django.views.decorators.cache import never_cache
+
+from datahub.oauth.admin.views import login, logout
+
+
+class OAuth2AdminSite(admin.AdminSite):
+    """Replace login and logout views with corresponding OAuth2 views."""
+
+    @never_cache
+    def login(self, request, extra_context=None):
+        """Replace login view."""
+        return login(request)
+
+    @never_cache
+    def logout(self, request, extra_context=None):
+        """Replace logout view."""
+        return logout(request)

--- a/datahub/oauth/admin/apps.py
+++ b/datahub/oauth/admin/apps.py
@@ -1,9 +1,7 @@
-from django.apps import AppConfig
+from django.contrib.admin.apps import AdminConfig
 
 
-class OAuthAdminConfig(AppConfig):
-    """Required to register the OAuth admin access as Django app"""
+class OAuthAdminConfig(AdminConfig):
+    """Required to override stock Django admin app with OAuth2 admin app."""
 
-    name = 'datahub.oauth.admin'
-
-    label = 'oauth_admin'
+    default_site = 'datahub.oauth.admin.admin.OAuth2AdminSite'

--- a/datahub/oauth/admin/middleware.py
+++ b/datahub/oauth/admin/middleware.py
@@ -1,0 +1,31 @@
+from time import time
+
+from django.contrib.auth import logout as django_logout
+from django.shortcuts import redirect
+
+from datahub.core.utils import reverse_with_query_string
+
+
+class OAuthSessionMiddleware:
+    """
+    OAuthSessionMiddleware checks if user has been logged in via OAuth.
+    """
+
+    def __init__(self, get_response):
+        """Get response."""
+        self.get_response = get_response
+
+    def __call__(self, request):
+        """
+        Check if OAuth2 expiration time is present in the session.
+
+        If OAuth2 expires on has passed it means we have to logout the user.
+        """
+        if request.user.is_authenticated:
+            oauth_expires_on = request.session.get('oauth.expires_on')
+            if oauth_expires_on is not None and oauth_expires_on < time():
+                django_logout(request)
+
+                return redirect(reverse_with_query_string('admin:login', {'next': request.path}))
+
+        return self.get_response(request)

--- a/datahub/oauth/admin/test/test_admin.py
+++ b/datahub/oauth/admin/test/test_admin.py
@@ -1,0 +1,33 @@
+from unittest.mock import patch
+
+import pytest
+from django.http import HttpResponse
+from django.urls import reverse
+
+from datahub.core.test_utils import AdminTestMixin
+
+pytestmark = pytest.mark.django_db
+
+
+class TestAdminSite(AdminTestMixin):
+    """Test that admin site login and logout views have been replaced with OAuth2 equivalents."""
+
+    @patch('datahub.oauth.admin.admin.login')
+    def test_oauth2_login_view_is_called_when_requesting_admin_login(self, _login):
+        """Tests that OAuth2 login view is called when accessing admin login."""
+        _login.return_value = HttpResponse()
+
+        login_url = reverse('admin:login')
+        self.client.get(login_url)
+
+        _login.assert_called_once()
+
+    @patch('datahub.oauth.admin.admin.logout')
+    def test_oauth2_login_view_is_called_when_requesting_admin_logout(self, _logout):
+        """Tests that OAuth2 logout view is called when accessing admin logout."""
+        _logout.return_value = HttpResponse()
+
+        logout_url = reverse('admin:logout')
+        self.client.get(logout_url)
+
+        _logout.assert_called_once()

--- a/datahub/oauth/admin/test/test_middleware.py
+++ b/datahub/oauth/admin/test/test_middleware.py
@@ -1,0 +1,65 @@
+from datetime import datetime
+
+import pytest
+from django.contrib.auth import login as django_login
+from django.urls import reverse
+from django.utils.timezone import utc
+from freezegun import freeze_time
+from rest_framework import status
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.core.utils import reverse_with_query_string
+from datahub.oauth.admin.middleware import OAuthSessionMiddleware
+from datahub.oauth.admin.test.utils import get_request_with_session
+
+pytestmark = pytest.mark.django_db
+
+
+FROZEN_TIME = datetime(2018, 6, 1, 2, tzinfo=utc)
+
+
+@freeze_time(FROZEN_TIME)
+def test_user_is_logged_out_from_admin_when_oauth2_session_has_expired():
+    """Tests that user is logged out if OAuth2 session is expired."""
+    adviser = AdviserFactory()
+
+    admin_url = reverse('admin:index')
+    request = get_request_with_session(admin_url)
+    request.session['oauth.expires_on'] = int(FROZEN_TIME.timestamp()) - 1
+    django_login(request, adviser)
+
+    assert request.user.is_authenticated
+
+    oauth_session_middleware = OAuthSessionMiddleware(_get_response)
+    response = oauth_session_middleware(request)
+
+    assert not request.user.is_authenticated
+
+    assert response.status_code == status.HTTP_302_FOUND
+    assert response.url == reverse_with_query_string('admin:login', {'next': request.path})
+    assert 'oauth.state' not in request.session
+
+
+@freeze_time(FROZEN_TIME)
+def test_user_is_not_logged_out_when_oauth2_session_is_not_expired():
+    """
+    Tests that user is not logged out if OAuth2 session is not expired.
+    """
+    adviser = AdviserFactory()
+
+    admin_url = reverse('admin:index')
+    request = get_request_with_session(admin_url)
+    request.session['oauth.expires_on'] = int(FROZEN_TIME.timestamp()) + 1
+
+    django_login(request, adviser)
+
+    assert request.user.is_authenticated
+
+    oauth_session_middleware = OAuthSessionMiddleware(_get_response)
+    oauth_session_middleware(request)
+
+    assert request.user.is_authenticated
+
+
+def _get_response(response):
+    return response

--- a/datahub/oauth/admin/test/test_utils.py
+++ b/datahub/oauth/admin/test/test_utils.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
@@ -12,11 +11,9 @@ from datahub.oauth.admin.test.utils import (
     get_request_with_session,
 )
 from datahub.oauth.admin.utils import (
-    fetch_oauth2_state,
     get_access_token,
     get_adviser_by_sso_user_profile,
     get_sso_user_profile,
-    store_oauth2_state,
 )
 
 pytestmark = pytest.mark.django_db
@@ -156,41 +153,3 @@ def test_get_adviser_by_sso_email_non_staff_or_active(flags):
         get_adviser_by_sso_user_profile({'email': 'some@email'})
 
     assert excinfo.value.detail == 'User not found.'
-
-
-@patch('datahub.oauth.admin.utils.cache')
-def test_store_oauth2_state(cache):
-    """Tests that store is being called with correct parameters."""
-    store_oauth2_state('1234', {'state': 1234}, 3600)
-
-    cache.set.assert_called_with(
-        'oauth2-state:1234',
-        {'state': 1234},
-        timeout=3600,
-    )
-
-
-@patch('datahub.oauth.admin.utils.cache')
-def test_store_oauth2_without_state(cache):
-    """Tests that ValueError is raised of state ID is not provided when storing the state."""
-    with pytest.raises(ValueError) as excinfo:
-        store_oauth2_state(None, {}, 3600)
-
-    assert str(excinfo.value) == 'A state ID is required.'
-
-
-@patch('datahub.oauth.admin.utils.cache')
-def test_fetch_oauth2_state(cache):
-    """Tests that store is being called with correct parameters."""
-    fetch_oauth2_state('1234')
-
-    cache.get.assert_called_with('oauth2-state:1234')
-
-
-@patch('datahub.oauth.admin.utils.cache')
-def test_fetch_oauth2_without_state(cache):
-    """Tests that ValueError is raised of state ID is not provided when storing the state."""
-    with pytest.raises(ValueError) as excinfo:
-        fetch_oauth2_state(None)
-
-    assert str(excinfo.value) == 'A state ID is required.'

--- a/datahub/oauth/admin/utils.py
+++ b/datahub/oauth/admin/utils.py
@@ -2,7 +2,6 @@ import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
-from django.core.cache import cache
 from django.utils.http import url_has_allowed_host_and_scheme
 from requests import HTTPError
 from rest_framework.exceptions import AuthenticationFailed
@@ -11,22 +10,6 @@ from datahub.company.models import Advisor
 from datahub.core.api_client import APIClient, TokenAuth
 
 logger = logging.getLogger(__name__)
-
-
-def store_oauth2_state(state_id, state, timeout):
-    """Store OAuth2 state data in cache."""
-    cache.set(
-        _get_oauth2_state_cache_key_for_state_id(state_id),
-        state,
-        timeout=timeout,
-    )
-
-
-def fetch_oauth2_state(state_id):
-    """Fetch OAuth2 state data from cache."""
-    return cache.get(
-        _get_oauth2_state_cache_key_for_state_id(state_id),
-    )
 
 
 def get_access_token(code, redirect_uri):
@@ -109,10 +92,3 @@ def _get_api_client(token=None):
         raise_for_status=True,
         default_timeout=settings.ADMIN_OAUTH2_REQUEST_TIMEOUT,
     )
-
-
-def _get_oauth2_state_cache_key_for_state_id(state_id):
-    if not state_id:
-        raise ValueError('A state ID is required.')
-
-    return f'oauth2-state:{state_id}'

--- a/datahub/oauth/admin/views.py
+++ b/datahub/oauth/admin/views.py
@@ -1,7 +1,8 @@
 import logging
+from secrets import token_urlsafe
+from time import time
 from urllib.parse import urlencode
 from urllib.parse import urljoin
-from uuid import uuid4
 
 from django.conf import settings
 from django.contrib.admin import site
@@ -18,7 +19,6 @@ from datahub.oauth.admin.utils import (
     get_adviser_by_sso_user_profile,
     get_safe_next_url_from_request,
     get_sso_user_profile,
-    store_oauth2_state,
 )
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ def login(request):
 
     Instead of using standard Django authentication, we use OAuth2 protocol to authenticate user.
     """
-    state_id = str(uuid4())
+    state_id = token_urlsafe(settings.ADMIN_OAUTH2_TOKEN_BYTE_LENGTH)
     redirect_uri = build_redirect_uri(request, reverse('admin_oauth_callback'))
 
     oauth_url_params = {
@@ -43,12 +43,9 @@ def login(request):
         'state': state_id,
         'idp': 'cirrus',
     }
-
     authorization_url = urljoin(settings.ADMIN_OAUTH2_BASE_URL, settings.ADMIN_OAUTH2_AUTH_PATH)
     authorization_redirect_url = f'{authorization_url}?{urlencode(oauth_url_params)}'
-
     request.session['oauth.state'] = state_id
-
     return redirect(authorization_redirect_url)
 
 
@@ -79,6 +76,8 @@ def callback(request):
     if state_id != request_state_id:
         return error_response(request, 'State mismatch.')
 
+    del request.session['oauth.state']
+
     code = request.GET.get('code')
     if code is None:
         return error_response(request, 'Forbidden.')
@@ -87,16 +86,13 @@ def callback(request):
         redirect_uri = build_redirect_uri(request, reverse('admin_oauth_callback'))
         access_token_data = get_access_token(code, redirect_uri)
         sso_user_profile = get_sso_user_profile(access_token_data['access_token'])
-
         user = get_adviser_by_sso_user_profile(sso_user_profile)
     except AuthenticationFailed as exc:
         logger.warning(f'Django Admin OAuth2 authentication failed: {exc}')
         return error_response(request, 'Forbidden.')
 
-    oauth_state = {'access_token_data': access_token_data}
-    store_oauth2_state(state_id, oauth_state, timeout=access_token_data['expires_in'])
-
     django_login(request, user)
+    request.session['oauth.expires_on'] = int(time()) + access_token_data['expires_in']
 
     next_url = get_safe_next_url_from_request(request)
     if next_url:

--- a/datahub/omis/order/test/test_admin.py
+++ b/datahub/omis/order/test/test_admin.py
@@ -26,11 +26,10 @@ class TestCancelOrderAdmin(AdminTestMixin):
         url = reverse('admin:order_order_cancel', args=(OrderFactory().pk,))
 
         client = Client()
-        response = client.post(url, data={}, follow=True)
+        response = client.post(url, data={})
 
-        assert response.status_code == 200
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        assert response.status_code == 302
+        assert response['Location'] == self.login_url_with_redirect(url)
 
     def test_403_if_no_permissions(self):
         """Test 403 if user doesn't have enough permissions."""

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -28,7 +28,6 @@ class TestUserView(APITestMixin):
 
         group = GroupFactory()
         group.permissions.add(permissions[0])
-
         role = TeamRoleFactory(name='Test Role')
 
         team = TeamFactory(name='Test Team', role=role)
@@ -48,9 +47,9 @@ class TestUserView(APITestMixin):
             response_data['permissions'].sort()
 
         expected_permissions = [
-            'admin.add_cats',
-            'admin.view_ipsum',
-            'admin.view_lorem',
+            f'{content_type.app_label}.add_cats',
+            f'{content_type.app_label}.view_ipsum',
+            f'{content_type.app_label}.view_lorem',
         ]
 
         assert response_data == {

--- a/sample.env
+++ b/sample.env
@@ -24,7 +24,6 @@ ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID=some-outgoing-id
 ACTIVITY_STREAM_OUTGOING_SECRET_ACCESS_KEY=some-outgoing-secret
 MARKET_ACCESS_ACCESS_KEY_ID=market-access-id
 MARKET_ACCESS_SECRET_ACCESS_KEY=market-access-key
-ADMIN_OAUTH2_ENABLED=False
 PAAS_IP_WHITELIST=1.2.3.4
 # Set this when using local environment
 #DISABLE_PAAS_IP_CHECK=true
@@ -43,3 +42,12 @@ COMPOSE_PROJECT_NAME=data-hub
 # be the same as MOCK_SSO_USERNAME in the frontend's .env file
 #DJANGO_SUPERUSER_EMAIL=some.person@digital.trade.gov.uk
 #DJANGO_SUPERUSER_PASSWORD=foobarbaz
+
+# OAuth2 settings for Django Admin access
+ADMIN_OAUTH2_ENABLED=False
+ADMIN_OAUTH2_TOKEN_FETCH_URL=http://localhost:8100/o/token
+ADMIN_OAUTH2_USER_PROFILE_URL=
+ADMIN_OAUTH2_AUTH_URL=http://localhost:8100/o/authorize
+ADMIN_OAUTH2_CLIENT_ID=oauth2-client-id
+ADMIN_OAUTH2_CLIENT_SECRET=oauth2-secret-id
+ADMIN_OAUTH2_REDIRECT_URL=http://localhost:8000/oauth/callback

--- a/templates/admin/oauth/error.html
+++ b/templates/admin/oauth/error.html
@@ -15,4 +15,6 @@
 
 {% block content %}
     {{ error }}
+    <br/>
+    Please contact Data Hub support if you think this is an error.
 {% endblock %}


### PR DESCRIPTION
### Description of change

This is branched off #2312 and contains integration of OAuth2 views into Django Admin.

Django admin native login and logout views are replaced with the views performing OAuth2 authentication.

New middleware has been added that checks if the requested path is a protected admin path and checks if OAuth2 state exists. If OAuth2 state doesn't exist, user is logged out and redirected to login page.

OAuth2 state is created during login process and stored in cache for a certain period of time (using cache timeout). OAuth2 state would only exist if user has successfully logged in.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
