### PR TITLE
Use Django TextChoices for investment fields

### DIFF
--- a/datahub/company/tasks.py
+++ b/datahub/company/tasks.py
@@ -30,7 +30,7 @@ def _automatic_company_archive(limit, simulate):
         ),
         active_investment_projects=FilteredRelation(
             'investor_investment_projects',
-            condition=Q(investor_investment_projects__status=InvestmentProject.STATUSES.ongoing),
+            condition=Q(investor_investment_projects__status=InvestmentProject.Status.ONGOING),
         ),
     ).filter(
         Q(latest_interaction_date__date__lt=_8y_ago) | Q(latest_interaction_date__isnull=True),

--- a/datahub/company/test/test_tasks.py
+++ b/datahub/company/test/test_tasks.py
@@ -285,15 +285,15 @@ class TestAutomaticCompanyArchive:
         'investment_projects_status, expected_archived',
         (
             (
-                [InvestmentProject.STATUSES.lost],
+                [InvestmentProject.Status.LOST],
                 True,
             ),
             (
-                [InvestmentProject.STATUSES.lost, InvestmentProject.STATUSES.ongoing],
+                [InvestmentProject.Status.LOST, InvestmentProject.Status.ONGOING],
                 False,
             ),
             (
-                [InvestmentProject.STATUSES.ongoing],
+                [InvestmentProject.Status.ONGOING],
                 False,
             ),
             (

--- a/datahub/dataset/investment_project/spi.py
+++ b/datahub/dataset/investment_project/spi.py
@@ -60,7 +60,7 @@ def proposition_formatter(propositions):
             'status': proposition['status'],
             'modified_on':
                 dateutil_parse(proposition['modified_on']).isoformat()
-                if proposition['status'] != PropositionStatus.ongoing else '',
+                if proposition['status'] != PropositionStatus.ONGOING else '',
             'adviser_id': proposition['adviser_id'],
         }
         for proposition in propositions

--- a/datahub/dataset/investment_project/test/test_spi.py
+++ b/datahub/dataset/investment_project/test/test_spi.py
@@ -58,13 +58,13 @@ def test_proposition_formatter():
         {
             'deadline': '2010-02-01T00:00:00+00:00',
             'modified_on': '2010-02-02T00:00:00+00:00',
-            'status': PropositionStatus.ongoing,
+            'status': PropositionStatus.ONGOING,
             'adviser_id': uuid4(),
         },
         {
             'deadline': '2010-02-01T00:00:00+00:00',
             'modified_on': '2010-02-02T00:00:00+00:00',
-            'status': PropositionStatus.completed,
+            'status': PropositionStatus.COMPLETED,
             'adviser_id': uuid4(),
         },
     ]
@@ -75,13 +75,13 @@ def test_proposition_formatter():
         {
             'deadline': '2010-02-01',
             'modified_on': '',
-            'status': PropositionStatus.ongoing,
+            'status': PropositionStatus.ONGOING,
             'adviser_id': propositions[0]['adviser_id'],
         },
         {
             'deadline': '2010-02-01',
             'modified_on': '2010-02-02T00:00:00+00:00',
-            'status': PropositionStatus.completed,
+            'status': PropositionStatus.COMPLETED,
             'adviser_id': propositions[1]['adviser_id'],
         },
     ]

--- a/datahub/dbmaintenance/management/commands/update_investment_project_status.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_status.py
@@ -22,7 +22,7 @@ class Command(CSVBaseCommand):
         """Process one single row."""
         pk = parse_uuid(row['id'])
         investment_project = InvestmentProject.objects.get(pk=pk)
-        status = parse_choice(row['status'], InvestmentProject.STATUSES)
+        status = parse_choice(row['status'], InvestmentProject.Status.choices)
 
         if investment_project.status == status:
             return

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_status.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_status.py
@@ -25,10 +25,10 @@ def test_run(s3_stubber, caplog, simulate):
     caplog.set_level('ERROR')
 
     original_statuses = [
-        InvestmentProject.STATUSES.ongoing,
-        InvestmentProject.STATUSES.ongoing,
-        InvestmentProject.STATUSES.won,
-        InvestmentProject.STATUSES.abandoned,
+        InvestmentProject.Status.ONGOING,
+        InvestmentProject.Status.ONGOING,
+        InvestmentProject.Status.WON,
+        InvestmentProject.Status.ABANDONED,
     ]
     investment_projects = InvestmentProjectFactory.create_batch(
         len(original_statuses),
@@ -69,18 +69,18 @@ def test_run(s3_stubber, caplog, simulate):
         assert [project.status for project in investment_projects] == original_statuses
     else:
         expected_statuses = [
-            InvestmentProject.STATUSES.ongoing,  # no change as the new value wasn't valid
-            InvestmentProject.STATUSES.ongoing,
-            InvestmentProject.STATUSES.dormant,
-            InvestmentProject.STATUSES.ongoing,
+            InvestmentProject.Status.ONGOING,  # no change as the new value wasn't valid
+            InvestmentProject.Status.ONGOING,
+            InvestmentProject.Status.DORMANT,
+            InvestmentProject.Status.ONGOING,
         ]
         assert [project.status for project in investment_projects] == expected_statuses
 
 
 def test_audit_log(s3_stubber):
     """Test that reversion revisions are created for updated rows."""
-    project_without_change = InvestmentProjectFactory(status=InvestmentProject.STATUSES.ongoing)
-    project_with_change = InvestmentProjectFactory(status=InvestmentProject.STATUSES.ongoing)
+    project_without_change = InvestmentProjectFactory(status=InvestmentProject.Status.ONGOING)
+    project_with_change = InvestmentProjectFactory(status=InvestmentProject.Status.ONGOING)
 
     bucket = 'test_bucket'
     object_key = 'test_key'

--- a/datahub/documents/test/factories.py
+++ b/datahub/documents/test/factories.py
@@ -2,7 +2,7 @@ import factory
 from django.utils.timezone import utc
 
 from datahub.company.test.factories import AdviserFactory
-from datahub.documents.models import UPLOAD_STATUSES
+from datahub.documents.models import UploadStatus
 
 
 class DocumentFactory(factory.django.DjangoModelFactory):
@@ -17,7 +17,7 @@ class DocumentFactory(factory.django.DjangoModelFactory):
     scanned_on = None
     av_clean = None
     av_reason = ''
-    status = UPLOAD_STATUSES.not_virus_scanned
+    status = UploadStatus.NOT_VIRUS_SCANNED
 
     class Meta:
         model = 'documents.Document'

--- a/datahub/documents/test/test_av_scan.py
+++ b/datahub/documents/test/test_av_scan.py
@@ -7,7 +7,7 @@ from requests_toolbelt.multipart.decoder import MultipartDecoder
 from rest_framework import status
 
 from datahub.documents.av_scan import _multipart_encoder, StreamWrapper, VirusScanException
-from datahub.documents.models import Document, UPLOAD_STATUSES
+from datahub.documents.models import Document, UploadStatus
 from datahub.documents.tasks import virus_scan_document
 from datahub.documents.test.factories import DocumentFactory
 
@@ -101,7 +101,7 @@ def test_virus_scan_document_bad_response_body(get_signed_url_mock, requests_moc
 
     document.refresh_from_db()
     assert document.av_clean is None
-    assert document.status == UPLOAD_STATUSES.virus_scanning_failed
+    assert document.status == UploadStatus.VIRUS_SCANNING_FAILED
     assert document.av_reason == error_message
 
 

--- a/datahub/documents/test/test_views.py
+++ b/datahub/documents/test/test_views.py
@@ -9,7 +9,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin
-from datahub.documents.models import Document, UPLOAD_STATUSES
+from datahub.documents.models import Document, UploadStatus
 from datahub.documents.test.my_entity_document.models import MyEntityDocument
 
 
@@ -169,4 +169,4 @@ class TestDocumentViews(APITestMixin):
         delete_document.assert_called_once_with(args=(document_pk,))
 
         entity_document.document.refresh_from_db()
-        assert entity_document.document.status == UPLOAD_STATUSES.deletion_pending
+        assert entity_document.document.status == UploadStatus.DELETION_PENDING

--- a/datahub/documents/utils.py
+++ b/datahub/documents/utils.py
@@ -73,7 +73,7 @@ def perform_delete_document(document_pk):
     Deletes Document and corresponding S3 file.
 
     :raises: DocumentDeleteException if document:
-        - doesn't have status=UPLOAD_STATUSES.deletion_pending
+        - doesn't have status=UploadStatus.DELETION_PENDING
         - response from S3 doesn't declare no content (status_code=204)
         - doesn't exist
     :raises: botocore.exceptions.ClientError if there was a problem with the S3 client
@@ -81,7 +81,7 @@ def perform_delete_document(document_pk):
 
     :param document_pk: id of the Document
     """
-    from datahub.documents.models import UPLOAD_STATUSES
+    from datahub.documents.models import UploadStatus
 
     document = get_document_by_pk(document_pk)
     if not document:
@@ -89,7 +89,7 @@ def perform_delete_document(document_pk):
             f'Document with ID {document_pk} not found.',
         )
 
-    if document.status != UPLOAD_STATUSES.deletion_pending:
+    if document.status != UploadStatus.DELETION_PENDING:
         raise DocumentDeleteException(
             f'Document with ID {document_pk} is not pending deletion.',
         )

--- a/datahub/investment/project/evidence/test/test_views.py
+++ b/datahub/investment/project/evidence/test/test_views.py
@@ -11,7 +11,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import TeamFactory
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
-from datahub.documents.models import Document, UPLOAD_STATUSES
+from datahub.documents.models import Document, UploadStatus
 from datahub.investment.project.evidence.models import EvidenceDocument, EvidenceDocumentPermission
 from datahub.investment.project.evidence.test.factories import EvidenceTagFactory
 from datahub.investment.project.evidence.test.utils import create_evidence_document
@@ -261,7 +261,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             ],
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document),
-            'status': UPLOAD_STATUSES.not_virus_scanned,
+            'status': UploadStatus.NOT_VIRUS_SCANNED,
             'signed_upload_url': 'http://document-about-ocelots',
             'created_on': format_date_or_datetime(entity_document.created_on),
             'modified_on': format_date_or_datetime(entity_document.modified_on),
@@ -325,7 +325,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             ],
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document),
-            'status': UPLOAD_STATUSES.virus_scanned,
+            'status': UploadStatus.VIRUS_SCANNED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'modified_on': format_date_or_datetime(entity_document.modified_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
@@ -381,7 +381,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             ],
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document),
-            'status': UPLOAD_STATUSES.not_virus_scanned,
+            'status': UploadStatus.NOT_VIRUS_SCANNED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'modified_on': format_date_or_datetime(entity_document.modified_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
@@ -480,7 +480,7 @@ class TestEvidenceDocumentViews(APITestMixin):
                 ],
                 'original_filename': 'test.txt',
                 'url': _get_document_url(entity_document),
-                'status': UPLOAD_STATUSES.virus_scanned,
+                'status': UploadStatus.VIRUS_SCANNED,
                 'created_on': format_date_or_datetime(entity_document.created_on),
                 'modified_on': format_date_or_datetime(entity_document.modified_on),
                 'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
@@ -576,7 +576,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             ],
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document),
-            'status': UPLOAD_STATUSES.virus_scanning_scheduled,
+            'status': UploadStatus.VIRUS_SCANNING_SCHEDULED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'modified_on': format_date_or_datetime(entity_document.modified_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -78,11 +78,10 @@ class IProjectAbstract(models.Model):
     class Meta:
         abstract = True
 
-    PRIORITIES = Choices(
-        ('1_low', 'low', 'Low'),
-        ('2_medium', 'medium', 'Medium'),
-        ('3_high', 'high', 'High'),
-    )
+    class Priority(models.TextChoices):
+        LOW = ('1_low', 'Low')
+        MEDIUM = ('2_medium', 'Medium')
+        HIGH = ('3_high', 'High')
 
     STATUSES = Choices(
         ('ongoing', 'Ongoing'),
@@ -126,7 +125,12 @@ class IProjectAbstract(models.Model):
         null=True, blank=True, on_delete=models.SET_NULL,
     )
 
-    priority = models.CharField(max_length=MAX_LENGTH, choices=PRIORITIES, blank=True, null=True)
+    priority = models.CharField(
+        max_length=MAX_LENGTH,
+        choices=Priority.choices,
+        blank=True,
+        null=True,
+    )
 
     approved_commitment_to_invest = models.BooleanField(null=True)
     approved_fdi = models.BooleanField(null=True)

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -83,14 +83,13 @@ class IProjectAbstract(models.Model):
         MEDIUM = ('2_medium', 'Medium')
         HIGH = ('3_high', 'High')
 
-    STATUSES = Choices(
-        ('ongoing', 'Ongoing'),
-        ('delayed', 'Delayed'),
-        ('dormant', 'Dormant'),
-        ('lost', 'Lost'),
-        ('abandoned', 'Abandoned'),
-        ('won', 'Won'),
-    )
+    class Status(models.TextChoices):
+        ONGOING = ('ongoing', 'Ongoing')
+        DELAYED = ('delayed', 'Delayed')
+        DORMANT = ('dormant', 'Dormant')
+        LOST = ('lost', 'Lost')
+        ABANDONED = ('abandoned', 'Abandoned')
+        WON = ('won', 'Won')
 
     INVOLVEMENT = Choices(
         ('unspecified', 'Unspecified'),
@@ -145,7 +144,7 @@ class IProjectAbstract(models.Model):
         default=InvestmentProjectStage.prospect.value.id,
     )
     status = models.CharField(
-        max_length=MAX_LENGTH, choices=STATUSES, default=STATUSES.ongoing,
+        max_length=MAX_LENGTH, choices=Status.choices, default=Status.ONGOING,
     )
     reason_delayed = models.TextField(blank=True, null=True)
     reason_abandoned = models.TextField(blank=True, null=True)

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -7,7 +7,6 @@ from itertools import chain
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
-from model_utils import Choices
 from mptt.fields import TreeForeignKey
 from reversion.models import Revision
 
@@ -91,11 +90,10 @@ class IProjectAbstract(models.Model):
         ABANDONED = ('abandoned', 'Abandoned')
         WON = ('won', 'Won')
 
-    INVOLVEMENT = Choices(
-        ('unspecified', 'Unspecified'),
-        ('not_involved', 'Not involved'),
-        ('involved', 'Involved'),
-    )
+    class Involvement(models.TextChoices):
+        UNSPECIFIED = ('unspecified', 'Unspecified')
+        NOT_INVOLVED = ('not_involved', 'Not involved')
+        INVOLVED = ('involved', 'Involved')
 
     name = models.CharField(max_length=MAX_LENGTH)
     description = models.TextField()
@@ -253,13 +251,13 @@ class IProjectAbstract(models.Model):
     def level_of_involvement_simplified(self):
         """Returns simplified level of involvement for the Investment Project."""
         if self.level_of_involvement_id is None:
-            return self.INVOLVEMENT.unspecified
+            return self.Involvement.UNSPECIFIED
 
         not_involved_id = constants.Involvement.no_involvement.value.id
         if force_uuid(self.level_of_involvement_id) == force_uuid(not_involved_id):
-            return self.INVOLVEMENT.not_involved
+            return self.Involvement.NOT_INVOLVED
 
-        return self.INVOLVEMENT.involved
+        return self.Involvement.INVOLVED
 
 
 class IProjectValueAbstract(models.Model):

--- a/datahub/investment/project/proposition/constants.py
+++ b/datahub/investment/project/proposition/constants.py
@@ -1,8 +1,9 @@
-from model_utils import Choices
+from django.db import models
 
 
-PropositionStatus = Choices(
-    ('ongoing', 'Ongoing'),
-    ('abandoned', 'Abandoned'),
-    ('completed', 'Completed'),
-)
+class PropositionStatus(models.TextChoices):
+    """Proposition statuses."""
+
+    ONGOING = ('ongoing', 'Ongoing')
+    ABANDONED = ('abandoned', 'Abandoned')
+    COMPLETED = ('completed', 'Completed')

--- a/datahub/investment/project/proposition/models.py
+++ b/datahub/investment/project/proposition/models.py
@@ -10,7 +10,7 @@ from rest_framework.reverse import reverse
 from datahub.core.exceptions import APIConflictException
 from datahub.core.models import BaseModel
 from datahub.core.utils import StrEnum
-from datahub.documents.models import AbstractEntityDocumentModel, UPLOAD_STATUSES
+from datahub.documents.models import AbstractEntityDocumentModel, UploadStatus
 from datahub.investment.project.proposition.constants import PropositionStatus
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -146,7 +146,7 @@ class Proposition(BaseModel):
         :raises ValidationError: when trying to complete proposition without uploaded documents
         :raises APIConflictException: when proposition status is not ongoing
         """
-        if self.documents.filter(document__status=UPLOAD_STATUSES.virus_scanned).count() == 0:
+        if self.documents.filter(document__status=UploadStatus.VIRUS_SCANNED).count() == 0:
             raise ValidationError({
                 'non_field_errors': ['Proposition has no documents uploaded.'],
             })

--- a/datahub/investment/project/proposition/models.py
+++ b/datahub/investment/project/proposition/models.py
@@ -114,7 +114,9 @@ class Proposition(BaseModel):
     )
     deadline = models.DateField()
     status = models.CharField(
-        max_length=MAX_LENGTH, choices=PropositionStatus, default=PropositionStatus.ongoing,
+        max_length=MAX_LENGTH,
+        choices=PropositionStatus.choices,
+        default=PropositionStatus.ONGOING,
     )
 
     name = models.CharField(max_length=MAX_LENGTH)
@@ -128,7 +130,7 @@ class Proposition(BaseModel):
 
     def _change_status(self, status, by, details):
         """Change status of a proposition."""
-        if self.status != PropositionStatus.ongoing:
+        if self.status != PropositionStatus.ONGOING:
             raise APIConflictException(
                 f'The action cannot be performed in the current status {self.status}.',
             )
@@ -150,7 +152,7 @@ class Proposition(BaseModel):
             raise ValidationError({
                 'non_field_errors': ['Proposition has no documents uploaded.'],
             })
-        self._change_status(PropositionStatus.completed, by, details)
+        self._change_status(PropositionStatus.COMPLETED, by, details)
 
     def abandon(self, by, details):
         """
@@ -159,7 +161,7 @@ class Proposition(BaseModel):
         :param by: the adviser who marked the proposition as abandoned
         :param details: reason of abandonment
         """
-        self._change_status(PropositionStatus.abandoned, by, details)
+        self._change_status(PropositionStatus.ABANDONED, by, details)
 
     class Meta:
         permissions = (

--- a/datahub/investment/project/proposition/test/factories.py
+++ b/datahub/investment/project/proposition/test/factories.py
@@ -14,7 +14,7 @@ class PropositionFactory(factory.django.DjangoModelFactory):
     adviser = factory.SubFactory(AdviserFactory)
 
     deadline = factory.Faker('future_date')
-    status = PropositionStatus.ongoing
+    status = PropositionStatus.ONGOING
 
     name = factory.Faker('text')
     scope = factory.Faker('text')

--- a/datahub/investment/project/proposition/test/test_views.py
+++ b/datahub/investment/project/proposition/test/test_views.py
@@ -11,7 +11,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
-from datahub.documents.models import Document, UPLOAD_STATUSES
+from datahub.documents.models import Document, UploadStatus
 from datahub.investment.project.proposition.constants import PropositionStatus
 from datahub.investment.project.proposition.models import (
     Proposition,
@@ -1456,7 +1456,7 @@ class TestPropositionDocumentViews(APITestMixin):
             },
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
-            'status': UPLOAD_STATUSES.not_virus_scanned,
+            'status': UploadStatus.NOT_VIRUS_SCANNED,
             'signed_upload_url': 'http://document-about-ocelots',
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
@@ -1512,7 +1512,7 @@ class TestPropositionDocumentViews(APITestMixin):
             },
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
-            'status': UPLOAD_STATUSES.not_virus_scanned,
+            'status': UploadStatus.NOT_VIRUS_SCANNED,
             'signed_upload_url': 'http://document-about-ocelots',
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
@@ -1599,7 +1599,7 @@ class TestPropositionDocumentViews(APITestMixin):
             'av_clean': True,
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
-            'status': UPLOAD_STATUSES.virus_scanned,
+            'status': UploadStatus.VIRUS_SCANNED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
@@ -1655,7 +1655,7 @@ class TestPropositionDocumentViews(APITestMixin):
             'av_clean': True,
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
-            'status': UPLOAD_STATUSES.virus_scanned,
+            'status': UploadStatus.VIRUS_SCANNED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
@@ -1730,7 +1730,7 @@ class TestPropositionDocumentViews(APITestMixin):
             },
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
-            'status': UPLOAD_STATUSES.not_virus_scanned,
+            'status': UploadStatus.NOT_VIRUS_SCANNED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
@@ -1776,7 +1776,7 @@ class TestPropositionDocumentViews(APITestMixin):
             },
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
-            'status': UPLOAD_STATUSES.not_virus_scanned,
+            'status': UploadStatus.NOT_VIRUS_SCANNED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
@@ -1887,7 +1887,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 },
                 'original_filename': 'test.txt',
                 'url': _get_document_url(entity_document.proposition, entity_document),
-                'status': UPLOAD_STATUSES.virus_scanned,
+                'status': UploadStatus.VIRUS_SCANNED,
                 'document_url': 'http://what',
                 'created_on': format_date_or_datetime(entity_document.created_on),
                 'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
@@ -1963,7 +1963,7 @@ class TestPropositionDocumentViews(APITestMixin):
 
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
-            'status': UPLOAD_STATUSES.virus_scanning_scheduled,
+            'status': UploadStatus.VIRUS_SCANNING_SCHEDULED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
@@ -2022,7 +2022,7 @@ class TestPropositionDocumentViews(APITestMixin):
 
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
-            'status': UPLOAD_STATUSES.virus_scanning_scheduled,
+            'status': UploadStatus.VIRUS_SCANNING_SCHEDULED,
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
@@ -2066,7 +2066,7 @@ class TestPropositionDocumentViews(APITestMixin):
         }
 
         entity_document.document.refresh_from_db()
-        assert entity_document.document.status == UPLOAD_STATUSES.not_virus_scanned
+        assert entity_document.document.status == UploadStatus.NOT_VIRUS_SCANNED
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_DELETE_PERMISSIONS)
     @patch('datahub.documents.tasks.delete_document.apply_async')
@@ -2176,7 +2176,7 @@ class TestPropositionDocumentViews(APITestMixin):
         }
 
         entity_document.document.refresh_from_db()
-        assert entity_document.document.status == UPLOAD_STATUSES.virus_scanned
+        assert entity_document.document.status == UploadStatus.VIRUS_SCANNED
         assert delete_document.called is False
 
     @patch('datahub.documents.tasks.delete_document.apply_async')

--- a/datahub/investment/project/proposition/test/test_views.py
+++ b/datahub/investment/project/proposition/test/test_views.py
@@ -127,7 +127,7 @@ class TestCreateProposition(APITestMixin):
                 'id': str(adviser.pk),
             },
             'deadline': '2018-02-10',
-            'status': PropositionStatus.ongoing,
+            'status': PropositionStatus.ONGOING,
             'name': 'My proposition.',
             'scope': 'Very broad scope.',
             'details': '',
@@ -220,7 +220,7 @@ class TestCreateProposition(APITestMixin):
                 'id': str(adviser.pk),
             },
             'deadline': '2018-02-10',
-            'status': PropositionStatus.ongoing,
+            'status': PropositionStatus.ONGOING,
             'name': 'My proposition.',
             'scope': 'Very broad scope.',
             'details': '',
@@ -487,17 +487,17 @@ class TestListPropositions(APITestMixin):
     @pytest.mark.parametrize(
         'proposition_status',
         (
-            PropositionStatus.ongoing,
-            PropositionStatus.abandoned,
-            PropositionStatus.completed,
+            PropositionStatus.ONGOING,
+            PropositionStatus.ABANDONED,
+            PropositionStatus.COMPLETED,
         ),
     )
     def test_filtered_by_status(self, proposition_status):
         """List of propositions filtered by status."""
         statuses = (
-            PropositionStatus.ongoing,
-            PropositionStatus.abandoned,
-            PropositionStatus.completed,
+            PropositionStatus.ONGOING,
+            PropositionStatus.ABANDONED,
+            PropositionStatus.COMPLETED,
         )
         investment_project = InvestmentProjectFactory()
         PropositionFactory.create_batch(
@@ -572,7 +572,7 @@ class TestGetProposition(APITestMixin):
                 'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
-            'status': PropositionStatus.ongoing,
+            'status': PropositionStatus.ONGOING,
             'name': proposition.name,
             'scope': proposition.scope,
             'details': '',
@@ -634,7 +634,7 @@ class TestGetProposition(APITestMixin):
                 'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
-            'status': PropositionStatus.ongoing,
+            'status': PropositionStatus.ONGOING,
             'name': proposition.name,
             'scope': proposition.scope,
             'details': '',
@@ -786,7 +786,7 @@ class TestCompleteProposition(APITestMixin):
                 'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
-            'status': PropositionStatus.completed,
+            'status': PropositionStatus.COMPLETED,
             'name': proposition.name,
             'scope': proposition.scope,
             'created_on': format_date_or_datetime(proposition.created_on),
@@ -881,7 +881,7 @@ class TestCompleteProposition(APITestMixin):
                 'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
-            'status': PropositionStatus.completed,
+            'status': PropositionStatus.COMPLETED,
             'name': proposition.name,
             'scope': proposition.scope,
             'created_on': format_date_or_datetime(proposition.created_on),
@@ -944,7 +944,7 @@ class TestCompleteProposition(APITestMixin):
 
     @pytest.mark.parametrize(
         'proposition_status', (
-            PropositionStatus.completed, PropositionStatus.abandoned,
+            PropositionStatus.COMPLETED, PropositionStatus.ABANDONED,
         ),
     )
     def test_cannot_complete_proposition_without_ongoing_status(self, proposition_status):
@@ -997,7 +997,7 @@ class TestCompleteProposition(APITestMixin):
         response_data = response.json()
         assert response_data['non_field_errors'] == ['Proposition has no documents uploaded.']
         proposition.refresh_from_db()
-        assert proposition.status == PropositionStatus.ongoing
+        assert proposition.status == PropositionStatus.ONGOING
 
 
 class TestAbandonProposition(APITestMixin):
@@ -1042,7 +1042,7 @@ class TestAbandonProposition(APITestMixin):
                 'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
-            'status': PropositionStatus.abandoned,
+            'status': PropositionStatus.ABANDONED,
             'name': proposition.name,
             'scope': proposition.scope,
             'created_on': format_date_or_datetime(proposition.created_on),
@@ -1136,7 +1136,7 @@ class TestAbandonProposition(APITestMixin):
                 'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
-            'status': PropositionStatus.abandoned,
+            'status': PropositionStatus.ABANDONED,
             'name': proposition.name,
             'scope': proposition.scope,
             'created_on': format_date_or_datetime(proposition.created_on),
@@ -1199,7 +1199,7 @@ class TestAbandonProposition(APITestMixin):
 
     @pytest.mark.parametrize(
         'proposition_status', (
-            PropositionStatus.completed, PropositionStatus.abandoned,
+            PropositionStatus.COMPLETED, PropositionStatus.ABANDONED,
         ),
     )
     def test_cannot_abandon_proposition_without_ongoing_status(self, proposition_status):
@@ -1249,7 +1249,7 @@ class TestAbandonProposition(APITestMixin):
         response_data = response.json()
         assert response_data['details'] == ['This field may not be blank.']
         proposition.refresh_from_db()
-        assert proposition.status == PropositionStatus.ongoing
+        assert proposition.status == PropositionStatus.ONGOING
 
 
 @pytest.mark.parametrize('http_method', ('get', 'post'))

--- a/datahub/investment/project/report/spi.py
+++ b/datahub/investment/project/report/spi.py
@@ -172,7 +172,7 @@ class SPIReport:
         for proposition in propositions:
             formatted.append(dateutil_parse(proposition['deadline']).strftime('%Y-%m-%d'))
             formatted.append(proposition['status'])
-            if proposition['status'] == PropositionStatus.ongoing:
+            if proposition['status'] == PropositionStatus.ONGOING:
                 modified_on = ''
             else:
                 modified_on = dateutil_parse(proposition['modified_on']).isoformat()

--- a/datahub/investment/project/report/test/test_spi.py
+++ b/datahub/investment/project/report/test/test_spi.py
@@ -296,7 +296,7 @@ def test_can_get_propositions_with_custom_formatting(propositions):
             'deadline': dateutil_parse(proposition['deadline']).strftime('%Y-%m-%d'),
             'status': proposition['status'],
             'modified_on': dateutil_parse(proposition['modified_on']).isoformat()
-            if proposition['status'] != PropositionStatus.ongoing else '',
+            if proposition['status'] != PropositionStatus.ONGOING else '',
             'adviser_id': str(proposition['adviser_id']),
         } for proposition in propositions]
 

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -492,12 +492,12 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         new_status = combiner.get_value('status')
 
         if str(new_stage.id) == InvestmentProjectStage.won.value.id:
-            data['status'] = InvestmentProject.STATUSES.won
+            data['status'] = InvestmentProject.Status.WON
         elif (
             old_stage and str(old_stage.id) == InvestmentProjectStage.won.value.id
-            and new_status == InvestmentProject.STATUSES.won
+            and new_status == InvestmentProject.Status.WON
         ):
-            data['status'] = InvestmentProject.STATUSES.ongoing
+            data['status'] = InvestmentProject.Status.ONGOING
 
     class Meta:
         model = InvestmentProject

--- a/datahub/investment/project/test/factories.py
+++ b/datahub/investment/project/test/factories.py
@@ -155,7 +155,7 @@ class WonInvestmentProjectFactory(VerifyWinInvestmentProjectFactory):
     """Investment project in the Won stage."""
 
     stage_id = InvestmentProjectStage.won.value.id
-    status = InvestmentProject.STATUSES.won
+    status = InvestmentProject.Status.WON
     actual_land_date = factory.Faker('past_date')
 
 

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -697,7 +697,7 @@ class TestRetrieveView(APITestMixin):
     def test_get_project_status(self):
         """Test getting project status fields."""
         project = InvestmentProjectFactory(
-            status=InvestmentProject.STATUSES.lost,
+            status=InvestmentProject.Status.LOST,
             reason_delayed='Problems getting planning permission.',
             date_abandoned=date(2019, 1, 1),
             reason_abandoned='No longer viable.',

--- a/datahub/mi_dashboard/query_utils.py
+++ b/datahub/mi_dashboard/query_utils.py
@@ -26,15 +26,15 @@ def get_level_of_involvement_simplified_expression():
     return Case(
         When(
             level_of_involvement_id=None,
-            then=Value(IProjectAbstract.INVOLVEMENT.unspecified),
+            then=Value(IProjectAbstract.Involvement.UNSPECIFIED),
         ),
         When(
             level_of_involvement_id=Involvement.no_involvement.value.id,
-            then=Value(IProjectAbstract.INVOLVEMENT.not_involved),
+            then=Value(IProjectAbstract.Involvement.NOT_INVOLVED),
         ),
         When(
             ~Q(level_of_involvement_id=Involvement.no_involvement.value.id),
-            then=Value(IProjectAbstract.INVOLVEMENT.involved),
+            then=Value(IProjectAbstract.Involvement.INVOLVED),
         ),
         output_field=CharField(),
     )

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -36,7 +36,7 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
     status = SingleOrListField(child=serializers.CharField(), required=False)
     uk_region_location = SingleOrListField(child=StringUUIDField(), required=False)
     level_of_involvement_simplified = SingleOrListField(
-        child=serializers.ChoiceField(choices=InvestmentProject.INVOLVEMENT),
+        child=serializers.ChoiceField(choices=InvestmentProject.Involvement.choices),
         required=False,
     )
     gross_value_added_start = serializers.IntegerField(required=False, min_value=0)

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -42,7 +42,7 @@ def project_with_max_gross_value_added():
             project_manager=AdviserFactory(),
             project_assurance_adviser=AdviserFactory(),
             fdi_value_id=constants.FDIValue.higher.value.id,
-            status=InvestmentProject.STATUSES.won,
+            status=InvestmentProject.Status.WON,
             uk_region_locations=[
                 constants.UKRegion.north_west.value.id,
             ],

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -72,7 +72,7 @@ def project_with_max_gross_value_added():
             project_manager=AdviserFactory(),
             project_assurance_adviser=AdviserFactory(),
             fdi_value_id=constants.FDIValue.higher.value.id,
-            status=InvestmentProject.STATUSES.won,
+            status=InvestmentProject.Status.WON,
             uk_region_locations=[
                 constants.UKRegion.north_west.value.id,
             ],
@@ -96,7 +96,7 @@ def setup_data(es_with_collector, project_with_max_gross_value_added):
             investor_company=CompanyFactory(
                 address_country_id=constants.Country.united_states.value.id,
             ),
-            status=InvestmentProject.STATUSES.ongoing,
+            status=InvestmentProject.Status.ONGOING,
             uk_region_locations=[
                 constants.UKRegion.east_midlands.value.id,
                 constants.UKRegion.isle_of_man.value.id,
@@ -118,7 +118,7 @@ def setup_data(es_with_collector, project_with_max_gross_value_added):
             project_manager=AdviserFactory(),
             project_assurance_adviser=AdviserFactory(),
             fdi_value_id=constants.FDIValue.higher.value.id,
-            status=InvestmentProject.STATUSES.delayed,
+            status=InvestmentProject.Status.DELAYED,
             uk_region_locations=[
                 constants.UKRegion.north_west.value.id,
             ],


### PR DESCRIPTION
### Description of change

Following on from https://github.com/uktrade/data-hub-api/pull/2544, this switches investment model fields from using [`model_utils.Choices`](https://django-model-utils.readthedocs.io/en/latest/utilities.html#choices) to [`django.db.models.TextChoices`](https://docs.djangoproject.com/en/3.0/ref/models/fields/#enumeration-types).

See https://github.com/uktrade/data-hub-api/pull/2544 for further background information.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
