### PR TITLE
Add utility function to rollback D&B updates

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_company_dnb_data.py
+++ b/datahub/dbmaintenance/management/commands/update_company_dnb_data.py
@@ -7,7 +7,7 @@ from datahub.company.models import Company
 from datahub.core.utils import log_to_sentry
 from datahub.dbmaintenance.management.base import CSVBaseCommand
 from datahub.dbmaintenance.utils import parse_uuid
-from datahub.dnb_api.constants import ALL_DNB_UPDATED_FIELDS
+from datahub.dnb_api.constants import ALL_DNB_UPDATED_SERIALIZER_FIELDS
 from datahub.dnb_api.tasks import sync_company_with_dnb
 
 
@@ -58,7 +58,7 @@ class Command(CSVBaseCommand):
             nargs='+',
             help='The DNBCompanySerializer fields to update.',
             required=False,
-            choices=ALL_DNB_UPDATED_FIELDS,
+            choices=ALL_DNB_UPDATED_SERIALIZER_FIELDS,
         )
 
     def _record_audit_log(self):

--- a/datahub/dnb_api/constants.py
+++ b/datahub/dnb_api/constants.py
@@ -15,3 +15,28 @@ ALL_DNB_UPDATED_FIELDS = (
     'global_ultimate_duns_number',
     'company_number',
 )
+
+ALL_DNB_UPDATED_MODEL_FIELDS = (
+    'name',
+    'trading_names',
+    'address_1',
+    'address_2',
+    'address_town',
+    'address_county',
+    'address_country',
+    'address_postcode',
+    'registered_address_1',
+    'registered_address_2',
+    'registered_address_town',
+    'registered_address_county',
+    'registered_address_country',
+    'registered_address_postcode',
+    'website',
+    'number_of_employees',
+    'is_number_of_employees_estimated',
+    'turnover',
+    'is_turnover_estimated',
+    'website',
+    'global_ultimate_duns_number',
+    'company_number',
+)

--- a/datahub/dnb_api/constants.py
+++ b/datahub/dnb_api/constants.py
@@ -1,7 +1,7 @@
 FEATURE_FLAG_DNB_COMPANY_SEARCH = 'dnb-company-search'
 FEATURE_FLAG_DNB_COMPANY_UPDATES = 'dnb-company-updates'
 
-ALL_DNB_UPDATED_FIELDS = (
+ALL_DNB_UPDATED_SERIALIZER_FIELDS = (
     'name',
     'trading_names',
     'address',

--- a/datahub/dnb_api/management/commands/update_companies_from_dnb_service.py
+++ b/datahub/dnb_api/management/commands/update_companies_from_dnb_service.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from django.core.management.base import BaseCommand
 
-from datahub.dnb_api.constants import ALL_DNB_UPDATED_FIELDS
+from datahub.dnb_api.constants import ALL_DNB_UPDATED_SERIALIZER_FIELDS
 from datahub.dnb_api.tasks import get_company_updates
 
 logger = getLogger(__name__)
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             nargs='+',
             help='The DNBCompanySerializer fields to update.',
             required=False,
-            choices=ALL_DNB_UPDATED_FIELDS,
+            choices=ALL_DNB_UPDATED_SERIALIZER_FIELDS,
         )
 
     def handle(self, *args, **options):

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -599,7 +599,7 @@ class TestRollbackDNBCompanyUpdate:
             assert getattr(company, field) == getattr(original_company, field)
 
         latest_version = Version.objects.get_for_object(company)[0]
-        latest_version.revision.comment = 'Reverted D&B update from: foo'
+        assert latest_version.revision.comment == 'Reverted D&B update from: foo'
 
     @pytest.mark.parametrize(
         'update_comment, error_message',
@@ -626,6 +626,6 @@ class TestRollbackDNBCompanyUpdate:
             update_descriptor='foo',
         )
 
-        with pytest.raises(RevisionNotFoundError) as e:
+        with pytest.raises(RevisionNotFoundError) as excinfo:
             rollback_dnb_company_update(company, update_comment)
-            assert str(e) == error_message
+            assert str(excinfo.value) == error_message

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -2,6 +2,7 @@ from urllib.parse import urljoin
 from uuid import UUID
 
 import pytest
+import reversion
 from django.conf import settings
 from django.forms.models import model_to_dict
 from django.utils.timezone import now
@@ -17,6 +18,7 @@ from reversion.models import Version
 
 from datahub.company.models import Company
 from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.dnb_api.constants import ALL_DNB_UPDATED_MODEL_FIELDS
 from datahub.dnb_api.utils import (
     DNBServiceConnectionError,
     DNBServiceError,
@@ -26,6 +28,8 @@ from datahub.dnb_api.utils import (
     format_dnb_company,
     get_company,
     get_company_update_page,
+    RevisionNotFoundError,
+    rollback_dnb_company_update,
     update_company_from_dnb,
 )
 from datahub.metadata.models import Country
@@ -554,3 +558,74 @@ class TestGetCompanyUpdatePage:
         assert str(excinfo.value) == expected_message
         assert len(caplog.records) == 1
         assert caplog.records[0].getMessage() == expected_message
+
+
+class TestRollbackDNBCompanyUpdate:
+    """
+    Test rollback_dnb_company_update utility function.
+    """
+
+    @pytest.mark.parametrize(
+        'fields, expected_fields',
+        (
+            (None, ALL_DNB_UPDATED_MODEL_FIELDS),
+            (['name'], ['name']),
+        ),
+    )
+    def test_rollback(
+        self,
+        formatted_dnb_company,
+        fields,
+        expected_fields,
+    ):
+        """
+        Test that rollback_dnb_company_update will roll back all DNB fields.
+        """
+        with reversion.create_revision():
+            company = CompanyFactory(duns_number=formatted_dnb_company['duns_number'])
+
+        original_company = Company.objects.get(id=company.id)
+
+        update_company_from_dnb(
+            company,
+            formatted_dnb_company,
+            update_descriptor='foo',
+        )
+
+        rollback_dnb_company_update(company, 'foo', fields_to_update=fields)
+
+        company.refresh_from_db()
+        for field in expected_fields:
+            assert getattr(company, field) == getattr(original_company, field)
+
+        latest_version = Version.objects.get_for_object(company)[0]
+        latest_version.revision.comment = 'Reverted D&B update from: foo'
+
+    @pytest.mark.parametrize(
+        'update_comment, error_message',
+        (
+            ('foo', 'Revision with comment: foo is the base version.'),
+            ('bar', 'Revision with comment: bar not found.'),
+        ),
+    )
+    def test_rollback_error(
+        self,
+        formatted_dnb_company,
+        update_comment,
+        error_message,
+    ):
+        """
+        Test that rollback_dnb_company_update will fail with the given error
+        message when there is an issue in finding the version to revert to.
+        """
+        company = CompanyFactory(duns_number=formatted_dnb_company['duns_number'])
+
+        update_company_from_dnb(
+            company,
+            formatted_dnb_company,
+            update_descriptor='foo',
+        )
+
+        with pytest.raises(RevisionNotFoundError) as e:
+            rollback_dnb_company_update(company, update_comment)
+            assert str(e) == error_message

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -356,7 +356,7 @@ def rollback_dnb_company_update(
     fields_to_update = fields_to_update or ALL_DNB_UPDATED_MODEL_FIELDS
     update_comment = f'Updated from D&B [{update_descriptor}]'
     rollback_version = _get_rollback_version(company, update_comment)
-    fields = rollback_version.field_dict if fields_to_update is None else {
+    fields = {
         name: value
         for name, value in rollback_version.field_dict.items()
         if name in fields_to_update

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -6,10 +6,12 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.timezone import now
 from requests.exceptions import ConnectionError, Timeout
 from rest_framework import serializers, status
+from reversion.models import Version
 
 from datahub.core import statsd
 from datahub.core.api_client import APIClient, TokenAuth
 from datahub.core.serializers import AddressSerializer
+from datahub.dnb_api.constants import ALL_DNB_UPDATED_MODEL_FIELDS
 from datahub.dnb_api.serializers import DNBCompanySerializer
 from datahub.metadata.models import Country
 
@@ -58,6 +60,12 @@ class DNBServiceConnectionError(Exception):
 class DNBServiceTimeoutError(Exception):
     """
     Exception for when a timeout was encountered when connecting to DNB service.
+    """
+
+
+class RevisionNotFoundError(Exception):
+    """
+    Exception for when a revision with the specified comment is not found.
     """
 
 
@@ -319,3 +327,42 @@ def get_company_update_page(last_updated_after, next_page=None):
         raise DNBServiceError(error_message, response.status_code)
 
     return response.json()
+
+
+def _get_rollback_version(company, update_comment):
+    versions = Version.objects.get_for_object(company)
+    for i, version in enumerate(versions):
+        if version.revision.comment == update_comment:
+            if (i + 1) < len(versions):
+                return versions[i + 1]
+            raise RevisionNotFoundError(
+                f'Revision with comment: {update_comment} is the base version.',
+            )
+    raise RevisionNotFoundError(
+        f'Revision with comment: {update_comment} not found.',
+    )
+
+
+def rollback_dnb_company_update(
+    company,
+    update_descriptor,
+    fields_to_update=None,
+):
+    """
+    Given a company, an update descriptor that identifies a particular update
+    patch and fields that default to ALL_DNB_UPDATE_FIELDS, rollback the record
+    to the state before the update was applied.
+    """
+    fields_to_update = fields_to_update or ALL_DNB_UPDATED_MODEL_FIELDS
+    update_comment = f'Updated from D&B [{update_descriptor}]'
+    rollback_version = _get_rollback_version(company, update_comment)
+    fields = rollback_version.field_dict if fields_to_update is None else {
+        name: value
+        for name, value in rollback_version.field_dict.items()
+        if name in fields_to_update
+    }
+    with reversion.create_revision():
+        reversion.set_comment(f'Reverted D&B update from: {update_descriptor}')
+        for field, value in fields.items():
+            setattr(company, field, value)
+        company.save(update_fields=fields)


### PR DESCRIPTION
### Description of change

Add a utility function for rolling back DNB company updates for a given company.

I would recommend reviewing each commit separately.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
