### PR TITLE
Correct link to master and develop diff in release docs

### DIFF
--- a/docs/How to prepare a release.md
+++ b/docs/How to prepare a release.md
@@ -11,7 +11,7 @@ As a general guide:
 * if it contains breaking API changes, then it's a major version
 * anything else is a minor version 
 
-You can run `towncrier --draft --version draft` to generate a draft changelog, or [look at the difference between develop and master](https://github.com/uktrade/data-hub-api/compare/develop...master), to help you decide.
+You can run `towncrier --draft --version draft` to generate a draft changelog, or [look at the difference between develop and master](https://github.com/uktrade/data-hub-api/compare/master...develop), to help you decide.
 
 ## Bump the version and update the changelog
 


### PR DESCRIPTION
### Description of change

The link to the diff between master and develop in the 'How to prepare a release' document had the branches the wrong way round.

This corrects that.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
