### PR TITLE
Set pytest junit_family to xunit2

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 addopts = --ds=config.settings.test
+junit_family=xunit2
 norecursedirs = env
 filterwarnings =
     ignore:`settings.OMIS_NOTIFICATION_API_KEY`


### PR DESCRIPTION
This sets the pytest option `junit_family` to `xuit2` to fix the following deprecation warning during the CircleCI build:

```
  /usr/local/lib/python3.7/site-packages/_pytest/junitxml.py:436: PytestDeprecationWarning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
  Add 'junit_family=legacy' to your pytest.ini file to silence this warning and make your suite compatible.
    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)
```

`xunit2` appears to work fine with CircleCI, so that setting has been used rather than `legacy`.

See https://docs.pytest.org/en/latest/deprecations.html#junit-family-default-value-change-to-xunit2 for more details.

### Description of change



### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
