### PR TITLE
Update to Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 
 # libyaml-dev is required for watchdog (celery auto-reloader)
 RUN apt-get update && apt-get install -y wget libyaml-dev

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This project uses Docker compose to setup and run all the necessary components. 
 
 Dependencies:
 
--   Python 3.7.x
+-   Python 3.8.x
 -   PostgreSQL 10 (note: PostgreSQL 9.6 is used for the MI database)
 -   redis 3.2
 -   Elasticsearch 6.8
@@ -75,7 +75,7 @@ Dependencies:
     cd data-hub-api
     ```
 
-2.  Install Python 3.7.
+2.  Install Python 3.8.
 
     [See this guide](https://docs.python-guide.org/starting/installation/) for detailed instructions for different platforms.
 
@@ -84,7 +84,7 @@ Dependencies:
     On Ubuntu:
 
     ```shell
-    sudo apt install build-essential libpq-dev python3.7-dev python3.7-venv
+    sudo apt install build-essential libpq-dev python3.8-dev python3.8-venv
     ```
 
     On macOS:
@@ -96,7 +96,7 @@ Dependencies:
 4.  Create and activate the virtualenv:
 
     ```shell
-    python3.7 -m venv env
+    python3.8 -m venv env
     source env/bin/activate
     pip install -U pip
     ```

--- a/changelog/python-3.8.feature.md
+++ b/changelog/python-3.8.feature.md
@@ -1,0 +1,1 @@
+Python was updated from version 3.7.5 to 3.8.1. This includes updating various indirect dependencies.

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -16,7 +16,7 @@ class StrEnum(str, Enum):
     """
     Enum subclass where members are also str instances.
 
-    Defined as per https://docs.python.org/3.7/library/enum.html#others
+    Defined as per https://docs.python.org/3.8/library/enum.html#others
     """
 
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
-- buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.7.3
+- buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.7.5
   stack: cflinuxfs3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,11 +13,11 @@ billiard==3.6.1.0
 boto3==1.10.46
 botocore==1.13.46         # via boto3, s3transfer
 celery[redis]==4.4
-certifi==2019.9.11        # via requests, sentry-sdk
+certifi==2019.11.28       # via requests, sentry-sdk
 chardet==3.0.4
 click==7.0                # via pip-tools, towncrier
-coverage==4.5.4           # via pytest-cov
-decorator==4.4.0          # via ipython, traitlets
+coverage==5.0.2           # via pytest-cov
+decorator==4.4.1          # via ipython, traitlets
 django-admin-ip-restrictor==1.0.0
 django-debug-toolbar==2.1
 django-environ==0.4.5
@@ -40,7 +40,7 @@ elasticsearch==6.4.0
 entrypoints==0.3          # via flake8
 execnet==1.7.1            # via pytest-xdist
 factory-boy==2.12.0
-faker==2.0.3              # via factory-boy
+faker==3.0.0              # via factory-boy
 flake8-blind-except==0.1.1
 flake8-bugbear==20.1.2
 flake8-commas==2.0.0
@@ -53,18 +53,18 @@ flake8-quotes==2.1.1
 flake8-string-format==0.2.3
 flake8==3.7.9
 freezegun==0.3.12
-future==0.18.1            # via notifications-python-client
+future==0.18.2            # via notifications-python-client
 gevent==1.4.0
 greenlet==0.4.15          # via gevent
 gunicorn==20.0.4
 icalendar==4.0.4
 idna==2.8                 # via requests
-importlib-metadata==0.23  # via kombu, pluggy, pytest
+importlib-metadata==1.3.0  # via kombu, pluggy, pytest
 incremental==17.5.0       # via towncrier
 ipaddress==1.0.23         # via mail-parser
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.11.1
-jedi==0.15.1              # via ipython
+jedi==0.15.2              # via ipython
 jinja2==2.10.3            # via towncrier
 jmespath==0.9.4           # via boto3, botocore
 kombu==4.6.7
@@ -73,29 +73,29 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 mohawk==1.1.0
 monotonic==1.5            # via notifications-python-client
-more-itertools==7.2.0     # via pytest, zipp
+more-itertools==8.0.2     # via pytest, zipp
 notifications-python-client==5.4.1
 oauthlib==2.1.0
-packaging==19.2           # via pytest, pytest-sugar
-parso==0.5.1              # via jedi
+packaging==20.0           # via pytest, pytest-sugar
+parso==0.5.2              # via jedi
 pathtools==0.1.2          # via watchdog
 pep8-naming==0.9.1
 pexpect==4.7.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pip-tools==4.3.0
 piprot==0.9.11
-pluggy==0.13.0            # via pytest
-prompt-toolkit==2.0.10    # via ipython
+pluggy==0.13.1            # via pytest
+prompt-toolkit==3.0.2     # via ipython
 psycogreen==1.0.1
 psycopg2==2.8.4
 ptyprocess==0.6.0         # via pexpect
-py==1.8.0                 # via pytest
+py==1.8.1                 # via pytest
 pycodestyle==2.5.0        # via flake8, flake8-debugger, flake8-import-order, flake8-print
 pydocstyle==5.0.1
 pyflakes==2.1.1           # via flake8
-pygments==2.4.2           # via ipython
+pygments==2.5.2           # via ipython
 pyjwt==1.7.1              # via notifications-python-client
-pyparsing==2.4.2          # via packaging
+pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
 pytest-django==3.7.0
 pytest-forked==1.1.3      # via pytest-xdist
@@ -113,8 +113,8 @@ requests_toolbelt==0.9.1
 s3transfer==0.2.1         # via boto3
 semantic_version==2.8.4
 sentry_sdk==0.13.5
-simplejson==3.16.0        # via mail-parser
-six==1.12.0               # via django-extensions, django-pglocks, elasticsearch-dsl, faker, flake8-print, freezegun, mail-parser, mohawk, packaging, pip-tools, piprot, prompt-toolkit, pytest-xdist, python-dateutil, requests-mock, traitlets
+simplejson==3.17.0        # via mail-parser
+six==1.13.0               # via django-extensions, django-pglocks, elasticsearch-dsl, faker, flake8-print, freezegun, mail-parser, mohawk, packaging, pip-tools, piprot, pytest-xdist, python-dateutil, requests-mock, traitlets
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.0           # via django, django-debug-toolbar
 statsd==3.3.0
@@ -124,10 +124,10 @@ toml==0.10.0              # via towncrier
 towncrier==19.2.0
 traitlets==4.3.3          # via ipython
 uritemplate==3.0.1
-urllib3==1.25.6           # via botocore, elasticsearch, requests, sentry-sdk
+urllib3==1.25.7           # via botocore, elasticsearch, requests, sentry-sdk
 vine==1.3.0               # via amqp, celery
 watchdog==0.9.0
-wcwidth==0.1.7            # via prompt-toolkit, pytest
+wcwidth==0.1.8            # via prompt-toolkit, pytest
 werkzeug==0.16.0
 whitenoise==5.0.1
 zipp==0.6.0               # via importlib-metadata

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.5
+python-3.8.1


### PR DESCRIPTION
### Description of change

This updates Python from version 3.7 to version 3.8.

For native local environments, you can follow the guide here to install Python 3.8:

https://docs.python-guide.org/starting/installation/#python-3-installation-guides

(For Ubuntu 18.04 and 19.10, it should be available without using a PPA.)

You will probably want to create a new virtual environment after installing Python 3.8 – refer to the README for more detailed set-up instructions.

(I have updated indirect dependencies as well, just in case there were any unknown Python 3.8 problems lurking in them...)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
