### PR TITLE
Add CSRF header to SwaggerUI requests

### DIFF
--- a/changelog/add-csrf-token-to-api-docs.feature.md
+++ b/changelog/add-csrf-token-to-api-docs.feature.md
@@ -1,0 +1,1 @@
+The CSRF token is now being added to API Docs request header. It is now possible to try POST requests.

--- a/datahub/core/templates/core/docs/swagger-ui.html
+++ b/datahub/core/templates/core/docs/swagger-ui.html
@@ -27,7 +27,11 @@
           SwaggerUIBundle.presets.apis,
           SwaggerUIBundle.SwaggerUIStandalonePreset
         ],
-        layout: "BaseLayout"
+        layout: "BaseLayout",
+        requestInterceptor: (req) => {
+            req.headers['X-CSRFToken'] = "{{csrf_token}}";
+            return req;
+        }
       })
     </script>
   </body>


### PR DESCRIPTION
### Description of change

This updates API docs template, so the CSRF token is included in the POST request. This enables us to try POST requests in the API browser. 
Currently the API would return an error about missing CSRF token when such request is made.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
