### PR TITLE
Link company with dnb admin part 3

### DIFF
--- a/changelog/company/link-company-with-dnb-admin-button.feature.md
+++ b/changelog/company/link-company-with-dnb-admin-button.feature.md
@@ -1,0 +1,2 @@
+A button was added to the admin company change list "Link Company With D&B" which
+puts the D&B link tool live for admin users.

--- a/datahub/company/templates/admin/company/company/change_list_object_tools.html
+++ b/datahub/company/templates/admin/company/company/change_list_object_tools.html
@@ -7,5 +7,12 @@
       Export One List
     </a>
   </li>
+  {% if has_change_permission %}
+  <li>
+    <a href="{% url opts|admin_urlname:'dnb-link-select-ids' %}">
+      Link Company with D&B
+    </a>
+  </li>
+  {% endif %}
   {{block.super}}
 {% endblock %}

--- a/datahub/company/test/admin/dnb_link/test_select_ids.py
+++ b/datahub/company/test/admin/dnb_link/test_select_ids.py
@@ -9,6 +9,48 @@ from datahub.core.test_utils import AdminTestMixin, create_test_user
 from datahub.core.utils import reverse_with_query_string
 
 
+class TestLinkCompanyLink(AdminTestMixin):
+    """
+    Tests the 'Link Company with D&B' link on the change list.
+    """
+
+    def test_link_exists(self):
+        """
+        Test that the link exists for a user with the change company permission.
+        """
+        list_route_name = admin_urlname(Company._meta, 'changelist')
+        list_url = reverse(list_route_name)
+
+        response = self.client.get(list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        company_link_route_name = admin_urlname(Company._meta, 'dnb-link-select-ids')
+        company_link_url = reverse(company_link_route_name)
+
+        assert company_link_url in response.rendered_content
+
+    def test_link_does_not_exist_with_only_view_permission(self):
+        """
+        Test that the link does not exist for a user with only the view company permission.
+        """
+        list_route_name = admin_urlname(Company._meta, 'changelist')
+        list_url = reverse(list_route_name)
+
+        user = create_test_user(
+            permission_codenames=(CompanyPermission.view_company,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+        client = self.create_client(user=user)
+        response = client.get(list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        company_link_route_name = admin_urlname(Company._meta, 'dnb-link-select-ids')
+        company_link_url = reverse(company_link_route_name)
+
+        assert company_link_url not in response.rendered_content
+
+
 class TestSelectIDsViewGet(AdminTestMixin):
     """
     Test response for GET requests on the select IDs view.


### PR DESCRIPTION
### Description of change

A button was added to the admin company change list "Link Company With D&B" which
puts the D&B link tool live for admin users.


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
