### PR TITLE
Add investment projects activity / SPI report dataset endpoint

### DIFF
--- a/changelog/investment/investment-projects-activity-dataset.api.md
+++ b/changelog/investment/investment-projects-activity-dataset.api.md
@@ -1,0 +1,20 @@
+The `GET /v4/dataset/investment-projects-activity-dataset` has been added. The endpoint returns SPI report records for 
+corresponding investment projects. The response has following fields:
+ 
+  - investment_project_id
+  - enquiry_processed
+  - enquiry_type
+  - enquiry_processed_by_id
+  - assigned_to_ist
+  - project_manager_assigned
+  - project_manager_assigned_by_id
+  - project_moved_to_won
+  - aftercare_offered_on
+  - propositions
+
+    The propositions is an array with following fields:
+    
+    - deadline
+    - status
+    - modified_on
+    - adviser_id

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -85,6 +85,7 @@ def get_array_agg_subquery(
     model,
     join_field_name,
     expression_to_aggregate,
+    filter=None,
     distinct=False,
     ordering=(),
 ):
@@ -112,6 +113,15 @@ def get_array_agg_subquery(
             ),
         )
 
+        Interaction.objects.annotate(
+            adviser_first_names=get_array_agg_subquery(
+                InteractionDITParticipant,
+                'interaction',
+                'first_name,
+                filter=Q('first_name__startswith='A'),
+            ),
+        )
+
     Note: The usage of this function differs from `get_string_agg_subquery()`, as this function
     omits the outer model from the subquery to avoid unwanted NULL values appearing in the
     returned arrays when rows don't have any values in the intermediate model being queried.
@@ -124,7 +134,12 @@ def get_array_agg_subquery(
     """
     return get_aggregate_subquery(
         model,
-        ArrayAgg(expression_to_aggregate, distinct=distinct, ordering=ordering),
+        ArrayAgg(
+            expression_to_aggregate,
+            distinct=distinct,
+            ordering=ordering,
+            filter=filter,
+        ),
         join_field_name=join_field_name,
     )
 

--- a/datahub/dataset/investment_project/pagination.py
+++ b/datahub/dataset/investment_project/pagination.py
@@ -1,0 +1,27 @@
+"""
+Pagination serializers determine the structure of the output that should
+be used for paginated responses.
+"""
+
+from rest_framework.response import Response
+
+from datahub.dataset.core.pagination import DatasetCursorPagination
+from datahub.dataset.investment_project.spi import SPIReportFormatter
+
+
+class InvestmentProjectActivityDatasetViewCursorPagination(DatasetCursorPagination):
+    """Cursor Pagination for SPI Report."""
+
+    ordering = ('created_on', 'pk')
+
+    def get_paginated_response(self, data):
+        """Get paginated response."""
+        spi_report = SPIReportFormatter()
+        results = spi_report.format(data)
+        return Response(
+            {
+                'next': self.get_next_link(),
+                'previous': self.get_previous_link(),
+                'results': results,
+            },
+        )

--- a/datahub/dataset/investment_project/spi.py
+++ b/datahub/dataset/investment_project/spi.py
@@ -1,0 +1,67 @@
+from dateutil.parser import parse as dateutil_parse
+
+from datahub.investment.project.proposition.models import PropositionStatus
+from datahub.investment.project.report.spi import SPIReport
+
+
+class SPIReportFormatter:
+    """
+    SPI Report Formatter changes the format of the SPI Report.
+
+    TODO: Once original SPI report is removed from Django admin, this format should be
+    implemented in the report itself.
+    """
+
+    required_fields_label_mapping = {
+        'Data Hub ID': 'investment_project_id',
+        'Enquiry processed': 'enquiry_processed',
+        'Enquiry type': 'enquiry_type',
+        'Enquiry processed by': 'enquiry_processed_by_id',
+        'Assigned to IST': 'assigned_to_ist',
+        'Project manager assigned': 'project_manager_assigned',
+        'Project manager assigned by': 'project_manager_assigned_by_id',
+        'Project moved to won': 'project_moved_to_won',
+        'Aftercare offered on': 'aftercare_offered_on',
+        'Propositions': 'propositions',
+    }
+
+    required_fields_value_mapping = {
+        'Enquiry processed by': lambda adviser: str(adviser),
+        'Project manager assigned by': lambda adviser: str(adviser.id),
+    }
+
+    def __init__(self):
+        """Initialise SPI Report Formatter."""
+        self._SPIReport = SPIReport(proposition_formatter=proposition_formatter)
+
+    def filter_fields(self, result):
+        """Filter results fields."""
+        return {
+            self.required_fields_label_mapping[key]: value
+            for key, value in result.items()
+            if key in self.required_fields_label_mapping
+        }
+
+    def format(self, investment_projects):
+        """
+        Enrich Investment Project record with SPI report data and only include required fields.
+        """
+        for investment_project in investment_projects:
+            spi_report_row = self._SPIReport.get_row(investment_project)
+            result = self.filter_fields(spi_report_row)
+            yield result
+
+
+def proposition_formatter(propositions):
+    """Returns a list of propositions with selected fields."""
+    return [
+        {
+            'deadline': dateutil_parse(proposition['deadline']).strftime('%Y-%m-%d'),
+            'status': proposition['status'],
+            'modified_on':
+                dateutil_parse(proposition['modified_on']).isoformat()
+                if proposition['status'] != PropositionStatus.ongoing else '',
+            'adviser_id': proposition['adviser_id'],
+        }
+        for proposition in propositions
+    ]

--- a/datahub/dataset/investment_project/test/test_spi.py
+++ b/datahub/dataset/investment_project/test/test_spi.py
@@ -1,0 +1,87 @@
+from uuid import uuid4
+
+import pytest
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.dataset.investment_project.spi import proposition_formatter, SPIReportFormatter
+from datahub.investment.project.proposition.models import PropositionStatus
+
+pytestmark = pytest.mark.django_db
+
+
+def test_spi_record_row_is_formatted():
+    """Test that SPI record row is being formatted correctly."""
+    formatter = SPIReportFormatter()
+    spi_report_row = {
+        'Project created on': 'project_created_on',
+        'Enquiry processed': 'enquiry_processed',
+        'Enquiry type': 'enquiry_type',
+        'Enquiry processed by': str(AdviserFactory().id),
+        'Assigned to IST': 'assigned_to_ist',
+        'Project manager assigned': 'project_manager_assigned',
+        'Project manager assigned by': str(AdviserFactory().id),
+        'Propositions': [{
+            'deadline': 'deadline',
+            'status': 'status',
+            'modified_on': 'modified_on',
+            'adviser_id': 'adviser_id',
+        }],
+        'Project moved to won': 'project_moved_to_won',
+        'Aftercare offered on': 'aftercare_offered_on',
+        'Project ID': 'project_id',
+        'Data Hub ID': 'data_hub_id',
+        'Project name': 'project_name',
+    }
+    filtered_row = formatter.filter_fields(spi_report_row)
+    assert filtered_row == {
+        'enquiry_processed': 'enquiry_processed',
+        'enquiry_type': 'enquiry_type',
+        'enquiry_processed_by_id': spi_report_row['Enquiry processed by'],
+        'assigned_to_ist': 'assigned_to_ist',
+        'project_manager_assigned': 'project_manager_assigned',
+        'project_manager_assigned_by_id': spi_report_row['Project manager assigned by'],
+        'propositions': [{
+            'deadline': 'deadline',
+            'status': 'status',
+            'modified_on': 'modified_on',
+            'adviser_id': 'adviser_id',
+        }],
+        'project_moved_to_won': 'project_moved_to_won',
+        'aftercare_offered_on': 'aftercare_offered_on',
+        'investment_project_id': 'data_hub_id',
+    }
+
+
+def test_proposition_formatter():
+    """Test that propositions are being formatted correctly."""
+    propositions = [
+        {
+            'deadline': '2010-02-01T00:00:00+00:00',
+            'modified_on': '2010-02-02T00:00:00+00:00',
+            'status': PropositionStatus.ongoing,
+            'adviser_id': uuid4(),
+        },
+        {
+            'deadline': '2010-02-01T00:00:00+00:00',
+            'modified_on': '2010-02-02T00:00:00+00:00',
+            'status': PropositionStatus.completed,
+            'adviser_id': uuid4(),
+        },
+    ]
+
+    formatted_propositions = proposition_formatter(propositions)
+
+    assert formatted_propositions == [
+        {
+            'deadline': '2010-02-01',
+            'modified_on': '',
+            'status': PropositionStatus.ongoing,
+            'adviser_id': propositions[0]['adviser_id'],
+        },
+        {
+            'deadline': '2010-02-01',
+            'modified_on': '2010-02-02T00:00:00+00:00',
+            'status': PropositionStatus.completed,
+            'adviser_id': propositions[1]['adviser_id'],
+        },
+    ]

--- a/datahub/dataset/investment_project/test/test_views.py
+++ b/datahub/dataset/investment_project/test/test_views.py
@@ -3,12 +3,15 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.company.test.factories import AdviserFactory, TeamFactory
 from datahub.core.test_utils import (
     format_date_or_datetime,
     get_attr_or_none,
     str_or_none,
 )
 from datahub.dataset.core.test import BaseDatasetViewTest
+from datahub.investment.project.proposition.models import PropositionDocument
+from datahub.investment.project.proposition.test.factories import PropositionFactory
 from datahub.investment.project.test.factories import (
     ActiveInvestmentProjectFactory,
     AssignPMInvestmentProjectFactory,
@@ -18,6 +21,64 @@ from datahub.investment.project.test.factories import (
     VerifyWinInvestmentProjectFactory,
     WonInvestmentProjectFactory,
 )
+from datahub.metadata.models import Team
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def ist_adviser():
+    """Provides IST adviser."""
+    team = TeamFactory(tags=[Team.TAGS.investment_services_team])
+    yield AdviserFactory(dit_team_id=team.id)
+
+
+@pytest.fixture
+def propositions(ist_adviser):
+    """Gets variety of propositions."""
+    investment_project = InvestmentProjectFactory(
+        project_manager=ist_adviser,
+    )
+    adviser = AdviserFactory(
+        first_name='John',
+        last_name='Doe',
+    )
+    items = [
+        PropositionFactory(
+            deadline='2017-01-05',
+            status='ongoing',
+            adviser=adviser,
+            investment_project=investment_project,
+            created_by=ist_adviser,
+        ),
+        PropositionFactory(
+            deadline='2017-01-05',
+            status='ongoing',
+            adviser=adviser,
+            investment_project=investment_project,
+            created_by=ist_adviser,
+        ),
+        PropositionFactory(
+            deadline='2017-01-05',
+            status='ongoing',
+            adviser=adviser,
+            investment_project=investment_project,
+            created_by=ist_adviser,
+        ),
+    ]
+
+    with freeze_time('2017-01-04 11:11:11'):
+        entity_document = PropositionDocument.objects.create(
+            proposition_id=items[1].pk,
+            original_filename='test.txt',
+            created_by=adviser,
+        )
+        entity_document.document.mark_as_scanned(True, '')
+        items[1].complete(by=adviser, details='what')
+
+        items[2].abandon(by=adviser, details='what')
+
+    yield items
 
 
 def get_expected_data_from_project(project):
@@ -187,3 +248,58 @@ class TestInvestmentProjectsDatasetViewSet(BaseDatasetViewTest):
                                        key=lambda item: item.pk) + [project_1, project_2]
         for index, project in enumerate(expected_project_list):
             assert str(project.id) == response_results[index]['id']
+
+
+class TestInvestmentProjectsActivityDatasetViewSet(BaseDatasetViewTest):
+    """
+    Tests for InvestmentProjectsActivityDatasetView
+
+    It only tests if results are being returned. The results are validated in separate tests
+    in the investment project app.
+    """
+
+    view_url = reverse('api-v4:dataset:investment-projects-activity-dataset')
+    factory = InvestmentProjectFactory
+
+    def test_propositions_are_being_formatted(self, data_flow_api_client, propositions):
+        """Test that returned propositions are being formatted correctly."""
+        response = data_flow_api_client.get(self.view_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_results = response.json()['results']
+        assert len(response_results[0]['propositions']) == len(propositions)
+
+        adviser_id = str(propositions[0].adviser_id)
+        assert response_results == [
+            {
+                'propositions': [
+                    {
+                        'deadline': '2017-01-05',
+                        'status': 'ongoing',
+                        'modified_on': '',
+                        'adviser_id': adviser_id,
+                    },
+                    {
+                        'deadline': '2017-01-05',
+                        'status': 'completed',
+                        'modified_on': '2017-01-04T11:11:11+00:00',
+                        'adviser_id': adviser_id,
+                    },
+                    {
+                        'deadline': '2017-01-05',
+                        'status': 'abandoned',
+                        'modified_on': '2017-01-04T11:11:11+00:00',
+                        'adviser_id': adviser_id,
+                    },
+                ],
+                'investment_project_id': str(propositions[0].investment_project.id),
+                'enquiry_processed': '',
+                'enquiry_type': '',
+                'enquiry_processed_by_id': '',
+                'assigned_to_ist': '',
+                'project_manager_assigned': '',
+                'project_manager_assigned_by_id': '',
+                'project_moved_to_won': '',
+                'aftercare_offered_on': '',
+            },
+        ]

--- a/datahub/dataset/investment_project/views.py
+++ b/datahub/dataset/investment_project/views.py
@@ -2,12 +2,18 @@ from django.contrib.postgres.aggregates import ArrayAgg
 
 from datahub.core.query_utils import (
     get_aggregate_subquery,
-    get_array_agg_subquery,
     get_empty_string_if_null_expression,
 )
+from datahub.core.query_utils import (
+    get_array_agg_subquery,
+)
 from datahub.dataset.core.views import BaseDatasetView
+from datahub.dataset.investment_project.pagination import (
+    InvestmentProjectActivityDatasetViewCursorPagination,
+)
 from datahub.investment.project.models import InvestmentProject
 from datahub.investment.project.query_utils import get_project_code_expression
+from datahub.investment.project.report.spi import get_spi_report_queryset
 from datahub.metadata.query_utils import get_sector_name_subquery
 
 
@@ -129,3 +135,21 @@ class InvestmentProjectsDatasetView(BaseDatasetView):
             'uk_company_sector',
             'uk_region_location_names',
         )
+
+
+class InvestmentProjectsActivityDatasetView(BaseDatasetView):
+    """
+    An APIView that provides 'get' action which queries and returns desired fields
+    for Investment Projects Activity Dataset to be consumed by Data-flow periodically.
+
+    Activity contains SPI report records and it is linked to Investment Project by Data Hub ID.
+    Because of the way the report is generated, the relevant SPI report fields are attached to
+    Investment Project record in the 'InvestmentProjectActivityDatasetViewCursorPagination'
+    pagination class and at the same time all other fields are being left out.
+    """
+
+    pagination_class = InvestmentProjectActivityDatasetViewCursorPagination
+
+    def get_dataset(self):
+        """Get dataset."""
+        return get_spi_report_queryset()

--- a/datahub/dataset/urls.py
+++ b/datahub/dataset/urls.py
@@ -11,7 +11,10 @@ from datahub.dataset.company_future_interest_countries.views import (
 from datahub.dataset.contact.views import ContactsDatasetView
 from datahub.dataset.event.views import EventsDatasetView
 from datahub.dataset.interaction.views import InteractionsDatasetView
-from datahub.dataset.investment_project.views import InvestmentProjectsDatasetView
+from datahub.dataset.investment_project.views import (
+    InvestmentProjectsActivityDatasetView,
+    InvestmentProjectsDatasetView,
+)
 from datahub.dataset.order.views import OMISDatasetView
 from datahub.dataset.team.views import TeamsDatasetView
 
@@ -37,6 +40,11 @@ urlpatterns = [
         'investment-projects-dataset',
         InvestmentProjectsDatasetView.as_view(),
         name='investment-projects-dataset',
+    ),
+    path(
+        'investment-projects-activity-dataset',
+        InvestmentProjectsActivityDatasetView.as_view(),
+        name='investment-projects-activity-dataset',
     ),
     path('events-dataset', EventsDatasetView.as_view(), name='events-dataset'),
 ]

--- a/datahub/investment/project/report/spi.py
+++ b/datahub/investment/project/report/spi.py
@@ -12,18 +12,51 @@ SPI5_START  - when project has been moved to won
 SPI5_END    - earliest interaction when aftercare was offered, only for new investor,
               only for IST managed projects
 """
+from dateutil.parser import parse as dateutil_parse
+from django.db.models import Q
 
 from datahub.core.constants import InvestmentProjectStage as Stage, Service
 from datahub.core.csv import csv_iterator
+from datahub.core.query_utils import (
+    get_array_agg_subquery,
+    get_full_name_expression,
+    JSONBBuildObject,
+)
 from datahub.interaction.models import Interaction
 from datahub.investment.project.constants import InvestorType
 from datahub.investment.project.models import InvestmentProject
 from datahub.investment.project.proposition.constants import PropositionStatus
+from datahub.investment.project.proposition.models import Proposition
 from datahub.metadata.models import Team
+from datahub.metadata.query_utils import get_service_name_subquery
+
+SPI1_END_SERVICE_IDS = {
+    Service.investment_enquiry_requested_more_information.value.id,
+    Service.investment_enquiry_confirmed_prospect.value.id,
+    Service.investment_enquiry_assigned_to_ist_cmc.value.id,
+    Service.investment_enquiry_assigned_to_ist_sas.value.id,
+    Service.investment_enquiry_assigned_to_hq.value.id,
+    Service.investment_enquiry_transferred_to_lep.value.id,
+    Service.investment_enquiry_transferred_to_da.value.id,
+    Service.investment_enquiry_transferred_to_lp.value.id,
+}
+
+SPI2_START_SERVICE_IDS = {
+    Service.investment_enquiry_assigned_to_ist_cmc.value.id,
+    Service.investment_enquiry_assigned_to_ist_sas.value.id,
+}
+
+SPI5_END_SERVICE_IDS = {
+    Service.investment_ist_aftercare_offered.value.id,
+}
+
+ALL_SPI_SERVICE_IDS = SPI1_END_SERVICE_IDS | SPI2_START_SERVICE_IDS | SPI5_END_SERVICE_IDS
 
 
 def format_date(d):
     """Date format used in the report."""
+    if type(d) == str:
+        d = dateutil_parse(d)
     return d.isoformat()
 
 
@@ -41,10 +74,13 @@ class SPIReport:
     SPI1_END = 'Enquiry processed'
     SPI1_END_INTERACTION_TYPE = 'Enquiry type'
     SPI1_END_BY = 'Enquiry processed by'
+
     SPI2_START = 'Assigned to IST'
     SPI2_END = 'Project manager assigned'
     SPI2_END_BY = 'Project manager assigned by'
+
     SPI3 = 'Propositions'
+
     SPI5_START = 'Project moved to won'
     SPI5_END = 'Aftercare offered on'
 
@@ -68,31 +104,15 @@ class SPIReport:
         SPI3: SPI3,
     }
 
-    SPI1_END_SERVICE_IDS = {
-        Service.investment_enquiry_requested_more_information.value.id,
-        Service.investment_enquiry_confirmed_prospect.value.id,
-        Service.investment_enquiry_assigned_to_ist_cmc.value.id,
-        Service.investment_enquiry_assigned_to_ist_sas.value.id,
-        Service.investment_enquiry_assigned_to_hq.value.id,
-        Service.investment_enquiry_transferred_to_lep.value.id,
-        Service.investment_enquiry_transferred_to_da.value.id,
-        Service.investment_enquiry_transferred_to_lp.value.id,
-    }
-
-    SPI2_START_SERVICE_IDS = {
-        Service.investment_enquiry_assigned_to_ist_cmc.value.id,
-        Service.investment_enquiry_assigned_to_ist_sas.value.id,
-    }
-
-    SPI5_END_SERVICE_IDS = {
-        Service.investment_ist_aftercare_offered.value.id,
-    }
-
     MAPPINGS = (
         (SPI1_END_SERVICE_IDS, SPI1_END),
         (SPI2_START_SERVICE_IDS, SPI2_START),
         (SPI5_END_SERVICE_IDS, SPI5_END),
     )
+
+    def __init__(self, proposition_formatter=None):
+        """Initialise the SPI Report."""
+        self.proposition_formatter = proposition_formatter
 
     def _get_spi_interactions(self, investment_project):
         """
@@ -100,30 +120,21 @@ class SPIReport:
 
         Takes earliest interaction for each SPI, if available.
         """
-        all_service_ids = (
-            self.SPI1_END_SERVICE_IDS
-            | self.SPI2_START_SERVICE_IDS
-            | self.SPI5_END_SERVICE_IDS
-        )
-
-        interactions = Interaction.objects.select_related(
-            'service',
-        ).filter(
-            investment_project_id=investment_project.id,
-            service_id__in=all_service_ids,
-        ).order_by('created_on')
+        if investment_project.spi_interactions is None:
+            return {}
 
         data = {}
-        for interaction in interactions:
+        for interaction in investment_project.spi_interactions:
             for service_ids, field_name in self.MAPPINGS:
                 if (
-                    str(interaction.service_id) in service_ids
+                    str(interaction['service_id']) in service_ids
                     and field_name not in data
                 ):
                     data[field_name] = {
-                        'created_by': interaction.created_by.name,
-                        'service_name': interaction.service.name,
-                        'created_on': format_date(interaction.created_on),
+                        'created_by_id': interaction['created_by_id'],
+                        'created_by_name': interaction['created_by_name'],
+                        'service_name': interaction['service_name'],
+                        'created_on': format_date(interaction['created_on']),
                     }
 
         return data
@@ -149,19 +160,6 @@ class SPIReport:
 
         return stage_log.created_on if stage_log else None
 
-    def _get_propositions(self, investment_project, ist_only=False):
-        """Gets project's propositions."""
-        qs = investment_project.proposition.select_related(
-            'adviser',
-            'created_by__dit_team',
-        )
-        if ist_only:
-            # Only teams tagged with investment services team
-            qs = qs.filter(
-                created_by__dit_team__tags__overlap=[Team.TAGS.investment_services_team],
-            )
-        return qs.order_by('created_on')
-
     def _format_propositions(self, propositions):
         """
         Formats propositions.
@@ -171,16 +169,15 @@ class SPIReport:
         deadline;ongoing;;adviser.name;deadline;completed;modified_on;adviser.name...
         """
         formatted = []
-
         for proposition in propositions:
-            formatted.append(proposition.deadline.isoformat())
-            formatted.append(proposition.status)
-            if proposition.status == PropositionStatus.ongoing:
+            formatted.append(dateutil_parse(proposition['deadline']).strftime('%Y-%m-%d'))
+            formatted.append(proposition['status'])
+            if proposition['status'] == PropositionStatus.ongoing:
                 modified_on = ''
             else:
-                modified_on = proposition.modified_on.isoformat()
+                modified_on = dateutil_parse(proposition['modified_on']).isoformat()
             formatted.append(modified_on)
-            formatted.append(proposition.adviser.name)
+            formatted.append(proposition['adviser_name'])
 
         return ';'.join(formatted)
 
@@ -188,6 +185,8 @@ class SPIReport:
         """Enriches the spi report with investment project details."""
         if spi_data is None:
             spi_data = {}
+
+        spi_data.update({field: '' for field in self.field_titles.keys() if field not in spi_data})
 
         spi_data[self.SPI_DH_ID] = str(investment_project.id)
         spi_data[self.SPI_PROJECT_ID] = investment_project.project_code
@@ -203,7 +202,7 @@ class SPIReport:
             spi_interaction = spi_interactions[self.SPI1_END]
             data[self.SPI1_END] = spi_interaction['created_on']
             data[self.SPI1_END_INTERACTION_TYPE] = spi_interaction['service_name']
-            data[self.SPI1_END_BY] = spi_interaction['created_by']
+            data[self.SPI1_END_BY] = spi_interaction['created_by_name']
 
         return data
 
@@ -226,10 +225,15 @@ class SPIReport:
         """Update data with SPI 3 propositions."""
         data = {}
 
-        propositions = self._get_propositions(investment_project, ist_only=True)
-        if propositions:
-            data[self.SPI3] = self._format_propositions(propositions)
+        if not investment_project.spi_propositions:
+            return data
 
+        formatter = (
+            self.proposition_formatter
+            if self.proposition_formatter else self._format_propositions
+        )
+
+        data[self.SPI3] = formatter(investment_project.spi_propositions)
         return data
 
     def get_spi5(self, investment_project, spi_interactions):
@@ -270,5 +274,39 @@ class SPIReport:
 
     def rows(self):
         """Return SPI report iterator."""
-        for investment_project in InvestmentProject.objects.order_by('created_on').iterator():
+        for investment_project in get_spi_report_queryset().iterator():
             yield self.get_row(investment_project)
+
+
+def get_spi_report_queryset():
+    """Get SPI Report queryset."""
+    return InvestmentProject.objects.select_related(
+        'investmentprojectcode',
+        'project_manager__dit_team',
+    ).annotate(
+        spi_propositions=get_array_agg_subquery(
+            Proposition,
+            'investment_project',
+            JSONBBuildObject(
+                deadline='deadline',
+                status='status',
+                adviser_id='adviser_id',
+                adviser_name=get_full_name_expression('adviser'),
+                modified_on='modified_on',
+            ),
+            ordering=('created_on',),
+        ),
+        spi_interactions=get_array_agg_subquery(
+            Interaction,
+            'investment_project',
+            JSONBBuildObject(
+                service_id='service_id',
+                service_name=get_service_name_subquery('service'),
+                created_by_id='created_by_id',
+                created_by_name=get_full_name_expression('created_by'),
+                created_on='created_on',
+            ),
+            filter=Q(service_id__in=ALL_SPI_SERVICE_IDS),
+            ordering=('created_on',),
+        ),
+    ).order_by('created_on')

--- a/datahub/investment/project/report/test/test_spi.py
+++ b/datahub/investment/project/report/test/test_spi.py
@@ -1,19 +1,23 @@
 import pytest
+from dateutil.parser import parse as dateutil_parse
 from django.utils.timezone import now
 from freezegun import freeze_time
 
 from datahub.company.test.factories import AdviserFactory, TeamFactory
-from datahub.core.constants import InvestmentProjectStage
-from datahub.core.constants import Service
+from datahub.core.constants import InvestmentProjectStage as InvestmentProjectStageConstant
+from datahub.core.constants import Service as ServiceConstant
+from datahub.core.test_utils import random_obj_for_queryset
 from datahub.interaction.test.factories import InvestmentProjectInteractionFactory
-from datahub.investment.project.constants import InvestorType
-from datahub.investment.project.proposition.models import PropositionDocument
+from datahub.investment.project.constants import InvestorType as InvestorTypeConstant
+from datahub.investment.project.proposition.models import PropositionDocument, PropositionStatus
 from datahub.investment.project.proposition.test.factories import PropositionFactory
+from datahub.investment.project.report.spi import ALL_SPI_SERVICE_IDS
 from datahub.investment.project.report.spi import SPIReport
 from datahub.investment.project.test.factories import (
     InvestmentProjectFactory,
     VerifyWinInvestmentProjectFactory,
 )
+from datahub.metadata.models import Service
 from datahub.metadata.models import Team
 
 pytestmark = pytest.mark.django_db
@@ -88,22 +92,22 @@ def test_can_see_spi1_start(spi_report):
 
     assert len(rows) == 1
     assert rows[0]['Project created on'] == investment_project.created_on.isoformat()
-    assert 'Enquiry processed' not in rows[0]
+    assert rows[0]['Enquiry processed'] == ''
 
 
 @pytest.mark.parametrize(
     'service_id,visible',
     (
-        (Service.investment_enquiry_requested_more_information.value.id, True),
-        (Service.investment_enquiry_confirmed_prospect.value.id, True),
-        (Service.investment_enquiry_assigned_to_ist_cmc.value.id, True),
-        (Service.investment_enquiry_assigned_to_ist_sas.value.id, True),
-        (Service.investment_enquiry_assigned_to_hq.value.id, True),
-        (Service.investment_enquiry_transferred_to_lep.value.id, True),
-        (Service.investment_enquiry_transferred_to_da.value.id, True),
-        (Service.investment_enquiry_transferred_to_lp.value.id, True),
-        (Service.inbound_referral.value.id, False),
-        (Service.account_management.value.id, False),
+        (ServiceConstant.investment_enquiry_requested_more_information.value.id, True),
+        (ServiceConstant.investment_enquiry_confirmed_prospect.value.id, True),
+        (ServiceConstant.investment_enquiry_assigned_to_ist_cmc.value.id, True),
+        (ServiceConstant.investment_enquiry_assigned_to_ist_sas.value.id, True),
+        (ServiceConstant.investment_enquiry_assigned_to_hq.value.id, True),
+        (ServiceConstant.investment_enquiry_transferred_to_lep.value.id, True),
+        (ServiceConstant.investment_enquiry_transferred_to_da.value.id, True),
+        (ServiceConstant.investment_enquiry_transferred_to_lp.value.id, True),
+        (ServiceConstant.inbound_referral.value.id, False),
+        (ServiceConstant.account_management.value.id, False),
     ),
 )
 def test_interaction_would_end_spi1_or_not(spi_report, service_id, visible):
@@ -120,27 +124,27 @@ def test_interaction_would_end_spi1_or_not(spi_report, service_id, visible):
     assert rows[0]['Project created on'] == investment_project.created_on.isoformat()
     if visible:
         assert rows[0]['Enquiry processed'] == interaction.created_on.isoformat()
-        assert rows[0]['Enquiry processed by'] == interaction.created_by.name
+        assert str(rows[0]['Enquiry processed by']) == interaction.created_by.name
         assert rows[0]['Enquiry type'] == interaction.service.name
     else:
-        assert 'Enquiry processed' not in rows[0]
-        assert 'Enquiry processed by' not in rows[0]
-        assert 'Enquiry type' not in rows[0]
+        assert rows[0]['Enquiry processed'] == ''
+        assert rows[0]['Enquiry processed by'] == ''
+        assert rows[0]['Enquiry type'] == ''
 
 
 @pytest.mark.parametrize(
     'service_id,visible',
     (
-        (Service.investment_enquiry_requested_more_information.value.id, False),
-        (Service.investment_enquiry_confirmed_prospect.value.id, False),
-        (Service.investment_enquiry_assigned_to_ist_cmc.value.id, True),
-        (Service.investment_enquiry_assigned_to_ist_sas.value.id, True),
-        (Service.investment_enquiry_assigned_to_hq.value.id, False),
-        (Service.investment_enquiry_transferred_to_lep.value.id, False),
-        (Service.investment_enquiry_transferred_to_da.value.id, False),
-        (Service.investment_enquiry_transferred_to_lp.value.id, False),
-        (Service.inbound_referral.value.id, False),
-        (Service.account_management.value.id, False),
+        (ServiceConstant.investment_enquiry_requested_more_information.value.id, False),
+        (ServiceConstant.investment_enquiry_confirmed_prospect.value.id, False),
+        (ServiceConstant.investment_enquiry_assigned_to_ist_cmc.value.id, True),
+        (ServiceConstant.investment_enquiry_assigned_to_ist_sas.value.id, True),
+        (ServiceConstant.investment_enquiry_assigned_to_hq.value.id, False),
+        (ServiceConstant.investment_enquiry_transferred_to_lep.value.id, False),
+        (ServiceConstant.investment_enquiry_transferred_to_da.value.id, False),
+        (ServiceConstant.investment_enquiry_transferred_to_lp.value.id, False),
+        (ServiceConstant.inbound_referral.value.id, False),
+        (ServiceConstant.account_management.value.id, False),
     ),
 )
 def test_interaction_would_start_spi2_or_not(spi_report, ist_adviser, service_id, visible):
@@ -159,7 +163,7 @@ def test_interaction_would_start_spi2_or_not(spi_report, ist_adviser, service_id
     if visible:
         assert rows[0]['Assigned to IST'] == interaction.created_on.isoformat()
     else:
-        assert 'Assigned to IST' not in rows[0]
+        assert rows[0]['Assigned to IST'] == ''
 
 
 def test_assigning_ist_project_manager_ends_spi2(spi_report, ist_adviser):
@@ -190,8 +194,8 @@ def test_assigning_non_ist_project_manager_doesnt_end_spi2(spi_report):
     rows = list(spi_report.rows())
 
     assert len(rows) == 1
-    assert 'Project manager assigned' not in rows[0]
-    assert 'Project manager assigned by' not in rows[0]
+    assert rows[0]['Project manager assigned'] == ''
+    assert rows[0]['Project manager assigned by'] == ''
 
 
 def test_earliest_interactions_are_being_selected(spi_report, ist_adviser):
@@ -201,15 +205,15 @@ def test_earliest_interactions_are_being_selected(spi_report, ist_adviser):
     )
 
     service_dates = (
-        (Service.investment_enquiry_confirmed_prospect.value.id, '2016-01-02'),
-        (Service.investment_enquiry_confirmed_prospect.value.id, '2016-01-03'),
-        (Service.investment_enquiry_confirmed_prospect.value.id, '2016-01-01'),
-        (Service.investment_enquiry_assigned_to_ist_sas.value.id, '2017-01-03'),
-        (Service.investment_enquiry_assigned_to_ist_sas.value.id, '2017-01-01'),
-        (Service.investment_enquiry_assigned_to_ist_sas.value.id, '2017-01-02'),
-        (Service.investment_ist_aftercare_offered.value.id, '2017-03-04'),
-        (Service.investment_ist_aftercare_offered.value.id, '2017-03-05'),
-        (Service.investment_ist_aftercare_offered.value.id, '2017-03-06'),
+        (ServiceConstant.investment_enquiry_confirmed_prospect.value.id, '2016-01-02'),
+        (ServiceConstant.investment_enquiry_confirmed_prospect.value.id, '2016-01-03'),
+        (ServiceConstant.investment_enquiry_confirmed_prospect.value.id, '2016-01-01'),
+        (ServiceConstant.investment_enquiry_assigned_to_ist_sas.value.id, '2017-01-03'),
+        (ServiceConstant.investment_enquiry_assigned_to_ist_sas.value.id, '2017-01-01'),
+        (ServiceConstant.investment_enquiry_assigned_to_ist_sas.value.id, '2017-01-02'),
+        (ServiceConstant.investment_ist_aftercare_offered.value.id, '2017-03-04'),
+        (ServiceConstant.investment_ist_aftercare_offered.value.id, '2017-03-05'),
+        (ServiceConstant.investment_ist_aftercare_offered.value.id, '2017-03-06'),
     )
     for service_date in service_dates:
         with freeze_time(service_date[1]):
@@ -226,7 +230,51 @@ def test_earliest_interactions_are_being_selected(spi_report, ist_adviser):
     assert rows[0]['Aftercare offered on'] == '2017-03-04T00:00:00+00:00'
 
 
-def test_can_get_propositions(spi_report, propositions):
+def test_only_ist_interactions_are_being_selected(spi_report, ist_adviser):
+    """Tests that report takes into account IST interactions only."""
+    investment_project = InvestmentProjectFactory(
+        project_manager=ist_adviser,
+    )
+
+    service_dates = (
+        (ServiceConstant.account_management.value.id, '2015-01-23'),
+        (
+            random_obj_for_queryset(Service.objects.exclude(pk__in=ALL_SPI_SERVICE_IDS)).id,
+            '2015-12-03',
+        ),
+        (ServiceConstant.investment_enquiry_confirmed_prospect.value.id, '2016-01-02'),
+        (
+            random_obj_for_queryset(Service.objects.exclude(pk__in=ALL_SPI_SERVICE_IDS)).id,
+            '2016-01-02',
+        ),
+        (
+            random_obj_for_queryset(Service.objects.exclude(pk__in=ALL_SPI_SERVICE_IDS)).id,
+            '2016-01-03',
+        ),
+        (ServiceConstant.investment_enquiry_confirmed_prospect.value.id, '2016-01-01'),
+        (
+            random_obj_for_queryset(Service.objects.exclude(pk__in=ALL_SPI_SERVICE_IDS)).id,
+            '2017-01-01',
+        ),
+        (ServiceConstant.investment_enquiry_assigned_to_ist_sas.value.id, '2017-01-03'),
+        (ServiceConstant.investment_ist_aftercare_offered.value.id, '2017-03-04'),
+    )
+    for service_date in service_dates:
+        with freeze_time(service_date[1]):
+            InvestmentProjectInteractionFactory(
+                investment_project=investment_project,
+                service_id=service_date[0],
+            )
+
+    rows = list(spi_report.rows())
+
+    assert len(rows) == 1
+    assert rows[0]['Enquiry processed'] == '2016-01-01T00:00:00+00:00'
+    assert rows[0]['Assigned to IST'] == '2017-01-03T00:00:00+00:00'
+    assert rows[0]['Aftercare offered on'] == '2017-03-04T00:00:00+00:00'
+
+
+def test_can_get_propositions_with_default_formatting(spi_report, propositions):
     """Check if we can see propositions in the report."""
     rows = list(spi_report.rows())
 
@@ -240,6 +288,46 @@ def test_can_get_propositions(spi_report, propositions):
     assert rows[0]['Propositions'] == ';'.join(expected)
 
 
+def test_can_get_propositions_with_custom_formatting(propositions):
+    """Check if we can see custom formatted propositions in the report."""
+
+    def proposition_formatter(propositions):
+        return [{
+            'deadline': dateutil_parse(proposition['deadline']).strftime('%Y-%m-%d'),
+            'status': proposition['status'],
+            'modified_on': dateutil_parse(proposition['modified_on']).isoformat()
+            if proposition['status'] != PropositionStatus.ongoing else '',
+            'adviser_id': str(proposition['adviser_id']),
+        } for proposition in propositions]
+
+    spi_report = SPIReport(proposition_formatter=proposition_formatter)
+    rows = list(spi_report.rows())
+
+    assert len(rows) == 1
+
+    expected = [
+        {
+            'deadline': '2017-01-05',
+            'status': 'ongoing',
+            'modified_on': '',
+            'adviser_id': str(propositions[0].adviser.id),
+        },
+        {
+            'deadline': '2017-01-05',
+            'status': 'completed',
+            'modified_on': '2017-01-04T11:11:11+00:00',
+            'adviser_id': str(propositions[1].adviser.id),
+        },
+        {
+            'deadline': '2017-01-05',
+            'status': 'abandoned',
+            'modified_on': '2017-01-04T11:11:11+00:00',
+            'adviser_id': str(propositions[0].adviser.id),
+        },
+    ]
+    assert rows[0]['Propositions'] == expected
+
+
 def test_can_get_spi5_start_and_end(spi_report, ist_adviser):
     """Tests if we can see spi5 start and end dates."""
     investment_project = VerifyWinInvestmentProjectFactory(
@@ -247,12 +335,12 @@ def test_can_get_spi5_start_and_end(spi_report, ist_adviser):
     )
 
     with freeze_time('2017-01-01'):
-        investment_project.stage_id = InvestmentProjectStage.won.value.id
+        investment_project.stage_id = InvestmentProjectStageConstant.won.value.id
         investment_project.save()
 
     with freeze_time('2017-01-15'):
         InvestmentProjectInteractionFactory(
-            service_id=Service.investment_ist_aftercare_offered.value.id,
+            service_id=ServiceConstant.investment_ist_aftercare_offered.value.id,
             investment_project=investment_project,
         )
 
@@ -269,20 +357,20 @@ def test_cannot_get_spi5_start_and_end_for_non_new_investor(
     """Tests if we are not going to see spi5 start and end dates if investor is not new."""
     investment_project = VerifyWinInvestmentProjectFactory(
         project_manager=ist_adviser,
-        investor_type_id=InvestorType.existing_investor.value.id,
+        investor_type_id=InvestorTypeConstant.existing_investor.value.id,
     )
 
     with freeze_time('2017-01-01'):
-        investment_project.stage_id = InvestmentProjectStage.won.value.id
+        investment_project.stage_id = InvestmentProjectStageConstant.won.value.id
         investment_project.save()
 
     with freeze_time('2017-01-15'):
         InvestmentProjectInteractionFactory(
-            service_id=Service.investment_ist_aftercare_offered.value.id,
+            service_id=ServiceConstant.investment_ist_aftercare_offered.value.id,
             investment_project=investment_project,
         )
 
     rows = list(spi_report.rows())
     assert len(rows) == 1
-    assert 'Project moved to won' not in rows[0]
-    assert 'Aftercare offered on' not in rows[0]
+    assert rows[0]['Project moved to won'] == ''
+    assert rows[0]['Aftercare offered on'] == ''


### PR DESCRIPTION
### Description of change

The `GET /v4/dataset/investment-projects-activity-dataset` has been added. The endpoint returns SPI report records for corresponding investment projects.

It updates the SPI report so that formatting of propositions can be changed, as the response of dataset is in JSON, so there is no need for `;` separated objects.

There will be a second PR that removes SPI report from Django admin. That should resolve duplicated `ist_adviser` and `propositions` fixtures in dataset app.

For a time being we will have to run both versions of the report (the endpoint and celery task). Once we remove the task and no longer need to support both looks, the implementation should become much cleaner.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
