### PR TITLE
Add additional query utilities

### DIFF
--- a/changelog/query-utils.internal.md
+++ b/changelog/query-utils.internal.md
@@ -1,0 +1,3 @@
+The following internal query utilities were added:
+
+- `get_array_agg_subquery()`

--- a/changelog/query-utils.internal.md
+++ b/changelog/query-utils.internal.md
@@ -1,3 +1,4 @@
 The following internal query utilities were added:
 
 - `get_array_agg_subquery()`
+- `JSONBBuildObject`

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.contrib.postgres.aggregates import StringAgg
+from django.contrib.postgres.aggregates import ArrayAgg, StringAgg
 from django.db.models import Case, CharField, F, Func, OuterRef, Subquery, Value, When
 from django.db.models.functions import Coalesce, Concat, NullIf
 
@@ -46,7 +46,53 @@ def get_string_agg_subquery(model, expression, delimiter=', ', distinct=False):
     )
 
 
-def get_aggregate_subquery(model, expression):
+def get_array_agg_subquery(
+    model,
+    join_field_name,
+    expression_to_aggregate,
+    distinct=False,
+    ordering=(),
+):
+    """
+    Get a subquery that aggregates values from a to-many relation as an array.
+
+    Can be used with a many-to-many through model, or any other model with a foreign key to the
+    model being annotated.
+
+    Usage examples:
+
+        Interaction.objects.annotate(
+            contact_first_names=get_array_agg_subquery(
+                Interaction.contacts.through,
+                'interaction',
+                'first_name',
+            ),
+        )
+
+        Interaction.objects.annotate(
+            adviser_first_names=get_array_agg_subquery(
+                InteractionDITParticipant,
+                'interaction',
+                'first_name',
+            ),
+        )
+
+    Note: The usage of this function differs from `get_string_agg_subquery()`, as this function
+    omits the outer model from the subquery to avoid unwanted NULL values appearing in the
+    returned arrays when rows don't have any values in the intermediate model being queried.
+
+    For example, this makes sure an annotation on interaction contacts gets a value of [] if
+    the interaction doesn't have any contacts. (If the Interaction model were included in the
+    subquery, the annotation value would instead be [None].)
+    """
+    return get_aggregate_subquery(
+        model,
+        ArrayAgg(expression_to_aggregate, distinct=distinct, ordering=ordering),
+        join_field_name=join_field_name,
+    )
+
+
+def get_aggregate_subquery(model, expression, join_field_name='pk'):
     """
     Gets a subquery that calculates an aggregate value of a to-many field.
 
@@ -63,10 +109,15 @@ def get_aggregate_subquery(model, expression):
     if not getattr(expression, 'contains_aggregate', False):
         raise ValueError('An aggregate expression must be provided.')
 
-    queryset = model.objects.annotate(
+    # For an explanation of the operations here, see
+    # https://docs.djangoproject.com/en/2.2/ref/models/expressions/#using-aggregates-within-a-subquery-expression
+    queryset = model.objects.filter(
+        **{join_field_name: OuterRef('pk')},
+    ).order_by(
+    ).values(
+        join_field_name,
+    ).annotate(
         _annotated_value=expression,
-    ).filter(
-        pk=OuterRef('pk'),
     ).values(
         '_annotated_value',
     )

--- a/datahub/core/test/test_query_utils.py
+++ b/datahub/core/test/test_query_utils.py
@@ -19,11 +19,27 @@ from datahub.core.query_utils import (
     get_queryset_object,
     get_string_agg_subquery,
     get_top_related_expression_subquery,
+    JSONBBuildObject,
 )
 from datahub.core.test.support.factories import BookFactory, PersonFactory, PersonListItemFactory
 from datahub.core.test.support.models import Book, Person, PersonListItem
 
 pytestmark = pytest.mark.django_db
+
+
+class TestJSONBBuildObject:
+    """Tests for JSONBBuildObject."""
+
+    def test_as_annotation(self):
+        """Test that the function can be used as an annotation."""
+        person = PersonFactory()
+        queryset = Person.objects.annotate(
+            data=JSONBBuildObject(first_name='first_name', last_name='last_name'),
+        )
+        assert queryset.first().data == {
+            'first_name': person.first_name,
+            'last_name': person.last_name,
+        }
 
 
 class TestGetStringAggSubquery:


### PR DESCRIPTION
### Description of change

This adds two new query utilities:

- `get_array_agg_subquery()` – this is similar to `get_string_agg_subquery()` except that it outputs an array
- `JSONBBuildObject` – this is a function that builds a JSONB value from other expressions

I'm planning to use these to efficiently get a list of (adviser name, team name) pairs for the latest interaction of each company returned in the `/v4/company-list/<pk>/item` endpoint.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
