### PR TITLE
Replace uses of deprecated Django utility functions

### DIFF
--- a/changelog/remove-uses-of-dep-django-utils.internal.md
+++ b/changelog/remove-uses-of-dep-django-utils.internal.md
@@ -1,0 +1,1 @@
+Uses of the deprecated Django function alias `force_text()` was replaced with `force_str()`.

--- a/changelog/remove-uses-of-dep-django-utils.internal.md
+++ b/changelog/remove-uses-of-dep-django-utils.internal.md
@@ -1,1 +1,1 @@
-Uses of the deprecated Django function alias `force_text()` was replaced with `force_str()`.
+Uses of the deprecated Django function aliases `force_text()` and `urlquote()` were replaced with `force_str()` and `urllib.parse.quote()`.

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -13,7 +13,7 @@ from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path
 from django.utils.decorators import method_decorator
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import format_html, format_html_join
 from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
@@ -239,7 +239,7 @@ class OrderAdmin(BaseModelAdminMixin, ViewAndChangeOnlyAdmin):
             context = dict(
                 self.admin_site.each_context(request),
                 title=_('Are you sure?'),
-                object_name=force_text(opts.verbose_name),
+                object_name=force_str(opts.verbose_name),
                 object=obj,
                 opts=opts,
                 app_label=opts.app_label,
@@ -259,7 +259,7 @@ class OrderAdmin(BaseModelAdminMixin, ViewAndChangeOnlyAdmin):
         opts = self.model._meta
 
         msg_dict = {
-            'name': force_text(opts.verbose_name),
+            'name': force_str(opts.verbose_name),
             'obj': format_html('<a href="{0}">{1}</a>', urlquote(request.path), obj),
         }
         msg = format_html(

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -1,4 +1,5 @@
 from functools import update_wrapper
+from urllib.parse import quote
 
 from django import forms
 from django.contrib import admin
@@ -15,7 +16,6 @@ from django.urls import path
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_str
 from django.utils.html import format_html, format_html_join
-from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_protect
@@ -260,7 +260,7 @@ class OrderAdmin(BaseModelAdminMixin, ViewAndChangeOnlyAdmin):
 
         msg_dict = {
             'name': force_str(opts.verbose_name),
-            'obj': format_html('<a href="{0}">{1}</a>', urlquote(request.path), obj),
+            'obj': format_html('<a href="{0}">{1}</a>', quote(request.path), obj),
         }
         msg = format_html(
             _('The {name} "{obj}" was cancelled successfully.'),


### PR DESCRIPTION
### Description of change

This replaces uses of the `force_text()` and `urlquote()` function aliases in Django as [these are deprecated from Django 3.0](https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0) and will be removed from Django 4.0.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
