### PR TITLE
Improve delete_orphaned_versions command

### DIFF
--- a/changelog/delete-orphaned-versions.bugfix.md
+++ b/changelog/delete-orphaned-versions.bugfix.md
@@ -1,0 +1,2 @@
+The `delete_orphaned_versions` command was modified to select records to be deleted in a fashion that is more 
+efficient in the environment it will run.


### PR DESCRIPTION
### Description of change

The `get_deleted` method wouldn't work in our environment so it has been replaced with a more efficient one that gives the same results.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
