### PR TITLE
add permissions to company export country data points and APIs

### DIFF
--- a/changelog/company/add_company_export_country_permissions.api.md
+++ b/changelog/company/add_company_export_country_permissions.api.md
@@ -1,0 +1,3 @@
+The `GET /v4/company/<pk>` API endpoint was updated to make sure `export_countries` field is included in the response only when the user has `company.view_companyexportcountry` permission. And omits otherwise.
+
+The `PATCH /v4/company/<pk>/export-detail` API endpoint was updated to make sure requests from users with `company.change_companyexportcountry` permission are honoured.

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -613,6 +613,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         )
         permissions = {
             f'company.{CompanyPermission.view_company_document}': 'archived_documents_url_path',
+            f'company.view_companyexportcountry': 'export_countries',
         }
 
 

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -261,6 +261,7 @@ class TestGetCompany(APITestMixin):
             permission_codenames=(
                 'view_company',
                 'view_company_document',
+                'view_companyexportcountry',
             ),
         )
         api_client = self.create_api_client(user=user)
@@ -502,7 +503,7 @@ class TestGetCompany(APITestMixin):
         user = create_test_user(
             permission_codenames=(
                 'view_company',
-                'view_company_document',
+                'view_companyexportcountry',
             ),
         )
         api_client = self.create_api_client(user=user)
@@ -522,6 +523,27 @@ class TestGetCompany(APITestMixin):
                 'status': item.status,
             } for item in company.export_countries.order_by('pk')
         ]
+
+    def test_check_company_dont_return_export_countries_with_no_permission(self):
+        """
+        Tests the company response has no export countries
+        without appropriate permission.
+        """
+        company = CompanyFactory()
+        export_country_one, export_country_two = CompanyExportCountryFactory.create_batch(2)
+        company.export_countries.set([export_country_one, export_country_two])
+        user = create_test_user(
+            permission_codenames=(
+                'view_company',
+            ),
+        )
+        api_client = self.create_api_client(user=user)
+
+        url = reverse('api-v4:company:item', kwargs={'pk': company.id})
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert 'export_countries' not in response.json()
 
     @pytest.mark.parametrize(
         'build_company',
@@ -1394,7 +1416,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         user = create_test_user(
             permission_codenames=(
                 'view_company',
-                'view_company_document',
+                'view_companyexportcountry',
             ),
         )
         api_client = self.create_api_client(user=user)
@@ -1736,6 +1758,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         (
             (),
             (CompanyPermission.change_company,),
+            ('change_companyexportcountry',),
         ),
     )
     def test_returns_403_if_without_permission(self, permission_codenames):

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -147,7 +147,16 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         serializer.save(request.user)
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
-    @action(methods=['patch'], detail=True)
+    @action(
+        methods=['patch'],
+        permission_classes=[
+            HasPermissions(
+                f'company.{CompanyPermission.change_company}',
+                f'company.change_companyexportcountry',
+            ),
+        ],
+        detail=True,
+    )
     def update_export_detail(self, request, *args, **kwargs):
         """
         Update export related information for the company.

--- a/fixtures/metadata/teams.yaml
+++ b/fixtures/metadata/teams.yaml
@@ -457,6 +457,12 @@
     - - export_largecapitalinvestorprofile
       - investor_profile
       - largecapitalinvestorprofile
+    - - view_companyexportcountry
+      - company
+      - companyexportcountry
+    - - change_companyexportcountry
+      - company
+      - companyexportcountry
   model: auth.group
 - fields:
     name: Regional account managers


### PR DESCRIPTION
### Description of change
Add company export country related permission to make sure appropriate user groups are allowed to view and change export countries for a company.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
