### PR TITLE
Add field `quote__accepted_on` to omis dataset endpoint

### DIFF
--- a/changelog/omis/dataset-api-endpoint-add-quote-accepted-on.api.md
+++ b/changelog/omis/dataset-api-endpoint-add-quote-accepted-on.api.md
@@ -1,0 +1,1 @@
+`GET /v4/dataset/omis-dataset`: The field `quote__accepted_on` was added to the omis dataset endpoint

--- a/datahub/dataset/order/test/test_views.py
+++ b/datahub/dataset/order/test/test_views.py
@@ -38,6 +38,9 @@ def get_expected_data_from_order(order):
         'invoice__subtotal_cost': get_attr_or_none(order, 'invoice.subtotal_cost'),
         'paid_on': format_date_or_datetime(order.paid_on),
         'primary_market__name': get_attr_or_none(order, 'primary_market.name'),
+        'quote__accepted_on': format_date_or_datetime(
+            get_attr_or_none(order, 'quote.accepted_on'),
+        ),
         'quote__created_on': format_date_or_datetime(get_attr_or_none(order, 'quote.created_on')),
         'reference': order.reference,
         'refund_created': (

--- a/datahub/dataset/order/views.py
+++ b/datahub/dataset/order/views.py
@@ -35,6 +35,7 @@ class OMISDatasetView(BaseDatasetView):
             'invoice__subtotal_cost',
             'paid_on',
             'primary_market__name',
+            'quote__accepted_on',
             'quote__created_on',
             'reference',
             'refund_created',


### PR DESCRIPTION
### Description of change

Add the quote accepted on field to the omis dataset response. This is now required for monthly omis data cuts going forward.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
