### PR TITLE
ES app for CompanyExportCountryHistory

### DIFF
--- a/changelog/company/add-company-export-country-history-search-app.feature.md
+++ b/changelog/company/add-company-export-country-history-search-app.feature.md
@@ -1,0 +1,3 @@
+A search app `ExportCountryHistory` was added to expose an API interface to the frontend. The app is supposed to 
+aggregate data from both `CompanyExportCountryHistory` model and related `Interactions` data with the possibility to 
+filter by `country.pk` and `company.pk`. The response should be in descending order by `history_date` datetime.  

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -302,6 +302,7 @@ SEARCH_APPS = [
     'datahub.search.company.CompanySearchApp',
     'datahub.search.contact.ContactSearchApp',
     'datahub.search.event.EventSearchApp',
+    'datahub.search.export_country_history.ExportCountryHistoryApp',
     'datahub.search.interaction.InteractionSearchApp',
     'datahub.search.investment.InvestmentSearchApp',
     'datahub.search.omis.OrderSearchApp',

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -1,7 +1,7 @@
 import uuid
 from random import choice
 
-import factory
+import factory.fuzzy
 from django.utils.timezone import now, utc
 
 from datahub.company.ch_constants import COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPING
@@ -10,6 +10,7 @@ from datahub.company.models import (
     Advisor,
     Company,
     CompanyExportCountry,
+    CompanyExportCountryHistory,
     ExportExperienceCategory,
 )
 from datahub.core import constants
@@ -209,8 +210,13 @@ class CompanyExportCountryHistoryFactory(factory.django.DjangoModelFactory):
     id = factory.LazyFunction(uuid.uuid4)
     company = factory.SubFactory(CompanyFactory)
     country = factory.LazyFunction(lambda: random_obj_for_model(Country))
-    status = CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting
+    status = factory.fuzzy.FuzzyChoice(
+        CompanyExportCountry.EXPORT_INTEREST_STATUSES,
+    )
     history_user = factory.SubFactory(AdviserFactory)
+    history_type = factory.fuzzy.FuzzyChoice(
+        CompanyExportCountryHistory.HISTORY_TYPES,
+    )
 
     class Meta:
         model = 'company.CompanyExportCountryHistory'

--- a/datahub/search/export_country_history/__init__.py
+++ b/datahub/search/export_country_history/__init__.py
@@ -1,0 +1,3 @@
+from datahub.search.export_country_history.apps import ExportCountryHistoryApp
+
+__all__ = ['ExportCountryHistoryApp']

--- a/datahub/search/export_country_history/apps.py
+++ b/datahub/search/export_country_history/apps.py
@@ -1,0 +1,20 @@
+from datahub.company.models import (
+    CompanyExportCountryHistory as DBCompanyExportCountryHistory,
+    CompanyPermission,
+)
+from datahub.search.apps import SearchApp
+from datahub.search.export_country_history.models import ExportCountryHistory
+
+
+class ExportCountryHistoryApp(SearchApp):
+    """SearchApp for export countries history timeline"""
+
+    name = 'export-country-history'
+    es_model = ExportCountryHistory
+    exclude_from_global_search = True
+    view_permissions = (f'company.{CompanyPermission.view_company}',)
+    queryset = DBCompanyExportCountryHistory.objects.select_related(
+        'history_user',
+        'country',
+        'company',
+    )

--- a/datahub/search/export_country_history/models.py
+++ b/datahub/search/export_country_history/models.py
@@ -1,0 +1,37 @@
+from elasticsearch_dsl import Date, Keyword
+
+from datahub.search import dict_utils, fields
+from datahub.search.models import BaseESModel
+
+DOC_TYPE = 'export-country-history'
+
+
+class ExportCountryHistory(BaseESModel):
+    """Elasticsearch representation of CompanyExportCountryHistory model."""
+
+    id = Keyword()
+    history_date = Date(index=False)
+    history_user = fields.id_unindexed_name_field()
+    history_type = Keyword(index=False)
+    country = fields.id_unindexed_name_field()
+
+    company = fields.id_unindexed_name_field()
+    status = Keyword(index=False)
+
+    MAPPINGS = {
+        'history_user': dict_utils.id_name_dict,
+        'country': dict_utils.id_name_dict,
+        'company': dict_utils.id_name_dict,
+    }
+
+    COMPUTED_MAPPINGS = {
+        'id': lambda obj: obj.history_id,  # Id required for indexing
+    }
+
+    class Meta:
+        """Default document meta data."""
+
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/export_country_history/serializers.py
+++ b/datahub/search/export_country_history/serializers.py
@@ -1,0 +1,37 @@
+from django.utils.translation import gettext_lazy
+from rest_framework import serializers
+
+from datahub.search.serializers import (
+    EntitySearchQuerySerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
+from datahub.search.utils import SearchOrdering, SortDirection
+
+
+class SearchExportCountryHistorySerializer(EntitySearchQuerySerializer):
+    """Serializer used to validate ExportCountryHistory search POST bodies."""
+
+    default_error_messages = {
+        'no_empty_field': gettext_lazy(
+            'Request must include either country or company parameters',
+        ),
+    }
+
+    DEFAULT_ORDERING = SearchOrdering('history_date', SortDirection.desc)
+
+    SORT_BY_FIELDS = (
+        'history_date',
+    )
+
+    country = SingleOrListField(child=StringUUIDField(), required=False)
+    company = SingleOrListField(child=StringUUIDField(), required=False)
+
+    def validate(self, data):
+        """Serializer should have at least one parameter"""
+        if not data.keys() & {'company', 'country'}:
+            raise serializers.ValidationError(
+                self.error_messages['no_empty_field'],
+            )
+
+        return data

--- a/datahub/search/export_country_history/signals.py
+++ b/datahub/search/export_country_history/signals.py
@@ -1,0 +1,19 @@
+from django.db import transaction
+from django.db.models.signals import post_save
+
+from datahub.company.models import CompanyExportCountryHistory as DBCompanyExportCountryHistory
+from datahub.search.export_country_history import ExportCountryHistoryApp
+from datahub.search.signals import SignalReceiver
+from datahub.search.sync_object import sync_object_async
+
+
+def export_country_history_sync_es(instance):
+    """Sync export country history to the Elasticsearch."""
+    transaction.on_commit(
+        lambda: sync_object_async(ExportCountryHistoryApp, instance.pk),
+    )
+
+
+receivers = (
+    SignalReceiver(post_save, DBCompanyExportCountryHistory, export_country_history_sync_es),
+)

--- a/datahub/search/export_country_history/test/test_models.py
+++ b/datahub/search/export_country_history/test/test_models.py
@@ -1,0 +1,31 @@
+import pytest
+
+from datahub.company.test.factories import CompanyExportCountryHistoryFactory
+from datahub.search.export_country_history.models import ExportCountryHistory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_export_country_history_to_dict(es):
+    """Test for export country history search model"""
+    export_country_history = CompanyExportCountryHistoryFactory()
+    result = ExportCountryHistory.db_object_to_dict(export_country_history)
+
+    assert result == {
+        'id': export_country_history.pk,
+        'company': {
+            'id': str(export_country_history.company.pk),
+            'name': export_country_history.company.name,
+        },
+        'country': {
+            'id': str(export_country_history.country.pk),
+            'name': export_country_history.country.name,
+        },
+        'history_date': export_country_history.history_date,
+        'history_type': export_country_history.history_type,
+        'history_user': {
+            'id': str(export_country_history.history_user.pk),
+            'name': export_country_history.history_user.name,
+        },
+        'status': export_country_history.status,
+    }

--- a/datahub/search/export_country_history/test/test_signals.py
+++ b/datahub/search/export_country_history/test/test_signals.py
@@ -1,0 +1,55 @@
+import pytest
+
+from datahub.company.models import CompanyExportCountryHistory
+from datahub.company.test.factories import CompanyExportCountryHistoryFactory
+from datahub.search.export_country_history.apps import ExportCountryHistoryApp
+
+pytestmark = pytest.mark.django_db
+
+
+def test_new_export_country_history_synced(es_with_signals):
+    """Test that new export country history is synced to ES."""
+    company_export_country_history = CompanyExportCountryHistoryFactory()
+    es_with_signals.indices.refresh()
+
+    assert es_with_signals.get(
+        index=ExportCountryHistoryApp.es_model.get_write_index(),
+        doc_type=ExportCountryHistoryApp.name,
+        id=company_export_country_history.pk,
+    )
+
+
+def test_updated_interaction_synced(es_with_signals):
+    """Test that when export country history is updated, it is synced to ES."""
+    export_country_history = CompanyExportCountryHistoryFactory(
+        history_type=CompanyExportCountryHistory.HISTORY_TYPES.insert,
+    )
+    history_type = CompanyExportCountryHistory.HISTORY_TYPES.update
+    export_country_history.history_type = history_type
+    export_country_history.save()
+    es_with_signals.indices.refresh()
+
+    result = es_with_signals.get(
+        index=ExportCountryHistoryApp.es_model.get_write_index(),
+        doc_type=ExportCountryHistoryApp.name,
+        id=export_country_history.pk,
+    )
+
+    assert result['_source'] == {
+        'history_user': {
+            'id': str(export_country_history.history_user.id),
+            'name': export_country_history.history_user.name,
+        },
+        'country': {
+            'id': str(export_country_history.country.id),
+            'name': export_country_history.country.name,
+        },
+        'company': {
+            'id': str(export_country_history.company.id),
+            'name': export_country_history.company.name,
+        },
+        'id': str(export_country_history.pk),
+        'history_type': export_country_history.history_type,
+        'history_date': export_country_history.history_date.isoformat(),
+        'status': str(export_country_history.status),
+    }

--- a/datahub/search/export_country_history/test/test_views.py
+++ b/datahub/search/export_country_history/test/test_views.py
@@ -1,0 +1,221 @@
+from datetime import datetime
+
+import pytest
+from django.utils.timezone import utc
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.test.factories import CompanyExportCountryHistoryFactory, CompanyFactory
+from datahub.core.constants import Country as CountryConstant
+from datahub.core.test_utils import (
+    APITestMixin,
+    create_test_user,
+)
+from datahub.metadata.models import Country
+from datahub.metadata.test.factories import TeamFactory
+from datahub.search.export_country_history import ExportCountryHistoryApp
+
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.es_collector_apps.with_args(ExportCountryHistoryApp),
+]
+
+FROZEN_DATETIME_1 = datetime(2001, 1, 22, 1, 2, 3, tzinfo=utc).isoformat()
+FROZEN_DATETIME_2 = datetime(2002, 2, 23, 4, 5, 6, tzinfo=utc).isoformat()
+FROZEN_DATETIME_3 = datetime(2003, 3, 24, 7, 8, 9, tzinfo=utc).isoformat()
+
+
+@pytest.fixture
+def setup_data():
+    """Sets up data for the tests."""
+    benchmark_country_japan = Country.objects.get(
+        pk=CountryConstant.japan.value.id,
+    )
+
+    benchmark_country_canada = Country.objects.get(
+        pk=CountryConstant.canada.value.id,
+    )
+
+    benchmark_company = CompanyFactory()
+
+    with freeze_time(FROZEN_DATETIME_1):
+        CompanyExportCountryHistoryFactory(
+            country=benchmark_country_japan,
+            company=benchmark_company,
+        )
+        CompanyExportCountryHistoryFactory(
+            company=benchmark_company,
+            country=benchmark_country_canada,
+        )
+        CompanyExportCountryHistoryFactory(
+            country=benchmark_country_canada,
+        )
+        CompanyExportCountryHistoryFactory()
+
+    with freeze_time(FROZEN_DATETIME_2):
+        CompanyExportCountryHistoryFactory(
+            country=benchmark_country_japan,
+        )
+
+    with freeze_time(FROZEN_DATETIME_3):
+        CompanyExportCountryHistoryFactory(
+            country=benchmark_country_japan,
+        )
+
+    yield str(benchmark_company.id)
+
+
+class TestSearchExportCountryHistory(APITestMixin):
+    """Tests search views."""
+
+    def test_export_country_history_search_no_permissions(self):
+        """Should return 403"""
+        user = create_test_user(dit_team=TeamFactory())
+        api_client = self.create_api_client(user=user)
+        url = reverse('api-v4:search:export-country-history')
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_export_country_history_search_with_empty_request(self, es_with_collector, setup_data):
+        """Should return 400."""
+        es_with_collector.flush_and_refresh()
+        error_response = 'Request must include either country or company parameters'
+
+        url = reverse('api-v4:search:export-country-history')
+
+        response = self.api_client.post(
+            url,
+            data={},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()['non_field_errors'][0] == error_response
+
+    def test_filtering_by_country_on_export_country_history_search(
+        self,
+        es_with_collector,
+        setup_data,
+    ):
+        """
+        Test ExportCountryHistory search app with country param.
+        """
+        es_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:export-country-history')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'country': CountryConstant.japan.value.id,
+            },
+        )
+
+        expected_data = {
+            'country': {
+                'id': CountryConstant.japan.value.id,
+            },
+        }
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 3
+        assert all(
+            result['country']['id'] == expected_data['country']['id']
+            for result in response.json()['results']
+        )
+
+    def test_filtering_by_company_on_export_country_history_search(
+        self,
+        es_with_collector,
+        setup_data,
+    ):
+        """
+        Test ExportCountryHistory search app with company param.
+        """
+        es_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:export-country-history')
+        company_id = setup_data
+
+        response = self.api_client.post(
+            url,
+            data={
+                'company': company_id,
+            },
+        )
+
+        expected_data = {
+            'company': {
+                'id': company_id,
+            },
+        }
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 2
+        assert all(
+            result['company']['id'] == expected_data['company']['id']
+            for result in response.json()['results']
+        )
+
+    def test_filtering_by_company_and_country_on_export_country_history_search(
+        self,
+        es_with_collector,
+        setup_data,
+    ):
+        """
+        Test ExportCountryHistory search app with company param.
+        """
+        es_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:export-country-history')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'company': setup_data,
+                'country': CountryConstant.canada.value.id,
+            },
+        )
+
+        expected_data = {
+            'company': {
+                'id': setup_data,
+            },
+            'country': {
+                'id': CountryConstant.canada.value.id,
+            },
+        }
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 1
+        assert all(
+            result['company']['id'] == expected_data['company']['id']
+            for result in response.json()['results']
+        )
+        assert all(
+            result['country']['id'] == expected_data['country']['id']
+            for result in response.json()['results']
+        )
+
+    def test_sorting_in_export_country_history(self, es_with_collector, setup_data):
+        """Tests the sorting of country history search response."""
+        es_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:export-country-history')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'country': CountryConstant.japan.value.id,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 3
+
+        date_times = [
+            result['history_date'] for result in response.json()['results']
+        ]
+
+        assert date_times == [FROZEN_DATETIME_3, FROZEN_DATETIME_2, FROZEN_DATETIME_1]

--- a/datahub/search/export_country_history/views.py
+++ b/datahub/search/export_country_history/views.py
@@ -1,0 +1,28 @@
+from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
+
+from datahub.oauth.scopes import Scope
+from datahub.search.export_country_history import ExportCountryHistoryApp
+from datahub.search.export_country_history.serializers import SearchExportCountryHistorySerializer
+from datahub.search.permissions import SearchPermissions
+from datahub.search.views import register_v4_view, SearchAPIView
+
+
+@register_v4_view()
+class ExportCountryHistoryView(SearchAPIView):
+    """Export country history search view."""
+
+    required_scopes = (Scope.internal_front_end,)
+    search_app = ExportCountryHistoryApp
+
+    permission_classes = (IsAuthenticatedOrTokenHasScope, SearchPermissions)
+    FILTER_FIELDS = [
+        'country',
+        'company',
+    ]
+
+    REMAP_FIELDS = {
+        'company': 'company.id',
+        'country': 'country.id',
+    }
+
+    serializer_class = SearchExportCountryHistorySerializer


### PR DESCRIPTION
Create ES app for CompanyExportCountryHistory to output history and related interaction data

### Description of change



### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
