### PR TITLE
Add a script to publish a release on GitHub

### DIFF
--- a/docs/How to prepare a release.md
+++ b/docs/How to prepare a release.md
@@ -83,7 +83,25 @@ Type the following:
 
 Click on `build`, follow the deployment and check that everything looks fine after it finishes.
 
-## Formalise the release
+## Publish the release on GitHub
+
+The final step is to publish the release on GitHub. To do this, you will need to [generate a GitHub personal access 
+token](https://github.com/settings/tokens) with the `public_repo` scope.
+
+Once you have this, you can either set it in the `GITHUB_TOKEN` environment variable, or enter it when prompted.
+
+When you have a token, run:
+
+```shell
+scripts/publish_release.py
+```
+
+This will create and publish the release on GitHub and open it in your web browser. 
+
+<details>
+<summary>If you are unable to use the script</summary>
+
+If you can‘t use the script for some reason, you can still manually create and publish the release.
 
 In GitHub, [create a release](https://github.com/uktrade/data-hub-api/releases/new) with the following values:
 
@@ -95,3 +113,5 @@ In GitHub, [create a release](https://github.com/uktrade/data-hub-api/releases/n
 And click on _Publish release_.
 
 For more information see the [GitHub documentation](https://help.github.com/articles/creating-releases/).
+
+</details>

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+
+"""
+This is a script that:
+
+- runs `git fetch`
+- gets the version number from origin/master
+- extracts the changelog for that version from CHANGELOG.md
+- creates a release on GitHub for that version
+- opens your web browser to the created release
+
+The script will abort if:
+
+- a tag for the current version already exists
+
+(This script works without checking out a different branch, as it does not have to commit
+anything.)
+
+A GitHub access token with the public_repo scope is required.
+"""
+
+import argparse
+import os
+import subprocess
+import webbrowser
+from getpass import getpass
+
+import requests
+from requests import HTTPError
+
+from script_utils.changelog import extract_version_changelog
+from script_utils.git import get_file_contents, remote_tag_exists
+
+GITHUB_RELEASE_API_URL = 'https://api.github.com/repos/uktrade/data-hub-api/releases'
+
+
+# Currently no real arguments – just used for --help etc.
+parser = argparse.ArgumentParser(
+    description="""Publishes the current release on GitHub.
+
+A GitHub access token with the public_repo scope is required. The token can be provided
+using the GITHUB_TOKEN environment variable. If that variable is not set, you will be prompted
+for a token.
+""",
+)
+
+
+class CommandError(Exception):
+    """A fatal error when running the script."""
+
+
+def publish_release():
+    """Publish the release on GitHub."""
+    remote = 'origin'
+    branch = 'master'
+
+    subprocess.run(['git', 'fetch'], check=True)
+
+    version = get_file_contents(f'{remote}/{branch}', 'datahub/VERSION').strip()
+    tag = f'v{version}'
+
+    if remote_tag_exists(tag):
+        raise CommandError(
+            f'A remote tag {tag} currently exists. It looks like this release has already been'
+            f' published.',
+        )
+
+    changelog = get_file_contents(f'{remote}/{branch}', 'CHANGELOG.md')
+    version_changelog = extract_version_changelog(changelog, version)
+
+    if not version_changelog:
+        raise CommandError(f'Failed to extract the changelog for version {version}.')
+
+    token = os.environ.get('GITHUB_TOKEN') or getpass('GitHub access token: ')
+
+    response = requests.post(
+        GITHUB_RELEASE_API_URL,
+        headers={
+            'Authorization': f'Bearer {token}',
+        },
+        json={
+            'tag_name': tag,
+            'target_commitish': 'master',
+            'name': tag,
+            'body': version_changelog,
+        },
+    )
+    response.raise_for_status()
+    response_data = response.json()
+
+    webbrowser.open(response_data['html_url'])
+
+    return tag
+
+
+def main():
+    """Run the script using command-line arguments."""
+    parser.parse_args()
+
+    try:
+        tag = publish_release()
+    except (CommandError, HTTPError, subprocess.CalledProcessError) as exc:
+        messages = [f'ERROR: {exc}']
+
+        if isinstance(exc, HTTPError) and exc.response is not None:
+            response_data = exc.response.json()
+            messages.append(f'Response: {response_data}')
+
+        print(*messages, sep='\n')  # noqa: T001
+        return
+
+    print(  # noqa: T001
+        f'Release {tag} was published and opened in your web browser. If anything is wrong, edit '
+        f'the release on GitHub.',
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/script_utils/changelog.py
+++ b/scripts/script_utils/changelog.py
@@ -1,0 +1,17 @@
+import re
+
+
+def extract_version_changelog(changelog, version):
+    """Extract the changelog for a particular version from the entire changelog."""
+    escaped_version = re.escape(version)
+
+    pattern = rf"""(?m:^)# Data Hub API {escaped_version} \([0-9-]+\)
+(?P<content>.*?)
+(# Data Hub API|$)"""
+
+    match = re.search(pattern, changelog, flags=re.DOTALL)
+
+    if match:
+        return match.group('content').strip()
+
+    return None

--- a/scripts/script_utils/git.py
+++ b/scripts/script_utils/git.py
@@ -12,6 +12,16 @@ def any_uncommitted_changes():
     return bool(result.stdout)
 
 
+def get_file_contents(branch, path):
+    """Get the contents of a file on a particular branch."""
+    result = subprocess.run(
+        ['git', 'show', f'{branch}:{path}'],
+        check=True,
+        capture_output=True,
+    )
+    return result.stdout.decode('utf-8')
+
+
 def local_branch_exists(branch):
     """Check if a local branch exists."""
     try:

--- a/scripts/script_utils/test/test_changelog.py
+++ b/scripts/script_utils/test/test_changelog.py
@@ -1,0 +1,119 @@
+import pytest
+
+from script_utils.changelog import extract_version_changelog
+
+CHANGELOG_CONTENT = """# Data Hub API 24.0.0 (2019-12-10)
+
+
+## Features
+
+- **Companies** A setting `DNB_AUTOMATIC_UPDATE_LIMIT` was added which can be used to limit the
+  number of companies updated by the `datahub.dnb_api.tasks.get_company_updates`
+  task.
+
+## Bug fixes
+
+- **Companies** A bug was fixed to ensure that DNB company updates can be ingested over multiple
+  pages from dnb-service.  Previously, the cursor value was not being extracted
+  from the URL for the next page correctly.
+
+
+# Data Hub API 23.2.0 (2019-12-02)
+
+
+## Bug fixes
+
+- **Companies** Merging two companies (via the admin site) now works when both companies are on
+  the same company list.
+
+## API
+
+- **Investment** `GET /v4/dataset/investment-projects-dataset`: The `competing_countries` field
+  was updated to return country names rather than ids
+- **OMIS** `GET /v4/dataset/omis-dataset`: The field `quote__accepted_on` was added to the omis
+  dataset endpoint
+
+
+# Data Hub API 23.1.0 (2019-11-28)
+
+
+## Removals
+
+- The `init_es` management command has been removed. Please use `migrate_es` instead.
+
+## Features
+
+- The `migrate_es` management command was updated to handle the case when indexes don‘t already
+  exist.
+
+  Hence, the `init_es` command is no longer required and has been removed.
+
+
+"""
+
+V24_0_0_EXPECTED = """## Features
+
+- **Companies** A setting `DNB_AUTOMATIC_UPDATE_LIMIT` was added which can be used to limit the
+  number of companies updated by the `datahub.dnb_api.tasks.get_company_updates`
+  task.
+
+## Bug fixes
+
+- **Companies** A bug was fixed to ensure that DNB company updates can be ingested over multiple
+  pages from dnb-service.  Previously, the cursor value was not being extracted
+  from the URL for the next page correctly."""
+
+
+V23_2_0_EXPECTED = """## Bug fixes
+
+- **Companies** Merging two companies (via the admin site) now works when both companies are on
+  the same company list.
+
+## API
+
+- **Investment** `GET /v4/dataset/investment-projects-dataset`: The `competing_countries` field
+  was updated to return country names rather than ids
+- **OMIS** `GET /v4/dataset/omis-dataset`: The field `quote__accepted_on` was added to the omis
+  dataset endpoint"""
+
+
+V23_1_0_EXPECTED = """## Removals
+
+- The `init_es` management command has been removed. Please use `migrate_es` instead.
+
+## Features
+
+- The `migrate_es` management command was updated to handle the case when indexes don‘t already
+  exist.
+
+  Hence, the `init_es` command is no longer required and has been removed."""
+
+
+@pytest.mark.parametrize(
+    'version,expected_result',
+    [
+        pytest.param(
+            '9.9.9',
+            None,
+            id='no-match',
+        ),
+        pytest.param(
+            '24.0.0',
+            V24_0_0_EXPECTED,
+            id='start-of-changelog',
+        ),
+        pytest.param(
+            '23.2.0',
+            V23_2_0_EXPECTED,
+            id='middle-of-changelog',
+        ),
+        pytest.param(
+            '23.1.0',
+            V23_1_0_EXPECTED,
+            id='end-of-changelog',
+        ),
+    ],
+)
+def test_extract_version_changelog(version, expected_result):
+    """Test extract_version_changelog() for various cases."""
+    assert extract_version_changelog(CHANGELOG_CONTENT, version) == expected_result

--- a/scripts/script_utils/test/test_git.py
+++ b/scripts/script_utils/test/test_git.py
@@ -5,6 +5,7 @@ import pytest
 
 from script_utils.git import (
     any_uncommitted_changes,
+    get_file_contents,
     local_branch_exists,
     remote_branch_exists,
     remote_tag_exists,
@@ -31,6 +32,13 @@ def test_any_uncommitted_changes(stdout, expected_result, mock_subprocess_run):
     mock_subprocess_run.return_value = subprocess.CompletedProcess((), 0, stdout=stdout)
 
     assert any_uncommitted_changes() == expected_result
+
+
+def test_get_file_contents(mock_subprocess_run):
+    """Test that get_file_contents() returns the contents of stdout."""
+    mock_subprocess_run.return_value = subprocess.CompletedProcess((), 0, stdout=b'file-contents')
+
+    assert get_file_contents('origin/master', 'file.txt') == 'file-contents'
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Description of change

This adds a new script, `script/publish_release.py`, that publishes a release on GitHub once it has been merged to master.

The script works without checking out a different branch, as it does not need to commit anything.

A GitHub access token with the `public_repo` scope is required to run the script.

I think it might be nice to prefix the three scripts with numbers to indicate the order they should be run in. But, I'll leave that as a follow-up task.

### To test

If you want to test this locally, the main way I can think of is to create a fork of this repo, and update `GITHUB_RELEASE_API_URL` to point at your fork.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
