### PR TITLE
Unify release scripts error-handling code

### DIFF
--- a/scripts/create_release_pr.py
+++ b/scripts/create_release_pr.py
@@ -22,6 +22,7 @@ import subprocess
 import webbrowser
 from urllib.parse import quote, urlencode
 
+from script_utils.command import CommandError, print_error
 from script_utils.git import (
     any_uncommitted_changes,
     local_branch_exists,
@@ -46,10 +47,6 @@ steps.
 parser = argparse.ArgumentParser(
     description='Create and push a release branch for the current version.',
 )
-
-
-class CommandError(Exception):
-    """A fatal error when running the script."""
 
 
 def create_release_branch():
@@ -119,7 +116,7 @@ def main():
     try:
         branch_name = create_release_branch()
     except (CommandError, subprocess.CalledProcessError) as exc:
-        print(f'ERROR: {exc}')  # noqa: T001
+        print_error(exc)
         return
 
     print(  # noqa: T001

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -24,6 +24,7 @@ import subprocess
 import webbrowser
 from urllib.parse import quote, urlencode
 
+from script_utils.command import CommandError, print_error
 from script_utils.git import any_uncommitted_changes, local_branch_exists, remote_branch_exists
 from script_utils.news_fragments import list_news_fragments
 from script_utils.versioning import (
@@ -39,10 +40,6 @@ parser = argparse.ArgumentParser(
     description='Bump the version, update the changelog and open a PR.',
 )
 parser.add_argument('release_type', type=ReleaseType, choices=ReleaseType.__members__.values())
-
-
-class CommandError(Exception):
-    """A fatal error when running the script."""
 
 
 def prepare_release(release_type):
@@ -114,7 +111,7 @@ def main():
     try:
         branch_name = prepare_release(args.release_type)
     except (CommandError, subprocess.CalledProcessError) as exc:
-        print(f'ERROR: {exc}')  # noqa: T001
+        print_error(exc)
         return
 
     print(  # noqa: T001

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -29,6 +29,7 @@ import requests
 from requests import HTTPError
 
 from script_utils.changelog import extract_version_changelog
+from script_utils.command import CommandError, print_error
 from script_utils.git import get_file_contents, remote_tag_exists
 
 GITHUB_RELEASE_API_URL = 'https://api.github.com/repos/uktrade/data-hub-api/releases'
@@ -43,10 +44,6 @@ using the GITHUB_TOKEN environment variable. If that variable is not set, you wi
 for a token.
 """,
 )
-
-
-class CommandError(Exception):
-    """A fatal error when running the script."""
 
 
 def publish_release():
@@ -100,13 +97,7 @@ def main():
     try:
         tag = publish_release()
     except (CommandError, HTTPError, subprocess.CalledProcessError) as exc:
-        messages = [f'ERROR: {exc}']
-
-        if isinstance(exc, HTTPError) and exc.response is not None:
-            response_data = exc.response.json()
-            messages.append(f'Response: {response_data}')
-
-        print(*messages, sep='\n')  # noqa: T001
+        print_error(exc)
         return
 
     print(  # noqa: T001

--- a/scripts/script_utils/command.py
+++ b/scripts/script_utils/command.py
@@ -1,0 +1,22 @@
+from subprocess import CalledProcessError
+
+from requests import HTTPError
+
+
+class CommandError(Exception):
+    """A fatal error when running a command."""
+
+
+def print_error(exc):
+    """Print an error that occurred when running a command."""
+    messages = [f'ERROR: {exc}']
+
+    if isinstance(exc, CalledProcessError) and exc.stderr:
+        stderr = exc.stderr.decode(errors='replace')
+        messages.append(f'Standard error: {stderr}')
+
+    if isinstance(exc, HTTPError) and exc.response is not None:
+        response_data = exc.response.json()
+        messages.append(f'Response: {response_data}')
+
+    print(*messages, sep='\n')  # noqa: T001

--- a/scripts/script_utils/test/test_command.py
+++ b/scripts/script_utils/test/test_command.py
@@ -1,0 +1,51 @@
+from subprocess import CalledProcessError
+from unittest.mock import Mock
+
+import pytest
+from requests import HTTPError
+
+from script_utils.command import CommandError, print_error
+
+
+@pytest.mark.parametrize(
+    'exc,expected_output',
+    [
+        (
+            CommandError('Test error'),
+            'ERROR: Test error\n',
+        ),
+        (
+            CalledProcessError(1, 'some-command'),
+            """ERROR: Command 'some-command' returned non-zero exit status 1.\n""",
+        ),
+        (
+            CalledProcessError(1, 'some-command', stderr=b'some error'),
+            """ERROR: Command 'some-command' returned non-zero exit status 1.
+Standard error: some error
+""",
+        ),
+        (
+            HTTPError('some error'),
+            'ERROR: some error\n',
+        ),
+        (
+            HTTPError(
+                'some error',
+                response=Mock(
+                    json=Mock(return_value={'error': 'message'}),
+                    # If the status code is an error code, Response.__bool__() will return False
+                    __bool__=Mock(return_value=False),
+                ),
+            ),
+            """ERROR: some error
+Response: {'error': 'message'}
+""",
+        ),
+    ],
+)
+def test_print_error(exc, expected_output, capsys):
+    """Test that print_error() prints the expected message for various exceptions."""
+    print_error(exc)
+
+    stdout, _ = capsys.readouterr()
+    assert expected_output == stdout


### PR DESCRIPTION
### Description of change

This unifies some of the error handling code in the release scripts to cut down on repetition.

This also amends the error handler to print the contents of stderr if a sub-process fails and stderr was captured.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
