### PR TITLE
Add celery task to ingest company updates

### DIFF
--- a/changelog/company-updates-task.feature.md
+++ b/changelog/company-updates-task.feature.md
@@ -1,0 +1,3 @@
+A celery task called `get_company_updates` was added.
+
+This task gets all the available company updates from the dnb-service and spawns downstream tasks to apply these updates to D&B matched company records in Data Hub.

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -1,5 +1,9 @@
+from datetime import datetime, time, timedelta
+
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from django.utils.timezone import now
+from django_pglocks import advisory_lock
 from rest_framework.status import is_server_error
 
 from datahub.company.models import Company
@@ -8,6 +12,7 @@ from datahub.dnb_api.utils import (
     DNBServiceError,
     DNBServiceTimeoutError,
     get_company,
+    get_company_update_page,
     update_company_from_dnb,
 )
 
@@ -48,3 +53,77 @@ def sync_company_with_dnb(self, company_id, fields_to_update=None):
     will be synced.
     """
     _sync_company_with_dnb(company_id, fields_to_update, self)
+
+
+def _get_company_updates(task, last_updated_after, fields_to_update):
+    yesterday = now() - timedelta(days=1)
+    midnight_yesterday = datetime.combine(yesterday, time.min)
+    last_updated_after = last_updated_after or midnight_yesterday.isoformat()
+    cursor = None
+
+    # TODO: In a following PR, we will bind this loop to an upper-limit
+    # on the number of records that we would like to update in a run.
+    while True:
+
+        try:
+            response = get_company_update_page(last_updated_after, cursor)
+
+        except DNBServiceError as exc:
+            if is_server_error(exc.status_code):
+                raise task.retry(exc=exc, countdown=60)
+            raise
+
+        except (DNBServiceConnectionError, DNBServiceTimeoutError) as exc:
+            raise task.retry(exc=exc, countdown=60)
+
+        # Spawn tasks that updates Data Hub companies
+        for data in response.get('results', []):
+            update_company.apply_async(
+                data,
+                fields_to_update=fields_to_update,
+            )
+
+        cursor = response.get('next')
+        if cursor is None:
+            break
+
+
+@shared_task(
+    bind=True,
+    acks_late=True,
+    priority=9,
+    max_retries=3,
+    queue='long-running',
+)
+def get_company_updates(self, last_updated_after=None, fields_to_update=None):
+    """
+    Gets the lastest updates for D&B companies from dnb-service.
+
+    The `dnb-service` exposes these updates as a cursor-paginated list. This
+    task goes through the pages and spawns tasks that update the records in
+    Data Hub.
+    """
+    with advisory_lock('get_company_updates', wait=False) as acquired:
+
+        if not acquired:
+            logger.info('Another instance of this task is already running.')
+            return
+
+        _get_company_updates(self, last_updated_after, fields_to_update)
+
+
+@shared_task(
+    bind=True,
+    acks_late=True,
+    priority=9,
+    max_retries=3,
+)
+def update_company(self, data, fields_to_update=None):
+    """
+    Get the latest updates for D&B companies from dnb-service. This is a stub at
+    the moment and will become a thin wrapper around `utils.update_company_from_dnb`.
+    """
+    raise NotImplementedError(
+        data=data,
+        fields_to_update=fields_to_update,
+    )

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -7,11 +7,15 @@ from django.conf import settings
 from django.forms.models import model_to_dict
 from django.utils.timezone import now
 from freezegun import freeze_time
+from rest_framework import status
 from reversion.models import Version
 
 from datahub.company.models import Company
 from datahub.company.test.factories import CompanyFactory
-from datahub.dnb_api.tasks import sync_company_with_dnb
+from datahub.dnb_api.tasks import (
+    get_company_updates,
+    sync_company_with_dnb,
+)
 from datahub.dnb_api.utils import (
     DNBServiceConnectionError,
     DNBServiceError,
@@ -222,3 +226,189 @@ def test_sync_company_with_dnb_retries_errors(monkeypatch, error, expect_retry):
 
     with pytest.raises(expected_exception_class):
         sync_company_with_dnb(company.id)
+
+
+class TestGetCompanyUpdates:
+    """
+    Tests for the get_company_updates task and the
+    associated _get_company_updates function.
+    """
+
+    @pytest.mark.parametrize(
+        'error, expect_retry',
+        (
+            (
+                DNBServiceError(
+                    'An error occurred',
+                    status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+                ),
+                True,
+            ),
+            (
+                DNBServiceError(
+                    'An error occurred',
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                ),
+                True,
+            ),
+            (
+                DNBServiceError(
+                    'An error occurred',
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                ),
+                True,
+            ),
+            (
+                DNBServiceError(
+                    'An error occurred',
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                ),
+                True,
+            ),
+            (
+                DNBServiceError(
+                    'An error occurred',
+                    status_code=403,
+                ),
+                False,
+            ),
+            (
+                DNBServiceError(
+                    'An error occurred',
+                    status_code=400,
+                ),
+                False,
+            ),
+            (
+                DNBServiceConnectionError(
+                    'An error occurred',
+                ),
+                True,
+            ),
+            (
+                DNBServiceTimeoutError(
+                    'An error occurred',
+                ),
+                True,
+            ),
+        ),
+    )
+    def test_errors(self, monkeypatch, error, expect_retry):
+        """
+        Test the get_company_updates task retries server errors.
+        """
+        mocked_get_company_update_page = mock.Mock(side_effect=error)
+        monkeypatch.setattr(
+            'datahub.dnb_api.tasks.get_company_update_page',
+            mocked_get_company_update_page,
+        )
+
+        mock_retry = mock.Mock(side_effect=Retry(exc=error))
+        monkeypatch.setattr(
+            'datahub.dnb_api.tasks.get_company_updates.retry',
+            mock_retry,
+        )
+
+        expected_exception_class = Retry if expect_retry else DNBServiceError
+        with pytest.raises(expected_exception_class):
+            get_company_updates()
+
+    @pytest.mark.parametrize(
+        'data',
+        (
+            {
+                None: {
+                    'next': 'page2',
+                    'results': [
+                        {'foo': 1},
+                        {'bar': 2},
+                    ],
+                },
+                'page2': {
+                    'next': None,
+                    'results': [
+                        {'baz': 3},
+                    ],
+                },
+            },
+        ),
+    )
+    @pytest.mark.parametrize(
+        'fields_to_update',
+        (
+            None,
+            ['foo', 'bar'],
+        ),
+    )
+    @freeze_time('2019-01-02T2:00:00')
+    def test_updates(self, monkeypatch, data, fields_to_update):
+        """
+        Test if the update_company task is called with the
+        right parameters for all the records spread across
+        pages.
+        """
+        mock_get_company_update_page = mock.Mock(
+            side_effect=lambda _, cursor: data[cursor],
+        )
+        monkeypatch.setattr(
+            'datahub.dnb_api.tasks.get_company_update_page',
+            mock_get_company_update_page,
+        )
+        mock_update_company = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.dnb_api.tasks.update_company',
+            mock_update_company,
+        )
+        get_company_updates(fields_to_update=fields_to_update)
+
+        assert mock_get_company_update_page.call_count == 2
+        mock_get_company_update_page.assert_any_call(
+            '2019-01-01T00:00:00',
+            None,
+        )
+        mock_get_company_update_page.assert_any_call(
+            '2019-01-01T00:00:00',
+            'page2',
+        )
+
+        assert mock_update_company.apply_async.call_count == 3
+        mock_update_company.apply_async.assert_any_call(
+            {'foo': 1},
+            fields_to_update=fields_to_update,
+        )
+        mock_update_company.apply_async.assert_any_call(
+            {'bar': 2},
+            fields_to_update=fields_to_update,
+        )
+        mock_update_company.apply_async.assert_any_call(
+            {'baz': 3},
+            fields_to_update=fields_to_update,
+        )
+
+    @pytest.mark.parametrize(
+        'lock_acquired, call_count',
+        (
+            (False, 0),
+            (True, 1),
+        ),
+    )
+    def test_lock(self, monkeypatch, lock_acquired, call_count):
+        """
+        Test that the task doesn't run if it cannot acquire
+        the advisory_lock.
+        """
+        mock_advisory_lock = mock.MagicMock()
+        mock_advisory_lock.return_value.__enter__.return_value = lock_acquired
+        monkeypatch.setattr(
+            'datahub.dnb_api.tasks.advisory_lock',
+            mock_advisory_lock,
+        )
+        mock_get_company_updates = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.dnb_api.tasks._get_company_updates',
+            mock_get_company_updates,
+        )
+
+        get_company_updates()
+
+        assert mock_get_company_updates.call_count == call_count


### PR DESCRIPTION
### Description of change

This PR puts in a long-running celery task around the `get_company_update_page` function we introduced in #2333 

There will be following PRs to:

1. Limit the number of updates applied in a given run.
2. Replace the `update_company` stub with a proper task that will apply the ingested updates to Data Hub records. 
3. Integrate this celery task with the one 2 and add integration tests.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
