### PR TITLE
Change logging to Sentry

### DIFF
--- a/datahub/company/tasks.py
+++ b/datahub/company/tasks.py
@@ -48,6 +48,7 @@ def _automatic_company_archive(limit, simulate):
         message = 'Automatically archived company'
         extra = {'company_id': str(company.id)}
         if simulate:
+            logger.info(f'[SIMULATION] {message}', extra=extra)
             log_to_sentry(f'[SIMULATION] {message}', extra=extra)
             continue
         company.archived = True
@@ -60,6 +61,7 @@ def _automatic_company_archive(limit, simulate):
                 'archived_on',
             ],
         )
+        logger.info(message, extra=extra)
         log_to_sentry(message, extra=extra)
 
 

--- a/datahub/company/test/test_tasks.py
+++ b/datahub/company/test/test_tasks.py
@@ -96,7 +96,7 @@ class TestAutomaticCompanyArchive:
         Test that a company without interaction that fits
         all the other criteria is archived.
         """
-        mock_log_to_sentry = mock.MagicMock()
+        mock_log_to_sentry = mock.Mock()
         monkeypatch.setattr(
             'datahub.company.tasks.log_to_sentry',
             mock_log_to_sentry,


### PR DESCRIPTION
### Description of change

We are currently in the process of rolling our `automatic-company-archive` tool. As a first step, we are running this with `simulate=True` so that we can audit the logs produced and validate if it is actually archiving the right companies.

We observed that the ELK is unable to capture all the logs e.g. during the last run, we emitted 1000 logs but only get 49 in ELK. 

In view of the above we have done the following:

1. Raised the [issue](https://uktrade.atlassian.net/jira/software/projects/OPS/boards/167?selectedIssue=OPS-46) with webops.
2. Switch to Sentry until ELK is fixed so that we can proceed with the rollout. This is what this PR is looking to accomplish.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
