### PR TITLE
Add integration tests for get_company_updates task

### DIFF
--- a/changelog/company/company-update-task-integration-tests.internal.md
+++ b/changelog/company/company-update-task-integration-tests.internal.md
@@ -1,3 +1,7 @@
 Integration tests were added for the `datahub.dnb_api.tasks.get_company_updates` task.
 These were not added as part of the original development as the task and it's dependent
 task (`datahub.dnb_api.tasks.update_company_from_dnb_data`) were developed in parallel.
+
+Additionally, the calls that `datahub.dnb_api.tasks.get_company_updates` makes to
+`datahub.dnb_api.tasks.update_company_from_dnb_data` were fixed to be the correct
+signature.

--- a/changelog/company/company-update-task-integration-tests.internal.md
+++ b/changelog/company/company-update-task-integration-tests.internal.md
@@ -1,0 +1,3 @@
+Integration tests were added for the `datahub.dnb_api.tasks.get_company_updates` task.
+These were not added as part of the original development as the task and it's dependent
+task (`datahub.dnb_api.tasks.update_company_from_dnb_data`) were developed in parallel.

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -81,8 +81,8 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
         # Spawn tasks that updates Data Hub companies
         for data in response.get('results', []):
             update_company_from_dnb_data.apply_async(
-                data,
-                fields_to_update=fields_to_update,
+                args=(data,),
+                kwargs={'fields_to_update': fields_to_update},
             )
 
         cursor = response.get('next')

--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -152,6 +152,14 @@ def dnb_response_uk():
 
 
 @pytest.fixture
+def dnb_company_updates_response_uk(dnb_response_uk):
+    return {
+        **dnb_response_uk,
+        'next': None,
+    }
+
+
+@pytest.fixture
 def dnb_company_search_datahub_companies():
     """
     Creates Data Hub companies for hydrating DNB search results with.

--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -153,6 +153,10 @@ def dnb_response_uk():
 
 @pytest.fixture
 def dnb_company_updates_response_uk(dnb_response_uk):
+    """
+    Returns a UK based DNB company in the format of the "company update" API endpoint
+    for dnb-service.
+    """
     return {
         **dnb_response_uk,
         'next': None,

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -433,7 +433,8 @@ class TestGetCompanyUpdates:
 
         company.refresh_from_db()
         assert company.name == update_response_body['results'][0]['primary_name']
-        assert company.global_ultimate_duns_number == update_response_body['results'][0]['global_ultimate_duns_number']
+        expected_gu_number = update_response_body['results'][0]['global_ultimate_duns_number']
+        assert company.global_ultimate_duns_number == expected_gu_number
 
     @freeze_time('2019-01-02T2:00:00')
     def test_updates_with_update_company_from_dnb_data_partial_fields(


### PR DESCRIPTION
### Description of change
Integration tests were added for the `datahub.dnb_api.tasks.get_company_updates` task. These were not added as part of the original development as the task and it's dependent task (`datahub.dnb_api.tasks.update_company_from_dnb_data`) were developed in parallel.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
