### PR TITLE
Remove deprecated adviser filters

### DIFF
--- a/changelog/adviser/deprecated-adviser-filters.api.md
+++ b/changelog/adviser/deprecated-adviser-filters.api.md
@@ -1,0 +1,1 @@
+`GET /adviser/`: The deprecated `first_name`, `first_name__icontains`, `last_name`, `last_name__icontains`, `email` and `email__icontains` query parameters were removed.

--- a/changelog/adviser/deprecated-adviser-filters.removal.md
+++ b/changelog/adviser/deprecated-adviser-filters.removal.md
@@ -1,0 +1,1 @@
+`GET /adviser/`: The deprecated `first_name`, `first_name__icontains`, `last_name`, `last_name__icontains`, `email` and `email__icontains` query parameters were removed.

--- a/datahub/company/test/test_adviser_views.py
+++ b/datahub/company/test/test_adviser_views.py
@@ -111,39 +111,24 @@ class TestAdviser(APITestMixin):
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
-    def test_adviser_filtered_view(self):
-        """Test filtering."""
-        adviser = AdviserFactory(last_name='UNIQUE')
-        url = reverse('api-v1:advisor-list')
-        response = self.api_client.get(url, data=dict(last_name__icontains='uniq'))
-        assert response.status_code == status.HTTP_200_OK
-        response_data = response.json()
-        assert len(response_data['results']) == 1
-        result = response_data['results'][0]
-        assert result['last_name'] == adviser.last_name
-        assert result['telephone_number'] == adviser.telephone_number
-        assert result['contact_email'] == adviser.contact_email
-        assert result['is_active'] == adviser.is_active
-
     def test_adviser_list_view_default_sort_order(self):
         """Test default sorting."""
         AdviserFactory(first_name='a', last_name='sorted adviser')
         AdviserFactory(first_name='z', last_name='sorted adviser')
         AdviserFactory(first_name='f', last_name='sorted adviser')
+
         url = reverse('api-v1:advisor-list')
-        response = self.api_client.get(
-            url,
-            data={
-                'last_name__icontains': 'sorted',
-            },
-        )
+        response = self.api_client.get(url)
+
         assert response.status_code == status.HTTP_200_OK
         result = response.json()
-        assert len(result['results']) == 3
+        assert len(result['results']) == 4
         results = result['results']
         assert [res['name'] for res in results] == [
             'a sorted adviser',
             'f sorted adviser',
+            # This is the test user making the request
+            'Testo Useri',
             'z sorted adviser',
         ]
 

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -246,11 +246,7 @@ class AdviserFilter(FilterSet):
 
     class Meta:
         model = Advisor
-        # TODO: Remove unused options following the deprecation period.
         fields = {
-            'first_name': ('exact', 'icontains'),
-            'last_name': ('exact', 'icontains'),
-            'email': ('exact', 'icontains'),
             'is_active': ('exact',),
         }
 


### PR DESCRIPTION
### Description of change

This removes various filters in the `/adviser/` endpoint that were deprecated in version 10.0.0.

(The deprecation was some time ago, but I've checked logs etc. and they aren't in use.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
