### PR TITLE
Deprecate dnb-match endpoints

### DIFF
--- a/changelog/dnb-match.deprecation.md
+++ b/changelog/dnb-match.deprecation.md
@@ -1,0 +1,5 @@
+The following `dnb-match` endpoints will be deprecated on or after 5 January 2020:
+
+- `GET v4/dnb-match/<uuid:company_pk>`
+- `POST v4/dnb-match/<uuid:company_pk>/select-match`
+- `POST v4/dnb-match/<uuid:company_pk>/select-no-match`


### PR DESCRIPTION
### Description of change

This deprecates:

- `GET v4/dnb-match/<uuid:company_pk>`
- `POST v4/dnb-match/<uuid:company_pk>/select-match`
- `POST v4/dnb-match/<uuid:company_pk>/select-no-match`

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
