### PR TITLE
Revise automatic company archive criteria

### DIFF
--- a/changelog/company/revise-automatic-company-archive-criteria.feature.md
+++ b/changelog/company/revise-automatic-company-archive-criteria.feature.md
@@ -1,0 +1,4 @@
+The following criteria were added to the `automatic-company-archive` Celery task:
+
+- Do not have any ongoing investment projects
+- Do not have any investor profiles

--- a/datahub/company/tasks.py
+++ b/datahub/company/tasks.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from dateutil.relativedelta import relativedelta
-from django.db.models import OuterRef, Q, Subquery
+from django.db.models import FilteredRelation, OuterRef, Q, Subquery
 from django.utils import timezone
 from django_pglocks import advisory_lock
 
@@ -9,11 +9,13 @@ from datahub.company.constants import AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG
 from datahub.company.models.company import Company
 from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.interaction.models import Interaction
+from datahub.investment.project.models import InvestmentProject
+
 
 logger = get_task_logger(__name__)
 
 
-def _automatic_company_archive(task, limit, simulate):
+def _automatic_company_archive(limit, simulate):
 
     _8y_ago = timezone.now() - relativedelta(years=8)
     _3m_ago = timezone.now() - relativedelta(months=3)
@@ -26,12 +28,17 @@ def _automatic_company_archive(task, limit, simulate):
         latest_interaction_date=Subquery(
             latest_interaction.values('date')[:1],
         ),
+        active_investment_projects=FilteredRelation(
+            'investor_investment_projects',
+            condition=Q(investor_investment_projects__status=InvestmentProject.STATUSES.ongoing),
+        ),
     ).filter(
         Q(latest_interaction_date__date__lt=_8y_ago) | Q(latest_interaction_date__isnull=True),
         archived=False,
         duns_number__isnull=True,
         orders__isnull=True,
         investor_profiles__isnull=True,
+        active_investment_projects__isnull=True,
         created_on__lt=_3m_ago,
         modified_on__lt=_3m_ago,
     )[:limit]
@@ -77,4 +84,4 @@ def automatic_company_archive(self, limit=1000, simulate=True):
             logger.info('Another instance of this task is already running.')
             return
 
-        _automatic_company_archive(self, limit, simulate)
+        _automatic_company_archive(limit, simulate)

--- a/datahub/company/tasks.py
+++ b/datahub/company/tasks.py
@@ -31,6 +31,7 @@ def _automatic_company_archive(task, limit, simulate):
         archived=False,
         duns_number__isnull=True,
         orders__isnull=True,
+        investor_profiles__isnull=True,
         created_on__lt=_3m_ago,
         modified_on__lt=_3m_ago,
     )[:limit]


### PR DESCRIPTION
### Description of change

The following criteria were added to the `automatic-company-archive` Celery task:

- Do not have any ongoing investment projects
- Do not have any investor profiles

[Here](https://docs.google.com/document/d/1IKuFHKkmSH_r4OAPpCmU5Hq0gjImy8PqOfinnG226xI/edit#) is the documents we are using to track the criteria for `automatic-company-archive` job.

I was concerned about the performance of the query so I did the following on prod:

```
In [2]: from dateutil.relativedelta import relativedelta
   ...: from django.db import connections
   ...: from django.db.models import FilteredRelation, OuterRef, Q, Subquery
   ...: from django.utils import timezone
   ...:
   ...: from datahub.company.models.company import Company
   ...: from datahub.interaction.models import Interaction
   ...:
   ...:
   ...: _8y_ago = timezone.now() - relativedelta(years=8)
   ...: _3m_ago = timezone.now() - relativedelta(months=3)
   ...:
   ...: latest_interaction = Interaction.objects.filter(
   ...:     company=OuterRef('pk'),
   ...: ).order_by('-date')
   ...:
   ...: qs = Company.objects.annotate(
   ...:     latest_interaction_date=Subquery(
   ...:         latest_interaction.values('date')[:1],
   ...:     ),
   ...:     active_investment_projects=FilteredRelation(
   ...:         'investor_investment_projects',
   ...:         condition=Q(investor_investment_projects__status='ongoing'),
   ...:     ),
   ...: ).filter(
   ...:     Q(latest_interaction_date__date__lt=_8y_ago) | Q(latest_interaction_date__isnull=True),
   ...:     archived=False,
   ...:     duns_number__isnull=True,
   ...:     orders__isnull=True,
   ...:     investor_profiles__isnull=True,
   ...:     active_investment_projects__isnull=True,
   ...:     created_on__lt=_3m_ago,
   ...:     modified_on__lt=_3m_ago,
   ...: )
   ...:
   ...: qs.explain(analyze=True).split('\n')
   ...:
Out[2]:
['Nested Loop Left Join  (cost=16008.86..967305.15 rows=1 width=712) (actual time=47.935..3859.437 rows=95980 loops=1)',
 '  Filter: (order_order.id IS NULL)',
 '  Rows Removed by Filter: 238',
 '  ->  Nested Loop Left Join  (cost=16008.57..967303.19 rows=1 width=704) (actual time=47.923..3309.665 rows=96158 loops=1)',
 '        Filter: (active_investment_projects.id IS NULL)',
 '        Rows Removed by Filter: 679',
 '        ->  Hash Left Join  (cost=16008.15..967302.22 rows=1 width=704) (actual time=47.915..2996.161 rows=96824 loops=1)',
 '              Hash Cond: (company_company.id = investor_profile_largecapitalinvestorprofile.investor_company_id)',
 '              Filter: (investor_profile_largecapitalinvestorprofile.id IS NULL)',
 '              Rows Removed by Filter: 4',
 '              ->  Bitmap Heap Scan on company_company  (cost=15994.90..966886.94 rows=107139 width=704) (actual time=47.817..2921.746 rows=96828 loops=1)',
 "                    Recheck Cond: ((duns_number IS NULL) AND (created_on < '2019-10-29 12:50:50.813871+00'::timestamp with time zone))",
 "                    Filter: ((NOT archived) AND (modified_on < '2019-10-29 12:50:50.813871+00'::timestamp with time zone) AND (((timezone('UTC'::text, (SubPlan 2)))::date < '2012-01-29'::date) OR ((SubPlan 3) IS NULL)))",
 '                    Rows Removed by Filter: 233710',
 '                    Heap Blocks: exact=22642',
 '                    ->  BitmapAnd  (cost=15994.90..15994.90 rows=328766 width=0) (actual time=44.364..44.364 rows=0 loops=1)',
 '                          ->  Bitmap Index Scan on company_company_duns_number_a97cc47a_like  (cost=0.00..7764.98 rows=331808 width=0) (actual time=14.367..14.367 rows=339640 loops=1)',
 '                                Index Cond: (duns_number IS NULL)',
 '                          ->  Bitmap Index Scan on company_company_created_on_3a9a33ef  (cost=0.00..8176.10 rows=415424 width=0) (actual time=29.153..29.153 rows=429412 loops=1)',
 "                                Index Cond: (created_on < '2019-10-29 12:50:50.813871+00'::timestamp with time zone)",
 '                    SubPlan 2',
 '                      ->  Limit  (cost=0.56..1.40 rows=1 width=8) (actual time=0.004..0.004 rows=1 loops=323086)',
 '                            ->  Index Only Scan using interaction_company_236ca9_idx on interaction_interaction u0_1  (cost=0.56..53.66 rows=63 width=8) (actual time=0.003..0.004 rows=1 loops=323086)',
 '                                  Index Cond: (company_id = company_company.id)',
 '                                  Heap Fetches: 121619',
 '                    SubPlan 3',
 '                      ->  Limit  (cost=0.56..1.40 rows=1 width=8) (actual time=0.003..0.003 rows=1 loops=284763)',
 '                            ->  Index Only Scan using interaction_company_236ca9_idx on interaction_interaction u0_2  (cost=0.56..53.66 rows=63 width=8) (actual time=0.002..0.002 rows=1 loops=284763)',
 '                                  Index Cond: (company_id = company_company.id)',
 '                                  Heap Fetches: 89076',
 '              ->  Hash  (cost=12.00..12.00 rows=100 width=32) (actual time=0.090..0.090 rows=105 loops=1)',
 '                    Buckets: 1024  Batches: 1  Memory Usage: 15kB',
 '                    ->  Seq Scan on investor_profile_largecapitalinvestorprofile  (cost=0.00..12.00 rows=100 width=32) (actual time=0.005..0.055 rows=105 loops=1)',
 '        ->  Index Scan using investment_investmentproject_investor_company_id_e8019d81 on investment_investmentproject active_investment_projects  (cost=0.41..0.96 rows=1 width=32) (actual time=0.002..0.002 rows=0 loops=96824)',
 '              Index Cond: (company_company.id = investor_company_id)',
 "              Filter: ((status)::text = 'ongoing'::text)",
 '              Rows Removed by Filter: 0',
 '  ->  Index Scan using order_order_company_id_2f818a26 on order_order  (cost=0.29..0.54 rows=2 width=32) (actual time=0.001..0.001 rows=0 loops=96158)',
 '        Index Cond: (company_company.id = company_id)',
 '  SubPlan 1',
 '    ->  Limit  (cost=0.56..1.40 rows=1 width=8) (actual time=0.002..0.003 rows=0 loops=95980)',
 '          ->  Index Only Scan using interaction_company_236ca9_idx on interaction_interaction u0  (cost=0.56..53.66 rows=63 width=8) (actual time=0.002..0.002 rows=0 loops=95980)',
 '                Index Cond: (company_id = company_company.id)',
 '                Heap Fetches: 32479',
 'Planning time: 1.162 ms',
 'Execution time: 3881.108 ms']
```

(TY @elcct for the help)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
