### PR TITLE
fixing a flaky company export country test to be consistent

### DIFF
--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -2144,13 +2144,11 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         and make sure old ones are removed.
         """
         company = CompanyFactory()
-        export_country_one, export_country_two = CompanyExportCountryFactory.create_batch(2)
-        company.export_countries.set([export_country_one, export_country_two])
-
-        new_countries = list(CountryModel.objects.order_by('id')[:10])
-        # remove one of the initial countries, if exists
-        if export_country_one in new_countries:
-            new_countries.remove(export_country_one)
+        new_countries = list(CountryModel.objects.order_by('id')[:3])
+        CompanyExportCountryFactory(
+            country=new_countries.pop(0),
+            company=company,
+        )
 
         input_data_items = [
             {


### PR DESCRIPTION
### Description of change
`test_update_company_export_countries_with_new_list_deletes_old_ones` test is failing intermittently because of its randomness. Fixed it be much simpler and consistent.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
