### PR TITLE
Feature/check dnb currency

### DIFF
--- a/changelog/company/check-dnb-currency.feature.md
+++ b/changelog/company/check-dnb-currency.feature.md
@@ -1,0 +1,5 @@
+The `format_dnb_company` now includes a check for `annual_sales_currency`.
+
+If `annual_sales_currency` is not US Dollars, we do not propagate `annual_sales` or `is_annual_sales_estimated` fields downstream.
+
+All D&B records that we have encountered until now have `annual_sales` in US dollars but we would like to monitor this behavior and not ingest bad data in case there is an exception.

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -180,10 +180,18 @@ def format_dnb_company(dnb_company):
     domain = dnb_company.get('domain')
     company_website = f'http://{domain}' if domain else ''
 
+    duns_number = dnb_company.get('duns_number')
+    is_turnover_in_usd = dnb_company.get('annual_sales_currency') == 'USD'
+
+    if not is_turnover_in_usd:
+        logger.error(f'D&B did not have USD turnover for: {duns_number}')
+        dnb_company.pop('annual_sales', None)
+        dnb_company.pop('is_annual_sales_estimated', None)
+
     return {
         'name': dnb_company.get('primary_name'),
         'trading_names': dnb_company.get('trading_names'),
-        'duns_number': dnb_company.get('duns_number'),
+        'duns_number': duns_number,
         'address': extract_address_from_dnb_company(dnb_company, 'address'),
         'registered_address': extract_address_from_dnb_company(
             dnb_company,


### PR DESCRIPTION
### Description of change

The `format_dnb_company` now includes a check for `annual_sales_currency`.

  If `annual_sales_currency` is not US Dollars, we do not propagate `annual_sales` or `is_annual_sales_estimated` fields downstream.

  All D&B records that we have encountered until now have `annual_sales` in US dollars but we would like to monitor this behavior and not ingest bad data in case there is an exception.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
