### PR TITLE
Add temporary get_dnb_one_list_tier_companies management command

### DIFF
--- a/changelog/company/get_dnb_one_list_tier_companies.internal.md
+++ b/changelog/company/get_dnb_one_list_tier_companies.internal.md
@@ -1,0 +1,2 @@
+A temporary management command `get_dnb_one_list_tier_companies` was added to enable the running
+of safe queries to facilitate the rollout of DNB company hierarchies.

--- a/datahub/dbmaintenance/management/commands/get_dnb_one_list_tier_companies.py
+++ b/datahub/dbmaintenance/management/commands/get_dnb_one_list_tier_companies.py
@@ -1,0 +1,74 @@
+from logging import getLogger
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from datahub.company.models import Company
+
+logger = getLogger(__name__)
+
+# TODO: Remove this query command when we are done with it.
+# Side note: commands of this format will only be necessary until we have a
+# readonly replica DB to perform safe queries against.
+
+
+def _get_company_ids(one_list_tier_ids, account_manager_ids):
+    """
+    Get an iterable of duns-linked company ids that match the one list tier and account manager
+    arguments. Matching companies will be determined by those that meet these filters
+    themselves, or those whose global headquarters do.
+    """
+    tier_matches = Q(one_list_tier_id__in=one_list_tier_ids)
+    headquarter_tier_matches = Q(global_headquarters__one_list_tier_id__in=one_list_tier_ids)
+
+    companies = Company.objects.filter(
+        duns_number__isnull=False,
+        archived=False,
+    ).filter(tier_matches | headquarter_tier_matches)
+
+    if account_manager_ids:
+        account_owner_matches = Q(one_list_account_owner_id__in=account_manager_ids)
+        headquarter_account_owner_matches = Q(
+            global_headquarters__one_list_account_owner_id__in=account_manager_ids,
+        )
+        companies = companies.filter(
+            account_owner_matches | headquarter_account_owner_matches,
+        )
+
+    ids = [str(result[0]) for result in companies.values_list('id')]
+    return ids
+
+
+class Command(BaseCommand):
+    """
+    Command to query for the ids of duns-linked companies for a particular set of
+    one list tiers and (optionally) particular set of account managers.
+    """
+
+    def add_arguments(self, parser):
+        """
+        Set arguments for the management command.
+        """
+        parser.add_argument(
+            '--one-list-tier-ids',
+            nargs='+',
+            help='The IDs of the one list tiers to filter by.',
+            required=True,
+        )
+        parser.add_argument(
+            '--account-manager-ids',
+            nargs='+',
+            help='The IDs of the account managers to filter by.',
+            required=False,
+        )
+
+    def handle(self, *args, **options):
+        """
+        Run the query and output the results as an info message to the log file.
+        """
+        one_list_tier_ids = options['one_list_tier_ids']
+        account_manager_ids = options.get('account_manager_ids') or []
+        ids = _get_company_ids(one_list_tier_ids, account_manager_ids)
+
+        all_ids_str = '\n'.join(str(company_id) for company_id in ids)
+        logger.info(all_ids_str)

--- a/datahub/dbmaintenance/test/commands/test_get_dnb_one_list_tier_companies.py
+++ b/datahub/dbmaintenance/test/commands/test_get_dnb_one_list_tier_companies.py
@@ -1,0 +1,188 @@
+from uuid import uuid4
+
+import pytest
+from django.core.management import call_command
+
+from datahub.company.models import Company
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.dbmaintenance.management.commands.get_dnb_one_list_tier_companies import (
+    _get_company_ids,
+)
+
+# TODO: Remove these tests when we are done with the query command
+
+pytestmark = pytest.mark.django_db
+
+ONE_LIST_TIER_A_IDS = [
+    'b91bf800-8d53-e311-aef3-441ea13961e2',
+    '7e0c261a-d447-e411-985c-e4115bead28a',
+]
+ONE_LIST_TIER_B_IDS = [
+    'bb1bf800-8d53-e311-aef3-441ea13961e2',
+    '23ef2218-37f7-4abf-aacb-7c49f65ee1e3',
+]
+MANAGER_1_ID = uuid4()
+MANAGER_2_ID = uuid4()
+
+
+@pytest.fixture
+def one_list_companies():
+    """
+    Test fixture of sample one list tier companies.
+    """
+    manager_1 = AdviserFactory(
+        first_name='Manager 1',
+        pk=MANAGER_1_ID,
+    )
+    manager_2 = AdviserFactory(
+        first_name='Manager 2',
+        pk=MANAGER_2_ID,
+    )
+
+    tier_a_headquarters = CompanyFactory(
+        name='Tier A Headquarters',
+        one_list_tier_id=ONE_LIST_TIER_A_IDS[0],
+        one_list_account_owner=manager_1,
+        duns_number='123456789',
+    )
+    CompanyFactory(
+        name='Tier A Subsidiary No Duns',
+        global_headquarters=tier_a_headquarters,
+    )
+    CompanyFactory(
+        name='Tier A Subsidiary With Duns',
+        global_headquarters=tier_a_headquarters,
+        duns_number='223456789',
+    )
+    CompanyFactory(
+        name='Tier A Standalone',
+        one_list_tier_id=ONE_LIST_TIER_A_IDS[1],
+        one_list_account_owner=manager_1,
+        duns_number='323456789',
+    )
+    CompanyFactory(
+        name='Tier A Standalone Manager 2',
+        one_list_tier_id=ONE_LIST_TIER_A_IDS[1],
+        one_list_account_owner=manager_2,
+        duns_number='423456789',
+    )
+
+    tier_b_headquarters = CompanyFactory(
+        name='Tier B Headquarters',
+        one_list_tier_id=ONE_LIST_TIER_B_IDS[0],
+        one_list_account_owner=manager_2,
+        duns_number='523456789',
+    )
+    CompanyFactory(
+        name='Tier B Subsidiary No Duns',
+        global_headquarters=tier_b_headquarters,
+    )
+    CompanyFactory(
+        name='Tier B Subsidiary With Duns',
+        global_headquarters=tier_b_headquarters,
+        duns_number='623456789',
+    )
+    CompanyFactory(
+        name='Tier B Standalone',
+        one_list_tier_id=ONE_LIST_TIER_B_IDS[1],
+        one_list_account_owner=manager_2,
+        duns_number='723456789',
+    )
+    CompanyFactory(
+        name='Tier B Standalone Manager 1',
+        one_list_tier_id=ONE_LIST_TIER_B_IDS[1],
+        one_list_account_owner=manager_1,
+        duns_number='823456789',
+    )
+
+    CompanyFactory(
+        name='No Tier',
+        duns_number='923456789',
+    )
+
+
+@pytest.mark.parametrize(
+    'one_list_tier_ids,account_manager_ids,expected_company_names',
+    (
+        # Test filtering by one tier, one manager
+        (
+            ONE_LIST_TIER_A_IDS,
+            [MANAGER_1_ID],
+            {'Tier A Headquarters', 'Tier A Subsidiary With Duns', 'Tier A Standalone'},
+        ),
+        # Test filtering by one tier, two managers
+        (
+            ONE_LIST_TIER_A_IDS,
+            [MANAGER_1_ID, MANAGER_2_ID],
+            {
+                'Tier A Headquarters',
+                'Tier A Subsidiary With Duns',
+                'Tier A Standalone',
+                'Tier A Standalone Manager 2',
+            },
+        ),
+        # Test filtering by one tier, no managers
+        (
+            ONE_LIST_TIER_A_IDS,
+            [],
+            {
+                'Tier A Headquarters',
+                'Tier A Subsidiary With Duns',
+                'Tier A Standalone',
+                'Tier A Standalone Manager 2',
+            },
+        ),
+        # Test filtering by two tiers, no managers
+        (
+            ONE_LIST_TIER_A_IDS + ONE_LIST_TIER_B_IDS,
+            [],
+            {
+                'Tier A Headquarters',
+                'Tier A Subsidiary With Duns',
+                'Tier A Standalone',
+                'Tier A Standalone Manager 2',
+                'Tier B Headquarters',
+                'Tier B Subsidiary With Duns',
+                'Tier B Standalone',
+                'Tier B Standalone Manager 1',
+            },
+        ),
+    ),
+)
+def test_get_company_ids(
+    one_list_companies,
+    one_list_tier_ids,
+    account_manager_ids,
+    expected_company_names,
+):
+    """
+    Test the _get_company_ids helper function.
+    """
+    company_ids = _get_company_ids(one_list_tier_ids, account_manager_ids)
+    companies = Company.objects.filter(pk__in=company_ids)
+    company_names = {company.name for company in companies}
+    assert company_names == set(expected_company_names)
+
+
+def test_command(caplog, one_list_companies):
+    """
+    Test the command prints out ids for the correct companies.
+    """
+    caplog.set_level('INFO')
+
+    call_command(
+        'get_dnb_one_list_tier_companies',
+        one_list_tier_ids=ONE_LIST_TIER_A_IDS,
+        account_manager_ids=[MANAGER_1_ID],
+    )
+
+    expected_company_names = [
+        'Tier A Headquarters',
+        'Tier A Subsidiary With Duns',
+        'Tier A Standalone',
+    ]
+    expected_companies = Company.objects.filter(name__in=expected_company_names).values_list('id')
+    expected_company_ids = [str(result[0]) for result in expected_companies]
+
+    for expected_id in expected_company_ids:
+        assert expected_id in caplog.text


### PR DESCRIPTION
### Description of change

This PR adds a temporary management command `get_dnb_one_list_tier_companies`.  This allows developers to get the company IDs for companies that are attributed to parameterised one list tier IDs and one list account manager IDs.

We need to use this command in order to get IDs that we can feed in to the `update_company_dnb_data` command.  The rollout of company updates using this command will be staged by running it for the companies attributed to particular global account managers who are engaged stakeholders.  The query command in this PR allows us to perform this staged rollout.

This command will be removed in a future PR once the rollout is complete.  As a side note, it's only necessary right now since we do not yet have a read only replica of the DB to perform safe ad-hoc queries on.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
