### PR TITLE
Feature/update search model for export countries without csv

### DIFF
--- a/changelog/company/export-countries.internal.md
+++ b/changelog/company/export-countries.internal.md
@@ -1,0 +1,1 @@
+Filtering by export countries is now being done with the `CompanyExportcountry` model.

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -30,8 +30,7 @@ class CompanySearchApp(SearchApp):
         'turnover_range',
         'uk_region',
     ).prefetch_related(
-        'export_to_countries',
-        'future_interest_countries',
+        'export_countries',
     ).annotate(
         latest_interaction_date=get_aggregate_subquery(
             DBCompany,

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -30,7 +30,7 @@ class CompanySearchApp(SearchApp):
         'turnover_range',
         'uk_region',
     ).prefetch_related(
-        'export_countries',
+        'export_countries__country',
     ).annotate(
         latest_interaction_date=get_aggregate_subquery(
             DBCompany,

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -23,15 +23,6 @@ def _adviser_field_with_indexed_id():
     )
 
 
-def _get_country_id_dict(obj):
-    if obj is None:
-        return
-
-    return {
-        'id': str(obj.country_id),
-    }
-
-
 def get_suggestions(db_company):
     """
     Returns a dictionary with the keys input and context.
@@ -86,7 +77,9 @@ def get_suggestions(db_company):
 
 
 class Company(BaseESModel):
-    """Elasticsearch representation of Company model."""
+    """
+    Elasticsearch representation of Company model.
+    """
 
     id = Keyword()
     archived = Boolean()
@@ -141,11 +134,11 @@ class Company(BaseESModel):
             dict_utils.contact_or_adviser_dict,
         ),
         'export_to_countries': lambda obj: [
-            _get_country_id_dict(o) for o in obj.export_countries.all()
+            dict_utils.id_name_dict(o.country) for o in obj.export_countries.all()
             if o.status == CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting
         ],
         'future_interest_countries': lambda obj: [
-            _get_country_id_dict(o) for o in obj.export_countries.all()
+            dict_utils.id_name_dict(o.country) for o in obj.export_countries.all()
             if o.status == CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest
         ],
         'latest_interaction_date': lambda obj: obj.latest_interaction_date,

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -14,8 +14,12 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.company.models import Company, CompanyPermission
-from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.company.models import Company, CompanyExportCountry, CompanyPermission
+from datahub.company.test.factories import (
+    AdviserFactory,
+    CompanyExportCountryFactory,
+    CompanyFactory,
+)
 from datahub.core import constants
 from datahub.core.exceptions import DataHubException
 from datahub.core.test_utils import (
@@ -47,7 +51,7 @@ def setup_data(es_with_collector):
     country_us = constants.Country.united_states.value.id
     country_anguilla = constants.Country.anguilla.value.id
     uk_region = constants.UKRegion.south_east.value.id
-    CompanyFactory(
+    company1 = CompanyFactory(
         name='abc defg ltd',
         trading_names=['helm', 'nop'],
         address_1='1 Fake Lane',
@@ -55,29 +59,51 @@ def setup_data(es_with_collector):
         address_country_id=country_uk,
         registered_address_country_id=country_uk,
         uk_region_id=uk_region,
-        export_to_countries=[
-            constants.Country.france.value.id,
-        ],
-        future_interest_countries=[
-            constants.Country.japan.value.id,
-            constants.Country.united_states.value.id,
-        ],
     )
-    CompanyFactory(
+    CompanyExportCountryFactory(
+        company=company1,
+        country=Country.objects.get(pk=constants.Country.france.value.id),
+        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+    )
+
+    CompanyExportCountryFactory(
+        company=company1,
+        country=Country.objects.get(pk=constants.Country.japan.value.id),
+        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+    )
+
+    CompanyExportCountryFactory(
+        company=company1,
+        country=Country.objects.get(pk=constants.Country.united_states.value.id),
+        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+    )
+    company2 = CompanyFactory(
         name='abc defg us ltd',
         trading_names=['helm', 'nop', 'qrs'],
         address_1='1 Fake Lane',
         address_town='Downtown',
         address_country_id=country_us,
         registered_address_country_id=country_us,
-        export_to_countries=[
-            constants.Country.canada.value.id,
-            constants.Country.france.value.id,
-        ],
-        future_interest_countries=[
-            constants.Country.japan.value.id,
-        ],
     )
+
+    CompanyExportCountryFactory(
+        company=company2,
+        country=Country.objects.get(pk=constants.Country.canada.value.id),
+        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+    )
+
+    CompanyExportCountryFactory(
+        company=company2,
+        country=Country.objects.get(pk=constants.Country.france.value.id),
+        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+    )
+
+    CompanyExportCountryFactory(
+        company=company2,
+        country=Country.objects.get(pk=constants.Country.japan.value.id),
+        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+    )
+
     CompanyFactory(
         name='archived',
         trading_names=[],

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -60,23 +60,25 @@ def setup_data(es_with_collector):
         registered_address_country_id=country_uk,
         uk_region_id=uk_region,
     )
+
     CompanyExportCountryFactory(
         company=company1,
-        country=Country.objects.get(pk=constants.Country.france.value.id),
+        country_id=constants.Country.france.value.id,
         status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
     )
 
     CompanyExportCountryFactory(
         company=company1,
-        country=Country.objects.get(pk=constants.Country.japan.value.id),
+        country_id=constants.Country.japan.value.id,
         status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
     )
 
     CompanyExportCountryFactory(
         company=company1,
-        country=Country.objects.get(pk=constants.Country.united_states.value.id),
+        country_id=constants.Country.united_states.value.id,
         status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
     )
+
     company2 = CompanyFactory(
         name='abc defg us ltd',
         trading_names=['helm', 'nop', 'qrs'],
@@ -88,19 +90,19 @@ def setup_data(es_with_collector):
 
     CompanyExportCountryFactory(
         company=company2,
-        country=Country.objects.get(pk=constants.Country.canada.value.id),
+        country_id=constants.Country.canada.value.id,
         status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
     )
 
     CompanyExportCountryFactory(
         company=company2,
-        country=Country.objects.get(pk=constants.Country.france.value.id),
+        country_id=constants.Country.france.value.id,
         status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
     )
 
     CompanyExportCountryFactory(
         company=company2,
-        country=Country.objects.get(pk=constants.Country.japan.value.id),
+        country_id=constants.Country.japan.value.id,
         status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
     )
 


### PR DESCRIPTION
### Description of change

Change elasticsearch mapping to use CompanyExportCountry for export countries data.
(cut of https://github.com/uktrade/data-hub-api/pull/2393/files without the CSV changes)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
