### PR TITLE
Enable querying the search endpoints in API browser

### DIFF
--- a/changelog/enable-search-queries-for-api-browser.feature.md
+++ b/changelog/enable-search-queries-for-api-browser.feature.md
@@ -1,0 +1,1 @@
+It is now possible to perform queries to search endpoints in the API browser.


### PR DESCRIPTION
### Description of change

In our API browser it was not possible to make queries to the search endpoints mostly due to "non-standard" nature of our search app.
This PR makes API browser aware of the query serialisers, so that we can edit the request body and perform a request. 
In case of the basic search, the description of query parameters has been added.
The response schema is hidden, because we would have to create it manually and I think it is not worth the effort. 
Currently the AutoSchema is still not flexible to extend as vital methods are private.

Basic search before:
![basic-search-before](https://user-images.githubusercontent.com/5889630/72341568-7e600a00-36c2-11ea-9849-5049ad9a53f4.png)

Basic search after:
![basic-search-after](https://user-images.githubusercontent.com/5889630/72341601-8fa91680-36c2-11ea-9095-f2b70514b5ab.png)

Entity search before:
![entity-search-before](https://user-images.githubusercontent.com/5889630/72341605-92a40700-36c2-11ea-9377-d19aac6662d2.png)

Entity search after:
![entity-search-after](https://user-images.githubusercontent.com/5889630/72341614-95066100-36c2-11ea-8008-ad2f8ebd3c24.png)


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
