### PR TITLE
Fix dnb turnover logs

### DIFF
--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -181,10 +181,16 @@ def format_dnb_company(dnb_company):
     company_website = f'http://{domain}' if domain else ''
 
     duns_number = dnb_company.get('duns_number')
-    is_turnover_in_usd = dnb_company.get('annual_sales_currency') == 'USD'
+    turnover_currency = dnb_company.get('annual_sales_currency')
 
-    if not is_turnover_in_usd:
-        logger.error(f'D&B did not have USD turnover for: {duns_number}')
+    if turnover_currency and turnover_currency != 'USD':
+        logger.error(
+            'D&B did not have USD turnover',
+            extra={
+                'duns_number': duns_number,
+                'currency': turnover_currency,
+            },
+        )
         dnb_company.pop('annual_sales', None)
         dnb_company.pop('is_annual_sales_estimated', None)
 


### PR DESCRIPTION
### Description of change

Two things wrong with the logs here:

1) We were getting entries for companies which had `annual_sales=None`.

2) Sentry wasn't able to merge the logs because each entry had the `duns_number` in the message.

This fixes both these problems. I have isolated the commits for each fix.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
