### PR TITLE
interaction journey sync to company

### DIFF
--- a/changelog/interaction/interaction-sync-export-countries.api.md
+++ b/changelog/interaction/interaction-sync-export-countries.api.md
@@ -1,0 +1,5 @@
+Interactions API `/v3/interaction`, `export_countries` tagged to an interaction are consolidated into `CompanyExportCountry` model, in order to maintain company export countries list. If a country added to an interaction doesn't already exist in company export countries, it will be added. If in case that country already exists, following business rules apply:
+
+* `Status` of `InteractionExportCountry` added to an interaction with current date overrides the entry within `CompanyExportCountry` with older date.
+* Whereas `Status` of `InteractionExportCountry` added to an interaction with past date can't override the entry within `CompanyExportCountry` with newer date.
+* An interaction added with future date, will be treated as current date and existing rules apply.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -419,6 +419,28 @@ class Company(ArchivableModel, BaseModel):
         self.one_list_tier = None
         self.save()
 
+    def add_export_country(self, country, status, record_date, adviser):
+        """
+        Add a company export_country, if it doesn't exist.
+        If the company already exists and incoming status is different
+        check if incoming record is newer and update.
+        """
+        export_country, created = CompanyExportCountry.objects.get_or_create(
+            country=country,
+            company=self,
+            defaults={
+                'status': status,
+                'created_by': adviser,
+                'modified_by': adviser,
+            },
+        )
+
+        if not created:
+            if export_country.status != status and export_country.modified_on < record_date:
+                export_country.status = status
+                export_country.modified_by = adviser
+                export_country.save()
+
 
 class OneListCoreTeamMember(models.Model):
     """

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -10,7 +10,12 @@ from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
 
 from datahub.company.models import Company, CompanyExportCountry
-from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
+from datahub.company.test.factories import (
+    AdviserFactory,
+    CompanyExportCountryFactory,
+    CompanyFactory,
+    ContactFactory,
+)
 from datahub.core.constants import Country, Service
 from datahub.core.test_utils import APITestMixin, create_test_user, random_obj_for_model
 from datahub.event.test.factories import EventFactory
@@ -345,6 +350,150 @@ class TestAddInteraction(APITestMixin):
             'archived_on': None,
             'archived_reason': None,
         }
+
+    @freeze_time('2017-04-18 13:25:30.986208')
+    @pytest.mark.parametrize('permissions', NON_RESTRICTED_ADD_PERMISSIONS)
+    def test_add_interaction_add_company_export_country(self, permissions):
+        """
+        Test add a new interaction with export country
+        make sure it syncs across to company as a new entry.
+        """
+        FeatureFlagFactory(code=INTERACTION_ADD_COUNTRIES, is_active=True)
+        adviser = create_test_user(permission_codenames=permissions, dit_team=TeamFactory())
+        company = CompanyFactory()
+        contact = ContactFactory(company=company)
+        communication_channel = random_obj_for_model(CommunicationChannel)
+
+        url = reverse('api-v3:interaction:collection')
+        request_data = {
+            'kind': Interaction.KINDS.interaction,
+            'communication_channel': communication_channel.pk,
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_participants': [
+                {'adviser': adviser.pk},
+            ],
+            'company': company.pk,
+            'contacts': [contact.pk],
+            'service': Service.inbound_referral.value.id,
+            'was_policy_feedback_provided': False,
+            'theme': Interaction.THEMES.export,
+            'were_countries_discussed': True,
+            'export_countries': [
+                {
+                    'country': {
+                        'id': Country.canada.value.id,
+                    },
+                    'status':
+                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                },
+            ],
+        }
+
+        api_client = self.create_api_client(user=adviser)
+        response = api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        export_countries = company.export_countries.all()
+        assert export_countries.count() == 1
+        assert str(export_countries[0].country.id) == Country.canada.value.id
+        currently_exporting = CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting
+        assert export_countries[0].status == currently_exporting
+
+    @freeze_time('2017-04-18 13:25:30.986208')
+    @pytest.mark.parametrize('permissions', NON_RESTRICTED_ADD_PERMISSIONS)
+    @pytest.mark.parametrize(
+        'export_country_date,interaction_date,expected_status',
+        (
+            # current dated interaction overriding existing older status
+            (
+                '2017-01-18',
+                '2017-04-18',
+                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+            ),
+            # past dated interaction can't override existing newer status
+            (
+                '2017-03-18',
+                '2017-02-18',
+                CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+            ),
+            # future dated interaction, will be treated as current
+            # and can't override existing much newer status
+            (
+                '2017-05-18',
+                '2018-02-18',
+                CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+            ),
+            # future dated interaction, will be treated as current
+            # and will override existing older status
+            (
+                '2017-03-18',
+                '2018-02-18',
+                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+            ),
+        ),
+    )
+    def test_add_interaction_update_company_export_country(
+        self,
+        permissions,
+        export_country_date,
+        interaction_date,
+        expected_status,
+    ):
+        """
+        Test add a new interaction with export country
+        consolidates to company export countries.
+        """
+        FeatureFlagFactory(code=INTERACTION_ADD_COUNTRIES, is_active=True)
+        adviser = create_test_user(permission_codenames=permissions, dit_team=TeamFactory())
+        company = CompanyFactory()
+        with freeze_time(export_country_date):
+            company.export_countries.set([
+                CompanyExportCountryFactory(
+                    company=company,
+                    country=meta_models.Country.objects.get(id=Country.canada.value.id),
+                    status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+                ),
+            ])
+        contact = ContactFactory(company=company)
+        communication_channel = random_obj_for_model(CommunicationChannel)
+
+        url = reverse('api-v3:interaction:collection')
+        request_data = {
+            'date': interaction_date,
+            'kind': Interaction.KINDS.interaction,
+            'communication_channel': communication_channel.pk,
+            'subject': 'whatever',
+            'dit_participants': [
+                {'adviser': adviser.pk},
+            ],
+            'company': company.pk,
+            'contacts': [contact.pk],
+            'service': Service.inbound_referral.value.id,
+            'was_policy_feedback_provided': False,
+            'theme': Interaction.THEMES.export,
+            'were_countries_discussed': True,
+            'export_countries': [
+                {
+                    'country': {
+                        'id': Country.canada.value.id,
+                    },
+                    'status':
+                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                },
+            ],
+        }
+
+        api_client = self.create_api_client(user=adviser)
+        response = api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        export_countries = company.export_countries.all()
+        assert export_countries.count() == 1
+        assert str(export_countries[0].country.id) == Country.canada.value.id
+        assert export_countries[0].status == expected_status
 
     @pytest.mark.parametrize(
         'data,errors',
@@ -1124,9 +1273,9 @@ class TestAddInteraction(APITestMixin):
         }
         errors = {
             'export_countries':
-                ['export_countries fields are not valid when feature flag is off.'],
+                ['export countries related fields are not valid when feature flag is off.'],
             'were_countries_discussed':
-                ['export_countries fields are not valid when feature flag is off.'],
+                ['export countries related fields are not valid when feature flag is off.'],
         }
 
         FeatureFlagFactory(code=INTERACTION_ADD_COUNTRIES, is_active=False)

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -37,6 +37,7 @@ from datahub.interaction.test.permissions import (
 )
 from datahub.interaction.test.views.utils import resolve_data
 from datahub.investment.project.test.factories import InvestmentProjectFactory
+from datahub.metadata import models as meta_models
 from datahub.metadata.test.factories import TeamFactory
 
 


### PR DESCRIPTION
### Description of change
This is third of three PR set, adding export countries to interaction journey.
First one is: https://github.com/uktrade/data-hub-api/pull/2358
Second is: https://github.com/uktrade/data-hub-api/pull/2370

This PR handles consolidation of `InteractionExportCountry` records into `CompanyExportCountry` model, allowing a `Company` to maintain countries with export interest independently.

If a country added to an interaction doesn't already exist at company level, it will be added. If in case that country already exists, following business rules apply:

* `Status` of `InteractionExportCountry` added to an interaction with current date overrides `CompanyExportCountry` with older status.
* Whereas `Status` of `InteractionExportCountry` added to an interaction with past date can't override `CompanyExportCountry` with newer status.
* An interaction added with future dated, will be treated as current date and existing rules apply.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
