### PR TITLE
Add config vars for CSRF_COOKIE_HTTPONLY and CSRF_COOKIE_SECURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `CELERY_TASK_ALWAYS_EAGER` | No | Can be set to True when running the app locally to run Celery tasks started from the web process synchronously. Not for use in production. |
 | `CELERY_TASK_SEND_SENT_EVENT` | No | Whether Celery workers send the `task-sent` event (default=True). |
 | `CELERY_WORKER_TASK_EVENTS` | No | Whether Celery workers send task events (by default) for use by monitoring tools such as Flower (default=True). |
+| `CSRF_COOKIE_HTTPONLY` | No | Whether to use HttpOnly flag on the CSRF cookie (default=False). |
+| `CSRF_COOKIE_SECURE` | No | Whether to use a secure cookie for the CSRF cookie (default=False). |
 | `DATA_FLOW_API_ACCESS_KEY_ID` | No | A non-secret access key ID, corresponding to `DATA_FLOW_API_SECRET_ACCESS_KEY`. The holder of the secret key can access the omis-dataset endpoint by Hawk authentication. |
 | `DATA_FLOW_API_SECRET_ACCESS_KEY` | If `DATA_FLOW_API_ACCESS_KEY_ID` is set | A secret key, corresponding to `DATA_FLOW_API_ACCESS_KEY_ID`. The holder of this key can access the omis-dataset endpoint by Hawk authentication. |
 | `DATABASE_CONN_MAX_AGE`  | No | [Maximum database connection age (in seconds).](https://docs.djangoproject.com/en/2.0/ref/databases/) |

--- a/changelog/crsftoken-settings.internal.md
+++ b/changelog/crsftoken-settings.internal.md
@@ -1,0 +1,2 @@
+We are now exposing  `CSRF_COOKIE_SECURE` and `CSRF_COOKIE_HTTPONLY` Django settings 
+via environment variables.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -598,3 +598,7 @@ DATAHUB_SUPPORT_EMAIL_ADDRESS = env('DATAHUB_SUPPORT_EMAIL_ADDRESS', default=Non
 STATSD_HOST = env('STATSD_HOST', default='localhost')
 STATSD_PORT = env('STATSD_PORT', default='9125')
 STATSD_PREFIX = env('STATSD_PREFIX', default='datahub-api')
+
+# Settings for CSRF cookie.
+CSRF_COOKIE_SECURE = env('CSRF_COOKIE_SECURE', default=False)
+CSRF_COOKIE_HTTPONLY = env('CSRF_COOKIE_HTTPONLY', default=False)


### PR DESCRIPTION
### Description of change

As per security recommendations `csrftoken` cookie should have `HttpOnly` and `Secure` flags set to true, this change allows to set these flags via environment variables.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
