### PR TITLE
Improve docker setup docs and default env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ More guides can be found in the [docs](./docs/) folder.
 
 This project uses Docker compose to setup and run all the necessary components. The docker-compose.yml file provided is meant to be used for running tests and development.
 
+**Note for Mac Users:** By default, docker on Mac will restrict itself to using just 2GB of memory. This [should be increased](https://docs.docker.com/docker-for-mac/#resources) to at least 4GB to avoid running in to unexpected problems.
+
 1.  Clone the repository:
 
     ```shell

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This project uses Docker compose to setup and run all the necessary components. 
 
 4.  Optionally, you may want to run a local copy of the data hub frontend.
     By default, you can run both the API and the frontend under one docker-compose
-    project.  [See the instructions in the frontend readme to set it up](https://github.com/uktrade/data-hub-frontend/#setting-up-with-docker-compose).
+    project.  [See the instructions in the frontend readme to set it up](https://github.com/uktrade/data-hub-frontend/#running-project-within-docker).
 
 ## Native installation (without Docker)
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ This project uses Docker compose to setup and run all the necessary components. 
     cp sample.env .env
     ```
 
+    If you're working with data-hub-frontend and mock-sso, `SUPERUSER_USERNAME` should
+    be the same as MOCK_SSO_USERNAME in the frontend's .env file.
+
 3.  Build and run the necessary containers for the required environment:
 
     ```shell

--- a/sample.env
+++ b/sample.env
@@ -15,7 +15,7 @@ AWS_ACCESS_KEY_ID=foo
 AWS_SECRET_ACCESS_KEY=bar
 DEFAULT_BUCKET=baz
 SSO_ENABLED=True
-RESOURCE_SERVER_INTROSPECTION_URL=http://mocksso:8080/o/introspect/
+RESOURCE_SERVER_INTROSPECTION_URL=http://mock-sso:8080/o/introspect/
 RESOURCE_SERVER_AUTH_TOKEN=sso-token
 ACTIVITY_STREAM_ACCESS_KEY_ID=some-id
 ACTIVITY_STREAM_SECRET_ACCESS_KEY=some-secret
@@ -30,11 +30,12 @@ PAAS_IP_WHITELIST=1.2.3.4
 #DISABLE_PAAS_IP_CHECK=true
 
 DIT_EMAIL_DOMAINS=trade.gov.uk,digital.trade.gov.uk
+DATA_HUB_FRONTEND_ACCESS_KEY_ID=frontend-key-id
+DATA_HUB_FRONTEND_SECRET_ACCESS_KEY=frontend-key
+
 # Determines the docker-compose project - by default, containers with the same
 # project name share a network and are able to communicate with eachother
 COMPOSE_PROJECT_NAME=data-hub
 # Some extra ENV variables to make superuser creation easier on docker copies
-#SUPERUSER_USERNAME=brendan.smith
+#SUPERUSER_USERNAME=some.person@digital.trade.gov.uk
 #SUPERUSER_PASSWORD=foobarbaz
-DATA_FLOW_API_ACCESS_KEY_ID=data-flow-api-id
-DATA_FLOW_API_SECRET_ACCESS_KEY=data-flow-api-access-key

--- a/sample.env
+++ b/sample.env
@@ -30,6 +30,8 @@ PAAS_IP_WHITELIST=1.2.3.4
 #DISABLE_PAAS_IP_CHECK=true
 
 DIT_EMAIL_DOMAINS=trade.gov.uk,digital.trade.gov.uk
+DATA_FLOW_API_ACCESS_KEY_ID=data-flow-api-id	
+DATA_FLOW_API_SECRET_ACCESS_KEY=data-flow-api-access-key
 DATA_HUB_FRONTEND_ACCESS_KEY_ID=frontend-key-id
 DATA_HUB_FRONTEND_SECRET_ACCESS_KEY=frontend-key
 

--- a/sample.env
+++ b/sample.env
@@ -39,5 +39,7 @@ DATA_HUB_FRONTEND_SECRET_ACCESS_KEY=frontend-key
 # project name share a network and are able to communicate with eachother
 COMPOSE_PROJECT_NAME=data-hub
 # Some extra ENV variables to make superuser creation easier on docker copies
+# If you're working with data-hub-frontend and mock-sso, SUPERUSER_USERNAME should
+# be the same as MOCK_SSO_USERNAME in the frontend's .env file
 #SUPERUSER_USERNAME=some.person@digital.trade.gov.uk
 #SUPERUSER_PASSWORD=foobarbaz


### PR DESCRIPTION
### Description of change
This PR improves default `sample.env` values to allow frontend/backend docker copies to work together out of the box.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
