### PR TITLE
Fix dnb company updates ingest pagination

### DIFF
--- a/changelog/company/dnb-company-updates-ingest-pagination.bugfix.md
+++ b/changelog/company/dnb-company-updates-ingest-pagination.bugfix.md
@@ -1,0 +1,3 @@
+A bug was fixed to ensure that DNB company updates can be ingested over multiple
+pages from dnb-service.  Previously, the cursor value was not being extracted
+from the URL for the next page correctly.

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -62,9 +62,9 @@ def sync_company_with_dnb(self, company_id, fields_to_update=None):
     _sync_company_with_dnb(company_id, fields_to_update, self)
 
 
-def _get_company_updates_from_api(last_updated_after, cursor, task):
+def _get_company_updates_from_api(last_updated_after, next_page, task):
     try:
-        return get_company_update_page(last_updated_after, cursor)
+        return get_company_update_page(last_updated_after, next_page)
 
     except DNBServiceError as exc:
         if is_server_error(exc.status_code):
@@ -75,26 +75,16 @@ def _get_company_updates_from_api(last_updated_after, cursor, task):
         raise task.retry(exc=exc, countdown=60)
 
 
-def _get_cursor(url):
-    if not url:
-        return None
-    parsed = urlparse.urlparse(url)
-    try:
-        return parse_qs(parsed.query).get('cursor')[0]
-    except IndexError:
-        return None
-
-
 def _get_company_updates(task, last_updated_after, fields_to_update):
     yesterday = now() - timedelta(days=1)
     midnight_yesterday = datetime.combine(yesterday, time.min)
     last_updated_after = last_updated_after or midnight_yesterday.isoformat()
-    cursor = None
+    next_page = None
     updates_remaining = settings.DNB_AUTOMATIC_UPDATE_LIMIT
 
     while True:
 
-        response = _get_company_updates_from_api(last_updated_after, cursor, task)
+        response = _get_company_updates_from_api(last_updated_after, next_page, task)
         dnb_company_updates = response.get('results', [])
 
         dnb_company_updates = dnb_company_updates[:updates_remaining]
@@ -112,8 +102,7 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
                 break
 
         next_page = response.get('next')
-        cursor = _get_cursor(next_page)
-        if cursor is None:
+        if next_page is None:
             break
 
 

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -1,6 +1,4 @@
-import urllib.parse as urlparse
 from datetime import datetime, time, timedelta
-from urllib.parse import parse_qs
 
 from celery import shared_task
 from celery.utils.log import get_task_logger

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -326,7 +326,7 @@ class TestGetCompanyUpdates:
                         {'bar': 2},
                     ],
                 },
-                'page2': {
+                'http://foo.bar/companies?cursor=page2': {
                     'next': None,
                     'results': [
                         {'baz': 3},
@@ -350,7 +350,7 @@ class TestGetCompanyUpdates:
         pages.
         """
         mock_get_company_update_page = mock.Mock(
-            side_effect=lambda _, cursor: data[cursor],
+            side_effect=lambda _, next_page: data[next_page],
         )
         monkeypatch.setattr(
             'datahub.dnb_api.tasks.get_company_update_page',
@@ -370,7 +370,7 @@ class TestGetCompanyUpdates:
         )
         mock_get_company_update_page.assert_any_call(
             '2019-01-01T00:00:00',
-            'page2',
+            'http://foo.bar/companies?cursor=page2',
         )
 
         assert mock_update_company.apply_async.call_count == 3
@@ -437,7 +437,7 @@ class TestGetCompanyUpdates:
                         {'foo': 1},
                     ],
                 },
-                'page2': {
+                'http://foo.bar/companies?cursor=page2': {
                     'next': None,
                     'results': [
                         {'bar': 2},
@@ -456,7 +456,7 @@ class TestGetCompanyUpdates:
         pages.
         """
         mock_get_company_update_page = mock.Mock(
-            side_effect=lambda _, cursor: data[cursor],
+            side_effect=lambda _, next_page: data[next_page],
         )
         monkeypatch.setattr(
             'datahub.dnb_api.tasks.get_company_update_page',

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -320,7 +320,7 @@ class TestGetCompanyUpdates:
         (
             {
                 None: {
-                    'next': 'page2',
+                    'next': 'http://foo.bar/companies?cursor=page2',
                     'results': [
                         {'foo': 1},
                         {'bar': 2},
@@ -432,7 +432,7 @@ class TestGetCompanyUpdates:
             # Test limit works correctly on the second page
             {
                 None: {
-                    'next': 'page2',
+                    'next': 'http://foo.bar/companies?cursor=page2',
                     'results': [
                         {'foo': 1},
                     ],

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -439,12 +439,12 @@ class TestGetCompanyUpdatePage:
         ),
     )
     @pytest.mark.parametrize(
-        'cursor', (
+        'next_page', (
             None,
-            'some-cursor',
+            'http://some.url/endpoint?cursor=some-cursor',
         ),
     )
-    def test_valid(self, requests_mock, last_updated_after, cursor):
+    def test_valid(self, requests_mock, last_updated_after, next_page):
         """
         Test if `get_company_update_page` returns the right response
         on the happy-path.
@@ -457,14 +457,16 @@ class TestGetCompanyUpdatePage:
             ],
         }
         mocker = requests_mock.get(
-            DNB_UPDATES_URL,
+            next_page if next_page else DNB_UPDATES_URL,
             status_code=status.HTTP_200_OK,
             json=expected_response,
         )
-        response = get_company_update_page(last_updated_after, cursor)
+        response = get_company_update_page(last_updated_after, next_page)
 
-        assert mocker.last_request.qs.get('last_updated_after') == [last_updated_after]
-        assert mocker.last_request.qs.get('cursor') == [cursor or '']
+        if next_page:
+            assert mocker.last_request.url == next_page
+        else:
+            assert mocker.last_request.qs.get('last_updated_after') == [last_updated_after]
 
         assert response == expected_response
 

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -269,7 +269,7 @@ def update_company_from_dnb(
         reversion.set_comment(update_comment)
 
 
-def get_company_update_page(last_updated_after, cursor=None):
+def get_company_update_page(last_updated_after, next_page=None):
     """
     Get the given company updates page from the dnb-service.
 
@@ -288,15 +288,19 @@ def get_company_update_page(last_updated_after, cursor=None):
     if not settings.DNB_SERVICE_BASE_URL:
         raise ImproperlyConfigured('The setting DNB_SERVICE_BASE_URL has not been set')
 
+    request_kwargs = {'timeout': 3.0}
+    url = next_page
+    if not next_page:
+        request_kwargs['params'] = {
+            'last_updated_after': last_updated_after,
+        }
+        url = 'companies/'
+
     try:
         response = api_client.request(
             'GET',
-            'companies/',
-            params={
-                'last_updated_after': last_updated_after,
-                'cursor': cursor or '',
-            },
-            timeout=3.0,
+            url,
+            **request_kwargs,
         )
 
     except ConnectionError as exc:


### PR DESCRIPTION
### Description of change
A bug was fixed to ensure that DNB company updates can be ingested over multiple pages from dnb-service.  Previously, the cursor value was not being extracted from the URL for the next page correctly.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
