### PR TITLE
Remove django-admin-ip-restrictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,6 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `ADMIN_OAUTH2_AUTH_PATH` | If `ADMIN_OAUTH2_ENABLED` is set | OAuth auth path for Django Admin SSO login. |
 | `ADMIN_OAUTH2_CLIENT_ID` | If `ADMIN_OAUTH2_ENABLED` is set | OAuth client ID for Django Admin SSO login. |
 | `ADMIN_OAUTH2_CLIENT_SECRET` | If `ADMIN_OAUTH2_ENABLED` is set | OAuth client secret for Django Admin SSO login. |
-| `ALLOWED_ADMIN_IPS` | No | IP addresses (comma-separated) that can access the admin site when RESTRICT_ADMIN is True. |
-| `ALLOWED_ADMIN_IP_RANGES` | No | IP address ranges (comma-separated) that can access the admin site when RESTRICT_ADMIN is True. |
 | `AV_V2_SERVICE_URL` | Yes | URL for ClamAV V2 service. If not configured, virus scanning will fail. |
 | `AWS_ACCESS_KEY_ID` | No | Used as part of [boto3 auto-configuration](http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials). |
 | `AWS_DEFAULT_REGION` | No | [Default region used by boto3.](http://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variable-configuration) |
@@ -324,7 +322,6 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `REPORT_BUCKET` | No | S3 bucket for report storage. |
 | `RESOURCE_SERVER_INTROSPECTION_URL` | If SSO enabled | RFC 7662 token introspection URL used for signle sign-on |
 | `RESOURCE_SERVER_AUTH_TOKEN` | If SSO enabled | Access token for RFC 7662 token introspection server |
-| `RESTRICT_ADMIN` | No | Whether to restrict access to the admin site by IP address. |
 | `SENTRY_ENVIRONMENT`  | Yes | Value for the environment tag in Sentry. |
 | `SKIP_ES_MAPPING_MIGRATIONS` | No | If non-empty, skip applying Elasticsearch mapping type migrations on deployment. |
 | `SKIP_MI_DATABASE_MIGRATIONS` | No | If non-empty, skip applying MI database migrations on deployment. Used in environments without a working MI database. |

--- a/changelog/remove-django-admin-ip-restrictor.removal.md
+++ b/changelog/remove-django-admin-ip-restrictor.removal.md
@@ -1,0 +1,1 @@
+The IP restriction functionality provided by `django-admin-ip-restrictor` was removed as it was not in use as we're using private networking and other mechanisms within GOV.UK PaaS instead.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -111,7 +111,6 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'admin_ip_restrictor.middleware.AdminIPRestrictorMiddleware',
     'datahub.core.reversion.NonAtomicRevisionMiddleware',
 ]
 
@@ -216,12 +215,6 @@ AUTHENTICATION_BACKENDS = [
     'datahub.core.auth.TeamModelPermissionsBackend'
 ]
 
-
-# django-admin-ip-restrictor
-
-RESTRICT_ADMIN = env.bool('RESTRICT_ADMIN', False)
-ALLOWED_ADMIN_IPS = env.list('ALLOWED_ADMIN_IPS', default=[])
-ALLOWED_ADMIN_IP_RANGES = env.list('ALLOWED_ADMIN_IP_RANGES', default=[])
 
 # OAuth2 settings to authenticate Django admin users
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,6 @@
 # Django and django related
 Django==2.2.9
 djangorestframework==3.11.0
-django-admin-ip-restrictor==2.1.1
 django-environ==0.4.5
 django-extensions==2.2.5
 django-filter==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,12 +18,10 @@ chardet==3.0.4
 click==7.0                # via pip-tools, towncrier
 coverage==5.0.2           # via pytest-cov
 decorator==4.4.1          # via ipython, traitlets
-django-admin-ip-restrictor==2.1.1
 django-debug-toolbar==2.1
 django-environ==0.4.5
 django-extensions==2.2.5
 django-filter==2.2.0
-django-ipware==2.1.0      # via django-admin-ip-restrictor
 django-js-asset==1.2.2    # via django-mptt
 django-model-utils==4.0.0
 django-mptt==0.10.0


### PR DESCRIPTION
### Description of change

This removes `django-admin-ip-restrictor` as it wasn't being used, and there are better mechanisms in GOV.UK PaaS which we are making use of.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
