### PR TITLE
Add dnb-company-updates feature flag

### DIFF
--- a/changelog/company/dnb-company-updates-feature-flag.feature.md
+++ b/changelog/company/dnb-company-updates-feature-flag.feature.md
@@ -1,0 +1,4 @@
+A feature flag was added `"dnb-company-updates"` which governs whether or not to
+run the logic within the `datahub.dnb_api.tasks.get_company_updates` celery task.
+This affords us the ability to easily switch on/off DNB company updates as needed 
+during the rollout of this feature.

--- a/datahub/dnb_api/constants.py
+++ b/datahub/dnb_api/constants.py
@@ -1,4 +1,5 @@
 FEATURE_FLAG_DNB_COMPANY_SEARCH = 'dnb-company-search'
+FEATURE_FLAG_DNB_COMPANY_UPDATES = 'dnb-company-updates'
 
 ALL_DNB_UPDATED_FIELDS = (
     'name',

--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -7,7 +7,10 @@ from freezegun import freeze_time
 from datahub.company.constants import BusinessTypeConstant
 from datahub.company.test.factories import CompanyFactory
 from datahub.core.constants import Country, Sector, UKRegion
-from datahub.dnb_api.constants import FEATURE_FLAG_DNB_COMPANY_SEARCH
+from datahub.dnb_api.constants import (
+    FEATURE_FLAG_DNB_COMPANY_SEARCH,
+    FEATURE_FLAG_DNB_COMPANY_UPDATES,
+)
 from datahub.feature_flag.test.factories import FeatureFlagFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
 
@@ -18,6 +21,14 @@ def dnb_company_search_feature_flag(db):
     Creates the dnb company search feature flag.
     """
     yield FeatureFlagFactory(code=FEATURE_FLAG_DNB_COMPANY_SEARCH)
+
+
+@pytest.fixture()
+def dnb_company_updates_feature_flag():
+    """
+    Creates the DNB company updates feature flag.
+    """
+    yield FeatureFlagFactory(code=FEATURE_FLAG_DNB_COMPANY_UPDATES)
 
 
 @pytest.fixture

--- a/datahub/email_ingestion/tasks.py
+++ b/datahub/email_ingestion/tasks.py
@@ -15,8 +15,8 @@ def ingest_emails():
     Ingest and process new emails for all mailboxes in the application - i.e.
     those in the MAILBOXES django setting.
     """
-    # TODO: remove feature flag check once we are happy with meeting invite
-    # email processing
+    # NOTE: This is a long-lived feature flag which allows us to quickly switch off email
+    # ingestion in case of any problems with third party (SMTP) services or security issues
     if not is_feature_flag_active(INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME):
         logger.info(
             f'Feature flag "{INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME}" is not active, '


### PR DESCRIPTION
### Description of change
A feature flag was added `"dnb-company-updates"` which governs whether or not to run the logic within the `datahub.dnb_api.tasks.get_company_updates` celery task.
This affords us the ability to easily switch on/off DNB company updates as needed  during the rollout of this feature.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
