### PR TITLE
Only ignore spaces in company search postcode filter for full postcodes

### DIFF
--- a/changelog/company/uk-postcode-search-space-handling.api.md
+++ b/changelog/company/uk-postcode-search-space-handling.api.md
@@ -1,0 +1,3 @@
+`POST /v4/search/company`: The behaviour of the `uk_postcode` filter was modified so that spaces are ignored only if a full postcode is searched for.
+
+This means that `AB11` and `AB1 1` are now distinct searches (where the former would match e.g. `AB11 1AA` and the latter would match e.g. `AB1 1AA`). (Previously, both searches were equivalent and matched both postcodes.)

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -97,14 +97,16 @@ def company_names_and_postcodes(es_with_collector):
         ('company_w1', 'w1 2AB'),  # AB in suffix to ensure not matched in AB tests
         ('company_w1a', 'W1A2AB'),  # AB in suffix to ensure not matched in AB tests
         ('company_w11', 'W112AB'),  # AB in suffix to ensure not matched in AB tests
-        ('company_ab1', 'AB11WC'),  # WC in suffix to ensure not matched in WC tests
+        ('company_ab1_1', 'AB11WC'),  # WC in suffix to ensure not matched in WC tests
         ('company_ab10', 'ab10 1WC'),  # WC in suffix to ensure not matched in WC tests
+        # to test the difference between searching for AB1 0 (sector) and AB10 (district)
+        ('company_ab1_0', 'AB1 0WC'),
         ('company_wc2b', 'WC2B4AB'),  # AB in suffix to ensure not matched in AB tests
         ('company_wc2n', 'WC2N9ZZ'),
         ('company_wc1x', 'w  C   1 x0aA'),
         ('company_wc1a', 'W C 1 A 1 G A'),
         ('company_se1', 'SE13A J'),
-        ('company_se1_2', 'SE13AJ'),
+        ('company_se1_3', 'SE13AJ'),
         ('company_se2', 'SE23AJ'),
         ('company_se3', 'SE33AJ'),
     ))
@@ -420,37 +422,36 @@ class TestSearch(APITestMixin):
             # Postcode area
             ('W', ['company_w1', 'company_w1a', 'company_w11']),
             ('WC', ['company_wc2b', 'company_wc2n', 'company_wc1x', 'company_wc1a']),
-            ('AB', ['company_ab1', 'company_ab10']),
+            ('AB', ['company_ab1_0', 'company_ab1_1', 'company_ab10']),
 
             # Postcode district
             ('W1', ['company_w1', 'company_w1a']),
             ('W11', ['company_w11']),
             ('WC2', ['company_wc2b', 'company_wc2n']),
-            ('AB1', ['company_ab1']),
-            ('AB10', ['company_ab10']),
-            ('SE1', ['company_se1', 'company_se1_2']),
+            ('AB1', ['company_ab1_0', 'company_ab1_1']),
+            ('AB10', ['company_ab10']),  # Should not match company_ab1_0
+            ('SE1', ['company_se1', 'company_se1_3']),
 
             # Postcode district with sub-district
             ('W1A', ['company_w1a']),
 
             # Postcode sector
-            ('SE1 3', ['company_se1', 'company_se1_2']),
-            ('WC2B4', ['company_wc2b']),
+            ('AB1 0', ['company_ab1_0']),  # Should not match company_ab10
+            ('SE1 3', ['company_se1', 'company_se1_3']),
+            ('WC2B 4', ['company_wc2b']),
 
             # Multiple postcodes searched
             (['W1', 'W11'], ['company_w1', 'company_w1a', 'company_w11']),
-            (['AB1', 'AB10'], ['company_ab1', 'company_ab10']),
+            (['AB1', 'AB10'], ['company_ab1_0', 'company_ab1_1', 'company_ab10']),
 
             # Valid and invalid
-            (['SE1', 'Invalid'], ['company_se1', 'company_se1_2']),
+            (['SE1', 'Invalid'], ['company_se1', 'company_se1_3']),
 
             # Mixed-case search
-            (['aB1', 'ab10'], ['company_ab1', 'company_ab10']),
+            (['aB1', 'ab10'], ['company_ab1_0', 'company_ab1_1', 'company_ab10']),
 
-            # Spaces
-            (['W     1', 'W   1   1     '], ['company_w1', 'company_w1a', 'company_w11']),
-
-            # Entire postcode
+            # Entire postcode (spaces should be ignored)
+            (['AB101WC', 'WC2B4AB'], ['company_ab10', 'company_wc2b']),
             (['AB10 1WC', 'WC2B 4AB'], ['company_ab10', 'company_wc2b']),
         ],
     )


### PR DESCRIPTION
### Description of change

This changes how the `uk_postcode` filter operates in company search so that e.g. `AB11` and `AB1 1` are distinct searches.

Previously, both searches were equivalent and they both matched the postcodes `AB11 9AA` and `AB1 1AA`. Now, they are treated as distinct searches  so that`AB11` matches `AB11 9AA` and not `AB1 1AA`  (and `AB1 1` matches `AB1 1AA`  and not `AB11 9AA`).

Spaces are still ignored for full postcodes, so that `AB1 1AA` still matches `AB11AA` (and vice versa).

This was done by removing the `space_remover` filter from the `postcode_search_analyzer` analyser and adding a `pattern_replace` filter to both the `postcode_analyzer` and `postcode_search_analyzer` analysers that adds a space in the correct position to full postcodes that don't have one.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
