### PR TITLE
Undo DNB updates tool

### DIFF
--- a/changelog/company/undo-dnb-updates-tool.feature.md
+++ b/changelog/company/undo-dnb-updates-tool.feature.md
@@ -1,0 +1,4 @@
+A management command `rollback_dnb_company_updates` was added to revert updates applied
+by either the `update_company_dnb_data` command or the `get_company_updates` task. 
+At present, the rollback command calls a stub function which will be fleshed out later -
+it is not ready for use.

--- a/datahub/dbmaintenance/management/commands/rollback_dnb_company_updates.py
+++ b/datahub/dbmaintenance/management/commands/rollback_dnb_company_updates.py
@@ -1,0 +1,39 @@
+from datahub.company.models import Company
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.dnb_api.utils import rollback_dnb_company_update
+
+
+class Command(CSVBaseCommand):
+    """
+    Command to rollback company updates made from DNB data.
+    """
+
+    help = """
+    Rollback company updates made from DNB data.  This consumes a one-column CSV file from S3 which
+    is a list of company IDs to rollback as well as an update descriptor string.  The command will
+    go through each company to rollback and will re-instate the fields updated by D&B.
+    """
+
+    def add_arguments(self, parser):
+        """
+        Set arguments for the management command.
+        """
+        super().add_arguments(parser)
+        parser.add_argument(
+            '-d',
+            '--update-descriptor',
+            help='The descriptor for the reversion version to rollback.',
+            required=True,
+            type=str,
+        )
+
+    def _process_row(self, row, update_descriptor, simulate=False, **options):
+        """Process one single row."""
+        pk = parse_uuid(row['id'])
+        company = Company.objects.get(pk=pk)
+
+        if simulate:
+            return
+
+        rollback_dnb_company_update(company, update_descriptor)

--- a/datahub/dbmaintenance/test/commands/test_rollback_dnb_company_updates.py
+++ b/datahub/dbmaintenance/test/commands/test_rollback_dnb_company_updates.py
@@ -1,0 +1,96 @@
+from io import BytesIO
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+
+from datahub.company.test.factories import CompanyFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@mock.patch(
+    'datahub.dbmaintenance.management.commands.rollback_dnb_company_updates.'
+    'rollback_dnb_company_update',
+)
+def test_run(mocked_rollback_dnb_company_update, s3_stubber):
+    """
+    Test that the command calls the rollback utility for the specified records.
+    """
+    companies = [
+        CompanyFactory(duns_number='123456789'),
+        CompanyFactory(duns_number='223456789'),
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id
+00000000-0000-0000-0000-000000000000
+{companies[0].id}
+{companies[1].id}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    update_descriptor = 'foobar'
+    call_command(
+        'rollback_dnb_company_updates',
+        bucket,
+        object_key,
+        update_descriptor=update_descriptor,
+    )
+
+    for company in companies:
+        mocked_rollback_dnb_company_update.assert_any_call(company, update_descriptor)
+
+
+@mock.patch(
+    'datahub.dbmaintenance.management.commands.rollback_dnb_company_updates.'
+    'rollback_dnb_company_update',
+)
+def test_simulate(mocked_rollback_dnb_company_update, s3_stubber):
+    """
+    Test that the command simulates rollbacks if --simulate is passed in.
+    """
+    companies = [
+        CompanyFactory(duns_number='123456789'),
+        CompanyFactory(duns_number='223456789'),
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id
+00000000-0000-0000-0000-000000000000
+{companies[0].id}
+{companies[1].id}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command(
+        'rollback_dnb_company_updates',
+        bucket,
+        object_key,
+        update_descriptor='foobar',
+        simulate=True,
+    )
+
+    assert not mocked_rollback_dnb_company_update.called


### PR DESCRIPTION
### Description of change

A management command `rollback_dnb_company_updates` was added to revert updates applied by either the `update_company_dnb_data` command or the `get_company_updates` task. 
At present, the rollback command calls a stub function which will be fleshed out later - it is not ready for use.


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
