### PR TITLE
Add interaction DIT participants to company list item endpoint

### DIFF
--- a/changelog/adviser/company-list-advisers.api.md
+++ b/changelog/adviser/company-list-advisers.api.md
@@ -1,0 +1,25 @@
+`GET /v4/company-list/<pk>/item`: The latest interaction of each list item now includes an array of DIT participants in the `dit_participants` field. In context, the field has the following structure:
+
+```json
+{
+    "results": [
+        {
+            "latest_interaction": {
+                "dit_participants": [
+                    {
+                       "adviser": {
+                           "id": ...,
+                           "name": ...
+                       },
+                       "team": {
+                           "id": ...,
+                           "name": ...
+                       }
+                    },
+                    ...
+                ]
+            }
+        }
+    ]
+}
+```

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -116,9 +116,11 @@ def get_array_agg_subquery(
     omits the outer model from the subquery to avoid unwanted NULL values appearing in the
     returned arrays when rows don't have any values in the intermediate model being queried.
 
-    For example, this makes sure an annotation on interaction contacts gets a value of [] if
-    the interaction doesn't have any contacts. (If the Interaction model were included in the
-    subquery, the annotation value would instead be [None].)
+    For example, this makes sure an annotation on interaction contacts doesn't get a value of
+    [None] if the interaction doesn't have any contacts.
+
+    Note, however, if there are no array values, the value of the annotation will be None and
+    not []. (If [] is desired, Coalesce can be used.)
     """
     return get_aggregate_subquery(
         model,

--- a/datahub/user/company_list/queryset.py
+++ b/datahub/user/company_list/queryset.py
@@ -1,8 +1,13 @@
-from django.db.models import DurationField, ExpressionWrapper, F
+from django.db.models import Case, DurationField, ExpressionWrapper, F, Q, When
 from django.db.models.functions import Now
 
-from datahub.core.query_utils import get_top_related_expression_subquery
-from datahub.interaction.models import Interaction
+from datahub.core.query_utils import (
+    get_array_agg_subquery,
+    get_full_name_expression,
+    get_top_related_expression_subquery,
+    JSONBBuildObject,
+)
+from datahub.interaction.models import Interaction, InteractionDITParticipant
 from datahub.user.company_list.models import CompanyListItem
 
 
@@ -20,6 +25,29 @@ def get_company_list_item_queryset():
         latest_interaction_created_on=_get_field_of_latest_interaction('created_on'),
         latest_interaction_date=_get_field_of_latest_interaction('date'),
         latest_interaction_subject=_get_field_of_latest_interaction('subject'),
+        latest_interaction_dit_participants=_get_field_of_latest_interaction(
+            get_array_agg_subquery(
+                InteractionDITParticipant,
+                'interaction',
+                JSONBBuildObject(
+                    adviser=_get_null_when_expression(
+                        JSONBBuildObject(
+                            id='adviser__id',
+                            name=get_full_name_expression('adviser'),
+                        ),
+                        Q(adviser__isnull=True),
+                    ),
+                    team=_get_null_when_expression(
+                        JSONBBuildObject(
+                            id='team__id',
+                            name='team__name',
+                        ),
+                        Q(team__isnull=True),
+                    ),
+                ),
+                ordering=('pk',),
+            ),
+        ),
         latest_interaction_time_ago=ExpressionWrapper(
             Now() - F('latest_interaction_date'),
             output_field=DurationField(),
@@ -32,7 +60,17 @@ def get_company_list_item_queryset():
 def _get_field_of_latest_interaction(field):
     return get_top_related_expression_subquery(
         Interaction.company.field,
-        F(field),
+        field,
         ('-date', '-created_on', 'pk'),
         outer_field='company_id',
+    )
+
+
+def _get_null_when_expression(expression, null_when_condition):
+    return Case(
+        When(
+            null_when_condition,
+            then=None,
+        ),
+        default=expression,
     )

--- a/datahub/user/company_list/queryset.py
+++ b/datahub/user/company_list/queryset.py
@@ -54,6 +54,15 @@ def get_company_list_item_queryset():
         ),
     ).select_related(
         'company',
+    ).only(
+        # Only select the fields we need to reduce data transfer time for large lists
+        # (in particular, companies have a lot of fields which are not needed here)
+        'id',
+        'created_on',
+        'company__id',
+        'company__archived',
+        'company__name',
+        'company__trading_names',
     )
 
 

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -45,6 +45,7 @@ class CompanyListItemSerializer(serializers.ModelSerializer):
             # See InteractionSerializer for more information
             'date': obj.latest_interaction_date.date(),
             'subject': obj.latest_interaction_subject,
+            'dit_participants': obj.latest_interaction_dit_participants or [],
         }
 
     class Meta:

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -26,6 +26,8 @@ class CompanyListItemSerializer(serializers.ModelSerializer):
 
     company = NestedRelatedField(
         Company,
+        # If this list of fields is changed, update the equivalent list in the QuerySet.only()
+        # call in the queryset module
         extra_fields=('archived', 'name', 'trading_names'),
     )
     latest_interaction = serializers.SerializerMethodField()


### PR DESCRIPTION
### Description of change

This adds a list of DIT participants to the latest interaction of each company returned by `GET /v4/company-list/<pk>/item`.

As a reminder, the retrieval of this data is done in the main query to avoid doing individual queries for each company list item. This was tricky in this case, as each interaction can have multiple participants. I came up with a somewhat creative solution of combining `ArrayAgg` and `JSONBBuildObject` to do this.

From checking one of the current worst cases in production, the execution time of the query according to `EXPLAIN ANALYSE` goes up from around 4ms to 9ms (which is still fast).

(As far as I can see, the bulk of query time is spent on data transfer, so I also added an optimisation for that to optimise that.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
