### PR TITLE
Add schedule for nightly run of D&B updates

### DIFF
--- a/changelog/company/auto-dnb-updates.feature.md
+++ b/changelog/company/auto-dnb-updates.feature.md
@@ -1,0 +1,3 @@
+A schedule was added for a nightly run of the celery task: `datahub.dnb_api.tasks.get_company_updates`.
+
+This task will ingest D&B updates from `dnb_service`. The number of updates applied in a single run will be controlled by the environment variable called `DNB_AUTOMATIC_UPDATE_LIMIT`.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -395,6 +395,10 @@ if REDIS_BASE_URL:
                 'refresh_gross_value_added_value_for_fdi_investment_projects'
             ),
             'schedule': crontab(minute=0, hour=3, day_of_month=21)
+        },
+        'update_companies_from_dnb_service': {
+            'task': 'datahub.dnb_api.tasks.get_company_updates',
+            'schedule': crontab(minute=0, hour=0),
         }
     }
     if env.bool('ENABLE_DAILY_ES_SYNC', False):


### PR DESCRIPTION
### Description of change

This adds a schedule for a nightly run of the celery task: `datahub.dnb_api.tasks.get_company_updates`.

This task will ingest D&B updates from `dnb_service`. The number of updates applied in a single run will be controlled by the environment variable called `DNB_AUTOMATIC_UPDATE_LIMIT`. Currently, this variable is set to 10. We will gradually ramp this up as we gain confidence.

P.S. This is behind a feature flag called `FEATURE_FLAG_DNB_COMPANY_UPDATES` that will be turned on now.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
