### PR TITLE
Fix missed root news fragments in release scripts

### DIFF
--- a/scripts/create_release_pr.py
+++ b/scripts/create_release_pr.py
@@ -74,7 +74,7 @@ def create_release_branch():
 
     news_fragment_paths = list_news_fragments()
     if news_fragment_paths:
-        joined_paths = '\n'.join(news_fragment_paths)
+        joined_paths = '\n'.join(str(path) for path in news_fragment_paths)
 
         raise CommandError(
             'These are news fragments on origin/develop:\n\n'

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -79,7 +79,7 @@ def prepare_release(release_type):
 
     remaining_news_fragment_paths = list_news_fragments()
     if remaining_news_fragment_paths:
-        joined_paths = '\n'.join(remaining_news_fragment_paths)
+        joined_paths = '\n'.join(str(path) for path in remaining_news_fragment_paths)
 
         raise CommandError(
             'These news fragments were left behind:\n\n'

--- a/scripts/script_utils/news_fragments.py
+++ b/scripts/script_utils/news_fragments.py
@@ -1,12 +1,23 @@
-import glob
-from pathlib import PurePath
+from pathlib import Path, PurePath
 
 
 IGNORED_FILES = {'.gitignore', '_template.md.jinja2', 'README.md'}
 ROOT_PATH = PurePath(__file__).parents[2]
+CHANGELOG_ROOT = ROOT_PATH / 'changelog'
 
 
 def list_news_fragments():
     """Return a list of files that are probable news fragments."""
-    changelog_files = glob.iglob(f'{ROOT_PATH}/changelog/**/*')
-    return set(changelog_files) - IGNORED_FILES
+    changelog_path = Path(CHANGELOG_ROOT)
+    return {
+        path for path in _list_files_recursively(changelog_path)
+        if path.name not in IGNORED_FILES
+    }
+
+
+def _list_files_recursively(path):
+    for child_path in path.iterdir():
+        if child_path.is_dir():
+            yield from _list_files_recursively(child_path)
+        else:
+            yield child_path

--- a/scripts/script_utils/test/fake_repo/changelog/README.md
+++ b/scripts/script_utils/test/fake_repo/changelog/README.md
@@ -1,0 +1,1 @@
+Test file.

--- a/scripts/script_utils/test/fake_repo/changelog/_template.md.jinja2
+++ b/scripts/script_utils/test/fake_repo/changelog/_template.md.jinja2
@@ -1,0 +1,1 @@
+Test file.

--- a/scripts/script_utils/test/fake_repo/changelog/adviser/.gitignore
+++ b/scripts/script_utils/test/fake_repo/changelog/adviser/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/scripts/script_utils/test/fake_repo/changelog/adviser/adviser-test.feature.md
+++ b/scripts/script_utils/test/fake_repo/changelog/adviser/adviser-test.feature.md
@@ -1,0 +1,1 @@
+Test file.

--- a/scripts/script_utils/test/fake_repo/changelog/misnamed.fragment.feature
+++ b/scripts/script_utils/test/fake_repo/changelog/misnamed.fragment.feature
@@ -1,0 +1,1 @@
+Test file.

--- a/scripts/script_utils/test/fake_repo/changelog/root-test.feature.md
+++ b/scripts/script_utils/test/fake_repo/changelog/root-test.feature.md
@@ -1,0 +1,1 @@
+Test file.

--- a/scripts/script_utils/test/test_news_fragments.py
+++ b/scripts/script_utils/test/test_news_fragments.py
@@ -1,0 +1,27 @@
+from pathlib import PurePath
+
+from script_utils.news_fragments import list_news_fragments
+
+
+def test_list_news_fragments(monkeypatch):
+    """
+    Test that list_news_fragments():
+
+    - picks up news fragments in the root changelog directory
+    - picks up news fragments in the changelog sub-directories
+    - picks up misnamed news fragments
+    - excludes ignored files
+    """
+    changelog_root = PurePath(__file__).parent / 'fake_repo' / 'changelog'
+    monkeypatch.setattr('script_utils.news_fragments.CHANGELOG_ROOT', changelog_root)
+
+    absolute_paths = list_news_fragments()
+    relative_paths = {
+        str(path.relative_to(changelog_root))
+        for path in absolute_paths
+    }
+    assert relative_paths == {
+        'misnamed.fragment.feature',
+        'root-test.feature.md',
+        'adviser/adviser-test.feature.md',
+    }


### PR DESCRIPTION
### Description of change

Just spotted that the `list_news_fragments()` function missed news fragments in the root of `changelog/` as it was not passing `recursive=True` to `iglob()`.

This would've caused `scripts/prepare_release.py` to fail if there were only root news fragments, and it would've also failed to return an error if a misnamed root news fragment was left behind.

The fix is more complicated than just passing `recursive=True`, as this would also cause `changelog/` sub-directories to be included.

Hence, the function has been rewritten using a different approach, and a test has been added.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
