### PR TITLE
Use Django TextChoices for interaction fields

### DIFF
--- a/datahub/activity_stream/interaction/serializers.py
+++ b/datahub/activity_stream/interaction/serializers.py
@@ -6,8 +6,8 @@ class InteractionActivitySerializer(ActivitySerializer):
     """Interaction serialiser for activity stream."""
 
     KINDS_JSON = {
-        Interaction.KINDS.interaction: 'Interaction',
-        Interaction.KINDS.service_delivery: 'ServiceDelivery',
+        Interaction.Kind.INTERACTION: 'Interaction',
+        Interaction.Kind.SERVICE_DELIVERY: 'ServiceDelivery',
     }
 
     class Meta:
@@ -34,9 +34,9 @@ class InteractionActivitySerializer(ActivitySerializer):
         }
 
     def _get_context(self, instance):
-        if instance.kind == Interaction.KINDS.interaction:
+        if instance.kind == Interaction.Kind.INTERACTION:
             context = self._get_project_context(instance.investment_project)
-        elif instance.kind == Interaction.KINDS.service_delivery:
+        elif instance.kind == Interaction.Kind.SERVICE_DELIVERY:
             context = self._get_event_context(instance.event)
         else:
             context = {}
@@ -94,7 +94,7 @@ class InteractionActivitySerializer(ActivitySerializer):
             interaction['object']['context'] = [context]
 
         if (
-            instance.kind == Interaction.KINDS.interaction
+            instance.kind == Interaction.Kind.INTERACTION
             and instance.communication_channel is not None
         ):
             interaction['object']['dit:communicationChannel'] = {

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -346,7 +346,7 @@ def test_kinds_mapping():
     """
     Tests if the mapping covers all kinds of interactions.
     """
-    model_kinds = {k for k, _ in Interaction.KINDS}
+    model_kinds = set(Interaction.Kind.values)
     serializer_kinds = {k for k in InteractionActivitySerializer.KINDS_JSON}
     assert model_kinds == serializer_kinds
 

--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -130,7 +130,7 @@ class InteractionCSVRowForm(forms.Form):
     }
 
     theme = forms.ChoiceField(choices=Interaction.THEMES)
-    kind = forms.ChoiceField(choices=Interaction.KINDS)
+    kind = forms.ChoiceField(choices=Interaction.Kind.choices)
     date = forms.DateField(input_formats=['%d/%m/%Y', '%Y-%m-%d'])
     # Used to attempt to find a matching contact (and company) for the interaction
     # Note that if a matching contact is not found, the interaction in question is
@@ -219,7 +219,7 @@ class InteractionCSVRowForm(forms.Form):
 
         # Ignore communication channel for service deliveries (as it is not a valid field for
         # service deliveries, but we are likely to get it in provided data anyway)
-        if kind == Interaction.KINDS.service_delivery:
+        if kind == Interaction.Kind.SERVICE_DELIVERY:
             data['communication_channel'] = None
 
         # Look up values for adviser_1 and adviser_2 (adding errors if the look-up fails)
@@ -438,7 +438,7 @@ class InteractionCSVRowForm(forms.Form):
             'was_policy_feedback_provided': False,
         }
 
-        if data['kind'] == Interaction.KINDS.service_delivery:
+        if data['kind'] == Interaction.Kind.SERVICE_DELIVERY:
             creation_data['is_event'] = bool(data.get('event_id'))
 
         return creation_data

--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -432,7 +432,7 @@ class InteractionCSVRowForm(forms.Form):
             'notes': data.get('notes'),
             'service': data['service'],
             'service_answers': data.get('service_answers'),
-            'status': Interaction.STATUSES.complete,
+            'status': Interaction.Status.COMPLETE,
             'subject': subject,
             'theme': data['theme'],
             'was_policy_feedback_provided': False,

--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -129,7 +129,7 @@ class InteractionCSVRowForm(forms.Form):
         'event': 'event_id',
     }
 
-    theme = forms.ChoiceField(choices=Interaction.THEMES)
+    theme = forms.ChoiceField(choices=Interaction.Theme.choices)
     kind = forms.ChoiceField(choices=Interaction.Kind.choices)
     date = forms.DateField(input_formats=['%d/%m/%Y', '%Y-%m-%d'])
     # Used to attempt to find a matching contact (and company) for the interaction

--- a/datahub/interaction/email_processors/processors.py
+++ b/datahub/interaction/email_processors/processors.py
@@ -130,7 +130,7 @@ class CalendarInteractionEmailProcessor(EmailProcessor):
             'company': {'id': data['top_company'].id},
             'date': data['date'],
             'dit_participants': dit_participants,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'status': Interaction.STATUSES.draft,
             'subject': data['subject'],
             'was_policy_feedback_provided': False,

--- a/datahub/interaction/email_processors/processors.py
+++ b/datahub/interaction/email_processors/processors.py
@@ -131,7 +131,7 @@ class CalendarInteractionEmailProcessor(EmailProcessor):
             'date': data['date'],
             'dit_participants': dit_participants,
             'kind': Interaction.Kind.INTERACTION,
-            'status': Interaction.STATUSES.draft,
+            'status': Interaction.Status.DRAFT,
             'subject': data['subject'],
             'was_policy_feedback_provided': False,
         }

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -151,13 +151,13 @@ class ServiceAnswerOption(BaseOrderedConstantModel):
 class ServiceAdditionalQuestion(BaseOrderedConstantModel):
     """Service additional question model."""
 
-    TYPES = Choices(
-        ('text', 'Text'),
-        ('money', 'Money'),
-    )
+    class Type(models.TextChoices):
+        TEXT = ('text', 'Text')
+        MONEY = ('money', 'Money')
+
     type = models.CharField(
         max_length=settings.CHAR_FIELD_MAX_LENGTH,
-        choices=TYPES,
+        choices=Type.choices,
     )
 
     is_required = models.BooleanField(default=False)

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -5,7 +5,6 @@ from django.contrib.postgres.fields import JSONField
 from django.contrib.postgres.indexes import GinIndex
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
-from model_utils import Choices
 from mptt.fields import TreeForeignKey
 
 from datahub.company.models import CompanyExportCountry
@@ -181,17 +180,17 @@ class Interaction(ArchivableModel, BaseModel):
         DRAFT = ('draft', 'Draft')
         COMPLETE = ('complete', 'Complete')
 
-    THEMES = Choices(
-        (None, 'Not set'),
-        ('export', 'Export'),
-        ('investment', 'Investment'),
-        ('other', 'Something else'),
-    )
+    class Theme(models.TextChoices):
+        EXPORT = ('export', 'Export')
+        INVESTMENT = ('investment', 'Investment')
+        OTHER = ('other', 'Something else')
+
+        __empty__ = 'Not set'
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     theme = models.CharField(
         max_length=MAX_LENGTH,
-        choices=THEMES,
+        choices=Theme.choices,
         null=True,
         blank=True,
     )

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -177,10 +177,9 @@ class Interaction(ArchivableModel, BaseModel):
         INTERACTION = ('interaction', 'Interaction')
         SERVICE_DELIVERY = ('service_delivery', 'Service delivery')
 
-    STATUSES = Choices(
-        ('draft', 'Draft'),
-        ('complete', 'Complete'),
-    )
+    class Status(models.TextChoices):
+        DRAFT = ('draft', 'Draft')
+        COMPLETE = ('complete', 'Complete')
 
     THEMES = Choices(
         (None, 'Not set'),
@@ -199,8 +198,8 @@ class Interaction(ArchivableModel, BaseModel):
     kind = models.CharField(max_length=MAX_LENGTH, choices=Kind.choices)
     status = models.CharField(
         max_length=MAX_LENGTH,
-        choices=STATUSES,
-        default=STATUSES.complete,
+        choices=Status.choices,
+        default=Status.COMPLETE,
     )
     # Set if the interaction was imported from an external source
     # (e.g. an .ics (iCalendar) file or a CSV file).

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -173,10 +173,9 @@ class ServiceAdditionalQuestion(BaseOrderedConstantModel):
 class Interaction(ArchivableModel, BaseModel):
     """Interaction."""
 
-    KINDS = Choices(
-        ('interaction', 'Interaction'),
-        ('service_delivery', 'Service delivery'),
-    )
+    class Kind(models.TextChoices):
+        INTERACTION = ('interaction', 'Interaction')
+        SERVICE_DELIVERY = ('service_delivery', 'Service delivery')
 
     STATUSES = Choices(
         ('draft', 'Draft'),
@@ -197,7 +196,7 @@ class Interaction(ArchivableModel, BaseModel):
         null=True,
         blank=True,
     )
-    kind = models.CharField(max_length=MAX_LENGTH, choices=KINDS)
+    kind = models.CharField(max_length=MAX_LENGTH, choices=Kind.choices)
     status = models.CharField(
         max_length=MAX_LENGTH,
         choices=STATUSES,
@@ -301,7 +300,7 @@ class Interaction(ArchivableModel, BaseModel):
     @property
     def is_event(self):
         """Whether this service delivery is for an event."""
-        if self.kind == self.KINDS.service_delivery:
+        if self.kind == self.Kind.SERVICE_DELIVERY:
             return bool(self.event)
         return None
 

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -402,7 +402,7 @@ class InteractionSerializer(serializers.ModelSerializer):
             'date': {'format': '%Y-%m-%d', 'input_formats': ['%Y-%m-%d']},
             'grant_amount_offered': {'min_value': 0},
             'net_company_receipt': {'min_value': 0},
-            'status': {'default': Interaction.STATUSES.complete},
+            'status': {'default': Interaction.Status.COMPLETE},
             'theme': {
                 'allow_blank': False,
                 'default': None,
@@ -465,13 +465,13 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('communication_channel', bool),
                     when=AndRule(
                         EqualsRule('kind', Interaction.Kind.INTERACTION),
-                        EqualsRule('status', Interaction.STATUSES.complete),
+                        EqualsRule('status', Interaction.Status.COMPLETE),
                     ),
                 ),
                 ValidationRule(
                     'required',
                     OperatorRule('service', bool),
-                    when=EqualsRule('status', Interaction.STATUSES.complete),
+                    when=EqualsRule('status', Interaction.Status.COMPLETE),
                 ),
                 ValidationRule(
                     'invalid_for_investment',

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -476,7 +476,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                 ValidationRule(
                     'invalid_for_investment',
                     EqualsRule('kind', Interaction.Kind.INTERACTION),
-                    when=EqualsRule('theme', Interaction.THEMES.investment),
+                    when=EqualsRule('theme', Interaction.Theme.INVESTMENT),
                 ),
                 ValidationRule(
                     'invalid_for_non_interaction',
@@ -532,7 +532,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                     'invalid_for_investment',
                     OperatorRule('were_countries_discussed', not_),
                     OperatorRule('export_countries', not_),
-                    when=EqualsRule('theme', Interaction.THEMES.investment),
+                    when=EqualsRule('theme', Interaction.Theme.INVESTMENT),
                 ),
                 ValidationRule(
                     'required',
@@ -542,7 +542,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                         IsFeatureFlagActive(INTERACTION_ADD_COUNTRIES),
                         InRule(
                             'theme',
-                            [Interaction.THEMES.export, Interaction.THEMES.other],
+                            [Interaction.Theme.EXPORT, Interaction.Theme.OTHER],
                         ),
                     ),
                 ),
@@ -553,7 +553,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                         OperatorRule('were_countries_discussed', bool),
                         InRule(
                             'theme',
-                            [Interaction.THEMES.export, Interaction.THEMES.other],
+                            [Interaction.Theme.EXPORT, Interaction.Theme.OTHER],
                         ),
                     ),
                 ),
@@ -566,7 +566,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                         OperatorRule('were_countries_discussed', not_),
                         InRule(
                             'theme',
-                            [Interaction.THEMES.export, Interaction.THEMES.other],
+                            [Interaction.Theme.EXPORT, Interaction.Theme.OTHER],
                         ),
                     ),
                 ),

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -464,7 +464,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                     'required',
                     OperatorRule('communication_channel', bool),
                     when=AndRule(
-                        EqualsRule('kind', Interaction.KINDS.interaction),
+                        EqualsRule('kind', Interaction.Kind.INTERACTION),
                         EqualsRule('status', Interaction.STATUSES.complete),
                     ),
                 ),
@@ -475,25 +475,25 @@ class InteractionSerializer(serializers.ModelSerializer):
                 ),
                 ValidationRule(
                     'invalid_for_investment',
-                    EqualsRule('kind', Interaction.KINDS.interaction),
+                    EqualsRule('kind', Interaction.Kind.INTERACTION),
                     when=EqualsRule('theme', Interaction.THEMES.investment),
                 ),
                 ValidationRule(
                     'invalid_for_non_interaction',
                     OperatorRule('investment_project', not_),
-                    when=EqualsRule('kind', Interaction.KINDS.service_delivery),
+                    when=EqualsRule('kind', Interaction.Kind.SERVICE_DELIVERY),
                 ),
                 ValidationRule(
                     'invalid_for_service_delivery',
                     OperatorRule('communication_channel', not_),
-                    when=EqualsRule('kind', Interaction.KINDS.service_delivery),
+                    when=EqualsRule('kind', Interaction.Kind.SERVICE_DELIVERY),
                 ),
                 ValidationRule(
                     'invalid_for_non_service_delivery',
                     OperatorRule('is_event', is_blank),
                     OperatorRule('event', is_blank),
                     OperatorRule('service_delivery_status', is_blank),
-                    when=EqualsRule('kind', Interaction.KINDS.interaction),
+                    when=EqualsRule('kind', Interaction.Kind.INTERACTION),
                 ),
                 ValidationRule(
                     'invalid_when_no_policy_feedback',
@@ -512,7 +512,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                 ValidationRule(
                     'required',
                     OperatorRule('is_event', is_not_blank),
-                    when=EqualsRule('kind', Interaction.KINDS.service_delivery),
+                    when=EqualsRule('kind', Interaction.Kind.SERVICE_DELIVERY),
                 ),
                 ValidationRule(
                     'too_many_contacts_for_event_service_delivery',
@@ -578,7 +578,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('event', bool),
                     when=AndRule(
                         OperatorRule('is_event', bool),
-                        EqualsRule('kind', Interaction.KINDS.service_delivery),
+                        EqualsRule('kind', Interaction.Kind.SERVICE_DELIVERY),
                     ),
                 ),
                 ValidationRule(
@@ -586,7 +586,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('event', not_),
                     when=AndRule(
                         OperatorRule('is_event', not_),
-                        EqualsRule('kind', Interaction.KINDS.service_delivery),
+                        EqualsRule('kind', Interaction.Kind.SERVICE_DELIVERY),
                     ),
                 ),
             ),

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -1190,7 +1190,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
             'notes': '',
             'service': service,
             'service_answers': None,
-            'status': Interaction.STATUSES.complete,
+            'status': Interaction.Status.COMPLETE,
             'subject': service.name,
             'theme': data['theme'],
             'was_policy_feedback_provided': False,
@@ -1234,7 +1234,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
             'notes': data['notes'],
             'service': service,
             'service_answers': None,
-            'status': Interaction.STATUSES.complete,
+            'status': Interaction.Status.COMPLETE,
             'subject': data['subject'],
             'theme': data['theme'],
             'was_policy_feedback_provided': False,
@@ -1274,7 +1274,7 @@ class TestInteractionCSVRowFormSaving:
         assert interaction.date == datetime(2018, 3, 2, tzinfo=utc)
         assert interaction.communication_channel == communication_channel
         assert interaction.service == service
-        assert interaction.status == Interaction.STATUSES.complete
+        assert interaction.status == Interaction.Status.COMPLETE
         assert interaction.subject == service.name
         assert interaction.event is None
         assert interaction.notes == ''
@@ -1322,7 +1322,7 @@ class TestInteractionCSVRowFormSaving:
         assert interaction.date == datetime(2018, 3, 2, tzinfo=utc)
         assert interaction.event == event
         assert interaction.service == service
-        assert interaction.status == Interaction.STATUSES.complete
+        assert interaction.status == Interaction.Status.COMPLETE
         assert interaction.subject == data['subject']
         assert interaction.event == event
         assert interaction.notes == data['notes']

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -112,7 +112,7 @@ class TestInteractionCSVRowFormValidation:
             pytest.param(
                 {
                     'kind': Interaction.Kind.SERVICE_DELIVERY,
-                    'theme': Interaction.THEMES.investment,
+                    'theme': Interaction.Theme.INVESTMENT,
                 },
                 {
                     'kind': ["This value can't be selected for investment interactions."],
@@ -374,7 +374,7 @@ class TestInteractionCSVRowFormValidation:
         communication_channel = random_communication_channel()
 
         resolved_data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -502,7 +502,7 @@ class TestInteractionCSVRowFormValidation:
             )
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'adviser_1': adviser.name,
             'communication_channel': communication_channel.name,
@@ -623,7 +623,7 @@ class TestInteractionCSVRowFormValidation:
             duplicate_tracker.add_item(resolved_duplicate_item)
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'adviser_1': adviser.name,
             'communication_channel': communication_channel.name,
@@ -651,7 +651,7 @@ class TestInteractionCSVRowFormValidation:
         communication_channel = random_communication_channel()
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -718,7 +718,7 @@ class TestInteractionCSVRowFormSerializerUsage:
         communication_channel = random_communication_channel()
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -784,7 +784,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
         communication_channel = random_communication_channel()
 
         resolved_data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -873,7 +873,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
         obj = object_creator()
 
         resolved_data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': kind,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -913,7 +913,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
         obj = object_creator()
 
         resolved_data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -967,7 +967,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
         obj = object_creator()
 
         resolved_data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.SERVICE_DELIVERY,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -993,7 +993,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
         communication_channel = random_communication_channel()
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': kind,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -1034,7 +1034,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
         communication_channel = random_communication_channel()
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -1073,7 +1073,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
         communication_channel = random_communication_channel()
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -1163,7 +1163,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
         communication_channel = random_communication_channel()
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -1204,7 +1204,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
         event = EventFactory()
 
         data = {
-            'theme': Interaction.THEMES.other,
+            'theme': Interaction.Theme.OTHER,
             'kind': Interaction.Kind.SERVICE_DELIVERY,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -1255,7 +1255,7 @@ class TestInteractionCSVRowFormSaving:
         source = {'test-source': 'test-value'}
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
@@ -1300,7 +1300,7 @@ class TestInteractionCSVRowFormSaving:
         source = {'test-source': 'test-value'}
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.SERVICE_DELIVERY,
             'date': '02/03/2018',
             'adviser_1': adviser_1.name,
@@ -1356,7 +1356,7 @@ class TestInteractionCSVRowFormSaving:
         service_answer = ServiceAnswerOptionFactory()
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
@@ -1388,7 +1388,7 @@ class TestInteractionCSVRowFormSaving:
         source = {'test-source': 'test-value'}
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
@@ -1419,7 +1419,7 @@ class TestInteractionCSVRowFormSaving:
         source = {'test-source': 'test-value'}
 
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '02/03/2018',
             'adviser_1': adviser.name,

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -111,7 +111,7 @@ class TestInteractionCSVRowFormValidation:
             ),
             pytest.param(
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'theme': Interaction.THEMES.investment,
                 },
                 {
@@ -278,7 +278,7 @@ class TestInteractionCSVRowFormValidation:
             pytest.param(
                 {
                     'communication_channel': '',
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                 },
                 {
                     'communication_channel': ['This field is required.'],
@@ -316,7 +316,7 @@ class TestInteractionCSVRowFormValidation:
             # This error comes from the serialiser validation rules
             pytest.param(
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'event_id': lambda: str(EventFactory().pk),
                 },
                 {
@@ -326,7 +326,7 @@ class TestInteractionCSVRowFormValidation:
             ),
             pytest.param(
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'service': lambda: ServiceAnswerOptionFactory().question.service.name,
                     'service_answer': 'Feline super heroes',
                 },
@@ -339,7 +339,7 @@ class TestInteractionCSVRowFormValidation:
             ),
             pytest.param(
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'service': lambda: ServiceFactory().name,
                     'service_answer': 'Feline friends',
                 },
@@ -353,7 +353,7 @@ class TestInteractionCSVRowFormValidation:
             ),
             pytest.param(
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'service': lambda: ServiceAnswerOptionFactory().question.service.name,
                     'service_answer': '',
                 },
@@ -375,7 +375,7 @@ class TestInteractionCSVRowFormValidation:
 
         resolved_data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -503,7 +503,7 @@ class TestInteractionCSVRowFormValidation:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'adviser_1': adviser.name,
             'communication_channel': communication_channel.name,
 
@@ -624,7 +624,7 @@ class TestInteractionCSVRowFormValidation:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'adviser_1': adviser.name,
             'communication_channel': communication_channel.name,
 
@@ -652,7 +652,7 @@ class TestInteractionCSVRowFormValidation:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'service': service.name,
@@ -719,7 +719,7 @@ class TestInteractionCSVRowFormSerializerUsage:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -785,7 +785,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
 
         resolved_data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': 'person@company.com',
@@ -801,7 +801,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
 
     @pytest.mark.parametrize(
         'kind',
-        (Interaction.KINDS.interaction, Interaction.KINDS.service_delivery),
+        (Interaction.Kind.INTERACTION, Interaction.Kind.SERVICE_DELIVERY),
     )
     @pytest.mark.parametrize(
         'field,object_creator,input_transformer',
@@ -914,7 +914,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
 
         resolved_data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -968,7 +968,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
 
         resolved_data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.service_delivery,
+            'kind': Interaction.Kind.SERVICE_DELIVERY,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -983,7 +983,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
 
     @pytest.mark.parametrize(
         'kind',
-        (Interaction.KINDS.interaction, Interaction.KINDS.service_delivery),
+        (Interaction.Kind.INTERACTION, Interaction.Kind.SERVICE_DELIVERY),
     )
     def test_subject_falls_back_to_service(self, kind):
         """Test that if subject is not specified, the name of the service is used instead."""
@@ -1035,7 +1035,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'service': service.name,
@@ -1074,7 +1074,7 @@ class TestInteractionCSVRowFormSuccessfulCleaning:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': 'person@company.com',
@@ -1164,7 +1164,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -1205,7 +1205,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
 
         data = {
             'theme': Interaction.THEMES.other,
-            'kind': Interaction.KINDS.service_delivery,
+            'kind': Interaction.Kind.SERVICE_DELIVERY,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -1256,7 +1256,7 @@ class TestInteractionCSVRowFormSaving:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -1301,7 +1301,7 @@ class TestInteractionCSVRowFormSaving:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.service_delivery,
+            'kind': Interaction.Kind.SERVICE_DELIVERY,
             'date': '02/03/2018',
             'adviser_1': adviser_1.name,
             'adviser_2': adviser_2.name,
@@ -1357,7 +1357,7 @@ class TestInteractionCSVRowFormSaving:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -1389,7 +1389,7 @@ class TestInteractionCSVRowFormSaving:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
             'contact_email': 'non-existent-contact@company.com',
@@ -1420,7 +1420,7 @@ class TestInteractionCSVRowFormSaving:
 
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,

--- a/datahub/interaction/test/admin_csv_import/test_views.py
+++ b/datahub/interaction/test/admin_csv_import/test_views.py
@@ -303,7 +303,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
             ),
             (
                 Interaction.THEMES.export,
-                Interaction.KINDS.interaction,
+                Interaction.Kind.INTERACTION,
                 '01/01/2018',
                 adviser.name,
                 'person@company.uk',

--- a/datahub/interaction/test/admin_csv_import/test_views.py
+++ b/datahub/interaction/test/admin_csv_import/test_views.py
@@ -302,7 +302,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
                 'communication_channel',
             ),
             (
-                Interaction.THEMES.export,
+                Interaction.Theme.EXPORT,
                 Interaction.Kind.INTERACTION,
                 '01/01/2018',
                 adviser.name,

--- a/datahub/interaction/test/admin_csv_import/utils.py
+++ b/datahub/interaction/test/admin_csv_import/utils.py
@@ -66,7 +66,7 @@ def make_matched_rows(num_records):
     return [
         {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': contact.email,
@@ -92,7 +92,7 @@ def make_multiple_matches_rows(num_records):
     return [
         {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': contact_email,
@@ -115,7 +115,7 @@ def make_unmatched_rows(num_records):
     return [
         {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
             'contact_email': f'unmatched{i}@unmatched.uk',

--- a/datahub/interaction/test/admin_csv_import/utils.py
+++ b/datahub/interaction/test/admin_csv_import/utils.py
@@ -65,7 +65,7 @@ def make_matched_rows(num_records):
 
     return [
         {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -91,7 +91,7 @@ def make_multiple_matches_rows(num_records):
 
     return [
         {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -114,7 +114,7 @@ def make_unmatched_rows(num_records):
 
     return [
         {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': '01/01/2018',
             'adviser_1': adviser.name,

--- a/datahub/interaction/test/email_processors/test_processors.py
+++ b/datahub/interaction/test/email_processors/test_processors.py
@@ -198,7 +198,7 @@ class TestCalendarInteractionEmailProcessor:
             'meeting': {'id': interaction_data['meeting_details']['uid']},
         }
         assert interaction.subject == expected_subject
-        assert interaction.status == Interaction.STATUSES.draft
+        assert interaction.status == Interaction.Status.DRAFT
 
         sender_participant = interaction.dit_participants.get(
             adviser__email__iexact=interaction_data['sender_email'],

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -93,7 +93,7 @@ class InteractionFactoryBase(factory.django.DjangoModelFactory):
 class CompanyInteractionFactory(InteractionFactoryBase):
     """Factory for creating an interaction relating to a company."""
 
-    kind = Interaction.KINDS.interaction
+    kind = Interaction.Kind.INTERACTION
     theme = factory.Iterator(tuple(filter(None, Interaction.THEMES._db_values)))
     communication_channel = factory.LazyFunction(
         lambda: random_obj_for_model(CommunicationChannel),
@@ -106,7 +106,7 @@ class CompanyInteractionFactoryWithPolicyFeedback(CompanyInteractionFactory):
     additionally provided.
     """
 
-    kind = Interaction.KINDS.interaction
+    kind = Interaction.Kind.INTERACTION
     communication_channel = factory.LazyFunction(
         lambda: random_obj_for_model(CommunicationChannel),
     )
@@ -135,7 +135,7 @@ class CompanyInteractionFactoryWithPolicyFeedback(CompanyInteractionFactory):
 class InvestmentProjectInteractionFactory(InteractionFactoryBase):
     """Factory for creating an interaction relating to an investment project."""
 
-    kind = Interaction.KINDS.interaction
+    kind = Interaction.Kind.INTERACTION
     theme = Interaction.THEMES.investment
     investment_project = factory.SubFactory(InvestmentProjectFactory)
     communication_channel = factory.LazyFunction(
@@ -146,7 +146,7 @@ class InvestmentProjectInteractionFactory(InteractionFactoryBase):
 class ServiceDeliveryFactory(InteractionFactoryBase):
     """Service delivery factory."""
 
-    kind = Interaction.KINDS.service_delivery
+    kind = Interaction.Kind.SERVICE_DELIVERY
     service_delivery_status = factory.LazyFunction(
         lambda: random_obj_for_model(ServiceDeliveryStatus),
     )
@@ -164,7 +164,7 @@ class ServiceDeliveryFactory(InteractionFactoryBase):
 class EventServiceDeliveryFactory(InteractionFactoryBase):
     """Event service delivery factory."""
 
-    kind = Interaction.KINDS.service_delivery
+    kind = Interaction.Kind.SERVICE_DELIVERY
     theme = Interaction.THEMES.export
     event = factory.SubFactory(EventFactory)
 
@@ -196,7 +196,7 @@ class InteractionExportCountryFactory(factory.django.DjangoModelFactory):
 class ExportCountriesInteractionFactory(InteractionFactoryBase):
     """Factory for creating an export interaction with export countries."""
 
-    kind = Interaction.KINDS.interaction
+    kind = Interaction.Kind.INTERACTION
     theme = factory.Iterator([Interaction.THEMES.export, Interaction.THEMES.other])
     were_countries_discussed = True
     communication_channel = factory.LazyFunction(

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -94,7 +94,7 @@ class CompanyInteractionFactory(InteractionFactoryBase):
     """Factory for creating an interaction relating to a company."""
 
     kind = Interaction.Kind.INTERACTION
-    theme = factory.Iterator(tuple(filter(None, Interaction.THEMES._db_values)))
+    theme = factory.Iterator(tuple(filter(None, Interaction.Theme.values)))
     communication_channel = factory.LazyFunction(
         lambda: random_obj_for_model(CommunicationChannel),
     )
@@ -136,7 +136,7 @@ class InvestmentProjectInteractionFactory(InteractionFactoryBase):
     """Factory for creating an interaction relating to an investment project."""
 
     kind = Interaction.Kind.INTERACTION
-    theme = Interaction.THEMES.investment
+    theme = Interaction.Theme.INVESTMENT
     investment_project = factory.SubFactory(InvestmentProjectFactory)
     communication_channel = factory.LazyFunction(
         lambda: random_obj_for_model(CommunicationChannel),
@@ -165,7 +165,7 @@ class EventServiceDeliveryFactory(InteractionFactoryBase):
     """Event service delivery factory."""
 
     kind = Interaction.Kind.SERVICE_DELIVERY
-    theme = Interaction.THEMES.export
+    theme = Interaction.Theme.EXPORT
     event = factory.SubFactory(EventFactory)
 
 
@@ -197,7 +197,7 @@ class ExportCountriesInteractionFactory(InteractionFactoryBase):
     """Factory for creating an export interaction with export countries."""
 
     kind = Interaction.Kind.INTERACTION
-    theme = factory.Iterator([Interaction.THEMES.export, Interaction.THEMES.other])
+    theme = factory.Iterator([Interaction.Theme.EXPORT, Interaction.Theme.OTHER])
     were_countries_discussed = True
     communication_channel = factory.LazyFunction(
         lambda: random_obj_for_model(CommunicationChannel),

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -81,7 +81,7 @@ class TestAddInteraction(APITestMixin):
             # empty string not allowed for theme
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -101,7 +101,7 @@ class TestAddInteraction(APITestMixin):
             # invalid theme not allowed
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -143,7 +143,7 @@ class TestAddInteraction(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -178,7 +178,7 @@ class TestAddInteraction(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -237,7 +237,7 @@ class TestAddInteraction(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -864,7 +864,7 @@ class TestInteractionVersioning(APITestMixin):
         response = self.api_client.post(
             reverse('api-v3:interaction:collection'),
             data={
-                'kind': Interaction.KINDS.interaction,
+                'kind': Interaction.Kind.INTERACTION,
                 'communication_channel': random_obj_for_model(CommunicationChannel).pk,
                 'subject': 'whatever',
                 'date': date.today().isoformat(),
@@ -898,7 +898,7 @@ class TestInteractionVersioning(APITestMixin):
         response = self.api_client.post(
             reverse('api-v3:interaction:collection'),
             data={
-                'kind': Interaction.KINDS.interaction,
+                'kind': Interaction.Kind.INTERACTION,
             },
         )
 

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -606,9 +606,9 @@ class TestUpdateInteraction(APITestMixin):
     @pytest.mark.parametrize(
         'current_status,new_status',
         (
-            (Interaction.STATUSES.draft, Interaction.STATUSES.draft),
-            (Interaction.STATUSES.draft, Interaction.STATUSES.complete),
-            (Interaction.STATUSES.complete, Interaction.STATUSES.complete),
+            (Interaction.Status.DRAFT, Interaction.Status.DRAFT),
+            (Interaction.Status.DRAFT, Interaction.Status.COMPLETE),
+            (Interaction.Status.COMPLETE, Interaction.Status.COMPLETE),
         ),
     )
     @freeze_time('2017-04-18 13:25:30.986208')
@@ -633,17 +633,17 @@ class TestUpdateInteraction(APITestMixin):
         'current_status,new_status,response_body',
         (
             (
-                Interaction.STATUSES.draft,
+                Interaction.Status.DRAFT,
                 None,
                 {'status': ['This field may not be null.']},
             ),
             (
-                Interaction.STATUSES.complete,
-                Interaction.STATUSES.draft,
+                Interaction.Status.COMPLETE,
+                Interaction.Status.DRAFT,
                 {'non_field_errors': ['The status of a complete interaction cannot change.']},
             ),
             (
-                Interaction.STATUSES.complete,
+                Interaction.Status.COMPLETE,
                 None,
                 {'status': ['This field may not be null.']},
             ),

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -71,7 +71,7 @@ class TestAddInteraction(APITestMixin):
             },
             # interaction with a status
             {
-                'status': Interaction.STATUSES.draft,
+                'status': Interaction.Status.DRAFT,
             },
             # investment project interaction
             {
@@ -121,7 +121,7 @@ class TestAddInteraction(APITestMixin):
         assert response_data == {
             'id': response_data['id'],
             'kind': Interaction.Kind.INTERACTION,
-            'status': request_data.get('status', Interaction.STATUSES.complete),
+            'status': request_data.get('status', Interaction.Status.COMPLETE),
             'theme': request_data.get('theme', None),
             'is_event': None,
             'service_delivery_status': None,
@@ -277,7 +277,7 @@ class TestAddInteraction(APITestMixin):
         assert response_data == {
             'id': response_data['id'],
             'kind': Interaction.Kind.INTERACTION,
-            'status': request_data.get('status', Interaction.STATUSES.complete),
+            'status': request_data.get('status', Interaction.Status.COMPLETE),
             'theme': request_data.get('theme', None),
             'is_event': None,
             'service_delivery_status': None,
@@ -1427,7 +1427,7 @@ class TestGetInteraction(APITestMixin):
         assert response_data == {
             'id': response_data['id'],
             'kind': Interaction.Kind.INTERACTION,
-            'status': Interaction.STATUSES.complete,
+            'status': Interaction.Status.COMPLETE,
             'theme': interaction.theme,
             'is_event': None,
             'service_delivery_status': None,
@@ -1549,7 +1549,7 @@ class TestGetInteraction(APITestMixin):
         assert response_data == {
             'id': response_data['id'],
             'kind': Interaction.Kind.INTERACTION,
-            'status': Interaction.STATUSES.complete,
+            'status': Interaction.Status.COMPLETE,
             'theme': interaction.theme,
             'is_event': None,
             'service_delivery_status': None,
@@ -1808,7 +1808,7 @@ class TestUpdateInteraction(APITestMixin):
         (
             (
                 {
-                    'status': Interaction.STATUSES.complete,
+                    'status': Interaction.Status.COMPLETE,
                     'service': Service.inbound_referral.value.id,
                 },
                 {
@@ -1817,7 +1817,7 @@ class TestUpdateInteraction(APITestMixin):
             ),
             (
                 {
-                    'status': Interaction.STATUSES.complete,
+                    'status': Interaction.Status.COMPLETE,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                 },
                 {
@@ -1836,7 +1836,7 @@ class TestUpdateInteraction(APITestMixin):
         requester = create_test_user(permission_codenames=permissions)
         draft_interaction = CompanyInteractionFactory(
             kind=Interaction.Kind.INTERACTION,
-            status=Interaction.STATUSES.draft,
+            status=Interaction.Status.DRAFT,
             service_id=None,
             communication_channel=None,
         )

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -59,7 +59,7 @@ class TestAddInteraction(APITestMixin):
             },
             # company interaction with investment theme
             {
-                'theme': Interaction.THEMES.investment,
+                'theme': Interaction.Theme.INVESTMENT,
             },
             # company interaction with blank notes
             {
@@ -202,12 +202,12 @@ class TestAddInteraction(APITestMixin):
         (
             # company interaction with export theme
             {
-                'theme': Interaction.THEMES.export,
+                'theme': Interaction.Theme.EXPORT,
                 'were_countries_discussed': False,
             },
             # export countries in an interaction (export and other)
             {
-                'theme': Interaction.THEMES.export,
+                'theme': Interaction.Theme.EXPORT,
                 'were_countries_discussed': True,
                 'export_countries': [
                     {
@@ -221,7 +221,7 @@ class TestAddInteraction(APITestMixin):
                 ],
             },
             {
-                'theme': Interaction.THEMES.other,
+                'theme': Interaction.Theme.OTHER,
                 'were_countries_discussed': True,
                 'export_countries': [
                     {
@@ -377,7 +377,7 @@ class TestAddInteraction(APITestMixin):
             'contacts': [contact.pk],
             'service': Service.inbound_referral.value.id,
             'was_policy_feedback_provided': False,
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'were_countries_discussed': True,
             'export_countries': [
                 {
@@ -472,7 +472,7 @@ class TestAddInteraction(APITestMixin):
             'contacts': [contact.pk],
             'service': Service.inbound_referral.value.id,
             'was_policy_feedback_provided': False,
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'were_countries_discussed': True,
             'export_countries': [
                 {
@@ -613,7 +613,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -636,7 +636,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.other,
+                    'theme': Interaction.Theme.OTHER,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -660,7 +660,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -683,7 +683,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -719,7 +719,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -746,7 +746,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -787,7 +787,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -817,7 +817,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -849,7 +849,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -882,7 +882,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -916,7 +916,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -957,7 +957,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.THEMES.export,
+                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1207,7 +1207,7 @@ class TestAddInteraction(APITestMixin):
             # were_countries_discussed can't be true for investment theme
             (
                 {
-                    'theme': Interaction.THEMES.investment,
+                    'theme': Interaction.Theme.INVESTMENT,
                     'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -1246,7 +1246,7 @@ class TestAddInteraction(APITestMixin):
         when feature flas is off.
         """
         data = {
-            'theme': Interaction.THEMES.export,
+            'theme': Interaction.Theme.EXPORT,
             'kind': Interaction.Kind.INTERACTION,
             'date': date.today().isoformat(),
             'subject': 'whatever',
@@ -1763,7 +1763,7 @@ class TestUpdateInteraction(APITestMixin):
         (
             (
                 None,
-                Interaction.THEMES.export,
+                Interaction.Theme.EXPORT,
             ),
             (
                 None,
@@ -1788,7 +1788,7 @@ class TestUpdateInteraction(APITestMixin):
 
     def test_cannot_unset_theme(self):
         """Test that a theme can't be removed from an interaction."""
-        interaction = CompanyInteractionFactory(theme=Interaction.THEMES.export)
+        interaction = CompanyInteractionFactory(theme=Interaction.Theme.EXPORT)
 
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = self.api_client.patch(
@@ -1909,7 +1909,7 @@ class TestUpdateInteraction(APITestMixin):
         requester = create_test_user(permission_codenames=permissions)
         interaction = CompanyInteractionFactory(
             subject='I am a subject',
-            theme=Interaction.THEMES.export,
+            theme=Interaction.Theme.EXPORT,
         )
 
         assert len(Interaction.objects.get(pk=interaction.pk).export_countries.all()) == 0

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -98,7 +98,7 @@ class TestAddInteraction(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -120,7 +120,7 @@ class TestAddInteraction(APITestMixin):
         response_data = response.json()
         assert response_data == {
             'id': response_data['id'],
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'status': request_data.get('status', Interaction.STATUSES.complete),
             'theme': request_data.get('theme', None),
             'is_event': None,
@@ -254,7 +254,7 @@ class TestAddInteraction(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -276,7 +276,7 @@ class TestAddInteraction(APITestMixin):
         response_data = response.json()
         assert response_data == {
             'id': response_data['id'],
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'status': request_data.get('status', Interaction.STATUSES.complete),
             'theme': request_data.get('theme', None),
             'is_event': None,
@@ -366,7 +366,7 @@ class TestAddInteraction(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -462,7 +462,7 @@ class TestAddInteraction(APITestMixin):
         url = reverse('api-v3:interaction:collection')
         request_data = {
             'date': interaction_date,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'dit_participants': [
@@ -501,7 +501,7 @@ class TestAddInteraction(APITestMixin):
             # required fields
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                 },
                 {
                     'contacts': ['This field is required.'],
@@ -517,7 +517,7 @@ class TestAddInteraction(APITestMixin):
             # required fields
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -538,7 +538,7 @@ class TestAddInteraction(APITestMixin):
             # communication_channel required for complete interaction
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -559,7 +559,7 @@ class TestAddInteraction(APITestMixin):
             # policy feedback fields required when policy feedback provided
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -584,7 +584,7 @@ class TestAddInteraction(APITestMixin):
             # policy feedback fields cannot be blank when policy feedback provided
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -612,7 +612,7 @@ class TestAddInteraction(APITestMixin):
             # were_countries_discussed can't be null for export interactions
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -635,7 +635,7 @@ class TestAddInteraction(APITestMixin):
             # were_countries_discussed can't be null for other interactions
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.other,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -659,7 +659,7 @@ class TestAddInteraction(APITestMixin):
             # were_countries_discussed can't be missing for export/other interactions
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -682,7 +682,7 @@ class TestAddInteraction(APITestMixin):
             # were_countries_discussed can't be missing when sending export_countries
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -718,7 +718,7 @@ class TestAddInteraction(APITestMixin):
             # export_countries cannot be blank when were_countries_discussed is True
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -745,7 +745,7 @@ class TestAddInteraction(APITestMixin):
             # export_countries cannot have same country more than once for a company
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -786,7 +786,7 @@ class TestAddInteraction(APITestMixin):
             # export_countries must be fully formed. Status can't be missing
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -816,7 +816,7 @@ class TestAddInteraction(APITestMixin):
             # export_countries must be fully formed. Country can't be missing
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -848,7 +848,7 @@ class TestAddInteraction(APITestMixin):
             # export_countries must be fully formed. status must be a valid choice
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -881,7 +881,7 @@ class TestAddInteraction(APITestMixin):
             # export_countries must be fully formed. country ID must be a valid UUID
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -915,7 +915,7 @@ class TestAddInteraction(APITestMixin):
             # export_countries must be fully formed. country UUID must be a valid Country
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -956,7 +956,7 @@ class TestAddInteraction(APITestMixin):
             # export_countries cannot be set when were_countries_discussed is False
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.THEMES.export,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
@@ -992,7 +992,7 @@ class TestAddInteraction(APITestMixin):
             # fields not allowed
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'notes': 'hello',
@@ -1040,7 +1040,7 @@ class TestAddInteraction(APITestMixin):
             # fields where None is not allowed
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'notes': 'hello',
@@ -1066,7 +1066,7 @@ class TestAddInteraction(APITestMixin):
             # no contradictory messages if event is None but and is_event is True
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1091,7 +1091,7 @@ class TestAddInteraction(APITestMixin):
             # no duplicate messages for event if provided and is_event is False
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1117,7 +1117,7 @@ class TestAddInteraction(APITestMixin):
             # dit_participants cannot be empty list
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1139,7 +1139,7 @@ class TestAddInteraction(APITestMixin):
             # status must be a valid choice
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1163,7 +1163,7 @@ class TestAddInteraction(APITestMixin):
             # service must be without children
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1185,7 +1185,7 @@ class TestAddInteraction(APITestMixin):
 
             (
                 {
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1208,7 +1208,7 @@ class TestAddInteraction(APITestMixin):
             (
                 {
                     'theme': Interaction.THEMES.investment,
-                    'kind': Interaction.KINDS.interaction,
+                    'kind': Interaction.Kind.INTERACTION,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1247,7 +1247,7 @@ class TestAddInteraction(APITestMixin):
         """
         data = {
             'theme': Interaction.THEMES.export,
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'date': date.today().isoformat(),
             'subject': 'whatever',
             'company': lambda: CompanyFactory(name='Martian Island'),
@@ -1304,7 +1304,7 @@ class TestAddInteraction(APITestMixin):
         response = api_client.post(
             url,
             data={
-                'kind': Interaction.KINDS.interaction,
+                'kind': Interaction.Kind.INTERACTION,
                 'company': company.pk,
                 'contacts': [contact.pk],
                 'communication_channel': random_obj_for_model(CommunicationChannel).pk,
@@ -1343,7 +1343,7 @@ class TestAddInteraction(APITestMixin):
         response = api_client.post(
             url,
             data={
-                'kind': Interaction.KINDS.interaction,
+                'kind': Interaction.Kind.INTERACTION,
                 'company': CompanyFactory().pk,
                 'contacts': [ContactFactory().pk],
                 'communication_channel': random_obj_for_model(CommunicationChannel).pk,
@@ -1377,7 +1377,7 @@ class TestAddInteraction(APITestMixin):
         response = api_client.post(
             url,
             data={
-                'kind': Interaction.KINDS.interaction,
+                'kind': Interaction.Kind.INTERACTION,
                 'company': CompanyFactory().pk,
                 'contacts': [ContactFactory().pk],
                 'communication_channel': random_obj_for_model(CommunicationChannel).pk,
@@ -1426,7 +1426,7 @@ class TestGetInteraction(APITestMixin):
         response_data['dit_participants'].sort(key=lambda item: item['adviser']['id'])
         assert response_data == {
             'id': response_data['id'],
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'status': Interaction.STATUSES.complete,
             'theme': interaction.theme,
             'is_event': None,
@@ -1548,7 +1548,7 @@ class TestGetInteraction(APITestMixin):
         )
         assert response_data == {
             'id': response_data['id'],
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'status': Interaction.STATUSES.complete,
             'theme': interaction.theme,
             'is_event': None,
@@ -1835,7 +1835,7 @@ class TestUpdateInteraction(APITestMixin):
         """
         requester = create_test_user(permission_codenames=permissions)
         draft_interaction = CompanyInteractionFactory(
-            kind=Interaction.KINDS.interaction,
+            kind=Interaction.Kind.INTERACTION,
             status=Interaction.STATUSES.draft,
             service_id=None,
             communication_channel=None,

--- a/datahub/interaction/test/views/test_service_answers.py
+++ b/datahub/interaction/test/views/test_service_answers.py
@@ -45,7 +45,7 @@ class TestServiceAnswers(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -180,7 +180,7 @@ class TestServiceAnswers(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.interaction,
+            'kind': Interaction.Kind.INTERACTION,
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -83,7 +83,7 @@ class TestAddServiceDelivery(APITestMixin):
         contact = ContactFactory(company=company)
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': Interaction.KINDS.service_delivery,
+            'kind': Interaction.Kind.SERVICE_DELIVERY,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_participants': [
@@ -103,7 +103,7 @@ class TestAddServiceDelivery(APITestMixin):
 
         assert response_data == {
             'id': response_data['id'],
-            'kind': Interaction.KINDS.service_delivery,
+            'kind': Interaction.Kind.SERVICE_DELIVERY,
             'status': request_data.get('status', Interaction.STATUSES.complete),
             'theme': request_data.get('theme', None),
             'is_event': request_data['is_event'],
@@ -181,7 +181,7 @@ class TestAddServiceDelivery(APITestMixin):
             # required fields
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                 },
                 {
                     'contacts': ['This field is required.'],
@@ -196,7 +196,7 @@ class TestAddServiceDelivery(APITestMixin):
             # required fields for service delivery
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': CompanyFactory,
@@ -215,7 +215,7 @@ class TestAddServiceDelivery(APITestMixin):
             # policy feedback fields cannot be omitted when policy feedback provided
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'notes': 'hello',
@@ -243,7 +243,7 @@ class TestAddServiceDelivery(APITestMixin):
             # policy feedback fields cannot be blank when policy feedback provided
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'notes': 'hello',
@@ -274,7 +274,7 @@ class TestAddServiceDelivery(APITestMixin):
             # fields not allowed
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'notes': 'hello',
@@ -318,7 +318,7 @@ class TestAddServiceDelivery(APITestMixin):
             # fields where None is not allowed
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'notes': 'hello',
@@ -348,7 +348,7 @@ class TestAddServiceDelivery(APITestMixin):
             # theme=investment not allowed
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': CompanyFactory,
@@ -375,7 +375,7 @@ class TestAddServiceDelivery(APITestMixin):
             # event field not allowed for non-event service delivery
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'notes': 'hello',
@@ -404,7 +404,7 @@ class TestAddServiceDelivery(APITestMixin):
             # event field required for event service delivery
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': CompanyFactory,
@@ -431,7 +431,7 @@ class TestAddServiceDelivery(APITestMixin):
             # multiple contacts not allowed for event service delivery
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': CompanyFactory,
@@ -459,7 +459,7 @@ class TestAddServiceDelivery(APITestMixin):
             # dit_participants cannot be empty list
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery,
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': CompanyFactory,

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -44,7 +44,7 @@ class TestAddServiceDelivery(APITestMixin):
             # non-event service delivery with theme
             {
                 'is_event': False,
-                'theme': Interaction.THEMES.export,
+                'theme': Interaction.Theme.EXPORT,
             },
             # non-event service delivery with blank notes
             {
@@ -365,7 +365,7 @@ class TestAddServiceDelivery(APITestMixin):
                     'was_policy_feedback_provided': False,
                     'is_event': False,
 
-                    'theme': Interaction.THEMES.investment,
+                    'theme': Interaction.Theme.INVESTMENT,
                 },
                 {
                     'kind': ["This value can't be selected for investment interactions."],

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -72,7 +72,7 @@ class TestAddServiceDelivery(APITestMixin):
             # Interaction with a status
             {
                 'is_event': False,
-                'status': Interaction.STATUSES.draft,
+                'status': Interaction.Status.DRAFT,
             },
         ),
     )
@@ -104,7 +104,7 @@ class TestAddServiceDelivery(APITestMixin):
         assert response_data == {
             'id': response_data['id'],
             'kind': Interaction.Kind.SERVICE_DELIVERY,
-            'status': request_data.get('status', Interaction.STATUSES.complete),
+            'status': request_data.get('status', Interaction.Status.COMPLETE),
             'theme': request_data.get('theme', None),
             'is_event': request_data['is_event'],
             'service_delivery_status': request_data.get('service_delivery_status'),

--- a/datahub/interaction/validators.py
+++ b/datahub/interaction/validators.py
@@ -160,7 +160,7 @@ class StatusChangeValidator:
         instance = serializer.instance
         if not instance:
             return
-        existing_interaction_complete = instance.status == Interaction.STATUSES.complete
+        existing_interaction_complete = instance.status == Interaction.Status.COMPLETE
         combiner = DataCombiner(instance, data)
         new_status = combiner.get_value('status')
         update_changes_status = new_status != instance.status

--- a/datahub/search/interaction/test/test_views.py
+++ b/datahub/search/interaction/test/test_views.py
@@ -372,7 +372,7 @@ class TestInteractionEntitySearchView(APITestMixin):
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'kind': Interaction.KINDS.service_delivery,
+            'kind': Interaction.Kind.SERVICE_DELIVERY,
         }
         response = self.api_client.post(url, request_data)
 


### PR DESCRIPTION
### Description of change

Now that we've updated to Django 3, this switches interaction model fields from using [`model_utils.Choices`](https://django-model-utils.readthedocs.io/en/latest/utilities.html#choices) to [`django.db.models.TextChoices`](https://docs.djangoproject.com/en/3.0/ref/models/fields/#enumeration-types).

The reasons for switching are:

- getting rid of the dependency on `model_utils`
- `TextChoices` has a better interface

I've followed the same styling conventions as in the examples in the Django docs, except that I've wrapped the tuples in brackets to be consistent with other class attributes in the code base.

(Other model fields will follow in separate PRs if this one goes through without objections.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
