### PR TITLE
Return string arrays rather than joined strings on investment projects

### DIFF
--- a/changelog/investment/dataset-api-endpoint-update-string-agg-fields.api.md
+++ b/changelog/investment/dataset-api-endpoint-update-string-agg-fields.api.md
@@ -1,0 +1,6 @@
+`GET /v4/dataset/investment-projects-dataset`: 5 comma joined string fields were changed to return arrays of strings:
+- `actual_uk_region_names`
+- `business_activity_names`
+- `delivery_partner_names`
+- `strategic_driver_names`
+- `uk_region_location_names`

--- a/datahub/dataset/investment_project/test/test_views.py
+++ b/datahub/dataset/investment_project/test/test_views.py
@@ -6,7 +6,6 @@ from rest_framework.reverse import reverse
 from datahub.core.test_utils import (
     format_date_or_datetime,
     get_attr_or_none,
-    join_attr_values,
     str_or_none,
 )
 from datahub.dataset.core.test import BaseDatasetViewTest
@@ -25,8 +24,9 @@ def get_expected_data_from_project(project):
     """Returns expected dictionary based on given project"""
     return {
         'actual_land_date': format_date_or_datetime(project.actual_land_date),
-        'actual_uk_region_names': (join_attr_values(project.actual_uk_regions.order_by('name'))
-                                   if project.actual_uk_regions.exists() else None),
+        'actual_uk_region_names': (
+            [region.name for region in project.actual_uk_regions.order_by('name')]
+        ) if project.actual_uk_regions.exists() else None,
         'address_1': project.address_1,
         'address_2': project.address_2,
         'address_town': project.address_town,
@@ -36,7 +36,9 @@ def get_expected_data_from_project(project):
             project.associated_non_fdi_r_and_d_project_id,
         ),
         'average_salary__name': get_attr_or_none(project, 'average_salary.name'),
-        'business_activity_names': join_attr_values(project.business_activities.order_by('name')),
+        'business_activity_names': (
+            [activity.name for activity in project.business_activities.order_by('name')]
+        ) if project.business_activities.exists() else None,
         'client_relationship_manager_id': str_or_none(project.client_relationship_manager_id),
         'client_requirements': project.client_requirements,
         'competing_countries': (
@@ -45,8 +47,10 @@ def get_expected_data_from_project(project):
         ),
         'created_by_id': str_or_none(project.created_by_id),
         'created_on': format_date_or_datetime(project.created_on),
-        'delivery_partner_names': (join_attr_values(project.delivery_partners.order_by('name'))
-                                   if project.delivery_partners.exists() else None),
+        'delivery_partner_names': (
+            [partner.name for partner in project.delivery_partners.order_by('name')]
+
+        ) if project.delivery_partners.exists() else None,
         'description': project.description,
         'estimated_land_date': format_date_or_datetime(project.estimated_land_date),
         'export_revenue': project.export_revenue,
@@ -105,8 +109,9 @@ def get_expected_data_from_project(project):
         'specific_programme__name': get_attr_or_none(project, 'specific_programme.name'),
         'stage__name': get_attr_or_none(project, 'stage.name'),
         'status': project.status,
-        'strategic_driver_names': (join_attr_values(project.strategic_drivers.order_by('name'))
-                                   if project.strategic_drivers.exists() else None),
+        'strategic_driver_names': (
+            [driver.name for driver in project.strategic_drivers.order_by('name')]
+        ) if project.strategic_drivers.exists() else None,
         'team_member_ids': (
             [
                 str(team_member.adviser_id)
@@ -117,9 +122,8 @@ def get_expected_data_from_project(project):
         'uk_company_id': str_or_none(project.uk_company_id),
         'uk_company_sector': get_attr_or_none(project, 'uk_company.sector.name'),
         'uk_region_location_names': (
-            join_attr_values(project.uk_region_locations.order_by('name'))
-            if project.uk_region_locations.exists() else None
-        ),
+            [region.name for region in project.uk_region_locations.order_by('name')]
+        ) if project.uk_region_locations.exists() else None,
     }
 
 


### PR DESCRIPTION
## Description of change

Data workspace users have reported issues with investment project csv downloads where fields are joined on commas but the joined text also contains commas (breaking the csv). This has resulted in requests that certain fields are joined with semicolons.

To enable us to tailor reports and reduce the number of changes to data hub this PR changes comma joined fields to string arrays so any future transformations can be done on the data workspace side.

The affected fields are
- `actual_uk_region_names`
- `business_activity_names`
- `delivery_partner_names`
- `strategic_driver_names`
- `uk_region_location_names`

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
