### PR TITLE
Sort endpoints in API docs

### DIFF
--- a/changelog/sort-paths-api-docs.feature.md
+++ b/changelog/sort-paths-api-docs.feature.md
@@ -1,0 +1,1 @@
+Endpoints are now sorted by path in the API docs.

--- a/changelog/update-swagger-ui.internal.md
+++ b/changelog/update-swagger-ui.internal.md
@@ -1,0 +1,1 @@
+Swagger UI, used in the API docs, was updated to version 3.25.0.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -279,12 +279,12 @@ REST_FRAMEWORK = {
 # See https://unpkg.com/ for info on unpkg and if are updating these (the integrity value
 # can be obtained by adding ?meta to the URL of the resource).
 SWAGGER_UI_CSS = {
-    'url': 'https://unpkg.com/swagger-ui-dist@3.23.1/swagger-ui.css',
-    'integrity': 'sha384-tgOpIqeb5Ds0xSeXMInWaZ1o8ujNJdUUIiDk/ZpnZjFDQl0t1yxsBpGsG8/fjDZS',
+    'url': 'https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui.css',
+    'integrity': 'sha384-WBdQ4nw0UWAWpf/c1u6DHcCmoT1wY63dk3fPmcb0vKhXP81/lK4GSIiU5nrA6qEs',
 }
 SWAGGER_UI_JS = {
-    'url': 'https://unpkg.com/swagger-ui-dist@3.23.1/swagger-ui-bundle.js',
-    'integrity': 'sha384-61ytfM+owD7jIzMmLJD2aRIp30qF9hY+2KyBhMk89VT/kR7Dhwa5UBTmwLZbA2Pz',
+    'url': 'https://unpkg.com/swagger-ui-dist@3.25.0/swagger-ui-bundle.js',
+    'integrity': 'sha384-LayfYpTwEewV6vK80x7XxHevzp5lS9x3eH/rfMVR26RiPbwjOdH1r6CUTPfABavZ',
 }
 
 # Simplified static file serving.

--- a/datahub/core/templates/core/docs/swagger-ui.html
+++ b/datahub/core/templates/core/docs/swagger-ui.html
@@ -28,10 +28,11 @@
           SwaggerUIBundle.SwaggerUIStandalonePreset
         ],
         layout: "BaseLayout",
+        operationsSorter: 'alpha',
         requestInterceptor: (req) => {
             req.headers['X-CSRFToken'] = "{{csrf_token}}";
             return req;
-        }
+        },
       })
     </script>
   </body>


### PR DESCRIPTION
### Description of change

This updates the Swagger UI configuration so that endpoints are sorted by path (instead of the somewhat arbitrary previous order).

Swagger UI was also updated to [the latest version](https://github.com/swagger-api/swagger-ui/releases).

### Screenshots

These show is a small subset of routes to highlight the difference.

#### Before

![image](https://user-images.githubusercontent.com/12693549/72982452-063ac800-3dd7-11ea-9266-0ddab574ba4e.png)

#### After

![image](https://user-images.githubusercontent.com/12693549/72982397-e3101880-3dd6-11ea-938e-27dcca3d689c.png)


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
