### PR TITLE
Correct Python version in CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,7 @@ workflows:
     jobs:
       - build:
           publish_coverage: true
-          python_image: python:3.7
+          python_image: python:3.8
           postgres_image: postgres:10
           mi_postgres_image: postgres:9.6
           es_image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
   This was introduced to not update `domain` & `registered_address` fields. This is because the data for these fields does not meet Data Hub standards. D&B have been informed of this and are working on a fix.
 
+- Python was updated from version 3.7.5 to 3.8.1. This includes updating various indirect dependencies.
+
 ## Internal changes
 
 - The following internal query utilities were added:

--- a/changelog/python-3.8.feature.md
+++ b/changelog/python-3.8.feature.md
@@ -1,1 +1,0 @@
-Python was updated from version 3.7.5 to 3.8.1. This includes updating various indirect dependencies.


### PR DESCRIPTION
### Description of change

This was missed in #2430.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
