### PR TITLE
Add identifiers to DNB update version comments

### DIFF
--- a/changelog/company/add-task-ids-to-rversion-comments.feature.md
+++ b/changelog/company/add-task-ids-to-rversion-comments.feature.md
@@ -1,0 +1,5 @@
+Companies updated with the `update_company_from_dnb` command and the 
+`update_companies_from_dnb_service` task are now saved with a reversion version
+which has a meaningful identifier in the comment. This identifier will help provide
+the groundwork for an "undo tool" which will allow us to reverse these automatic
+updates in the event of a problem.

--- a/datahub/dbmaintenance/management/commands/update_company_dnb_data.py
+++ b/datahub/dbmaintenance/management/commands/update_company_dnb_data.py
@@ -1,6 +1,8 @@
 import logging
 import time
 
+from django.utils.timezone import now
+
 from datahub.company.models import Company
 from datahub.dbmaintenance.management.base import CSVBaseCommand
 from datahub.dbmaintenance.utils import parse_uuid
@@ -29,6 +31,8 @@ class Command(CSVBaseCommand):
         Set some initial state related to API rate limiting.
         """
         self.last_called_api_time = time.perf_counter()
+        timestamp = now().isoformat(timespec='seconds')
+        self.update_descriptor = f'command:update_company_dnb_data:{timestamp}'
         super().__init__(*args, **kwargs)
 
     def add_arguments(self, parser):
@@ -70,5 +74,5 @@ class Command(CSVBaseCommand):
         self._limit_call_rate()
 
         sync_company_with_dnb.apply(
-            args=(pk, fields),
+            args=(pk, fields, self.update_descriptor),
         )

--- a/datahub/dbmaintenance/test/commands/test_update_company_dnb_data.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_dnb_data.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 import pytest
 from django.core.management import call_command
+from freezegun import freeze_time
 
 from datahub.company.test.factories import CompanyFactory
 from datahub.dbmaintenance.management.commands.update_company_dnb_data import (
@@ -64,6 +65,7 @@ def mock_sync_company_with_dnb(monkeypatch):
         ['global_ultimate_duns_number', 'name'],
     ),
 )
+@freeze_time('2019-01-01 11:12:13')
 def test_run(s3_stubber, caplog, mock_time, mock_sync_company_with_dnb, fields):
     """
     Test that the command updates the specified records (ignoring ones with errors).
@@ -110,7 +112,13 @@ def test_run(s3_stubber, caplog, mock_time, mock_sync_company_with_dnb, fields):
     assert mock_sync_company_with_dnb.call_count == 4
     for company in companies:
         if company.duns_number:
-            mock_sync_company_with_dnb.assert_any_call(args=(company.id, fields))
+            mock_sync_company_with_dnb.assert_any_call(
+                args=(
+                    company.id,
+                    fields,
+                    'command:update_company_dnb_data:2019-01-01T11:12:13+00:00',
+                ),
+            )
 
 
 def test_simulate(s3_stubber, caplog, mock_time, mock_sync_company_with_dnb):

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -58,6 +58,8 @@ def sync_company_with_dnb(self, company_id, fields_to_update=None, update_descri
 
     `company_id` identifies the company record to sync and `fields_to_update` defines an iterable
     of company serializer fields that should be updated - if it is None, all fields will be synced.
+    `update_descriptor` can be specified and will be embedded within the reversion comment for
+    the new company version.
     """
     if not update_descriptor:
         update_descriptor = f'celery:sync_company_with_dnb:{self.request.id}'

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -25,7 +25,7 @@ from datahub.feature_flag.utils import is_feature_flag_active
 logger = get_task_logger(__name__)
 
 
-def _sync_company_with_dnb(company_id, fields_to_update, task):
+def _sync_company_with_dnb(company_id, fields_to_update, task, update_descriptor):
     dh_company = Company.objects.get(id=company_id)
 
     try:
@@ -41,7 +41,7 @@ def _sync_company_with_dnb(company_id, fields_to_update, task):
         dh_company,
         dnb_company,
         fields_to_update=fields_to_update,
-        update_descriptor='celery:sync_company_with_dnb',
+        update_descriptor=update_descriptor,
     )
 
 
@@ -51,7 +51,7 @@ def _sync_company_with_dnb(company_id, fields_to_update, task):
     priority=9,
     max_retries=3,
 )
-def sync_company_with_dnb(self, company_id, fields_to_update=None):
+def sync_company_with_dnb(self, company_id, fields_to_update=None, update_descriptor=None):
     """
     Sync a company record with data sourced from DNB. This task will interact with dnb-service to
     get the latest data for the company.
@@ -59,7 +59,9 @@ def sync_company_with_dnb(self, company_id, fields_to_update=None):
     `company_id` identifies the company record to sync and `fields_to_update` defines an iterable
     of company serializer fields that should be updated - if it is None, all fields will be synced.
     """
-    _sync_company_with_dnb(company_id, fields_to_update, self)
+    if not update_descriptor:
+        update_descriptor = f'celery:sync_company_with_dnb:{self.request.id}'
+    _sync_company_with_dnb(company_id, fields_to_update, self, update_descriptor)
 
 
 def _write_audit_log(audit):
@@ -117,6 +119,7 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
     update_results = []
     start_time = now()
     logger.info('Started get_company_updates task')
+    update_descriptor = f'celery:get_company_updates:{task.request.id}'
 
     while True:
 
@@ -129,7 +132,10 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
         for data in dnb_company_updates:
             result = update_company_from_dnb_data.apply_async(
                 args=(data,),
-                kwargs={'fields_to_update': fields_to_update},
+                kwargs={
+                    'fields_to_update': fields_to_update,
+                    'update_descriptor': update_descriptor,
+                },
             )
             update_results.append(result)
 
@@ -184,7 +190,7 @@ def get_company_updates(self, last_updated_after=None, fields_to_update=None):
     acks_late=True,
     priority=9,
 )
-def update_company_from_dnb_data(dnb_company_data, fields_to_update=None):
+def update_company_from_dnb_data(dnb_company_data, fields_to_update=None, update_descriptor=None):
     """
     Update the company with the latest data from dnb-service. This task should be called
     when some other logic interacts with dnb-service to get the company data as the task itself
@@ -205,6 +211,9 @@ def update_company_from_dnb_data(dnb_company_data, fields_to_update=None):
             },
         )
         raise
+
+    if not update_descriptor:
+        update_descriptor = 'celery:company_update'
 
     update_company_from_dnb(
         dh_company,

--- a/update-companies-from-dnb-service-command.feature.md
+++ b/update-companies-from-dnb-service-command.feature.md
@@ -1,2 +1,0 @@
-A management command `./manage.py update_companies_from_dnb_service` was added which
-allows for manual runs of the `get_company_updates` celery task.


### PR DESCRIPTION
### Description of change

Companies updated with the `update_company_from_dnb` command and the 
 `update_companies_from_dnb_service` task are now saved with a reversion version which has a meaningful identifier in the comment. This identifier will help provide the groundwork for an "undo tool" which will allow us to reverse these automatic updates in the event of a problem.

The logic for the undo tool will be fed in through iterative PRs which will follow this one.  For context, the undo tool will take a list of company IDs as input along with a reversion version comment substring (which this PR provides) - it will revert changes to D&B fields to the version which occurs before the version with the matching comment.

In the case of this PR, the comments will likely look like this:
`"Updated from D&B [celery:get_company_updates:{task_id}]"`
`"Updated from D&B [command:update_company_dnb_data:{command_run_datetime}]"`


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
