### PR TITLE
Add audit to update_company_dnb_data

### DIFF
--- a/changelog/company/update-company-dnb-data-audit-log.feature.md
+++ b/changelog/company/update-company-dnb-data-audit-log.feature.md
@@ -1,0 +1,2 @@
+The `update_company_dnb_data` command was adjusted so that an audit log is fired
+to sentry after a successful run.

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -150,8 +150,7 @@ def log_to_sentry(message, extra=None, level='info'):
     log info or warning-level messages to sentry; for error messages, a standard python logger can
     be used with the `extra` kwarg.
     """
-    if not extra:
-        extra = {}
+    extra = extra or {}
     with sentry_sdk.push_scope() as scope:
         for key, value in extra.items():
             scope.set_extra(key, value)

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from uuid import UUID
 
 import requests
+import sentry_sdk
 from django.conf import settings
 from django.urls import reverse
 from django.utils.http import urlencode
@@ -141,3 +142,17 @@ def get_financial_year(date_obj):
     if date_obj.month > 3:
         return date_obj.year
     return date_obj.year - 1
+
+
+def log_to_sentry(message, extra=None, level='info'):
+    """
+    Log a message to sentry directly.  This will only normally be needed if there is a desire to
+    log info or warning-level messages to sentry; for error messages, a standard python logger can
+    be used with the `extra` kwarg.
+    """
+    if not extra:
+        extra = {}
+    with sentry_sdk.push_scope() as scope:
+        for key, value in extra.items():
+            scope.set_extra(key, value)
+        sentry_sdk.capture_message(message, level=level)

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -501,11 +501,11 @@ class TestGetCompanyUpdates:
             kwargs=expected_kwargs,
         )
 
-    @mock.patch('datahub.dnb_api.tasks._write_audit_log')
+    @mock.patch('datahub.dnb_api.tasks.log_to_sentry')
     @freeze_time('2019-01-02T2:00:00')
     def test_updates_with_update_company_from_dnb_data(
         self,
-        mocked_write_audit_log,
+        mocked_log_to_sentry,
         monkeypatch,
         dnb_company_updates_response_uk,
     ):
@@ -528,8 +528,9 @@ class TestGetCompanyUpdates:
         assert company.name == dnb_company['primary_name']
         expected_gu_number = dnb_company['global_ultimate_duns_number']
         assert company.global_ultimate_duns_number == expected_gu_number
-        mocked_write_audit_log.assert_called_with(
-            {
+        mocked_log_to_sentry.assert_called_with(
+            'get_company_updates task completed.',
+            extra={
                 'success_count': 1,
                 'failure_count': 0,
                 'updated_company_ids': [str(company.pk)],
@@ -539,11 +540,11 @@ class TestGetCompanyUpdates:
             },
         )
 
-    @mock.patch('datahub.dnb_api.tasks._write_audit_log')
+    @mock.patch('datahub.dnb_api.tasks.log_to_sentry')
     @freeze_time('2019-01-02T2:00:00')
     def test_updates_with_update_company_from_dnb_data_partial_fields(
         self,
-        mocked_write_audit_log,
+        mocked_log_to_sentry,
         monkeypatch,
         dnb_company_updates_response_uk,
     ):
@@ -566,8 +567,9 @@ class TestGetCompanyUpdates:
         assert company.name == dnb_company['primary_name']
         assert company.global_ultimate_duns_number == ''
 
-        mocked_write_audit_log.assert_called_with(
-            {
+        mocked_log_to_sentry.assert_called_with(
+            'get_company_updates task completed.',
+            extra={
                 'success_count': 1,
                 'failure_count': 0,
                 'updated_company_ids': [str(company.pk)],
@@ -577,11 +579,11 @@ class TestGetCompanyUpdates:
             },
         )
 
-    @mock.patch('datahub.dnb_api.tasks._write_audit_log')
+    @mock.patch('datahub.dnb_api.tasks.log_to_sentry')
     @freeze_time('2019-01-02T2:00:00')
     def test_updates_with_update_company_from_dnb_data_with_failure(
         self,
-        mocked_write_audit_log,
+        mocked_log_to_sentry,
         monkeypatch,
         dnb_company_updates_response_uk,
     ):
@@ -610,8 +612,9 @@ class TestGetCompanyUpdates:
         assert company.name == dnb_company['primary_name']
         expected_gu_number = dnb_company['global_ultimate_duns_number']
         assert company.global_ultimate_duns_number == expected_gu_number
-        mocked_write_audit_log.assert_called_with(
-            {
+        mocked_log_to_sentry.assert_called_with(
+            'get_company_updates task completed.',
+            extra={
                 'success_count': 1,
                 'failure_count': 1,
                 'updated_company_ids': [str(company.pk)],


### PR DESCRIPTION
### Description of change
The `update_company_dnb_data` command was adjusted so that an audit log is fired to sentry after a successful run.

It made sense to refactor code using sentry's `push_scope` to use a common Data Hub utility function, so this was done in the first commit.


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
