### PR TITLE
Patch MAX_DATABAG_BREADTH for sentry

### DIFF
--- a/config/settings/common_sentry.py
+++ b/config/settings/common_sentry.py
@@ -1,8 +1,12 @@
 import sentry_sdk
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk import serializer
 
 from config.settings.common import *
+
+# Monkeypatch the constant that trims data in `extra`
+MAX_DATABAG_BREADTH = 1000
 
 # Logging
 LOGGING = {

--- a/config/settings/common_sentry.py
+++ b/config/settings/common_sentry.py
@@ -6,7 +6,7 @@ from sentry_sdk import serializer
 from config.settings.common import *
 
 # Monkeypatch the constant that trims data in `extra`
-MAX_DATABAG_BREADTH = 1000
+serializer.MAX_DATABAG_BREADTH = 1000
 
 # Logging
 LOGGING = {


### PR DESCRIPTION
### Description of change

This patches a constant in Sentry to raise the upper limit of e.g. elements in an array that we plonk in the `extra` kwarg [here](https://github.com/uktrade/data-hub-api/blob/develop/datahub/dnb_api/tasks.py#L89).

The original value for this constant was 10 which meant that we were getting:

![Screenshot 2020-01-21 at 15 14 59](https://user-images.githubusercontent.com/3349430/72816936-d7024a80-3c60-11ea-9560-90bfb53f4acb.png)

i.e. 10 IDs instead of 41.

I found the solution [here](https://forum.sentry.io/t/python-sdk-extra-data-capped-at-400-characters/6909).

Sentry also does some trimming server side and we would know when we run into it but for now, this should help a lot with monitoring automatic-updates.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
