### PR TITLE
Add countries to interaction journey

### DIFF
--- a/changelog/interaction/interaction-add-export-countries.api.md
+++ b/changelog/interaction/interaction-add-export-countries.api.md
@@ -1,0 +1,5 @@
+Interactions API `/v3/interaction` now allows to specify if there was a discussion of countries during the interaction and add one or more export countries along with their status.
+
+`were_countries_discussed` is a nullable boolean field.
+
+`export_countries` field is of type `InteractionExportCountry` and takes a list of `country` and `status` combinations where `country` is of type `Country` and `status` is a choice of `Not interested`, `Currently exporting to` or `Future country of interest`.

--- a/datahub/interaction/queryset.py
+++ b/datahub/interaction/queryset.py
@@ -2,7 +2,11 @@ from django.db.models import OuterRef, Prefetch, Subquery
 
 from datahub.company.models import Contact
 from datahub.core.model_helpers import get_m2m_model
-from datahub.interaction.models import Interaction, InteractionDITParticipant
+from datahub.interaction.models import (
+    Interaction,
+    InteractionDITParticipant,
+    InteractionExportCountry,
+)
 
 
 def get_base_interaction_queryset():
@@ -50,7 +54,16 @@ def get_interaction_queryset():
 
     queryset = get_base_interaction_queryset()
 
-    return queryset.annotate(
+    return queryset.prefetch_related(
+        Prefetch(
+            'export_countries',
+            queryset=(
+                InteractionExportCountry.objects
+                                        .order_by('country__name')
+                                        .select_related('country')
+            ),
+        ),
+    ).annotate(
         first_name_of_first_contact=Subquery(
             first_contact_queryset.values('contact__first_name'),
         ),

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -185,6 +185,30 @@ class InteractionDITParticipantFactory(factory.django.DjangoModelFactory):
         model = 'interaction.InteractionDITParticipant'
 
 
+class ExportCountriesInteractionFactory(InteractionFactoryBase):
+    """Factory for creating an export interaction with export countries."""
+
+    kind = Interaction.KINDS.interaction
+    theme = factory.Iterator([Interaction.THEMES.export, Interaction.THEMES.other])
+    were_countries_discussed = True
+    communication_channel = factory.LazyFunction(
+        lambda: random_obj_for_model(CommunicationChannel),
+    )
+
+    @to_many_field
+    def export_countries(self, **kwargs):
+        """
+        Instances of InteractionExportCountryFactory.
+        Defaults to one InteractionExportCountryFactory.
+        """
+        return [
+            InteractionExportCountryFactory(
+                interaction=self,
+                **kwargs,
+            ),
+        ]
+
+
 class InteractionExportCountryFactory(factory.django.DjangoModelFactory):
     """Factory for Interaction export country."""
 

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -785,36 +785,6 @@ class TestGetInteraction(APITestMixin):
             'archived_reason': None,
         }
 
-    @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
-    @freeze_time('2017-04-18 13:25:30.986208')
-    def test_non_restricted_user_can_get_multiple_export_countries_interaction(self, permissions):
-        """Test that a user can get an interaction with multiple export countries."""
-        requester = create_test_user(permission_codenames=permissions)
-        interaction = ExportCountriesInteractionFactory()
-        interaction.export_countries.set([
-            InteractionExportCountryFactory(
-                interaction=interaction,
-            )
-            for _ in range(3)
-        ])
-        api_client = self.create_api_client(user=requester)
-        url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = api_client.get(url)
-
-        assert response.status_code == status.HTTP_200_OK
-        response_data = response.json()
-        response_data['export_countries'].sort(key=lambda item: item['country']['name'])
-        assert response_data['export_countries'] == [
-            {
-                'country': {
-                    'id': str(export_country.country.id),
-                    'name': export_country.country.name,
-                },
-                'status': export_country.status,
-            }
-            for export_country in interaction.export_countries.order_by('country__name')
-        ]
-
     @freeze_time('2017-04-18 13:25:30.986208')
     def test_restricted_user_can_get_associated_investment_project_interaction(self):
         """Test that a restricted user can get an associated investment project interaction."""

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -153,6 +153,8 @@ class TestAddServiceDelivery(APITestMixin):
             'service_answers': None,
             'investment_project': None,
             'archived_documents_url_path': '',
+            'were_countries_discussed': request_data.get('were_countries_discussed'),
+            'export_countries': request_data.get('export_countries', []),
             'created_by': {
                 'id': str(self.user.pk),
                 'first_name': self.user.first_name,


### PR DESCRIPTION
### Description of change
This is the first of three part change: Adding export_countries to Interaction API.

Other two are:
* Adding validations 
* synchronising interaction export countries to company export countries 

NOTE:
Don't merge until all three parts are reviewed.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
