### PR TITLE
Link company with dnb admin step 2

### DIFF
--- a/changelog/company/link-company-with-dnb-step-2.feature.md
+++ b/changelog/company/link-company-with-dnb-step-2.feature.md
@@ -1,0 +1,2 @@
+A view was added to allow admin users to review and confirm changes that will 
+be made for D&B company linking.

--- a/datahub/company/admin/dnb_link/forms.py
+++ b/datahub/company/admin/dnb_link/forms.py
@@ -1,0 +1,44 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy
+
+from datahub.company.models import Company
+from datahub.core.admin import RawIdWidget
+
+
+class SelectIdsToLinkForm(forms.Form):
+    """
+    Form used for selecting Data Hub company id and D&B duns number for linking.
+    """
+
+    COMPANY_ALREADY_DNB_LINKED = gettext_lazy(
+        'This company has already been linked with a D&B company.',
+    )
+    DUNS_NUMBER_ALREADY_LINKED = gettext_lazy(
+        'This duns number has already been linked with a Data Hub company.',
+    )
+
+    company = forms.ModelChoiceField(
+        Company.objects.all(),
+        widget=RawIdWidget(Company),
+        label='Data Hub Company',
+    )
+    duns_number = forms.CharField(min_length=9, max_length=9)
+
+    def clean_company(self):
+        """
+        Check that the company does not already have a duns number.
+        """
+        company = self.cleaned_data['company']
+        if company.duns_number:
+            raise ValidationError(self.COMPANY_ALREADY_DNB_LINKED)
+        return company
+
+    def clean_duns_number(self):
+        """
+        Check that the duns_number chosen has not already been linked to a Data Hub company.
+        """
+        duns_number = self.cleaned_data['duns_number']
+        if Company.objects.filter(duns_number=duns_number).exists():
+            raise ValidationError(self.DUNS_NUMBER_ALREADY_LINKED)
+        return duns_number

--- a/datahub/company/admin/dnb_link/review_changes.py
+++ b/datahub/company/admin/dnb_link/review_changes.py
@@ -1,15 +1,122 @@
+from django.contrib import messages
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
 from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
+from django.views.decorators.csrf import csrf_protect
+from rest_framework import serializers
+
+from datahub.company.admin.dnb_link.forms import SelectIdsToLinkForm
+from datahub.company.admin.utils import (
+    AdminException,
+    format_company_diff,
+    redirect_with_message,
+)
+from datahub.dnb_api.link_company import link_company_with_dnb
+from datahub.dnb_api.utils import (
+    DNBServiceConnectionError,
+    DNBServiceError,
+    DNBServiceInvalidRequest,
+    DNBServiceInvalidResponse,
+    DNBServiceTimeoutError,
+    get_company,
+)
 
 
+def _build_error_message(all_errors):
+    error_message = ''
+    for field, errors in all_errors.items():
+        concatenated_errors = ', '.join(errors)
+        error_message += f'{field}: {concatenated_errors} '
+    return error_message
+
+
+def _link_company_with_dnb(dh_company_id, duns_number, user, error_url):
+    # We don't need to catch CompanyAlreadyDNBLinkedException as our form will
+    # do this validation for us
+    try:
+        link_company_with_dnb(dh_company_id, duns_number, user)
+    except serializers.ValidationError:
+        message = 'Data from D&B did not pass the Data Hub validation checks.'
+        raise AdminException(message, error_url)
+    except (
+        DNBServiceError,
+        DNBServiceConnectionError,
+        DNBServiceTimeoutError,
+        DNBServiceInvalidResponse,
+    ):
+        message = 'Something went wrong in an upstream service.'
+        raise AdminException(message, error_url)
+    except DNBServiceInvalidRequest:
+        message = 'No matching company found in D&B database.'
+        raise AdminException(message, error_url)
+
+
+def _get_company(duns_number, error_url):
+    try:
+        return get_company(duns_number)
+
+    except (
+        DNBServiceError,
+        DNBServiceConnectionError,
+        DNBServiceTimeoutError,
+        DNBServiceInvalidResponse,
+    ):
+        message = 'Something went wrong in an upstream service.'
+        raise AdminException(message, error_url)
+
+    except DNBServiceInvalidRequest:
+        message = 'No matching company found in D&B database.'
+        raise AdminException(message, error_url)
+
+
+@redirect_with_message
+@method_decorator(csrf_protect)
 def dnb_link_review_changes(model_admin, request):
     """
     View to allow users to review changes that would be applied to a record before linking it.
     POSTs make the link and redirect the user to view the updated record.
     """
-    # TODO: Remove this temporary redirect
-    company_change_url = reverse(
+    if not model_admin.has_change_permission(request):
+        raise PermissionDenied()
+
+    company_list_page = reverse(
         admin_urlname(model_admin.model._meta, 'changelist'),
     )
-    return HttpResponseRedirect(company_change_url)
+
+    form = SelectIdsToLinkForm(data=request.GET)
+    if not form.is_valid():
+        message = _build_error_message(form.errors)
+        raise AdminException(message, company_list_page)
+
+    dh_company = form.cleaned_data['company']
+    duns_number = form.cleaned_data['duns_number']
+
+    is_post = request.method == 'POST'
+
+    if is_post:
+        _link_company_with_dnb(dh_company.pk, duns_number, request.user, company_list_page)
+
+        messages.add_message(request, messages.SUCCESS, 'Company linked to D&B successfully.')
+        company_change_page = reverse(
+            admin_urlname(model_admin.model._meta, 'change'),
+            kwargs={'object_id': dh_company.pk},
+        )
+        return HttpResponseRedirect(company_change_page)
+
+    dnb_company = _get_company(duns_number, company_list_page)
+
+    return TemplateResponse(
+        request,
+        'admin/company/company/update-from-dnb.html',
+        {
+            **model_admin.admin_site.each_context(request),
+            'media': model_admin.media,
+            'opts': model_admin.model._meta,
+            'title': gettext_lazy('Confirm Link Company with D&B'),
+            'diff': format_company_diff(dh_company, dnb_company),
+        },
+    )

--- a/datahub/company/admin/dnb_link/select_ids.py
+++ b/datahub/company/admin/dnb_link/select_ids.py
@@ -1,53 +1,13 @@
-from django import forms
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
-from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
 from django.views.decorators.csrf import csrf_protect
 
-from datahub.company.models import Company
-from datahub.core.admin import RawIdWidget
+from datahub.company.admin.dnb_link.forms import SelectIdsToLinkForm
 from datahub.core.utils import reverse_with_query_string
-
-
-class SelectIdsToLinkForm(forms.Form):
-    """
-    Form used for selecting Data Hub company id and D&B duns number for linking.
-    """
-
-    COMPANY_ALREADY_DNB_LINKED = gettext_lazy(
-        'This company has already been linked with a D&B company.',
-    )
-    DUNS_NUMBER_ALREADY_LINKED = gettext_lazy(
-        'This duns number has already been linked with a Data Hub company.',
-    )
-
-    company = forms.ModelChoiceField(
-        Company.objects.all(),
-        widget=RawIdWidget(Company),
-        label='Data Hub Company',
-    )
-    duns_number = forms.CharField(min_length=9, max_length=9)
-
-    def clean_company(self):
-        """
-        Check that the company does not already have a duns number.
-        """
-        company = self.cleaned_data['company']
-        if company.duns_number:
-            raise ValidationError(self.COMPANY_ALREADY_DNB_LINKED)
-        return company
-
-    def clean_duns_number(self):
-        """
-        Check that the duns_number chosen has not already been linked to a Data Hub company.
-        """
-        duns_number = self.cleaned_data['duns_number']
-        if Company.objects.filter(duns_number=duns_number).exists():
-            raise ValidationError(self.DUNS_NUMBER_ALREADY_LINKED)
-        return duns_number
 
 
 @method_decorator(csrf_protect)

--- a/datahub/company/templates/admin/company/company/update-from-dnb.html
+++ b/datahub/company/templates/admin/company/company/update-from-dnb.html
@@ -13,8 +13,10 @@
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+{% if object %}
 &rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a>
-&rsaquo; {% trans 'Update from D&B' %}
+{% endif %}
+&rsaquo; {{title}}
 </div>
 {% endblock %}
 

--- a/datahub/company/test/admin/conftest.py
+++ b/datahub/company/test/admin/conftest.py
@@ -1,0 +1,37 @@
+import pytest
+
+
+@pytest.fixture
+def dnb_response():
+    """
+    Minimal valid DNB response
+    """
+    return {
+        'results': [
+            {
+                'address_line_1': '10 Fake Drive',
+                'address_line_2': '',
+                'address_postcode': 'AB0 1CD',
+                'address_town': 'London',
+                'address_county': '',
+                'address_country': 'GB',
+                'registered_address_line_1': '11 Fake Drive',
+                'registered_address_line_2': '',
+                'registered_address_postcode': 'AB0 2CD',
+                'registered_address_town': 'London',
+                'registered_address_county': '',
+                'registered_address_country': 'GB',
+                'domain': 'foo.com',
+                'duns_number': '123456789',
+                'primary_name': 'FOO BICYCLES LIMITED',
+                'trading_names': [],
+                'registration_numbers': [
+                    {
+                        'registration_number': '012345',
+                        'registration_type': 'uk_companies_house_number',
+                    },
+                ],
+                'global_ultimate_duns_number': '987654321',
+            },
+        ],
+    }

--- a/datahub/company/test/admin/dnb_link/test_review_changes.py
+++ b/datahub/company/test/admin/dnb_link/test_review_changes.py
@@ -1,0 +1,282 @@
+from urllib.parse import urljoin
+
+import pytest
+from django.conf import settings
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.contrib.messages import get_messages
+from rest_framework import status
+
+from datahub.company.models import Company, CompanyPermission
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+from datahub.core.utils import reverse_with_query_string
+
+
+DNB_SEARCH_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/search/')
+
+
+def _get_review_changes_url(company, duns_number):
+    review_changes_route_name = admin_urlname(Company._meta, 'dnb-link-review-changes')
+    data = {
+        'company': company.id,
+        'duns_number': duns_number,
+    }
+    return reverse_with_query_string(
+        review_changes_route_name,
+        data,
+    )
+
+
+class TestReviewChangesViewGet(AdminTestMixin):
+    """
+    Test the review changes view with GET requests.
+    """
+
+    def test_permission_required(self):
+        """
+        Test that a user without permission to change companies gets a 403.
+        """
+        review_changes_url = _get_review_changes_url(CompanyFactory(), '123456789')
+        user = create_test_user(
+            permission_codenames=(CompanyPermission.view_company,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+        client = self.create_client(user=user)
+        response = client.get(review_changes_url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        'data_overrides,expected_error',
+        (
+            (
+                {'company': None, 'duns_number': None},  # No data
+                'Company: This field is required. duns_number: This field is required.',
+            ),
+            (
+                {
+                    'company': 'abc123',  # Invalid company ID
+                },
+                'Company: “abc123” is not a valid UUID.',
+            ),
+            (
+                {
+                    'duns_number': '1',  # Invalid duns number
+                },
+                'Duns_number: Ensure this value has at least 9 characters (it has 1).',
+            ),
+        ),
+    )
+    def test_validation_errors_rendered(self, data_overrides, expected_error):
+        """
+        Test that validation errors are rendered as expected.
+        """
+        review_changes_route_name = admin_urlname(Company._meta, 'dnb-link-review-changes')
+        data = {
+            'company': CompanyFactory().id,
+            'duns_number': '123456789',
+            **data_overrides,
+        }
+        review_changes_url = reverse_with_query_string(
+            review_changes_route_name,
+            {key: value for key, value in data.items() if value is not None},
+        )
+
+        response = self.client.get(review_changes_url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert expected_error in response.rendered_content
+
+    def test_dh_company_already_linked_renders_error(self):
+        """
+        Test that a validation error is rendered if the Data Hub company is already D&B linked.
+        """
+        review_changes_url = _get_review_changes_url(
+            CompanyFactory(duns_number='123456789'),
+            '999999999',
+        )
+
+        response = self.client.get(review_changes_url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        expected_error = 'This company has already been linked with a D&amp;B company.'
+        assert expected_error in response.rendered_content
+
+    def test_duns_number_already_linked_renders_error(self):
+        """
+        Test that a validation error is rendered if the duns number has already been linked to a
+        Data Hub company.
+        """
+        duns_number = '123456789'
+        CompanyFactory(duns_number=duns_number)
+        review_changes_url = _get_review_changes_url(
+            CompanyFactory(),
+            duns_number,
+        )
+
+        response = self.client.get(review_changes_url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        expected_error = 'This duns number has already been linked with a Data Hub company.'
+        assert expected_error in response.rendered_content
+
+    def test_changes_returned(self, requests_mock, dnb_response):
+        """
+        Test that the review changes view renders proposed D&B changes.
+        """
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response,
+        )
+        review_changes_url = _get_review_changes_url(
+            CompanyFactory(),
+            '123456789',
+        )
+        response = self.client.get(review_changes_url)
+        assert response.status_code == status.HTTP_200_OK
+        dnb_company = dnb_response['results'][0]
+        assert dnb_company['address_line_1'] in response.rendered_content
+        assert dnb_company['primary_name'] in response.rendered_content
+
+
+class TestReviewChangesViewPost(AdminTestMixin):
+    """
+    Test the review changes view with POST requests.
+    """
+
+    def test_post(self, requests_mock, dnb_response):
+        """
+        Test that a post request to 'review changes' updates the company.
+        """
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response,
+        )
+        dh_company = CompanyFactory()
+        review_changes_url = _get_review_changes_url(dh_company, '123456789')
+        response = self.client.post(review_changes_url)
+        assert response.status_code == status.HTTP_302_FOUND
+
+        dh_company.refresh_from_db()
+        dnb_company = dnb_response['results'][0]
+
+        assert dh_company.name == dnb_company['primary_name']
+        assert dh_company.address_1 == dnb_company['address_line_1']
+        assert dh_company.address_2 == dnb_company['address_line_2']
+        assert dh_company.address_town == dnb_company['address_town']
+        assert dh_company.address_county == dnb_company['address_county']
+        assert dh_company.address_country.iso_alpha2_code == dnb_company['address_country']
+        assert (
+            dh_company.global_ultimate_duns_number
+            == dnb_company['global_ultimate_duns_number']
+        )
+
+
+class TestReviewChangesViewDNBErrors(AdminTestMixin):
+    """
+    Test the review changes view - for both GET and POST - when dnb-service returns errors.
+    """
+
+    @pytest.mark.parametrize(
+        'http_method',
+        ('GET', 'POST'),
+    )
+    @pytest.mark.parametrize(
+        'dnb_response_code',
+        (
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
+    def test_dnb_service_error(self, requests_mock, http_method, dnb_response_code):
+        """
+        Tests that the users get an error message if the dnb-service
+        doesn't return with a 200 status code.
+        """
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=dnb_response_code,
+        )
+        review_changes_url = _get_review_changes_url(CompanyFactory(), '123456789')
+        if http_method == 'GET':
+            response = self.client.get(review_changes_url)
+        else:
+            response = self.client.post(review_changes_url)
+        assert response.status_code == status.HTTP_302_FOUND
+
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 1
+        assert str(messages[0]) == 'Something went wrong in an upstream service.'
+
+    @pytest.mark.parametrize(
+        'http_method',
+        ('GET', 'POST'),
+    )
+    @pytest.mark.parametrize(
+        'search_results, expected_message',
+        (
+            (
+                [],
+                'No matching company found in D&B database.',
+            ),
+            (
+                ['foo', 'bar'],
+                'Something went wrong in an upstream service.',
+            ),
+            (
+                [{'duns_number': '012345678'}],
+                'Something went wrong in an upstream service.',
+            ),
+        ),
+    )
+    def test_dnb_response_invalid(
+        self,
+        requests_mock,
+        http_method,
+        search_results,
+        expected_message,
+    ):
+        """
+        Test if we get anything other than a single company from dnb-service,
+        we return an error message to the user.
+        """
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json={'results': search_results},
+        )
+        review_changes_url = _get_review_changes_url(CompanyFactory(), '123456789')
+        if http_method == 'GET':
+            response = self.client.get(review_changes_url)
+        else:
+            response = self.client.post(review_changes_url)
+        assert response.status_code == status.HTTP_302_FOUND
+
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 1
+        assert str(messages[0]) == expected_message
+
+    def test_post_dnb_data_invalid(
+        self,
+        requests_mock,
+        dnb_response,
+    ):
+        """
+        Tests that if the data returned from DNB does not clear DataHub validation, we show an
+        appropriate message to our users.
+        """
+        dnb_response['results'][0]['primary_name'] = None
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response,
+        )
+        review_changes_url = _get_review_changes_url(CompanyFactory(), '123456789')
+        response = self.client.post(review_changes_url)
+        assert response.status_code == status.HTTP_302_FOUND
+
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 1
+        assert str(messages[0]) == 'Data from D&B did not pass the Data Hub validation checks.'

--- a/datahub/company/test/admin/test_update_from_dnb.py
+++ b/datahub/company/test/admin/test_update_from_dnb.py
@@ -16,42 +16,6 @@ from datahub.core.test_utils import AdminTestMixin, create_test_user
 DNB_SEARCH_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/search/')
 
 
-@pytest.fixture
-def dnb_response():
-    """
-    Minimal valid DNB response
-    """
-    return {
-        'results': [
-            {
-                'address_line_1': '10 Fake Drive',
-                'address_line_2': '',
-                'address_postcode': 'AB0 1CD',
-                'address_town': 'London',
-                'address_county': '',
-                'address_country': 'GB',
-                'registered_address_line_1': '11 Fake Drive',
-                'registered_address_line_2': '',
-                'registered_address_postcode': 'AB0 2CD',
-                'registered_address_town': 'London',
-                'registered_address_county': '',
-                'registered_address_country': 'GB',
-                'domain': 'foo.com',
-                'duns_number': '123456789',
-                'primary_name': 'FOO BICYCLES LIMITED',
-                'trading_names': [],
-                'registration_numbers': [
-                    {
-                        'registration_number': '012345',
-                        'registration_type': 'uk_companies_house_number',
-                    },
-                ],
-                'global_ultimate_duns_number': '987654321',
-            },
-        ],
-    }
-
-
 class TestUpdateFromDNB(AdminTestMixin):
     """
     Tests GET requests to 'Update from DNB'.

--- a/datahub/dnb_api/link_company.py
+++ b/datahub/dnb_api/link_company.py
@@ -32,7 +32,10 @@ def link_company_with_dnb(
     company.save()
     sync_company_with_dnb.apply(
         args=(company.id,),
-        kwargs={'update_descriptor': update_descriptor},
+        kwargs={
+            'update_descriptor': update_descriptor,
+            'retry_failures': False,
+        },
         throw=True,
     )
     company.refresh_from_db()


### PR DESCRIPTION
### Description of change
A view was added to allow admin users to review and confirm changes that will be made for D&B company linking.

I'd recommend reviewing the commits in order.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
