### PR TITLE
Fix use of deprecated Elasticsearch `context` suggester query parameter

### DIFF
--- a/changelog/elasticsearch-context.internal.md
+++ b/changelog/elasticsearch-context.internal.md
@@ -1,0 +1,1 @@
+The Elasticsearch suggester query parameter `contexts` is now used instead of the deprecated `context` parameter.

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -132,7 +132,7 @@ def build_autocomplete_query(es_model, keyword_search, limit, fields_to_include,
     }
 
     if context:
-        completion_dict['context'] = context
+        completion_dict['contexts'] = context
 
     return autocomplete_search.suggest(
         'autocomplete',

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -341,7 +341,7 @@ def test_build_entity_permission_query_no_conditions(filters, expected):
                         'completion': {
                             'field': 'suggest',
                             'size': 1,
-                            'context': {'country': [CountryConstant.canada.value.id]},
+                            'contexts': {'country': [CountryConstant.canada.value.id]},
                         },
                         'text': 'goodbye',
                     },
@@ -360,7 +360,7 @@ def test_build_entity_permission_query_no_conditions(filters, expected):
                         'completion': {
                             'field': 'suggest',
                             'size': 1,
-                            'context': {'country': 'hello'},
+                            'contexts': {'country': 'hello'},
                         },
                         'text': 'goodbye',
                     },


### PR DESCRIPTION
### Description of change

This fixes the following deprecation warning that was being logged by Elasticsearch:

```
Deprecated field [context] used, expected [contexts] instead
```

(Note: This does not tackle the more difficult `The ability to query with no context on a context enabled completion field is deprecated and will be removed in the next major release.`)

### To test

Elasticsearch should no longer log `Deprecated field [context] used, expected [contexts] instead` when running `pytest -k TestAutocompleteSearch`.

This can be checked:

- on CircleCI in the Elasticsearch container output
- locally in the Elasticsearch log (in a native installation, this is probably at `/var/log/elasticsearch/elasticsearch_deprecation.log`)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
