### PR TITLE
Add create company referral view

### DIFF
--- a/changelog/company/add-referral-view.api.md
+++ b/changelog/company/add-referral-view.api.md
@@ -1,0 +1,1 @@
+A new endpoint, `POST /v4/company-referral`, was added. This creates a new company referral. Refer to the API documentation for the schema.

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -8,6 +8,7 @@ from datahub.activity_stream import urls as activity_stream_urls
 from datahub.company import views as company_views
 from datahub.company.urls import company as company_urls
 from datahub.company.urls import contact as contact_urls
+from datahub.company_referral import urls as company_referral_urls
 from datahub.dataset import urls as dataset_urls
 from datahub.dnb_api import urls as dnb_api_urls
 from datahub.event import urls as event_urls
@@ -59,6 +60,7 @@ v3_urls = [
 
 v4_urls = [
     path('', include((company_urls.urls, 'company'), namespace='company')),
+    path('', include((company_referral_urls, 'company-referral'), namespace='company-referral')),
     path('dnb/', include((dnb_api_urls, 'dnb_api'), namespace='dnb-api')),
     path('', include((search_urls.urls_v4, 'search'), namespace='search')),
     path(

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -71,6 +71,16 @@ NestedAdviserWithTeamField = partial(
     ),
 )
 
+NestedAdviserWithEmailAndTeamField = partial(
+    NestedRelatedField,
+    'company.Advisor',
+    extra_fields=(
+        'name',
+        'contact_email',
+        ('dit_team', NestedRelatedField('metadata.Team')),
+    ),
+)
+
 # like NestedAdviserField but includes dit_team with uk_region and country
 NestedAdviserWithEmailAndTeamGeographyField = partial(
     NestedRelatedField,

--- a/datahub/company_referral/serializers.py
+++ b/datahub/company_referral/serializers.py
@@ -1,0 +1,35 @@
+from rest_framework import serializers
+
+from datahub.company.serializers import NestedAdviserWithEmailAndTeamField
+from datahub.company_referral.models import CompanyReferral
+from datahub.core.serializers import NestedRelatedField
+
+
+class CompanyReferralSerializer(serializers.ModelSerializer):
+    """Serialiser for company referrals."""
+
+    company = NestedRelatedField('company.Company')
+    contact = NestedRelatedField('company.Contact', required=False, allow_null=True)
+    created_by = NestedAdviserWithEmailAndTeamField(read_only=True)
+    recipient = NestedAdviserWithEmailAndTeamField()
+
+    class Meta:
+        model = CompanyReferral
+        fields = (
+            'id',
+            'company',
+            'completed_on',
+            'contact',
+            'created_by',
+            'created_on',
+            'recipient',
+            'status',
+            'subject',
+            'notes',
+        )
+        read_only_fields = (
+            'id',
+            'completed_on',
+            'created_on',
+            'status',
+        )

--- a/datahub/company_referral/test/test_views.py
+++ b/datahub/company_referral/test/test_views.py
@@ -1,0 +1,276 @@
+from collections.abc import Mapping
+from datetime import datetime
+from unittest.mock import ANY
+from uuid import UUID
+
+import pytest
+from django.utils.timezone import utc
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
+from datahub.company_referral.models import CompanyReferral
+from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
+
+FROZEN_DATETIME = datetime(2020, 1, 24, 16, 26, 50, tzinfo=utc)
+
+collection_url = reverse('api-v4:company-referral:collection')
+
+
+class TestAddCompanyReferral(APITestMixin):
+    """Tests for the add company referral view."""
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if the user is unauthenticated."""
+        response = api_client.post(collection_url, data={})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames,expected_status',
+        (
+            ([], status.HTTP_403_FORBIDDEN),
+            (['add_companyreferral'], status.HTTP_201_CREATED),
+        ),
+    )
+    def test_permission_checking(self, permission_codenames, expected_status, api_client):
+        """
+        Test that the expected status is returned depending on the permissions the user has.
+        """
+        user = create_test_user(permission_codenames=permission_codenames)
+        api_client = self.create_api_client(user=user)
+
+        request_data = {
+            'subject': 'Test referral',
+            'company': {
+                'id': CompanyFactory().pk,
+            },
+            'recipient': {
+                'id': AdviserFactory().pk,
+            },
+        }
+
+        response = api_client.post(collection_url, data=request_data)
+        assert response.status_code == expected_status
+
+    @pytest.mark.parametrize(
+        'request_data,expected_response_data',
+        (
+            pytest.param(
+                {},
+                {
+                    'company': ['This field is required.'],
+                    'recipient': ['This field is required.'],
+                    'subject': ['This field is required.'],
+                },
+                id='omitted-fields',
+            ),
+            pytest.param(
+                {
+                    'company': None,
+                    'notes': None,
+                    'recipient': None,
+                    'subject': None,
+                },
+                {
+                    'company': ['This field may not be null.'],
+                    'notes': ['This field may not be null.'],
+                    'recipient': ['This field may not be null.'],
+                    'subject': ['This field may not be null.'],
+                },
+                id='non-null-fields',
+            ),
+            pytest.param(
+                {
+                    # The value this field shouldn't be allowed to be an empty string
+                    'subject': '',
+
+                    # Provide values for other required fields (so we don't get errors for them)
+                    'company': {
+                        'id': CompanyFactory,
+                    },
+                    'recipient': {
+                        'id': AdviserFactory,
+                    },
+                },
+                {
+                    'subject': ['This field may not be blank.'],
+                },
+                id='non-blank-fields',
+            ),
+        ),
+    )
+    def test_validates_input(self, request_data, expected_response_data):
+        """Test validation for various scenarios."""
+        resolved_request_data = _resolve_data(request_data)
+        response = self.api_client.post(collection_url, data=resolved_request_data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_response_data
+
+    @freeze_time(FROZEN_DATETIME)
+    def test_can_create_a_referral_without_optional_fields(self):
+        """Test that a referral can be created without optional values filled in."""
+        company = CompanyFactory()
+        recipient = AdviserFactory()
+        subject = 'Test referral'
+
+        request_data = {
+            'subject': subject,
+            'company': {
+                'id': company.pk,
+            },
+            'recipient': {
+                'id': recipient.pk,
+            },
+        }
+
+        response = self.api_client.post(collection_url, data=request_data)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+        assert response_data == {
+            'company': {
+                'id': str(company.pk),
+                'name': company.name,
+            },
+            'completed_on': None,
+            'contact': None,
+            'created_by': {
+                'contact_email': self.user.contact_email,
+                'dit_team': {
+                    'id': str(self.user.dit_team.pk),
+                    'name': self.user.dit_team.name,
+                },
+                'id': str(self.user.pk),
+                'name': self.user.name,
+            },
+            'created_on': format_date_or_datetime(FROZEN_DATETIME),
+            'id': ANY,
+            'notes': '',
+            'recipient': {
+                'contact_email': recipient.contact_email,
+                'dit_team': {
+                    'id': str(recipient.dit_team.pk),
+                    'name': recipient.dit_team.name,
+                },
+                'id': str(recipient.pk),
+                'name': recipient.name,
+            },
+            'status': CompanyReferral.STATUSES.outstanding,
+            'subject': subject,
+        }
+
+    @freeze_time(FROZEN_DATETIME)
+    def test_can_create_a_referral_with_optional_fields(self):
+        """Test that a referral can be created with all optional values filled in."""
+        company = CompanyFactory()
+        contact = ContactFactory()
+        recipient = AdviserFactory()
+        subject = 'Test referral'
+        notes = 'Some notes'
+
+        request_data = {
+            'subject': subject,
+            'company': {
+                'id': company.pk,
+            },
+            'recipient': {
+                'id': recipient.pk,
+            },
+            'contact': {
+                'id': contact.pk,
+            },
+            'notes': notes,
+        }
+
+        response = self.api_client.post(collection_url, data=request_data)
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+        assert response_data == {
+            'company': {
+                'id': str(company.pk),
+                'name': company.name,
+            },
+            'completed_on': None,
+            'contact': {
+                'id': str(contact.pk),
+                'name': contact.name,
+            },
+            'created_by': {
+                'contact_email': self.user.contact_email,
+                'dit_team': {
+                    'id': str(self.user.dit_team.pk),
+                    'name': self.user.dit_team.name,
+                },
+                'id': str(self.user.pk),
+                'name': self.user.name,
+            },
+            'created_on': format_date_or_datetime(FROZEN_DATETIME),
+            'id': ANY,
+            'notes': notes,
+            'recipient': {
+                'contact_email': recipient.contact_email,
+                'dit_team': {
+                    'id': str(recipient.dit_team.pk),
+                    'name': recipient.dit_team.name,
+                },
+                'id': str(recipient.pk),
+                'name': recipient.name,
+            },
+            'status': CompanyReferral.STATUSES.outstanding,
+            'subject': subject,
+        }
+
+    @freeze_time(FROZEN_DATETIME)
+    def test_persists_data_to_the_database(self):
+        """Test that created referrals are saved to the database."""
+        request_data = {
+            'subject': 'Test referral',
+            'company': {
+                'id': CompanyFactory().pk,
+            },
+            'contact': {
+                'id': ContactFactory().pk,
+            },
+            'notes': 'Test notes',
+            'recipient': {
+                'id': AdviserFactory().pk,
+            },
+        }
+
+        response = self.api_client.post(collection_url, data=request_data)
+        assert response.status_code == status.HTTP_201_CREATED
+
+        pk = response.json()['id']
+        referral_data = CompanyReferral.objects.values().get(pk=pk)
+
+        assert referral_data == {
+            'company_id': request_data['company']['id'],
+            'completed_by_id': None,
+            'completed_on': None,
+            'contact_id': request_data['contact']['id'],
+            'created_by_id': self.user.pk,
+            'created_on': FROZEN_DATETIME,
+            'id': UUID(pk),
+            'modified_by_id': self.user.pk,
+            'modified_on': FROZEN_DATETIME,
+            'notes': request_data['notes'],
+            'recipient_id': request_data['recipient']['id'],
+            'status': CompanyReferral.STATUSES.outstanding,
+            'subject': request_data['subject'],
+        }
+
+
+def _resolve_data(data):
+    """Resolve callables in values used in parametrised tests."""
+    if isinstance(data, Mapping):
+        return {key: _resolve_data(value) for key, value in data.items()}
+
+    if callable(data):
+        resolved_value = data()
+    else:
+        resolved_value = data
+
+    return getattr(resolved_value, 'pk', resolved_value)

--- a/datahub/company_referral/urls.py
+++ b/datahub/company_referral/urls.py
@@ -1,0 +1,15 @@
+from django.urls import path
+
+from datahub.company_referral.views import CompanyReferralViewSet
+
+urlpatterns = [
+    path(
+        'company-referral',
+        CompanyReferralViewSet.as_view(
+            {
+                'post': 'create',
+            },
+        ),
+        name='collection',
+    ),
+]

--- a/datahub/company_referral/views.py
+++ b/datahub/company_referral/views.py
@@ -1,0 +1,17 @@
+from datahub.company_referral.models import CompanyReferral
+from datahub.company_referral.serializers import CompanyReferralSerializer
+from datahub.core.viewsets import CoreViewSet
+from datahub.oauth.scopes import Scope
+
+
+class CompanyReferralViewSet(CoreViewSet):
+    """Company referral view set."""
+
+    serializer_class = CompanyReferralSerializer
+    required_scopes = (Scope.internal_front_end,)
+    queryset = CompanyReferral.objects.select_related(
+        'company',
+        'contact',
+        'created_by__team',
+        'recipient__team',
+    )


### PR DESCRIPTION
### Description of change

This adds a view at `POST /v4/company-referral` for creating a company referral.

Similar patterns to other apps have been used.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
