### PR TITLE
Fix error when merging two companies on same company list

### DIFF
--- a/changelog/company/merging-tool-company-list.bugfix.md
+++ b/changelog/company/merging-tool-company-list.bugfix.md
@@ -1,0 +1,1 @@
+Merging two companies (via the admin site) now works when both companies are on the same company list.


### PR DESCRIPTION
### Description of change

This fixes an unhandled error when merging two companies that are both on the same company list.

The intention for this case was that any references to the archived company on lists would be updated to refer to retained company.

However, if both companies were on the same company list, the previous logic was trying to create a duplicate company list item which resulted in an `IntegrityError` being raised.

This has been corrected so that in this particular case, the archived company is removed from the list instead.

This wasn't that easy to fix since the logic required for this is different from the general case – I've tried to incorporate the required logic in a non-obtrusive way.

The first commit was a small refactor to make things a little bit easier to follow – would recommend looking at the two commits separately.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
