### PR TITLE
Add `modified_on` field to the interactions dataset response

### DIFF
--- a/changelog/interaction/dataset-api-endpoint-add-modified-on.api.md
+++ b/changelog/interaction/dataset-api-endpoint-add-modified-on.api.md
@@ -1,0 +1,1 @@
+`GET /v4/dataset/interactions-dataset`: The field `modified_on` was added to the interactions dataset endpoint.

--- a/datahub/dataset/interaction/test/test_views.py
+++ b/datahub/dataset/interaction/test/test_views.py
@@ -47,6 +47,7 @@ def get_expected_data_from_interaction(interaction):
             else None
         ),
         'kind': interaction.kind,
+        'modified_on': format_date_or_datetime(interaction.modified_on),
         'net_company_receipt': (
             float(interaction.net_company_receipt)
             if interaction.net_company_receipt is not None

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -56,6 +56,7 @@ class InteractionsDatasetView(BaseDatasetView):
             'interaction_link',
             'investment_project_id',
             'kind',
+            'modified_on',
             'net_company_receipt',
             'notes',
             'policy_area_names',


### PR DESCRIPTION
### Description of change

Add `modified_on` field to the interaction dataset response. This will allow us to accurately report on changes made after an interaction is created on data workspace.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
