### PR TITLE
Update Django to version 3.0.3

### DIFF
--- a/changelog/optimise-exists-filtering.internal.md
+++ b/changelog/optimise-exists-filtering.internal.md
@@ -1,0 +1,1 @@
+Some data retention and `dbmaintenance` queries were updated to filter on `Exists()` subqueries directly (rather than via an annotation) following the update to Django 3.0.

--- a/changelog/update-to-django-3.internal.md
+++ b/changelog/update-to-django-3.internal.md
@@ -1,0 +1,1 @@
+Django was updated from version 2.2.9 to 3.0.3.

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -54,7 +54,7 @@ GOVUK_PAY_URL = 'https://payments.example.com/'
 INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE = 5 * 1024
 
 # The default password hasher is intentionally slow and slows downs tests
-# See https://docs.djangoproject.com/en/2.2/topics/testing/overview/#password-hashing
+# See https://docs.djangoproject.com/en/3.0/topics/testing/overview/#password-hashing
 PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.MD5PasswordHasher',
 ]

--- a/datahub/company/test/admin/merge/test_step_1.py
+++ b/datahub/company/test/admin/merge/test_step_1.py
@@ -152,7 +152,7 @@ class TestMergeWithAnotherCompanyViewPost(AdminTestMixin):
             ),
             (
                 '1234',
-                "'1234' is not a valid UUID.",
+                '“1234” is not a valid UUID.',
             ),
             (
                 '',

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -147,7 +147,7 @@ def get_aggregate_subquery(model, expression, join_field_name='pk'):
         raise ValueError('An aggregate expression must be provided.')
 
     # For an explanation of the operations here, see
-    # https://docs.djangoproject.com/en/2.2/ref/models/expressions/#using-aggregates-within-a-subquery-expression
+    # https://docs.djangoproject.com/en/3.0/ref/models/expressions/#using-aggregates-within-a-subquery-expression
     queryset = model.objects.filter(
         **{join_field_name: OuterRef('pk')},
     ).order_by(

--- a/datahub/core/test/test_admin_csv_import.py
+++ b/datahub/core/test/test_admin_csv_import.py
@@ -55,7 +55,7 @@ row2é\r
 
         assert 'csv_file' in form.errors
         assert form.errors['csv_file'] == [
-            f"File extension '{ext[1:]}' is not allowed. Allowed extensions are: 'csv'.",
+            f'File extension “{ext[1:]}” is not allowed. Allowed extensions are: csv.',
         ]
 
     def test_does_not_allow_file_without_required_column(self):

--- a/datahub/core/test/test_migration_utils.py
+++ b/datahub/core/test/test_migration_utils.py
@@ -239,7 +239,7 @@ class TestLoadYamlInMigration:
             with mock.patch('datahub.core.migration_utils.open', mocked_read, create=True):
                 load_yaml_data_in_migration(migration_apps, 'path-to-file.yaml')
         assert str(excinfo.value) == (
-            "[\"'invalid' value must be an integer.\"]: (book:pk=1) field_value was 'invalid'"
+            "['“invalid” value must be an integer.']: (book:pk=1) field_value was 'invalid'"
         )
 
     def test_invalid_field_raises_exception(self, migration_apps):
@@ -260,7 +260,7 @@ class TestLoadYamlInMigration:
             with mock.patch('datahub.core.migration_utils.open', mocked_read, create=True):
                 load_yaml_data_in_migration(migration_apps, 'path-to-file.yaml')
         assert str(excinfo.value) == (
-            "[\"'invalid' value has an invalid date format. It must be in YYYY-MM-DD format.\"]: "
+            "['“invalid” value has an invalid date format. It must be in YYYY-MM-DD format.']: "
             "(book:pk=1) field_value was 'invalid'"
         )
 

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -289,7 +289,7 @@ class TestInteractionCSVRowFormValidation:
                 {'event_id': 'non_existent_event_id'},
                 {
                     'event_id': [
-                        "'non_existent_event_id' is not a valid UUID.",
+                        '“non_existent_event_id” is not a valid UUID.',
                     ],
                 },
                 id='event_id invalid',

--- a/datahub/investment/investor_profile/test/test_views.py
+++ b/datahub/investment/investor_profile/test/test_views.py
@@ -162,11 +162,11 @@ class TestLargeCapitalProfileListView(APITestMixin):
             ),
             (
                 'hello',
-                {'investor_company_id': ["'hello' is not a valid UUID."]},
+                {'investor_company_id': ['“hello” is not a valid UUID.']},
             ),
             (
                 1,
-                {'investor_company_id': ["'1' is not a valid UUID."]},
+                {'investor_company_id': ['“1” is not a valid UUID.']},
             ),
         ),
     )

--- a/datahub/oauth/admin/utils.py
+++ b/datahub/oauth/admin/utils.py
@@ -3,7 +3,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.core.cache import cache
-from django.utils.http import is_safe_url
+from django.utils.http import url_has_allowed_host_and_scheme
 from requests import HTTPError
 from rest_framework.exceptions import AuthenticationFailed
 
@@ -79,7 +79,7 @@ def get_adviser_by_sso_user_profile(sso_user_profile):
 def get_safe_next_url_from_request(request):
     """Get safe next URL from request."""
     next_url = request.GET.get('next')
-    if is_safe_url(
+    if url_has_allowed_host_and_scheme(
         url=next_url,
         allowed_hosts={request.get_host()},
         require_https=request.is_secure(),

--- a/datahub/omis/order/test/test_admin.py
+++ b/datahub/omis/order/test/test_admin.py
@@ -60,7 +60,7 @@ class TestCancelOrderAdmin(AdminTestMixin):
         response = self.client.get(url, follow=True)
         assert response.status_code == 200
         assert [msg.message for msg in response.context['messages']] == [
-            f'order with ID "{order_id}" doesn\'t exist. Perhaps it was deleted?',
+            f'order with ID “{order_id}” doesn’t exist. Perhaps it was deleted?',
         ]
 
     def test_400_popup_not_allowed(self):

--- a/datahub/omis/order/test/test_models.py
+++ b/datahub/omis/order/test/test_models.py
@@ -713,7 +713,7 @@ class TestOrderAssignee:
         assert str(assignee.country_id) == constants.Country.france.value.id
 
         # adviser belonging to a team without country
-        team = TeamFactory(country=None)
+        team = TeamFactory(country_id=None)
         adviser = AdviserFactory(dit_team=team)
         assignee = OrderAssigneeFactory(adviser=adviser)
 

--- a/datahub/omis/order/test/test_utils.py
+++ b/datahub/omis/order/test/test_utils.py
@@ -119,7 +119,7 @@ class TestPopulateBillingData:
             billing_address_town='',
             billing_address_county='',
             billing_address_postcode='',
-            billing_address_country=None,
+            billing_address_country_id=None,
 
             company=company,
             contact=ContactFactory.build(),

--- a/datahub/user/company_list/test/test_views.py
+++ b/datahub/user/company_list/test/test_views.py
@@ -153,7 +153,7 @@ class TestListCompanyListsView(APITestMixin):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            'items__company_id': ["'invalid_id' is not a valid UUID."],
+            'items__company_id': ['“invalid_id” is not a valid UUID.'],
         }
 
     def test_can_filter_by_valid_company_id(self):

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # Django and django related
-Django==2.2.9
+django==3.0.3
 djangorestframework==3.11.0
 django-environ==0.4.5
 django-extensions==2.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@
 amqp==2.5.2               # via kombu
 apipkg==1.5               # via execnet
 argh==0.26.2              # via watchdog
+asgiref==3.2.3            # via django
 attrs==19.3.0             # via flake8-bugbear, pytest
 backcall==0.1.0           # via ipython
 billiard==3.6.2.0
@@ -29,7 +30,7 @@ django-oauth-toolkit==1.2.0
 django-pglocks==1.0.4
 django-redis==4.11.0
 django-reversion==3.0.5
-django==2.2.9
+django==3.0.3
 djangorestframework==3.11.0
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore


### PR DESCRIPTION
### Description of change

Note: This is currently blocked as Django 3.0.3 hasn't been released yet. It is going to be released on 3 February around 10am.

This updates Django from version 2.2.9 to version 3.0.3.

Release notes: https://docs.djangoproject.com/en/3.0/releases/3.0/

A few tests were updated because they were inadvertently setting e.g. both `country` to `None` and `country_id` to a non-`None` value when instantiating models. The tests were relying on incorrect behaviour in older version of Django in this case.

Some other tests were updated due to changed error messages in Django.

(See #2482 for more background information on the update.)

Some follow-up tasks would be to:
- use the new enumeration types in place of `model_utils.Choices`: https://docs.djangoproject.com/en/3.0/ref/models/fields/#field-choices-enum-types (I have started on this on another branch)
- ~update `Exists()` filtering in line with: https://docs.djangoproject.com/en/3.0/ref/models/expressions/#filtering-on-a-subquery-or-exists-expressions~
- remove the `createsuperuserwithpassword` management command: https://docs.djangoproject.com/en/3.0/ref/django-admin/#django-admin-createsuperuser

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
