### PR TITLE
Add dnb_modified_on filter to admin

### DIFF
--- a/changelog/company/dnb-modified-on-admin-filter.feature.md
+++ b/changelog/company/dnb-modified-on-admin-filter.feature.md
@@ -1,0 +1,3 @@
+The company list view in Django admin now has a filter for `dnb_modified_on` field.
+
+This allows us to e.g. filter companies that were updated during today.

--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -213,6 +213,9 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
         'name',
         'registered_address_country',
     )
+    list_filter = (
+        'dnb_modified_on',
+    )
     inlines = (
         OneListCoreTeamMemberInline,
     )


### PR DESCRIPTION
### Description of change

The company list view in Django admin now has a filter for `dnb_modified_on` field.

This allows us to e.g. filter companies that were updated today.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
