### PR TITLE
Bump celery to 4.4

### DIFF
--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -1,7 +1,7 @@
 from datetime import datetime, time, timedelta
 
 from celery import shared_task
-from celery.result import allow_join_result, ResultSet
+from celery.result import ResultSet
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.utils.timezone import now
@@ -141,9 +141,10 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
             break
 
     # Wait for all update tasks to finish...
-    # TODO: Use disable_sync_subtasks after updating to Celery 4.4
-    with allow_join_result():
-        ResultSet(results=update_results).join(propagate=False)
+    ResultSet(results=update_results).join(
+        propagate=False,
+        disable_sync_subtasks=False,
+    )
     _record_audit(update_results, task, start_time)
     logger.info('Finished get_company_updates task')
 

--- a/requirements.in
+++ b/requirements.in
@@ -42,7 +42,7 @@ elasticsearch==6.4.0
 elasticsearch-dsl==6.3.1
 
 # Celery
-celery[redis]==4.3
+celery[redis]==4.4
 billiard==3.6.1.0  # Not used directly, but pinned as it has been a source of breakage in the past
 kombu==4.6.7  # Not used directly, but pinned as it has been a source of breakage in the past
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ backcall==0.1.0           # via ipython
 billiard==3.6.1.0
 boto3==1.10.8
 botocore==1.13.8          # via boto3, s3transfer
-celery[redis]==4.3
+celery[redis]==4.4
 certifi==2019.9.11        # via requests, sentry-sdk
 chardet==3.0.4
 click==7.0                # via pip-tools, towncrier


### PR DESCRIPTION
### Description of change

Bumping Celery to 4.4 in order to get around [this](https://github.com/celery/celery/pull/5435) issue.

Dependabot didn't pick this up because of [this](https://github.com/dependabot/feedback/issues/801) issue.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
