### PR TITLE
Adding readonly export_countries field to company API

### DIFF
--- a/changelog/company/return_export_countries_to_company.api.md
+++ b/changelog/company/return_export_countries_to_company.api.md
@@ -1,0 +1,29 @@
+`GET /v4/company/<pk>`: Expose export countries as `export_countries` from new `CompanyExportCountry` model within company response. The field has following structure:
+
+ ```json
+{
+    "export_countries": [
+        {
+        "country": {
+            "name": ...,
+            "id": ...
+        },
+        "status": "currently_exporting"
+        },
+        {
+        "country": {
+            "name": ...,
+            "id": ...
+        },
+        "status": "not_interested"
+        },
+        {
+        "country": {
+            "name": ...,
+            "id": ...
+        },
+        "status": "future_interest"
+        },
+    ]
+}
+```

--- a/datahub/company/queryset.py
+++ b/datahub/company/queryset.py
@@ -1,4 +1,4 @@
-from datahub.company.models import Contact
+from datahub.company.models import CompanyExportCountry, Contact
 
 
 def get_contact_queryset():
@@ -10,3 +10,8 @@ def get_contact_queryset():
         'address_country',
         'archived_by',
     )
+
+
+def get_export_country_queryset():
+    """Gets the export country query set used by views."""
+    return CompanyExportCountry.objects.order_by('pk').select_related('country')

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -195,6 +195,18 @@ class ContactSerializer(PermittedFieldsModelSerializer):
         }
 
 
+class CompanyExportCountrySerializer(serializers.ModelSerializer):
+    """
+    CompanyExportCountry serializer.
+    """
+
+    country = NestedRelatedField(meta_models.Country)
+
+    class Meta:
+        model = CompanyExportCountry
+        fields = ('country', 'status')
+
+
 class CompanySerializer(PermittedFieldsModelSerializer):
     """
     Base Company read/write serializer
@@ -269,6 +281,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         allow_null=True,
     )
     address = AddressSerializer(source_model=Company, address_source_prefix='address')
+    export_countries = CompanyExportCountrySerializer(many=True, read_only=True)
 
     # Use our RelaxedURLField instead to automatically fix URLs without a scheme
     serializer_field_mapping = {
@@ -474,6 +487,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'is_global_ultimate',
             'global_ultimate_duns_number',
             'dnb_modified_on',
+            'export_countries',
         )
         read_only_fields = (
             'archived',
@@ -493,6 +507,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'is_global_ultimate',
             'global_ultimate_duns_number',
             'dnb_modified_on',
+            'export_countries',
         )
         dnb_read_only_fields = (
             'name',

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -93,6 +93,13 @@ class CompanyFactory(factory.django.DjangoModelFactory):
         """
         return []
 
+    @to_many_field
+    def export_countries(self):  # noqa: D102
+        """
+        Add support for setting `export_countries`.
+        """
+        return []
+
     class Params:
         hq = factory.Trait(
             headquarter_type=factory.LazyFunction(lambda: random_obj_for_model(HeadquarterType)),

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -15,7 +15,10 @@ from datahub.company.models import (
     CompanyPermission,
     Contact,
 )
-from datahub.company.queryset import get_contact_queryset
+from datahub.company.queryset import (
+    get_contact_queryset,
+    get_export_country_queryset,
+)
 from datahub.company.serializers import (
     AdviserSerializer,
     CompanySerializer,
@@ -80,6 +83,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         'sector__parent__parent',
         'sector__parent',
         'sector',
+        Prefetch('export_countries', queryset=get_export_country_queryset()),
     )
 
     @action(

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -427,6 +427,7 @@ class TestDNBCompanyCreateAPI(APITestMixin):
                 dnb_company['global_ultimate_duns_number'] == dnb_company['duns_number']
             ),
             'dnb_modified_on': '2019-01-01T11:12:13Z',
+            'export_countries': [],
         }
 
     @override_settings(DNB_SERVICE_BASE_URL=None)


### PR DESCRIPTION
### Description of change
This is first part of two part feature to allow GET/PATCH of CompanyExportCountry data within company API.

This adds readonly export_countries field to expose new CompanyExportCountry model data along with old export country fields.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
