### PR TITLE
Add companies postcode filter

### DIFF
--- a/changelog/company/company-search-postcode-filter.api.md
+++ b/changelog/company/company-search-postcode-filter.api.md
@@ -1,0 +1,3 @@
+`POST /v4/search/company`: A `uk_postcode` filter was added for the `address_postcode` and `registered_address_postcode` 
+fields for UK based companies. The filter accepts a single or a partial postcode as well as an array of postcodes. 
+Multiple postcodes are matched with `or` query.

--- a/changelog/elasticsearch-postcode-improvement.internal.md
+++ b/changelog/elasticsearch-postcode-improvement.internal.md
@@ -1,0 +1,4 @@
+`Elasticsearch`: The new `postcode_analyzer` and `postcode_search_analyzer` analyzers were added. Analyzers can be used 
+to enable partial search for area, district, sub-district, sector and a whole postcode. 
+
+The search is case insensitive and any spaces are filtered out before analysis.

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -109,6 +109,8 @@ class Company(BaseESModel):
     turnover_range = fields.id_name_field()
     uk_region = fields.id_name_field()
     uk_based = Boolean()
+    uk_address_postcode = fields.PostcodeKeyword()
+    uk_registered_address_postcode = fields.PostcodeKeyword()
     vat_number = Keyword(index=False)
     duns_number = Keyword()
     website = Text()
@@ -131,6 +133,9 @@ class Company(BaseESModel):
             dict_utils.contact_or_adviser_dict,
         ),
         'latest_interaction_date': lambda obj: obj.latest_interaction_date,
+        'uk_address_postcode': lambda obj: obj.address_postcode if obj.uk_based else '',
+        'uk_registered_address_postcode':
+            lambda obj: obj.registered_address_postcode if obj.uk_based else '',
     }
 
     MAPPINGS = {

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -30,6 +30,7 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
     )
     latest_interaction_date_after = RelaxedDateField(required=False)
     latest_interaction_date_before = RelaxedDateField(required=False)
+    uk_postcode = SingleOrListField(child=serializers.CharField(), required=False)
 
     SORT_BY_FIELDS = (
         'modified_on',

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -18,7 +18,6 @@ def test_mapping(es):
         CompanySearchApp.es_model.get_write_index(),
         CompanySearchApp.name,
     )
-
     assert mapping.to_dict() == {
         'company': {
             'dynamic': 'false',
@@ -217,6 +216,16 @@ def test_mapping(es):
                             },
                         },
                     },
+                },
+                'uk_address_postcode': {
+                    'analyzer': 'postcode_analyzer',
+                    'search_analyzer': 'postcode_search_analyzer',
+                    'type': 'text',
+                },
+                'uk_registered_address_postcode': {
+                    'analyzer': 'postcode_analyzer',
+                    'search_analyzer': 'postcode_search_analyzer',
+                    'type': 'text',
                 },
                 'one_list_group_global_account_manager': {
                     'properties': {
@@ -558,6 +567,8 @@ def test_indexed_doc(es):
         'turnover_range',
         'uk_based',
         'uk_region',
+        'uk_address_postcode',
+        'uk_registered_address_postcode',
         'vat_number',
         'duns_number',
         'website',

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -53,6 +53,8 @@ class TestCompanyElasticModel:
             'turnover_range',
             'uk_based',
             'uk_region',
+            'uk_address_postcode',
+            'uk_registered_address_postcode',
             'vat_number',
             'duns_number',
             'website',

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -40,6 +40,10 @@ class SearchCompanyAPIViewMixin:
     es_sort_by_remappings = {
         'name': 'name.keyword',
     }
+    fields_to_exclude = (
+        'uk_address_postcode',
+        'uk_registered_address_postcode',
+    )
 
     FILTER_FIELDS = (
         'archived',
@@ -54,6 +58,7 @@ class SearchCompanyAPIViewMixin:
         'one_list_group_global_account_manager',
         'latest_interaction_date_after',
         'latest_interaction_date_before',
+        'uk_postcode',
     )
 
     REMAP_FIELDS = {
@@ -78,6 +83,10 @@ class SearchCompanyAPIViewMixin:
         'sector_descends': [
             'sector.id',
             'sector.ancestors.id',
+        ],
+        'uk_postcode': [
+            'uk_address_postcode',
+            'uk_registered_address_postcode',
         ],
     }
 

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -2,7 +2,11 @@ from functools import partial
 
 from elasticsearch_dsl import Keyword, Object, Text
 
-from datahub.search.elasticsearch import lowercase_asciifolding_normalizer
+from datahub.search.elasticsearch import (
+    lowercase_asciifolding_normalizer,
+    postcode_analyzer,
+    postcode_search_analyzer,
+)
 
 # Keyword with normalisation to improve sorting (by keeping e, E, è, ê etc. together).
 NormalizedKeyword = partial(
@@ -16,6 +20,12 @@ TextWithTrigram = partial(
     fields={
         'trigram': TrigramText(),
     },
+)
+# Keyword with normalisation that recognises UK postcodes to improve searching
+PostcodeKeyword = partial(
+    Text,
+    analyzer=postcode_analyzer,
+    search_analyzer=postcode_search_analyzer,
 )
 
 


### PR DESCRIPTION
### Description of change

`POST /v4/search/company`: A `uk_postcode` filter was added for the `address_postcode` and `registered_address_postcode` 
fields for UK based companies. The filter accepts a single or a partial postcode as well as an array of postcodes. Multiple postcodes are 
matched with `or` query.

Because we only want to analyse UK postcodes I created two properties - `uk_address_postcode` and `uk_registered_address_postcode` that only return value of corresponding postcode fields if given company is UK based. These properties are indexed and analysed with the analysers described below.

`Elasticsearch`: The search of UK postcodes has been improved so that any entity having a field storing UK postcode 
should use new `postcode_analyzer` and `postcode_search_analyzer` analyzers. It is now possible to perform partial 
search for area, area and district, area and sub-district and also area, district and sector and whole postcode. 
Postcodes are case insensitive and any spaces are filtered out before analysis.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
