### PR TITLE
Add allow_join_result to avoid RuntimeError

### DIFF
--- a/changelog/company/result-in-task.bugfix.md
+++ b/changelog/company/result-in-task.bugfix.md
@@ -1,0 +1,3 @@
+A bug was fixed that resulted in a runtime error in the `get_company_updates` celery task.
+
+The error happened when `get_company_updates` tried to wait on the results of sub-tasks in order to produce an audit log.

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -2,7 +2,7 @@ from datetime import datetime, time, timedelta
 
 import sentry_sdk
 from celery import shared_task
-from celery.result import ResultSet
+from celery.result import allow_join_result, ResultSet
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.utils.timezone import now
@@ -151,7 +151,9 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
             break
 
     # Wait for all update tasks to finish...
-    ResultSet(results=update_results).join(propagate=False)
+    # TODO: Use disable_sync_subtasks after updating to Celery 4.4
+    with allow_join_result():
+        ResultSet(results=update_results).join(propagate=False)
     _record_audit(update_results, task, start_time)
     logger.info('Finished get_company_updates task')
 

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -521,7 +521,7 @@ class TestGetCompanyUpdates:
             'datahub.dnb_api.tasks.get_company_update_page',
             mock_get_company_update_page,
         )
-        task_result = get_company_updates.apply()
+        task_result = get_company_updates.apply_async()
 
         company.refresh_from_db()
         dnb_company = dnb_company_updates_response_uk['results'][0]


### PR DESCRIPTION
### Description of change

This is a bug that came about because we didn't use `apply_async` in the relevant tests. Fixing the tests exposes the problem.

I have a fix for the problem with a todo note to move to a better fix when we upgrade to Celery 4.4

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
