### PR TITLE
Add list company referrals endpoint

### DIFF
--- a/changelog/company/company-referrals-list-endpoint.api.md
+++ b/changelog/company/company-referrals-list-endpoint.api.md
@@ -1,0 +1,2 @@
+A new endpoint, `GET /v4/company-referral` has been added. It lists referral sent or received by the adviser. 
+Refer to the API documentation for the schema.

--- a/datahub/company_referral/urls.py
+++ b/datahub/company_referral/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
         CompanyReferralViewSet.as_view(
             {
                 'post': 'create',
+                'get': 'list',
             },
         ),
         name='collection',

--- a/datahub/company_referral/views.py
+++ b/datahub/company_referral/views.py
@@ -1,3 +1,5 @@
+from django.db.models import Q
+
 from datahub.company_referral.models import CompanyReferral
 from datahub.company_referral.serializers import CompanyReferralSerializer
 from datahub.core.viewsets import CoreViewSet
@@ -15,3 +17,15 @@ class CompanyReferralViewSet(CoreViewSet):
         'created_by__dit_team',
         'recipient__dit_team',
     )
+
+    def get_queryset(self):
+        """
+        Get a queryset for list action that is filtered to the authenticated user's sent and
+        received referrals, otherwise return original queryset.
+        """
+        if self.action == 'list':
+            return super().get_queryset().filter(
+                Q(created_by=self.request.user) | Q(recipient=self.request.user),
+            )
+
+        return super().get_queryset()


### PR DESCRIPTION
### Description of change

A new endpoint, `GET /v4/company-referral` has been added. It lists referral sent or received by the adviser. 
Refer to the API documentation for the schema.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
