### PR TITLE
Rename UK postcode Elasticsearch analysers

### DIFF
--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -218,13 +218,13 @@ def test_mapping(es):
                     },
                 },
                 'uk_address_postcode': {
-                    'analyzer': 'postcode_analyzer',
-                    'search_analyzer': 'postcode_search_analyzer',
+                    'analyzer': 'postcode_analyzer_v2',
+                    'search_analyzer': 'postcode_search_analyzer_v2',
                     'type': 'text',
                 },
                 'uk_registered_address_postcode': {
-                    'analyzer': 'postcode_analyzer',
-                    'search_analyzer': 'postcode_search_analyzer',
+                    'analyzer': 'postcode_analyzer_v2',
+                    'search_analyzer': 'postcode_search_analyzer_v2',
                     'type': 'text',
                 },
                 'one_list_group_global_account_manager': {

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -86,7 +86,7 @@ normalise_postcode_filter = analysis.token_filter(
 
 
 postcode_analyzer = analysis.CustomAnalyzer(
-    'postcode_analyzer',
+    'postcode_analyzer_v2',
     type='custom',
     tokenizer='keyword',
     filter=(space_remover, 'lowercase', normalise_postcode_filter, postcode_filter),
@@ -94,7 +94,7 @@ postcode_analyzer = analysis.CustomAnalyzer(
 
 
 postcode_search_analyzer = analysis.CustomAnalyzer(
-    'postcode_search_analyzer',
+    'postcode_search_analyzer_v2',
     type='custom',
     tokenizer='keyword',
     filter=('lowercase', normalise_postcode_filter),


### PR DESCRIPTION
### Description of change

This fixes an oversight in #2474. Because the postcode analyser names weren't changed, the mapping type was not actually changed and so the migration logic doesn't kick in.

This updates the analyser names so that migration logic kicks in.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
