### PR TITLE
Add ability to filter advisers by permission

### DIFF
--- a/changelog/adviser/adviser-permission-filter.api.md
+++ b/changelog/adviser/adviser-permission-filter.api.md
@@ -1,0 +1,5 @@
+`GET /adviser/`: A new query parameter, `permissions__has`, was added. This filters results to 
+advisers with a particular permission.
+
+For example, `GET /adviser/?permissions__has=company_referral.change_companyreferral` returns
+advisers that are allowed to update company referrals. 


### PR DESCRIPTION
### Description of change

This adds a new query parameter, `permissions__has,` to `GET /adviser/`. This filters results to advisers with a particular permission.

This is so advisers that don't have permission to do something can be excluded from selection in a form in the front end.

For example, `GET /adviser/?permissions__has=company_referral.change_companyreferral` returns
advisers that are allowed to update company referrals.

The pseudo-operator (`has`) is a suffix to try and be consistent with other filters.

This is blocked by https://github.com/uktrade/data-hub-api/pull/2486.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
