### PR TITLE
Return country names rather than ids as competing_countries

### DIFF
--- a/changelog/investment/dataset-api-endpoint-competing-countries-field-update.api.md
+++ b/changelog/investment/dataset-api-endpoint-competing-countries-field-update.api.md
@@ -1,0 +1,1 @@
+`GET /v4/dataset/investment-projects-dataset`: The `competing_countries` field was updated to return country names rather than ids

--- a/datahub/dataset/investment_project/test/test_views.py
+++ b/datahub/dataset/investment_project/test/test_views.py
@@ -41,7 +41,7 @@ def get_expected_data_from_project(project):
         'client_relationship_manager_id': str_or_none(project.client_relationship_manager_id),
         'client_requirements': project.client_requirements,
         'competing_countries': (
-            [str(country.id) for country in project.competitor_countries.order_by('id')]
+            [country.name for country in project.competitor_countries.order_by('name')]
             if project.competitor_countries.exists() else [None]
         ),
         'created_by_id': str_or_none(project.created_by_id),

--- a/datahub/dataset/investment_project/views.py
+++ b/datahub/dataset/investment_project/views.py
@@ -30,7 +30,7 @@ class InvestmentProjectsDatasetView(BaseDatasetView):
             ),
             competing_countries=get_aggregate_subquery(
                 InvestmentProject,
-                ArrayAgg('competitor_countries__id', ordering=('competitor_countries__id',)),
+                ArrayAgg('competitor_countries__name', ordering=('competitor_countries__name',)),
             ),
             delivery_partner_names=get_investment_project_to_many_string_agg_subquery(
                 'delivery_partners__name',


### PR DESCRIPTION
### Description of change

Fixes the issue where ids were returned for `competing_countries` rather than country names on the investment projects dataset. As countries are not synced to data workspace the country ids are unfortunately meaningless.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
