### PR TITLE
Add company dataset fields required for policy feedback report

### DIFF
--- a/changelog/company/dataset-api-endpoint-add-policy-feedback-fields.api.md
+++ b/changelog/company/dataset-api-endpoint-add-policy-feedback-fields.api.md
@@ -1,0 +1,3 @@
+`GET /v4/dataset/companies-dataset`: 2 new fields were added to the companies dataset response:
+- `global_headquarters_id`
+- `global_ultimate_duns_number`

--- a/datahub/dataset/company/test/test_views.py
+++ b/datahub/dataset/company/test/test_views.py
@@ -32,6 +32,12 @@ def get_expected_data_from_company(company):
             company,
             'export_experience_category.name',
         ),
+        'global_headquarters_id': (
+            str(company.global_headquarters_id)
+            if company.global_headquarters_id is not None
+            else None
+        ),
+        'global_ultimate_duns_number': company.global_ultimate_duns_number,
         'headquarter_type__name': get_attr_or_none(
             'company',
             'headquarter_type.name',

--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -30,6 +30,8 @@ class CompaniesDatasetView(BaseDatasetView):
             'description',
             'duns_number',
             'export_experience_category__name',
+            'global_headquarters_id',
+            'global_ultimate_duns_number',
             'headquarter_type__name',
             'id',
             'is_number_of_employees_estimated',


### PR DESCRIPTION
### Description of change

Add two new fields to the companies dataset api endpoint.

- `global_headquarters_id`
- `global_ultimate_duns_number`

These fields are required for running the policy feedback report on data workspace.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
