### PR TITLE
Refactor dnb update admin tool to break out reusable functionality

### DIFF
--- a/changelog/company/refactor-update-from-dnb-admin.internal.md
+++ b/changelog/company/refactor-update-from-dnb-admin.internal.md
@@ -1,0 +1,3 @@
+The `update_from_dnb` admin tool was refactored to break out some useful utilities
+for use by other modules.  This will aid in the new "Link Company with D&B" tool
+which will follow shortly.

--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -11,10 +11,10 @@ from django.utils.safestring import mark_safe
 from reversion.admin import VersionAdmin
 
 from datahub.company.admin.archiving.unarchive import unarchive_company
-from datahub.company.admin.dnb import update_from_dnb
 from datahub.company.admin.merge.step_1 import merge_select_other_company
 from datahub.company.admin.merge.step_2 import select_primary_company
 from datahub.company.admin.merge.step_3 import confirm_merge
+from datahub.company.admin.update_from_dnb import update_from_dnb
 from datahub.company.models import Company, OneListCoreTeamMember
 from datahub.core.admin import BaseModelAdminMixin, get_change_link
 from datahub.core.templatetags.datahub_extras import admin_change_link

--- a/datahub/company/admin/update_from_dnb.py
+++ b/datahub/company/admin/update_from_dnb.py
@@ -1,0 +1,95 @@
+import logging
+
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.core.exceptions import PermissionDenied, SuspiciousOperation
+from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
+from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.http import require_http_methods
+from rest_framework import serializers
+
+from datahub.company.admin.utils import (
+    AdminException,
+    format_company_diff,
+    redirect_with_message,
+)
+from datahub.dnb_api.utils import (
+    DNBServiceConnectionError,
+    DNBServiceError,
+    DNBServiceInvalidRequest,
+    DNBServiceInvalidResponse,
+    DNBServiceTimeoutError,
+    get_company,
+    update_company_from_dnb,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@redirect_with_message
+@method_decorator(require_http_methods(['GET', 'POST']))
+@method_decorator(csrf_protect)
+def update_from_dnb(model_admin, request, object_id):
+    """
+    Tool to let admin users update company with a valid `duns_number`
+    by pulling fresh data from D&B.
+
+    The company record will be versioned after the update from
+    D&B is applied.
+
+    The `pending_dnb_investigation` field will
+    be set to False.
+    """
+    if not model_admin.has_change_permission(request):
+        raise PermissionDenied()
+
+    dh_company = model_admin.get_object(request, object_id)
+
+    company_change_page = reverse(
+        admin_urlname(model_admin.model._meta, 'change'),
+        kwargs={'object_id': dh_company.pk},
+    )
+
+    if dh_company is None or dh_company.duns_number is None:
+        raise SuspiciousOperation()
+
+    try:
+        dnb_company = get_company(dh_company.duns_number)
+
+    except (
+        DNBServiceError,
+        DNBServiceConnectionError,
+        DNBServiceTimeoutError,
+        DNBServiceInvalidResponse,
+    ):
+        message = 'Something went wrong in an upstream service.'
+        raise AdminException(message, company_change_page)
+
+    except DNBServiceInvalidRequest:
+        message = 'No matching company found in D&B database.'
+        raise AdminException(message, company_change_page)
+
+    if request.method == 'GET':
+        return TemplateResponse(
+            request,
+            'admin/company/company/update-from-dnb.html',
+            {
+                **model_admin.admin_site.each_context(request),
+                'media': model_admin.media,
+                'opts': model_admin.model._meta,
+                'object': dh_company,
+                'title': gettext_lazy('Confirm update from D&B'),
+                'diff': format_company_diff(dh_company, dnb_company),
+            },
+        )
+
+    try:
+        update_company_from_dnb(dh_company, dnb_company, request.user)
+        return HttpResponseRedirect(company_change_page)
+    except serializers.ValidationError:
+        message = 'Data from D&B did not pass the Data Hub validation checks.'
+        raise AdminException(message, company_change_page)

--- a/datahub/company/admin/utils.py
+++ b/datahub/company/admin/utils.py
@@ -1,34 +1,12 @@
 import functools
-import logging
 
 from django.contrib import messages
-from django.contrib.admin.templatetags.admin_urls import admin_urlname
-from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import HttpResponseRedirect
-from django.template.response import TemplateResponse
-from django.urls import reverse
-from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy
-from django.views.decorators.csrf import csrf_protect
-from django.views.decorators.http import require_http_methods
-from rest_framework import serializers
 
-from datahub.dnb_api.utils import (
-    DNBServiceConnectionError,
-    DNBServiceError,
-    DNBServiceInvalidRequest,
-    DNBServiceInvalidResponse,
-    DNBServiceTimeoutError,
-    get_company,
-    update_company_from_dnb,
-)
 from datahub.metadata.models import Country
 
 
-logger = logging.getLogger(__name__)
-
-
-def _format_company_diff(dh_company, dnb_company):
+def format_company_diff(dh_company, dnb_company):
     """
     Format the Datahub and D&B companies for templates.
     """
@@ -151,68 +129,3 @@ class AdminException(Exception):
     Exception in an admin view. Contains the message
     to be displayed to the usr and the redirect_url.
     """
-
-
-@redirect_with_message
-@method_decorator(require_http_methods(['GET', 'POST']))
-@method_decorator(csrf_protect)
-def update_from_dnb(model_admin, request, object_id):
-    """
-    Tool to let admin users update company with a valid `duns_number`
-    by pulling fresh data from D&B.
-
-    The company record will be versioned after the update from
-    D&B is applied.
-
-    The `pending_dnb_investigation` field will
-    be set to False.
-    """
-    if not model_admin.has_change_permission(request):
-        raise PermissionDenied()
-
-    dh_company = model_admin.get_object(request, object_id)
-
-    company_change_page = reverse(
-        admin_urlname(model_admin.model._meta, 'change'),
-        kwargs={'object_id': dh_company.pk},
-    )
-
-    if dh_company is None or dh_company.duns_number is None:
-        raise SuspiciousOperation()
-
-    try:
-        dnb_company = get_company(dh_company.duns_number)
-
-    except (
-        DNBServiceError,
-        DNBServiceConnectionError,
-        DNBServiceTimeoutError,
-        DNBServiceInvalidResponse,
-    ):
-        message = 'Something went wrong in an upstream service.'
-        raise AdminException(message, company_change_page)
-
-    except DNBServiceInvalidRequest:
-        message = 'No matching company found in D&B database.'
-        raise AdminException(message, company_change_page)
-
-    if request.method == 'GET':
-        return TemplateResponse(
-            request,
-            'admin/company/company/update-from-dnb.html',
-            {
-                **model_admin.admin_site.each_context(request),
-                'media': model_admin.media,
-                'opts': model_admin.model._meta,
-                'object': dh_company,
-                'title': gettext_lazy('Confirm update from D&B'),
-                'diff': _format_company_diff(dh_company, dnb_company),
-            },
-        )
-
-    try:
-        update_company_from_dnb(dh_company, dnb_company, request.user)
-        return HttpResponseRedirect(company_change_page)
-    except serializers.ValidationError:
-        message = 'Data from D&B did not pass the Data Hub validation checks.'
-        raise AdminException(message, company_change_page)


### PR DESCRIPTION
### Description of change

The `update_from_dnb` admin tool was refactored to break out some useful utilities
for use by other modules.  This will aid in the new "Link Company with D&B" tool
which will follow shortly.

This is the first PR to lay the foundations for the "Link Company with D&B" tool.  More will follow that build on this.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
