### PR TITLE
Update release instructions

### DIFF
--- a/docs/How to prepare a release.md
+++ b/docs/How to prepare a release.md
@@ -11,7 +11,7 @@ As a general guide:
 * if it contains breaking API changes, then it's a major version
 * anything else is a minor version 
 
-You can run `towncrier --draft --version draft` to generate a draft changelog and help you decide.
+You can run `towncrier --draft --version draft` to generate a draft changelog, or [look at the difference between develop and master](https://github.com/uktrade/data-hub-api/compare/develop...master), to help you decide.
 
 ## Bump the version and update the changelog
 
@@ -21,6 +21,8 @@ Once you've reviewed the draft changelog and decided on the release type, you ca
 scripts/prepare_release.py <major|minor|patch>
 ```
 
+<details>
+<summary>What the command does</summary>
 The command will:
 
 - determine the new version number
@@ -29,17 +31,16 @@ The command will:
 - commit the changes
 - push the branch
 - open your browser window ready to create a PR
+</details>
 
-If the command fails, review the error and investigate.
+If the command succeeds, it will open your web browser ready to create a PR to merge `changelog/<version>` into 
+`develop`.
 
-In your web browser, check the changelog preview, and then open a PR to merge `changelog/<version>` 
-into `develop`.
-
-Assign at least two developers for review.
+Check the changelog preview is as expected, add at least two developers as reviewers and click 'Create pull request'.
 
 When ready, merge `changelog/<version>` into `develop` and delete the merged branch.
 
-## Prepare the release
+## Create the release PR
 
 Create and push a release branch from develop by running:
 
@@ -47,45 +48,31 @@ Create and push a release branch from develop by running:
 scripts/create_release_pr.py
 ```
 
+<details>
+<summary>What the command does</summary>
 The command will:
 
 - run `git fetch`
 - create a branch `release/<version>` based on `origin/develop`
 - push this branch
 - open a web browser window to the create PR page for the pushed branch (with `master` as the base branch)
+</details>
 
-Once your web browser has opened, double-check that the details are correct and that the base branch is set to `master`.
+If the command succeeds, it will open your web browser ready to create a PR to merge `release/<version>` into `master`. 
+
+Double-check that the details are correct and that the base branch is set to `master`.
 
 Add at least two developers as reviewers and click 'Create pull request'.
 
-## Release to staging
+## Deploy to staging
 
 After the PR has been reviewed, merge it into `master` and delete the merged branch.
 The release will be automatically deployed to staging via Jenkins.
 Check that everything looks fine before proceeding.
 
-## Release to production
-Releasing to production happens manually but after it has been announced and approved by the Live Services Team.
+## Tag and publish the release on GitHub
 
-Post in the `#data-hub` slack channel the following (replace `<version>` with the version number and `<service-manager>` with the person resposible for approvals):
-
-```
-@here Data Hub API version <version> is ready to be deployed. Please check the release notes to know how this will affect you: https://github.com/uktrade/data-hub-api/blob/master/CHANGELOG.md. @<service-manager> Are you happy for us to release?
-```
-
-After the approval, the release can be deployed.
-
-In jenkins, go to the _datahub_ tab, the _datahub-api_ project and click on _Build with Parameters_.
-
-Type the following:
-* **environment**: `production`
-* **git commit**: `master`
-
-Click on `build`, follow the deployment and check that everything looks fine after it finishes.
-
-## Publish the release on GitHub
-
-The final step is to publish the release on GitHub. To do this, you will need to [generate a GitHub personal access 
+Following the automatic staging deployment, the next step is create a release on GitHub. To do this, you will need to [generate a GitHub personal access 
 token](https://github.com/settings/tokens) with the `public_repo` scope.
 
 Once you have this, you can either set it in the `GITHUB_TOKEN` environment variable, or enter it when prompted.
@@ -96,7 +83,7 @@ When you have a token, run:
 scripts/publish_release.py
 ```
 
-This will create and publish the release on GitHub and open it in your web browser. 
+This will tag, create and publish the release on GitHub and open it in your web browser. 
 
 <details>
 <summary>If you are unable to use the script</summary>
@@ -115,3 +102,23 @@ And click on _Publish release_.
 For more information see the [GitHub documentation](https://help.github.com/articles/creating-releases/).
 
 </details>
+
+## Deploy to production
+Deployment to production happens manually but after the release has been announced on Slack.
+
+Post in the `#data-hub` slack channel the following (replacing `<version>` with the version number):
+
+```
+@here Data Hub API version <version> is ready to be deployed to production. Have a look at the release notes to see how this will affect you: https://github.com/uktrade/data-hub-api/blob/master/CHANGELOG.md.
+Will deploy in 30 minutes or so if no objections.
+```
+
+If no objections are received, the release can be deployed to production.
+
+In Jenkins, go to the _datahub_ tab, the _datahub-api_ project and click on _Build with Parameters_.
+
+Type the following:
+* **environment**: `production`
+* **git commit**: `master`
+
+Click on `build`, follow the deployment and check that everything looks fine after it finishes.


### PR DESCRIPTION
### Description of change

This makes some proposed changes to the release instructions. The main changes are:

- moving the publish release step before the deploy to production step, so that the release is tagged before it is deployed to production (as this seems more logical)
- updating the deploy to production section to more closely reflect current practices
- adding a link to the diff between develop and master to the 'Decide on the release type' section
- putting some less interesting details in `<details>` tags

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
