### PR TITLE
Use correct field for `possible_uk_regions`

### DIFF
--- a/changelog/investment/dataset-api-endpoint-uk-region-location-names.api.md
+++ b/changelog/investment/dataset-api-endpoint-uk-region-location-names.api.md
@@ -1,0 +1,1 @@
+`GET /v4/dataset/investment-projects-dataset`: The `allow_blank_possible_uk_regions` field was removed and replaced with `uk_region_location_names`.

--- a/datahub/dataset/investment_project/test/test_views.py
+++ b/datahub/dataset/investment_project/test/test_views.py
@@ -31,7 +31,6 @@ def get_expected_data_from_project(project):
         'address_2': project.address_2,
         'address_town': project.address_town,
         'address_postcode': project.address_postcode,
-        'allow_blank_possible_uk_regions': project.allow_blank_possible_uk_regions,
         'anonymous_description': project.anonymous_description,
         'associated_non_fdi_r_and_d_project_id': str_or_none(
             project.associated_non_fdi_r_and_d_project_id,
@@ -117,6 +116,10 @@ def get_expected_data_from_project(project):
         'total_investment': float(project.total_investment) if project.total_investment else None,
         'uk_company_id': str_or_none(project.uk_company_id),
         'uk_company_sector': get_attr_or_none(project, 'uk_company.sector.name'),
+        'uk_region_location_names': (
+            join_attr_values(project.uk_region_locations.order_by('name'))
+            if project.uk_region_locations.exists() else None
+        ),
     }
 
 

--- a/datahub/dataset/investment_project/views.py
+++ b/datahub/dataset/investment_project/views.py
@@ -49,6 +49,9 @@ class InvestmentProjectsDatasetView(BaseDatasetView):
                 ArrayAgg('team_members__adviser_id', ordering=('team_members__id',)),
             ),
             uk_company_sector=get_sector_name_subquery('uk_company__sector'),
+            uk_region_location_names=get_investment_project_to_many_string_agg_subquery(
+                'uk_region_locations__name',
+            ),
         ).values(
             'actual_land_date',
             'actual_uk_region_names',
@@ -56,7 +59,6 @@ class InvestmentProjectsDatasetView(BaseDatasetView):
             'address_2',
             'address_town',
             'address_postcode',
-            'allow_blank_possible_uk_regions',
             'anonymous_description',
             'associated_non_fdi_r_and_d_project_id',
             'average_salary__name',
@@ -109,4 +111,5 @@ class InvestmentProjectsDatasetView(BaseDatasetView):
             'total_investment',
             'uk_company_id',
             'uk_company_sector',
+            'uk_region_location_names',
         )


### PR DESCRIPTION
### Description of change

- Removes the `allow_blank_possible_uk_regions` field as it is not needed on data workspace.
- Adds the field `uk_region_location_names` which is required for monthly FDI reporting.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
