### PR TITLE
Add function to get a page of company updates

### DIFF
--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -25,6 +25,7 @@ from datahub.dnb_api.utils import (
     DNBServiceTimeoutError,
     format_dnb_company,
     get_company,
+    get_company_update_page,
     update_company_from_dnb,
 )
 from datahub.metadata.models import Country
@@ -33,6 +34,7 @@ pytestmark = pytest.mark.django_db
 
 
 DNB_SEARCH_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/search/')
+DNB_UPDATES_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/')
 
 
 @pytest.fixture
@@ -423,3 +425,130 @@ class TestUpdateCompanyFromDNB:
         with pytest.raises(serializers.ValidationError) as excinfo:
             update_company_from_dnb(company, formatted_dnb_company, adviser)
             assert str(excinfo) == 'Data from D&B did not pass the Data Hub validation checks.'
+
+
+class TestGetCompanyUpdatePage:
+    """
+    Test for the `get_company_update_page` utility function.
+    """
+
+    @pytest.mark.parametrize(
+        'last_updated_after', (
+            '2019-11-11T12:00:00',
+            '2019-11-11',
+        ),
+    )
+    @pytest.mark.parametrize(
+        'cursor', (
+            None,
+            'some-cursor',
+        ),
+    )
+    def test_valid(self, requests_mock, last_updated_after, cursor):
+        """
+        Test if `get_company_update_page` returns the right response
+        on the happy-path.
+        """
+        expected_response = {
+            'previous': None,
+            'next': f'{DNB_UPDATES_URL}?cursor=next-cursor',
+            'results': [
+                {'key': 'value'},
+            ],
+        }
+        mocker = requests_mock.get(
+            DNB_UPDATES_URL,
+            status_code=status.HTTP_200_OK,
+            json=expected_response,
+        )
+        response = get_company_update_page(last_updated_after, cursor)
+
+        assert mocker.last_request.qs.get('last_updated_after') == [last_updated_after]
+        assert mocker.last_request.qs.get('cursor') == [cursor or '']
+
+        assert response == expected_response
+
+    @pytest.mark.parametrize(
+        'dnb_response_status',
+        (
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
+    def test_dnb_service_error(
+        self,
+        caplog,
+        requests_mock,
+        dnb_response_status,
+    ):
+        """
+        Test if the dnb-service returns a status code that is not
+        200, we log it and raise the exception with an appropriate
+        message.
+        """
+        requests_mock.get(
+            DNB_UPDATES_URL,
+            status_code=dnb_response_status,
+        )
+
+        with pytest.raises(DNBServiceError) as e:
+            get_company_update_page(last_updated_after='foo')
+
+        expected_message = f'DNB service returned an error status: {dnb_response_status}'
+
+        assert e.value.args[0] == expected_message
+        assert len(caplog.records) == 1
+        assert caplog.records[0].getMessage() == expected_message
+
+    @pytest.mark.parametrize(
+        'request_exception, expected_exception, expected_message',
+        (
+            (
+                ConnectionError,
+                DNBServiceConnectionError,
+                'Encountered an error connecting to DNB service',
+            ),
+            (
+                ConnectTimeout,
+                DNBServiceConnectionError,
+                'Encountered an error connecting to DNB service',
+            ),
+            (
+                Timeout,
+                DNBServiceTimeoutError,
+                'Encountered a timeout interacting with DNB service',
+            ),
+            (
+                ReadTimeout,
+                DNBServiceTimeoutError,
+                'Encountered a timeout interacting with DNB service',
+            ),
+        ),
+    )
+    def test_get_company_dnb_service_request_error(
+        self,
+        caplog,
+        requests_mock,
+        request_exception,
+        expected_exception,
+        expected_message,
+    ):
+        """
+        Test if there is an error connecting to dnb-service, we log it and raise
+        the exception with an appropriate message.
+        """
+        requests_mock.get(
+            DNB_UPDATES_URL,
+            exc=request_exception,
+        )
+
+        with pytest.raises(expected_exception) as excinfo:
+            get_company_update_page(last_updated_after='foo')
+
+        assert str(excinfo.value) == expected_message
+        assert len(caplog.records) == 1
+        assert caplog.records[0].getMessage() == expected_message

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ filterwarnings =
 markers =
     es_collector_apps: used in conjunction with the es_with_collector fixture to configure which
     search apps should be synced to Elasticsearch
+requests_mock_case_sensitive = True


### PR DESCRIPTION
### Description of change

This PR adds a function gets a page of company updates from `dnb-service`. Following PRs would add a task that calls this function and hopefully does something useful with it.

The interesting bit here is: https://github.com/uktrade/data-hub-api/blob/3d51bd0845f8b3180b6597da13c98cfaf4024d2d/pytest.ini#L9

This was needed because of a [known bug](https://requests-mock.readthedocs.io/en/latest/knownissues.html#case-insensitivity) in `requests_mock` library which meant that the query string parameters were being lowercased.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
