### PR TITLE
Remove unnecessary id attributes from model factories

### DIFF
--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -27,7 +27,6 @@ from datahub.metadata.test.factories import TeamFactory
 class AdviserFactory(factory.django.DjangoModelFactory):
     """Adviser factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     first_name = factory.Faker('first_name')
     last_name = factory.Faker('last_name')
     dit_team = factory.SubFactory(TeamFactory)
@@ -44,7 +43,6 @@ class AdviserFactory(factory.django.DjangoModelFactory):
 class CompanyFactory(factory.django.DjangoModelFactory):
     """Company factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SelfAttribute('created_by')
     name = factory.Faker('company')
@@ -154,7 +152,6 @@ def _get_random_company_category():
 class ContactFactory(factory.django.DjangoModelFactory):
     """Contact factory"""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SelfAttribute('created_by')
     title_id = constants.Title.wing_commander.value.id
@@ -196,7 +193,6 @@ class ArchivedContactFactory(ContactFactory):
 class CompanyExportCountryFactory(factory.django.DjangoModelFactory):
     """Factory for Company export country"""
 
-    id = factory.LazyFunction(uuid.uuid4)
     company = factory.SubFactory(CompanyFactory)
     country = factory.LazyFunction(lambda: random_obj_for_model(Country))
     status = CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting

--- a/datahub/core/test/support/factories.py
+++ b/datahub/core/test/support/factories.py
@@ -1,5 +1,4 @@
 from random import choice
-from uuid import uuid4
 
 import factory
 
@@ -11,7 +10,6 @@ from datahub.core.test.support.models import Book
 class MetadataModelFactory(factory.django.DjangoModelFactory):
     """MetadataModel factory."""
 
-    id = factory.LazyFunction(uuid4)
     name = factory.Faker('sentence')
 
     class Meta:

--- a/datahub/documents/test/factories.py
+++ b/datahub/documents/test/factories.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 from django.utils.timezone import utc
 
@@ -10,7 +8,6 @@ from datahub.documents.models import UPLOAD_STATUSES
 class DocumentFactory(factory.django.DjangoModelFactory):
     """Document factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     bucket_id = 'default'

--- a/datahub/event/test/factories.py
+++ b/datahub/event/test/factories.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 from django.utils.timezone import utc
 
@@ -12,7 +10,6 @@ from datahub.event.constants import EventType, LocationType, Programme
 class EventFactory(factory.django.DjangoModelFactory):
     """Event factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SelfAttribute('created_by')
     name = factory.Faker('text')

--- a/datahub/feature_flag/test/factories.py
+++ b/datahub/feature_flag/test/factories.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 from django.utils.timezone import now
 
@@ -9,7 +7,6 @@ from datahub.company.test.factories import AdviserFactory
 class FeatureFlagFactory(factory.django.DjangoModelFactory):
     """Factory for creating a feature flag."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     code = factory.Sequence(lambda n: f'CODE_{n}')
     description = factory.Faker('sentence', nb_words=8)
     is_active = True

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 import factory
 from django.utils.timezone import now, utc
 
@@ -24,7 +22,6 @@ from datahub.metadata.test.factories import ServiceFactory
 class ServiceQuestionFactory(factory.django.DjangoModelFactory):
     """ServiceQuestion factory."""
 
-    id = factory.LazyFunction(uuid4)
     name = factory.Faker('word')
     service = factory.SubFactory(ServiceFactory)
 
@@ -35,7 +32,6 @@ class ServiceQuestionFactory(factory.django.DjangoModelFactory):
 class ServiceAnswerOptionFactory(factory.django.DjangoModelFactory):
     """ServiceQuestion factory."""
 
-    id = factory.LazyFunction(uuid4)
     name = factory.Faker('word')
     question = factory.SubFactory(ServiceQuestionFactory)
 
@@ -46,7 +42,6 @@ class ServiceAnswerOptionFactory(factory.django.DjangoModelFactory):
 class CommunicationChannelFactory(factory.django.DjangoModelFactory):
     """CommunicationChannel factory."""
 
-    id = factory.LazyFunction(uuid4)
     name = factory.Faker('word')
 
     class Meta:
@@ -188,7 +183,6 @@ class InteractionDITParticipantFactory(factory.django.DjangoModelFactory):
 class InteractionExportCountryFactory(factory.django.DjangoModelFactory):
     """Factory for Interaction export country."""
 
-    id = factory.LazyFunction(uuid4)
     interaction = factory.SubFactory(CompanyInteractionFactory)
     country = factory.LazyFunction(lambda: random_obj_for_model(Country))
     status = factory.Iterator(tuple(CompanyExportCountry.EXPORT_INTEREST_STATUSES._db_values))

--- a/datahub/investment/project/evidence/test/factories.py
+++ b/datahub/investment/project/evidence/test/factories.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 
 from datahub.investment.project.evidence.models import EvidenceDocument, EvidenceTag
@@ -9,7 +7,6 @@ from datahub.investment.project.test.factories import InvestmentProjectFactory
 class EvidenceTagFactory(factory.django.DjangoModelFactory):
     """Evidence tag factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     name = factory.Faker('sentence', nb_words=2)
 
     class Meta:

--- a/datahub/investment/project/proposition/test/factories.py
+++ b/datahub/investment/project/proposition/test/factories.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 from django.utils.timezone import now
 
@@ -11,8 +9,6 @@ from datahub.investment.project.test.factories import InvestmentProjectFactory
 
 class PropositionFactory(factory.django.DjangoModelFactory):
     """Investment project proposition factory."""
-
-    id = factory.LazyFunction(uuid.uuid4)
 
     investment_project = factory.SubFactory(InvestmentProjectFactory)
     adviser = factory.SubFactory(AdviserFactory)

--- a/datahub/investment/project/report/test/factories.py
+++ b/datahub/investment/project/report/test/factories.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 from django.utils.timezone import now
 
@@ -9,8 +7,6 @@ from datahub.investment.project.report.models import SPIReport
 
 class SPIReportFactory(factory.django.DjangoModelFactory):
     """Investment project report factory."""
-
-    id = factory.LazyFunction(uuid.uuid4)
 
     s3_key = factory.Faker('slug')
 

--- a/datahub/investment/project/test/factories.py
+++ b/datahub/investment/project/test/factories.py
@@ -1,6 +1,5 @@
 """Model instance factories for investment tests."""
 
-import uuid
 from datetime import date
 from decimal import Decimal
 
@@ -34,7 +33,6 @@ from datahub.metadata.models import UKRegion
 class InvestmentProjectFactory(factory.django.DjangoModelFactory):
     """Investment project factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SelfAttribute('created_by')
     name = factory.Sequence(lambda n: f'name {n}')

--- a/datahub/metadata/test/factories.py
+++ b/datahub/metadata/test/factories.py
@@ -1,4 +1,3 @@
-import uuid
 from random import randrange, sample
 
 import factory
@@ -10,7 +9,6 @@ from datahub.metadata.models import Service
 class ServiceFactory(factory.django.DjangoModelFactory):
     """Service factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     segment = factory.Sequence(lambda n: f'name {n}')
 
     contexts = factory.LazyFunction(
@@ -27,7 +25,6 @@ class ServiceFactory(factory.django.DjangoModelFactory):
 class ChildServiceFactory(factory.django.DjangoModelFactory):
     """Child service factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     segment = factory.Sequence(lambda n: f'child name {n}')
     parent = factory.SubFactory(ServiceFactory)
     contexts = factory.LazyFunction(
@@ -44,7 +41,6 @@ class ChildServiceFactory(factory.django.DjangoModelFactory):
 class TeamRoleFactory(factory.django.DjangoModelFactory):
     """TeamRole factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     name = factory.Sequence(lambda n: f'name {n}')
 
     class Meta:
@@ -54,7 +50,6 @@ class TeamRoleFactory(factory.django.DjangoModelFactory):
 class TeamFactory(factory.django.DjangoModelFactory):
     """Team factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     name = factory.Sequence(lambda n: f'name {n}')
     role = factory.SubFactory(TeamRoleFactory)
     uk_region_id = constants.UKRegion.east_midlands.value.id
@@ -68,7 +63,6 @@ class TeamFactory(factory.django.DjangoModelFactory):
 class ReferralSourceActivityFactory(factory.django.DjangoModelFactory):
     """ReferralSourceActivity factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     name = factory.Sequence(lambda n: f'name {n}')
 
     class Meta:
@@ -78,7 +72,6 @@ class ReferralSourceActivityFactory(factory.django.DjangoModelFactory):
 class ReferralSourceWebsiteFactory(factory.django.DjangoModelFactory):
     """ReferralSourceWebsite factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     name = factory.Sequence(lambda n: f'name {n}')
 
     class Meta:
@@ -88,7 +81,6 @@ class ReferralSourceWebsiteFactory(factory.django.DjangoModelFactory):
 class ReferralSourceMarketingFactory(factory.django.DjangoModelFactory):
     """ReferralSourceMarketing factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     name = factory.Sequence(lambda n: f'name {n}')
 
     class Meta:
@@ -98,7 +90,6 @@ class ReferralSourceMarketingFactory(factory.django.DjangoModelFactory):
 class SectorFactory(factory.django.DjangoModelFactory):
     """Sector factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     segment = factory.Sequence(lambda n: f'name {n}')
 
     class Meta:

--- a/datahub/omis/order/test/factories.py
+++ b/datahub/omis/order/test/factories.py
@@ -1,5 +1,4 @@
 import datetime
-import uuid
 
 import factory
 from django.utils.timezone import now, utc
@@ -20,7 +19,6 @@ from datahub.omis.quote.test.factories import (
 class OrderFactory(factory.django.DjangoModelFactory):
     """Order factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SelfAttribute('created_by')
     company = factory.SubFactory(CompanyFactory)
@@ -154,7 +152,6 @@ class OrderWithoutLeadAssigneeFactory(OrderFactory):
 class OrderSubscriberFactory(factory.django.DjangoModelFactory):
     """Order Subscriber factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     order = factory.SubFactory(OrderFactory)
     adviser = factory.SubFactory(AdviserFactory)
@@ -166,7 +163,6 @@ class OrderSubscriberFactory(factory.django.DjangoModelFactory):
 class OrderAssigneeFactory(factory.django.DjangoModelFactory):
     """Order Assignee factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     order = factory.SubFactory(OrderFactory)
     adviser = factory.SubFactory(AdviserFactory)
@@ -184,8 +180,6 @@ class OrderAssigneeCompleteFactory(OrderAssigneeFactory):
 
 class HourlyRateFactory(factory.django.DjangoModelFactory):
     """HourlyRate factory."""
-
-    id = factory.LazyFunction(uuid.uuid4)
 
     class Meta:
         model = 'order.HourlyRate'

--- a/datahub/omis/payment/test/factories.py
+++ b/datahub/omis/payment/test/factories.py
@@ -1,5 +1,4 @@
 import random
-import uuid
 
 import factory
 from django.utils.timezone import utc
@@ -13,7 +12,6 @@ from datahub.omis.payment.models import RefundStatus
 class PaymentFactory(factory.django.DjangoModelFactory):
     """Payment factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     order = factory.SubFactory(OrderPaidFactory)
     reference = factory.Faker('pystr')
     transaction_reference = factory.Faker('pystr')
@@ -29,7 +27,6 @@ class PaymentFactory(factory.django.DjangoModelFactory):
 class PaymentGatewaySessionFactory(factory.django.DjangoModelFactory):
     """PaymentGatewaySession factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     order = factory.SubFactory(OrderWithAcceptedQuoteFactory)
     status = constants.PaymentGatewaySessionStatus.created
     govuk_payment_id = factory.Faker('pystr', min_chars=27, max_chars=27)
@@ -41,7 +38,6 @@ class PaymentGatewaySessionFactory(factory.django.DjangoModelFactory):
 class RequestedRefundFactory(factory.django.DjangoModelFactory):
     """Factory for refund requested."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SelfAttribute('created_by')
     order = factory.SubFactory(OrderPaidFactory)

--- a/datahub/omis/quote/test/factories.py
+++ b/datahub/omis/quote/test/factories.py
@@ -1,5 +1,3 @@
-import uuid
-
 import factory
 from django.utils.timezone import now
 
@@ -10,7 +8,6 @@ from datahub.omis.quote.models import TermsAndConditions
 class QuoteFactory(factory.django.DjangoModelFactory):
     """Order factory."""
 
-    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SelfAttribute('created_by')
     reference = factory.Faker('text', max_nb_chars=10)


### PR DESCRIPTION
### Description of change

Various model factories were defining an `id` attribute as `id = factory.LazyFunction(uuid.uuid4)`.

This is unnecessary as all UUID `id` fields on models specify a default and so pick up a value automatically.

Hence, this removes all such attributes from all factories.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
