### PR TITLE
Add celery task to apply company updates

### DIFF
--- a/changelog/company/company-update-task.feature.md
+++ b/changelog/company/company-update-task.feature.md
@@ -1,0 +1,2 @@
+A celery task was added which takes a dictionary of company data sourced from
+dnb-service and updates the company record corresponding to it in Data Hub.

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -48,10 +48,11 @@ def _sync_company_with_dnb(company_id, fields_to_update, task):
 )
 def sync_company_with_dnb(self, company_id, fields_to_update=None):
     """
-    Sync a company record with data sourced from DNB. `company_id` identifies the
-    company record to sync and `fields_to_update` defines an iterable of
-    company serializer fields that should be updated - if it is None, all fields
-    will be synced.
+    Sync a company record with data sourced from DNB. This task will interact with dnb-service to
+    get the latest data for the company.
+
+    `company_id` identifies the company record to sync and `fields_to_update` defines an iterable
+    of company serializer fields that should be updated - if it is None, all fields will be synced.
     """
     _sync_company_with_dnb(company_id, fields_to_update, self)
 
@@ -117,11 +118,13 @@ def get_company_updates(self, last_updated_after=None, fields_to_update=None):
     acks_late=True,
     priority=9,
 )
-def update_company(company_data, fields_to_update=None):
+def update_company_from_dnb_data(dnb_company_data, fields_to_update=None):
     """
-    Update the company from latest data from dnb-service.
+    Update the company with the latest data from dnb-service. This task should be called
+    when some other logic interacts with dnb-service to get the company data as the task itself
+    will not interact with dnb-service.
     """
-    dnb_company = format_dnb_company(company_data)
+    dnb_company = format_dnb_company(dnb_company_data)
     duns_number = dnb_company['duns_number']
 
     try:

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -80,7 +80,7 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
 
         # Spawn tasks that updates Data Hub companies
         for data in response.get('results', []):
-            update_company.apply_async(
+            update_company_from_dnb_data.apply_async(
                 data,
                 fields_to_update=fields_to_update,
             )

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -122,7 +122,20 @@ def update_company(company_data, fields_to_update=None):
     Update the company from latest data from dnb-service.
     """
     dnb_company = format_dnb_company(company_data)
-    dh_company = Company.objects.get(duns_number=dnb_company['duns_number'])
+    duns_number = dnb_company['duns_number']
+
+    try:
+        dh_company = Company.objects.get(duns_number=duns_number)
+    except Company.DoesNotExist:
+        logger.error(
+            'Company matching duns_number was not found',
+            extra={
+                'duns_number': duns_number,
+                'dnb_company': dnb_company,
+            },
+        )
+        raise
+
     update_company_from_dnb(
         dh_company,
         dnb_company,

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -15,6 +15,7 @@ from datahub.company.test.factories import CompanyFactory
 from datahub.dnb_api.tasks import (
     get_company_updates,
     sync_company_with_dnb,
+    update_company,
 )
 from datahub.dnb_api.utils import (
     DNBServiceConnectionError,
@@ -412,3 +413,143 @@ class TestGetCompanyUpdates:
         get_company_updates()
 
         assert mock_get_company_updates.call_count == call_count
+
+
+@freeze_time('2019-01-01 11:12:13')
+def test_update_company(dnb_response_uk):
+    """
+    Test the update_company command when all DNB fields are updated.
+    """
+    company = CompanyFactory(duns_number='123456789')
+    original_company = Company.objects.get(id=company.id)
+    task_result = update_company.apply_async(args=[dnb_response_uk['results'][0]])
+    assert task_result.successful()
+    company.refresh_from_db()
+    uk_country = Country.objects.get(iso_alpha2_code='GB')
+    assert model_to_dict(company) == {
+        'address_1': 'Unit 10, Ockham Drive',
+        'address_2': '',
+        'address_country': uk_country.id,
+        'address_county': '',
+        'address_postcode': 'UB6 0F2',
+        'address_town': 'GREENFORD',
+        'archived': False,
+        'archived_by': None,
+        'archived_documents_url_path': original_company.archived_documents_url_path,
+        'archived_on': None,
+        'archived_reason': None,
+        'business_type': original_company.business_type_id,
+        'company_number': '01261539',
+        'created_by': original_company.created_by_id,
+        'description': None,
+        'dnb_investigation_data': None,
+        'duns_number': '123456789',
+        'employee_range': original_company.employee_range_id,
+        'export_experience_category': original_company.export_experience_category_id,
+        'export_potential': None,
+        'export_to_countries': [],
+        'future_interest_countries': [],
+        'global_headquarters': None,
+        'global_ultimate_duns_number': '291332174',
+        'great_profile_status': None,
+        'headquarter_type': None,
+        'id': original_company.id,
+        'is_number_of_employees_estimated': True,
+        'is_turnover_estimated': None,
+        'modified_by': original_company.modified_by_id,
+        'name': 'FOO BICYCLE LIMITED',
+        'number_of_employees': 260,
+        'one_list_account_owner': None,
+        'one_list_tier': None,
+        'pending_dnb_investigation': False,
+        'reference_code': '',
+        'registered_address_1': 'C/O LONE VARY',
+        'registered_address_2': '',
+        'registered_address_country': uk_country.id,
+        'registered_address_county': '',
+        'registered_address_postcode': 'UB6 0F2',
+        'registered_address_town': 'GREENFORD',
+        'sector': original_company.sector_id,
+        'trading_names': [],
+        'transfer_reason': '',
+        'transferred_by': None,
+        'transferred_on': None,
+        'transferred_to': None,
+        'turnover': 50651895,
+        'turnover_range': original_company.turnover_range_id,
+        'uk_region': original_company.uk_region_id,
+        'vat_number': '',
+        'website': 'http://foo.com',
+        'dnb_modified_on': now(),
+    }
+
+
+@freeze_time('2019-01-01 11:12:13')
+def test_update_company_partial_fields(dnb_response_uk):
+    """
+    Test the update_company command when a subset of DNB fields are updated.
+    """
+    company = CompanyFactory(duns_number='123456789')
+    original_company = Company.objects.get(id=company.id)
+    task_result = update_company.apply_async(
+        args=[dnb_response_uk['results'][0]],
+        kwargs={'fields_to_update': ['global_ultimate_duns_number']},
+    )
+    assert task_result.successful()
+    company.refresh_from_db()
+    assert model_to_dict(company) == {
+        'address_1': original_company.address_1,
+        'address_2': original_company.address_2,
+        'address_country': original_company.address_country_id,
+        'address_county': original_company.address_county,
+        'address_postcode': original_company.address_postcode,
+        'address_town': original_company.address_town,
+        'archived': original_company.archived,
+        'archived_by': original_company.archived_by,
+        'archived_documents_url_path': original_company.archived_documents_url_path,
+        'archived_on': original_company.archived_on,
+        'archived_reason': original_company.archived_reason,
+        'business_type': original_company.business_type_id,
+        'company_number': original_company.company_number,
+        'created_by': original_company.created_by_id,
+        'description': original_company.description,
+        'dnb_investigation_data': original_company.dnb_investigation_data,
+        'duns_number': original_company.duns_number,
+        'employee_range': original_company.employee_range_id,
+        'export_experience_category': original_company.export_experience_category_id,
+        'export_potential': original_company.export_potential,
+        'export_to_countries': [],
+        'future_interest_countries': [],
+        'global_headquarters': original_company.global_headquarters,
+        'global_ultimate_duns_number': '291332174',
+        'great_profile_status': original_company.great_profile_status,
+        'headquarter_type': original_company.headquarter_type,
+        'id': original_company.id,
+        'is_number_of_employees_estimated': original_company.is_number_of_employees_estimated,
+        'is_turnover_estimated': original_company.is_turnover_estimated,
+        'modified_by': original_company.modified_by_id,
+        'name': original_company.name,
+        'number_of_employees': original_company.number_of_employees,
+        'one_list_account_owner': original_company.one_list_account_owner,
+        'one_list_tier': original_company.one_list_tier,
+        'pending_dnb_investigation': original_company.pending_dnb_investigation,
+        'reference_code': original_company.reference_code,
+        'registered_address_1': original_company.registered_address_1,
+        'registered_address_2': original_company.registered_address_2,
+        'registered_address_country': original_company.registered_address_country_id,
+        'registered_address_county': original_company.registered_address_county,
+        'registered_address_postcode': original_company.registered_address_postcode,
+        'registered_address_town': original_company.registered_address_town,
+        'sector': original_company.sector_id,
+        'trading_names': original_company.trading_names,
+        'transfer_reason': original_company.transfer_reason,
+        'transferred_by': None,
+        'transferred_on': None,
+        'transferred_to': None,
+        'turnover': original_company.turnover,
+        'turnover_range': original_company.turnover_range_id,
+        'uk_region': original_company.uk_region_id,
+        'vat_number': original_company.vat_number,
+        'website': original_company.website,
+        'dnb_modified_on': now(),
+    }

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -357,7 +357,7 @@ class TestGetCompanyUpdates:
         )
         mock_update_company = mock.Mock()
         monkeypatch.setattr(
-            'datahub.dnb_api.tasks.update_company',
+            'datahub.dnb_api.tasks.update_company_from_dnb_data',
             mock_update_company,
         )
         get_company_updates(fields_to_update=fields_to_update)

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -163,7 +163,7 @@ def format_dnb_company(dnb_company):
     # Extract companies house number for UK Companies
     registration_numbers = {
         reg['registration_type']: reg.get('registration_number')
-        for reg in dnb_company['registration_numbers']
+        for reg in dnb_company.get('registration_numbers') or []
     }
 
     domain = dnb_company.get('domain')


### PR DESCRIPTION
### Description of change

This PR adds a `update_company` celery task which will be used in an automatic process for regularly updating DNB company details.  The producer task which pages through an API endpoint of updates will emit `update_company` tasks for each company to update.

This task is a thin wrapper around existing DNB utility functions that we are already using. 


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
