### PR TITLE
Add view for retrieving a company referral

### DIFF
--- a/changelog/company/get-referral.api.md
+++ b/changelog/company/get-referral.api.md
@@ -1,0 +1,1 @@
+A new endpoint, `GET /v4/company-referral/<id>`, was added. This retrieves a single referral object.

--- a/datahub/company_referral/test/factories.py
+++ b/datahub/company_referral/test/factories.py
@@ -11,6 +11,8 @@ class CompanyReferralFactory(factory.django.DjangoModelFactory):
     recipient = factory.SubFactory(AdviserFactory)
     subject = factory.Faker('sentence', nb_words=8)
     notes = factory.Faker('paragraph', nb_sentences=10)
+    created_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
 
     class Meta:
         model = 'company_referral.CompanyReferral'

--- a/datahub/company_referral/test/test_views.py
+++ b/datahub/company_referral/test/test_views.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from datetime import datetime
 from unittest.mock import ANY
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from django.utils.timezone import utc
@@ -11,11 +11,16 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.company_referral.models import CompanyReferral
+from datahub.company_referral.test.factories import CompanyReferralFactory
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
 
 FROZEN_DATETIME = datetime(2020, 1, 24, 16, 26, 50, tzinfo=utc)
 
 collection_url = reverse('api-v4:company-referral:collection')
+
+
+def _item_url(pk):
+    return reverse('api-v4:company-referral:item', kwargs={'pk': pk})
 
 
 class TestAddCompanyReferral(APITestMixin):
@@ -260,6 +265,87 @@ class TestAddCompanyReferral(APITestMixin):
             'recipient_id': request_data['recipient']['id'],
             'status': CompanyReferral.STATUSES.outstanding,
             'subject': request_data['subject'],
+        }
+
+
+class TestGetCompanyReferral(APITestMixin):
+    """Tests for the get company referral view."""
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if the user is unauthenticated."""
+        referral = CompanyReferralFactory()
+        url = _item_url(referral.pk)
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames,expected_status',
+        (
+            ([], status.HTTP_403_FORBIDDEN),
+            (['view_companyreferral'], status.HTTP_200_OK),
+        ),
+    )
+    def test_permission_checking(self, permission_codenames, expected_status, api_client):
+        """
+        Test that the expected status is returned depending on the permissions the user has.
+        """
+        referral = CompanyReferralFactory()
+        user = create_test_user(permission_codenames=permission_codenames)
+
+        url = _item_url(referral.pk)
+        api_client = self.create_api_client(user=user)
+
+        response = api_client.get(url)
+        assert response.status_code == expected_status
+
+    def test_returns_404_for_non_existent_referral(self):
+        """Test that a 404 is returned for a non-existent referral ID."""
+        url = _item_url(uuid4())
+        response = self.api_client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_retrieve_a_referral(self):
+        """Test that a single referral can be retrieved."""
+        referral = CompanyReferralFactory()
+        url = _item_url(referral.pk)
+
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data == {
+            'company': {
+                'id': str(referral.company.pk),
+                'name': referral.company.name,
+            },
+            'completed_on': None,
+            'contact': {
+                'id': str(referral.contact.pk),
+                'name': referral.contact.name,
+            },
+            'created_by': {
+                'contact_email': referral.created_by.contact_email,
+                'dit_team': {
+                    'id': str(referral.created_by.dit_team.pk),
+                    'name': referral.created_by.dit_team.name,
+                },
+                'id': str(referral.created_by.pk),
+                'name': referral.created_by.name,
+            },
+            'created_on': format_date_or_datetime(referral.created_on),
+            'id': str(referral.pk),
+            'notes': referral.notes,
+            'recipient': {
+                'contact_email': referral.recipient.contact_email,
+                'dit_team': {
+                    'id': str(referral.recipient.dit_team.pk),
+                    'name': referral.recipient.dit_team.name,
+                },
+                'id': str(referral.recipient.pk),
+                'name': referral.recipient.name,
+            },
+            'status': referral.status,
+            'subject': referral.subject,
         }
 
 

--- a/datahub/company_referral/urls.py
+++ b/datahub/company_referral/urls.py
@@ -12,4 +12,13 @@ urlpatterns = [
         ),
         name='collection',
     ),
+    path(
+        'company-referral/<uuid:pk>',
+        CompanyReferralViewSet.as_view(
+            {
+                'get': 'retrieve',
+            },
+        ),
+        name='item',
+    ),
 ]

--- a/datahub/company_referral/views.py
+++ b/datahub/company_referral/views.py
@@ -12,6 +12,6 @@ class CompanyReferralViewSet(CoreViewSet):
     queryset = CompanyReferral.objects.select_related(
         'company',
         'contact',
-        'created_by__team',
-        'recipient__team',
+        'created_by__dit_team',
+        'recipient__dit_team',
     )


### PR DESCRIPTION
### Description of change

This adds the endpoint `GET /v4/company-referral/<id>` for retrieving a single company referral object using its ID.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
