### PR TITLE
Automatic company archive Celery task

### DIFF
--- a/changelog/company/automatic-company-archive.feature.md
+++ b/changelog/company/automatic-company-archive.feature.md
@@ -1,0 +1,8 @@
+A new Celery task called `automatic_company_archive` was added to Data Hub API.
+
+This task would run every Saturday at 8pm in *simulation mode* with an upper limit of a *1000 companies*. In simulation mode, this task would log the IDs of the companies that would have been automatically archived using the following criteria:
+
+- Do not have any OMIS orders
+- Do not have any interactions during the last 8 years
+- Not matched to any D&B records
+- Not created or modified during the last 3 months

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -389,7 +389,11 @@ if REDIS_BASE_URL:
         'update_companies_from_dnb_service': {
             'task': 'datahub.dnb_api.tasks.get_company_updates',
             'schedule': crontab(minute=0, hour=0),
-        }
+        },
+        'automatic_company_archive': {
+            'task': 'datahub.company.tasks.automatic_company_archive',
+            'schedule': crontab(minute=0, hour=20, day_of_week='SAT'),
+        },
     }
     if env.bool('ENABLE_DAILY_ES_SYNC', False):
         CELERY_BEAT_SCHEDULE['sync_es'] = {

--- a/datahub/company/constants.py
+++ b/datahub/company/constants.py
@@ -5,6 +5,7 @@ from datahub.core.constants import Constant
 
 
 NOTIFY_DNB_INVESTIGATION_FEATURE_FLAG = 'notify-dnb-investigations'
+AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG = 'automatic-company-archive'
 
 
 class BusinessTypeConstant(Enum):

--- a/datahub/company/tasks.py
+++ b/datahub/company/tasks.py
@@ -1,0 +1,79 @@
+from celery import shared_task
+from celery.utils.log import get_task_logger
+from dateutil.relativedelta import relativedelta
+from django.db.models import OuterRef, Q, Subquery
+from django.utils import timezone
+from django_pglocks import advisory_lock
+
+from datahub.company.constants import AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG
+from datahub.company.models.company import Company
+from datahub.feature_flag.utils import is_feature_flag_active
+from datahub.interaction.models import Interaction
+
+logger = get_task_logger(__name__)
+
+
+def _automatic_company_archive(task, limit, simulate):
+
+    _8y_ago = timezone.now() - relativedelta(years=8)
+    _3m_ago = timezone.now() - relativedelta(months=3)
+
+    latest_interaction = Interaction.objects.filter(
+        company=OuterRef('pk'),
+    ).order_by('-date')
+
+    companies_to_be_archived = Company.objects.annotate(
+        latest_interaction_date=Subquery(
+            latest_interaction.values('date')[:1],
+        ),
+    ).filter(
+        Q(latest_interaction_date__date__lt=_8y_ago) | Q(latest_interaction_date__isnull=True),
+        archived=False,
+        duns_number__isnull=True,
+        orders__isnull=True,
+        created_on__lt=_3m_ago,
+        modified_on__lt=_3m_ago,
+    )[:limit]
+
+    for company in companies_to_be_archived:
+        message = f'Automatically archived company: {company.id}'
+        if simulate:
+            logger.info(f'[SIMULATION] {message}')
+            return
+        company.archived = True
+        company.archived_reason = 'This record was automatically archived due to inactivity'
+        company.archived_on = timezone.now()
+        company.save(
+            update_fields=[
+                'archived',
+                'archived_reason',
+                'archived_on',
+            ],
+        )
+        logger.info(message)
+
+
+@shared_task(
+    bind=True,
+    acks_late=True,
+    priority=9,
+    max_retries=3,
+    queue='long-running',
+)
+def automatic_company_archive(self, limit=1000, simulate=True):
+    """
+    Archive inactive companies.
+    """
+    if not is_feature_flag_active(AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG):
+        logger.info(
+            f'Feature flag "{AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG}" is not active, exiting.',
+        )
+        return
+
+    with advisory_lock('automatic_company_archive', wait=False) as acquired:
+
+        if not acquired:
+            logger.info('Another instance of this task is already running.')
+            return
+
+        _automatic_company_archive(self, limit, simulate)

--- a/datahub/company/test/test_tasks.py
+++ b/datahub/company/test/test_tasks.py
@@ -1,0 +1,256 @@
+import logging
+from unittest import mock
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone
+from freezegun import freeze_time
+
+from datahub.company.constants import AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG
+from datahub.company.models import Company
+from datahub.company.tasks import automatic_company_archive
+from datahub.company.test.factories import CompanyFactory
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.interaction.test.factories import CompanyInteractionFactory
+from datahub.omis.order.test.factories import OrderFactory
+
+
+@pytest.fixture()
+def automatic_company_archive_feature_flag():
+    """
+    Creates the automatic company archive feature flag.
+    """
+    yield FeatureFlagFactory(code=AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG)
+
+
+@pytest.mark.django_db
+class TestAutomaticCompanyArchive:
+    """
+    Tests for the automatic_company_archive task.
+    """
+
+    def test_no_feature_flag(
+        self,
+        caplog,
+    ):
+        """
+        Test that if the feature flag is not enabled, the
+        task will not run.
+        """
+        caplog.set_level(logging.INFO, logger='datahub.company.tasks')
+        automatic_company_archive.apply_async(kwargs={'simulate': False})
+        assert caplog.messages == [
+            f'Feature flag "{AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG}" is not active, exiting.',
+        ]
+
+    @pytest.mark.parametrize(
+        'lock_acquired, call_count',
+        (
+            (False, 0),
+            (True, 1),
+        ),
+    )
+    def test_lock(
+        self,
+        monkeypatch,
+        automatic_company_archive_feature_flag,
+        lock_acquired,
+        call_count,
+    ):
+        """
+        Test that the task doesn't run if it cannot acquire
+        the advisory_lock.
+        """
+        mock_advisory_lock = mock.MagicMock()
+        mock_advisory_lock.return_value.__enter__.return_value = lock_acquired
+        monkeypatch.setattr(
+            'datahub.company.tasks.advisory_lock',
+            mock_advisory_lock,
+        )
+        mock_automatic_company_archive = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.company.tasks._automatic_company_archive',
+            mock_automatic_company_archive,
+        )
+        automatic_company_archive()
+        assert mock_automatic_company_archive.call_count == call_count
+
+    @pytest.mark.parametrize(
+        'simulate',
+        (
+            True,
+            False,
+        ),
+    )
+    @freeze_time('2020-01-01-12:00:00')
+    def test_success_no_interactions(
+        self,
+        caplog,
+        automatic_company_archive_feature_flag,
+        simulate,
+    ):
+        """
+        Test that a company without interaction that fits
+        all the other criteria is archived.
+        """
+        caplog.set_level(logging.INFO, logger='datahub.company.tasks')
+        gt_3m_ago = timezone.now() - relativedelta(months=3, days=1)
+        with freeze_time(gt_3m_ago):
+            company = CompanyFactory()
+        task_result = automatic_company_archive.apply_async(
+            kwargs={'simulate': simulate},
+        )
+        company.refresh_from_db()
+        if simulate:
+            assert caplog.messages == [
+                f'[SIMULATION] Automatically archived company: {company.id}',
+            ]
+        else:
+            assert task_result.successful()
+            assert company.archived
+            assert caplog.messages == [
+                f'Automatically archived company: {company.id}',
+            ]
+
+    @pytest.mark.parametrize(
+        'interaction_date_delta, expected_archived',
+        (
+            (relativedelta(), False),
+            (relativedelta(years=8), False),
+            (relativedelta(years=8, days=1), True),
+        ),
+    )
+    @freeze_time('2020-01-01-12:00:00')
+    def test_interactions(
+        self,
+        automatic_company_archive_feature_flag,
+        interaction_date_delta,
+        expected_archived,
+    ):
+        """
+        Test that a company with interactions on various dates
+        around the 8y boundary are archived or not as expected.
+        """
+        gt_3m_ago = timezone.now() - relativedelta(months=3, days=1)
+        with freeze_time(gt_3m_ago):
+            company = CompanyFactory()
+        CompanyInteractionFactory(
+            company=company,
+            date=timezone.now() - interaction_date_delta,
+        )
+        task_result = automatic_company_archive.apply_async(
+            kwargs={'simulate': False},
+        )
+        assert task_result.successful()
+        company.refresh_from_db()
+        assert company.archived == expected_archived
+
+    @pytest.mark.parametrize(
+        'created_on_delta, expected_archived',
+        (
+            (relativedelta(), False),
+            (relativedelta(months=3), False),
+            (relativedelta(months=3, days=1), True),
+        ),
+    )
+    @freeze_time('2020-01-01-12:00:00')
+    def test_created_on(
+        self,
+        automatic_company_archive_feature_flag,
+        created_on_delta,
+        expected_archived,
+    ):
+        """
+        Test that a company created_on dates around the 3m boundary
+        are archived or not as expected.
+        """
+        created_on = timezone.now() - created_on_delta
+        with freeze_time(created_on):
+            company = CompanyFactory()
+        CompanyInteractionFactory(
+            company=company,
+            date=timezone.now() - relativedelta(years=8, days=1),
+        )
+        task_result = automatic_company_archive.apply_async(kwargs={'simulate': False})
+        assert task_result.successful()
+        company.refresh_from_db()
+        assert company.archived == expected_archived
+
+    @pytest.mark.parametrize(
+        'modified_on_delta, expected_archived',
+        (
+            (relativedelta(), False),
+            (relativedelta(months=3), False),
+            (relativedelta(months=3, days=1), True),
+        ),
+    )
+    @freeze_time('2020-01-01-12:00:00')
+    def test_modified_on(
+        self,
+        automatic_company_archive_feature_flag,
+        modified_on_delta,
+        expected_archived,
+    ):
+        """
+        Test that a company modified_on dates around the 3m boundary
+        are archived or not as expected.
+        """
+        gt_3m_ago = timezone.now() - relativedelta(months=3, days=1)
+        with freeze_time(gt_3m_ago):
+            company = CompanyFactory()
+        CompanyInteractionFactory(
+            company=company,
+            date=timezone.now() - relativedelta(years=8, days=1),
+        )
+        with freeze_time(timezone.now() - modified_on_delta):
+            company.save()
+        task_result = automatic_company_archive.apply_async(kwargs={'simulate': False})
+        assert task_result.successful()
+        archived_company = Company.objects.get(pk=company.id)
+        assert archived_company.archived == expected_archived
+        assert archived_company.modified_on == company.modified_on
+
+    @freeze_time('2020-01-01-12:00:00')
+    def test_success_orders(
+        self,
+        automatic_company_archive_feature_flag,
+    ):
+        """
+        Test that a company with OMIS orders is not archived.
+        """
+        gt_3m_ago = timezone.now() - relativedelta(months=3, days=1)
+        with freeze_time(gt_3m_ago):
+            company = CompanyFactory()
+        OrderFactory(company=company)
+        task_result = automatic_company_archive.apply_async(kwargs={'simulate': False})
+        assert task_result.successful()
+        company.refresh_from_db()
+        assert not company.archived
+
+    @freeze_time('2020-01-01-12:00:00')
+    def test_limit(
+        self,
+        automatic_company_archive_feature_flag,
+    ):
+        """
+        Test that we can set a limit to the number of companies
+        that are automatically archived.
+        """
+        gt_3m_ago = timezone.now() - relativedelta(months=3, days=1)
+        with freeze_time(gt_3m_ago):
+            companies = CompanyFactory.create_batch(3)
+        task_result = automatic_company_archive.apply_async(
+            kwargs={
+                'simulate': False,
+                'limit': 2,
+            },
+        )
+        assert task_result.successful()
+
+        archived_companies_count = 0
+        for company in companies:
+            company.refresh_from_db()
+            if company.archived:
+                archived_companies_count += 1
+
+        assert archived_companies_count == 2


### PR DESCRIPTION
### Description of change

This introduces a new Celery task called `automatic_company_archive` to the Data Hub API.

This task will automatically archive companies that:

- Do not have any OMIS orders
- Do not have any interactions during the last 8 years
- Not matched to any D&B records
- Not created or modified during the last 3 months

This criteria was discussed in [this document](https://docs.google.com/document/d/1IKuFHKkmSH_r4OAPpCmU5Hq0gjImy8PqOfinnG226xI/edit#). 

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
