### PR TITLE
Add additional fields to interactions dataset endpoint

### DIFF
--- a/changelog/interaction/dataset-api-endpoint-add-policy-fields.api.md
+++ b/changelog/interaction/dataset-api-endpoint-add-policy-fields.api.md
@@ -1,0 +1,4 @@
+`GET /v4/dataset/interactions-dataset`: 3 new fields were added to the interactions dataset response:
+- `policy_area_names`
+- `policy_feedback_notes`
+- `policy_issue_type_names`

--- a/datahub/dataset/interaction/test/test_views.py
+++ b/datahub/dataset/interaction/test/test_views.py
@@ -53,7 +53,15 @@ def get_expected_data_from_interaction(interaction):
             else None
         ),
         'notes': interaction.notes,
+        'policy_area_names': (
+            [x.name for x in interaction.policy_areas.all()]
+            if interaction.policy_areas.exists() else None
+        ),
         'policy_feedback_notes': interaction.policy_feedback_notes,
+        'policy_issue_type_names': (
+            [x.name for x in interaction.policy_issue_types.all()]
+            if interaction.policy_areas.exists() else None
+        ),
         'sector': get_attr_or_none(interaction, 'company.sector.name'),
         'service_delivery_status__name': get_attr_or_none(
             interaction,

--- a/datahub/dataset/interaction/test/test_views.py
+++ b/datahub/dataset/interaction/test/test_views.py
@@ -53,6 +53,7 @@ def get_expected_data_from_interaction(interaction):
             else None
         ),
         'notes': interaction.notes,
+        'policy_feedback_notes': interaction.policy_feedback_notes,
         'sector': get_attr_or_none(interaction, 'company.sector.name'),
         'service_delivery_status__name': get_attr_or_none(
             interaction,

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -45,6 +45,7 @@ class InteractionsDatasetView(BaseDatasetView):
             'kind',
             'net_company_receipt',
             'notes',
+            'policy_feedback_notes',
             'sector',
             'service_delivery_status__name',
             'service_delivery',

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -2,6 +2,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 
 from datahub.core.query_utils import (
     get_aggregate_subquery,
+    get_array_agg_subquery,
     get_front_end_url_expression,
 )
 from datahub.dataset.core.views import BaseDatasetView
@@ -28,6 +29,18 @@ class InteractionsDatasetView(BaseDatasetView):
                 ArrayAgg('contacts__id', ordering=('contacts__id',)),
             ),
             interaction_link=get_front_end_url_expression('interaction', 'pk'),
+            policy_area_names=get_array_agg_subquery(
+                Interaction.policy_areas.through,
+                'interaction',
+                'policyarea__name',
+                ordering=('policyarea__order',),
+            ),
+            policy_issue_type_names=get_array_agg_subquery(
+                Interaction.policy_issue_types.through,
+                'interaction',
+                'policyissuetype__name',
+                ordering=('policyissuetype__order',),
+            ),
             sector=get_sector_name_subquery('company__sector'),
             service_delivery=get_service_name_subquery('service'),
         ).values(
@@ -45,7 +58,9 @@ class InteractionsDatasetView(BaseDatasetView):
             'kind',
             'net_company_receipt',
             'notes',
+            'policy_area_names',
             'policy_feedback_notes',
+            'policy_issue_type_names',
             'sector',
             'service_delivery_status__name',
             'service_delivery',


### PR DESCRIPTION
### Description of change

Adds 3 new fields to the interactions dataset endpoint to enable automation of the policy feedback report:

- `policy_feedback_notes`
- `policy_area_names`
- `policy_issue_type_names`


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
