### PR TITLE
Use Django TextChoices for remaining model fields

### DIFF
--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -150,7 +150,7 @@ def merge_companies(source_company: Company, target_company: Company, user):
 
     source_company.mark_as_transferred(
         target_company,
-        Company.TRANSFER_REASONS.duplicate,
+        Company.TransferReason.DUPLICATE,
         user,
     )
 

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -55,9 +55,8 @@ class OneListTier(BaseOrderedConstantModel):
 class Company(ArchivableModel, BaseModel):
     """Representation of the company."""
 
-    TRANSFER_REASONS = Choices(
-        ('duplicate', 'Duplicate record'),
-    )
+    class TransferReason(models.TextChoices):
+        DUPLICATE = ('duplicate', 'Duplicate record')
 
     EXPORT_POTENTIAL_SCORES = Choices(
         ('very_high', 'Very High'),
@@ -218,7 +217,7 @@ class Company(ArchivableModel, BaseModel):
     transfer_reason = models.CharField(
         max_length=MAX_LENGTH,
         blank=True,
-        choices=TRANSFER_REASONS,
+        choices=TransferReason.choices,
         help_text='The reason data for this company was transferred.',
     )
     transferred_on = models.DateTimeField(blank=True, null=True)

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -11,7 +11,6 @@ from django.core.validators import (
 )
 from django.db import models
 from django.utils.timezone import now
-from model_utils import Choices
 from mptt.fields import TreeForeignKey
 
 from datahub.core import constants, reversion
@@ -550,11 +549,10 @@ class CompanyExportCountryHistory(models.Model):
     company and/or country.
     """
 
-    HISTORY_TYPES = Choices(
-        ('insert', 'Inserted'),
-        ('update', 'Updated'),
-        ('delete', 'Deleted'),
-    )
+    class HistoryType(models.TextChoices):
+        INSERT = ('insert', 'Inserted')
+        UPDATE = ('update', 'Updated')
+        DELETE = ('delete', 'Deleted')
 
     history_id = models.UUIDField(
         primary_key=True,
@@ -570,7 +568,7 @@ class CompanyExportCountryHistory(models.Model):
     )
     history_type = models.CharField(
         max_length=settings.CHAR_FIELD_MAX_LENGTH,
-        choices=HISTORY_TYPES,
+        choices=HistoryType.choices,
     )
     id = models.UUIDField(db_index=True)
     country = models.ForeignKey(

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -502,11 +502,10 @@ class CompanyExportCountry(BaseModel):
         - future_interest_countries
     """
 
-    EXPORT_INTEREST_STATUSES = Choices(
-        ('not_interested', 'Not interested'),
-        ('currently_exporting', 'Currently exporting to'),
-        ('future_interest', 'Future country of interest'),
-    )
+    class Status(models.TextChoices):
+        NOT_INTERESTED = ('not_interested', 'Not interested')
+        CURRENTLY_EXPORTING = ('currently_exporting', 'Currently exporting to')
+        FUTURE_INTEREST = ('future_interest', 'Future country of interest')
 
     id = models.UUIDField(
         primary_key=True,
@@ -524,7 +523,7 @@ class CompanyExportCountry(BaseModel):
     )
     status = models.CharField(
         max_length=settings.CHAR_FIELD_MAX_LENGTH,
-        choices=EXPORT_INTEREST_STATUSES,
+        choices=Status.choices,
     )
 
     class Meta:
@@ -586,7 +585,7 @@ class CompanyExportCountryHistory(models.Model):
     )
     status = models.CharField(
         max_length=settings.CHAR_FIELD_MAX_LENGTH,
-        choices=CompanyExportCountry.EXPORT_INTEREST_STATUSES,
+        choices=CompanyExportCountry.Status.choices,
     )
 
     class Meta:

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -65,11 +65,11 @@ class Company(ArchivableModel, BaseModel):
         LOW = ('low', 'Low')
         VERY_LOW = ('very_low', 'Very Low')
 
-    GREAT_PROFILE_STATUSES = Choices(
-        ('published', 'Published'),
-        ('unpublished', 'Unpublished'),
-        (None, 'No profile or not known'),
-    )
+    class GreatProfileStatus(models.TextChoices):
+        PUBLISHED = ('published', 'Published')
+        UNPUBLISHED = ('unpublished', 'Unpublished')
+
+        __empty__ = 'No profile or not known'
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     name = models.CharField(max_length=MAX_LENGTH)
@@ -246,7 +246,7 @@ class Company(ArchivableModel, BaseModel):
         max_length=MAX_LENGTH,
         null=True,
         blank=True,
-        choices=GREAT_PROFILE_STATUSES,
+        choices=GreatProfileStatus.choices,
         help_text='Whether this company has a profile and agreed to be published or not',
     )
     global_ultimate_duns_number = models.CharField(

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -58,13 +58,12 @@ class Company(ArchivableModel, BaseModel):
     class TransferReason(models.TextChoices):
         DUPLICATE = ('duplicate', 'Duplicate record')
 
-    EXPORT_POTENTIAL_SCORES = Choices(
-        ('very_high', 'Very High'),
-        ('high', 'High'),
-        ('medium', 'Medium'),
-        ('low', 'Low'),
-        ('very_low', 'Very Low'),
-    )
+    class ExportPotentialScore(models.TextChoices):
+        VERY_HIGH = ('very_high', 'Very High')
+        HIGH = ('high', 'High')
+        MEDIUM = ('medium', 'Medium')
+        LOW = ('low', 'Low')
+        VERY_LOW = ('very_low', 'Very Low')
 
     GREAT_PROFILE_STATUSES = Choices(
         ('published', 'Published'),
@@ -240,7 +239,7 @@ class Company(ArchivableModel, BaseModel):
         max_length=MAX_LENGTH,
         null=True,
         blank=True,
-        choices=EXPORT_POTENTIAL_SCORES,
+        choices=ExportPotentialScore.choices,
         help_text='Score that signifies export potential, imported from Data Science',
     )
     great_profile_status = models.CharField(

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -344,7 +344,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
                 company=instance,
                 adviser=adviser,
                 export_countries=future_interest_countries,
-                status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                status=CompanyExportCountry.Status.FUTURE_INTEREST,
             )
 
         if export_to_countries is not None:
@@ -352,10 +352,10 @@ class CompanySerializer(PermittedFieldsModelSerializer):
                 company=instance,
                 adviser=adviser,
                 export_countries=export_to_countries,
-                status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             )
 
-        not_interested_status = CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested
+        not_interested_status = CompanyExportCountry.Status.NOT_INTERESTED
         CompanyExportCountry.objects.filter(
             company=instance,
         ).exclude(
@@ -768,13 +768,13 @@ class UpdateExportDetailsSerializer(serializers.Serializer):
         """
         currently_exporting_items = CompanyExportCountry.objects.filter(
             company=company,
-            status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+            status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
         )
         exporting_to_countries = [item.country for item in currently_exporting_items]
 
         future_interest_items = CompanyExportCountry.objects.filter(
             company=company,
-            status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+            status=CompanyExportCountry.Status.FUTURE_INTEREST,
         )
         future_interest_countries = [item.country for item in future_interest_items]
 

--- a/datahub/company/signals.py
+++ b/datahub/company/signals.py
@@ -67,9 +67,9 @@ def record_export_country_history_update(sender, instance, created, raw, **kwarg
     if raw:
         return
 
-    action = CompanyExportCountryHistory.HISTORY_TYPES.update
+    action = CompanyExportCountryHistory.HistoryType.UPDATE
     if created:
-        action = CompanyExportCountryHistory.HISTORY_TYPES.insert
+        action = CompanyExportCountryHistory.HistoryType.INSERT
 
     _record_export_country_history(instance, action)
 
@@ -83,7 +83,7 @@ def record_export_country_history_delete(sender, instance, **kwargs):
     """
     Record export country deletions to history.
     """
-    action = CompanyExportCountryHistory.HISTORY_TYPES.delete
+    action = CompanyExportCountryHistory.HistoryType.DELETE
 
     _record_export_country_history(instance, action)
 

--- a/datahub/company/test/admin/merge/test_step_3.py
+++ b/datahub/company/test/admin/merge/test_step_3.py
@@ -244,7 +244,7 @@ class TestConfirmMergeViewPost(AdminTestMixin):
         )
         assert source_company.modified_by == self.user
         assert source_company.modified_on == merge_time
-        assert source_company.transfer_reason == Company.TRANSFER_REASONS.duplicate
+        assert source_company.transfer_reason == Company.TransferReason.DUPLICATE
         assert source_company.transferred_by == self.user
         assert source_company.transferred_on == merge_time
         assert source_company.transferred_to == target_company

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -142,7 +142,7 @@ class DuplicateCompanyFactory(ArchivedCompanyFactory):
     transferred_by = factory.SubFactory(AdviserFactory)
     transferred_on = factory.Faker('past_datetime', tzinfo=utc)
     transferred_to = factory.SubFactory(CompanyFactory)
-    transfer_reason = Company.TRANSFER_REASONS.duplicate
+    transfer_reason = Company.TransferReason.DUPLICATE
 
 
 def _get_random_company_category():

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -212,9 +212,7 @@ class CompanyExportCountryHistoryFactory(factory.django.DjangoModelFactory):
     country = factory.LazyFunction(lambda: random_obj_for_model(Country))
     status = factory.fuzzy.FuzzyChoice(CompanyExportCountry.Status.choices)
     history_user = factory.SubFactory(AdviserFactory)
-    history_type = factory.fuzzy.FuzzyChoice(
-        CompanyExportCountryHistory.HISTORY_TYPES,
-    )
+    history_type = factory.fuzzy.FuzzyChoice(CompanyExportCountryHistory.HistoryType.choices)
 
     class Meta:
         model = 'company.CompanyExportCountryHistory'

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -196,7 +196,7 @@ class CompanyExportCountryFactory(factory.django.DjangoModelFactory):
 
     company = factory.SubFactory(CompanyFactory)
     country = factory.LazyFunction(lambda: random_obj_for_model(Country))
-    status = CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting
+    status = CompanyExportCountry.Status.CURRENTLY_EXPORTING
     created_by = factory.SubFactory(AdviserFactory)
 
     class Meta:
@@ -210,9 +210,7 @@ class CompanyExportCountryHistoryFactory(factory.django.DjangoModelFactory):
     id = factory.LazyFunction(uuid.uuid4)
     company = factory.SubFactory(CompanyFactory)
     country = factory.LazyFunction(lambda: random_obj_for_model(Country))
-    status = factory.fuzzy.FuzzyChoice(
-        CompanyExportCountry.EXPORT_INTEREST_STATUSES,
-    )
+    status = factory.fuzzy.FuzzyChoice(CompanyExportCountry.Status.choices)
     history_user = factory.SubFactory(AdviserFactory)
     history_type = factory.fuzzy.FuzzyChoice(
         CompanyExportCountryHistory.HISTORY_TYPES,

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -1489,11 +1489,11 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         (
             (
                 'export_to_countries',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             ),
             (
                 'future_interest_countries',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                CompanyExportCountry.Status.FUTURE_INTEREST,
             ),
         ),
     )
@@ -1528,11 +1528,11 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         (
             (
                 'export_to_countries',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             ),
             (
                 'future_interest_countries',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                CompanyExportCountry.Status.FUTURE_INTEREST,
             ),
         ),
     )
@@ -1581,11 +1581,11 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         (
             (
                 'export_to_countries',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             ),
             (
                 'future_interest_countries',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                CompanyExportCountry.Status.FUTURE_INTEREST,
             ),
         ),
     )
@@ -1650,14 +1650,14 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
             CompanyExportCountryFactory(
                 country=country,
                 company=company,
-                status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                status=CompanyExportCountry.Status.FUTURE_INTEREST,
             )
 
         for country in initial_export_to_countries:
             CompanyExportCountryFactory(
                 country=country,
                 company=company,
-                status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             )
 
         new_countries = list(CountryModel.objects.order_by('?')[:5])
@@ -1688,14 +1688,14 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
 
         actual_export_to_countries = CompanyExportCountry.objects.filter(
             company=company,
-            status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+            status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
         ).order_by(
             'country__pk',
         )
 
         actual_future_interest_countries = CompanyExportCountry.objects.filter(
             company=company,
-            status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+            status=CompanyExportCountry.Status.FUTURE_INTEREST,
         ).order_by(
             'country__pk',
         )
@@ -1722,7 +1722,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         CompanyExportCountry(
             country=not_interested_country,
             company=company,
-            status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+            status=CompanyExportCountry.Status.NOT_INTERESTED,
         ).save()
 
         new_countries = list(CountryModel.objects.order_by('id')[:5])
@@ -1741,7 +1741,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         )
         assert response.status_code == status.HTTP_200_OK
         not_interested = company.export_countries.filter(
-            status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+            status=CompanyExportCountry.Status.NOT_INTERESTED,
         )
         assert len(not_interested) == 1
         assert not_interested[0].country == not_interested_country
@@ -1872,7 +1872,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
                                 'id': Country.canada.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                                CompanyExportCountry.Status.FUTURE_INTEREST,
                         },
                     ],
                 },
@@ -1911,14 +1911,14 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
                                 'id': Country.canada.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                                CompanyExportCountry.Status.FUTURE_INTEREST,
                         },
                         {
                             'country': {
                                 'id': Country.canada.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+                                CompanyExportCountry.Status.NOT_INTERESTED,
                         },
                     ],
                 },
@@ -1952,7 +1952,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
                                 'id': '1234',
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -1969,7 +1969,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
                                 'id': '4dee26c2-799d-49a8-a533-c30c595c942c',
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -2004,9 +2004,9 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
     def _get_export_interest_status(self):
         """Helper function to randomly select export status"""
         export_interest_statuses = [
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+            CompanyExportCountry.Status.CURRENTLY_EXPORTING,
+            CompanyExportCountry.Status.FUTURE_INTEREST,
+            CompanyExportCountry.Status.NOT_INTERESTED,
         ]
         return random.choice(export_interest_statuses)
 
@@ -2024,7 +2024,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
                         'name': Country.canada.value.name,
                     },
                     'status':
-                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                        CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                 },
             ],
         }
@@ -2036,7 +2036,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         export_countries = company.export_countries.all()
         assert export_countries.count() == 1
         assert str(export_countries[0].country.id) == Country.canada.value.id
-        currently_exporting = CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting
+        currently_exporting = CompanyExportCountry.Status.CURRENTLY_EXPORTING
         assert export_countries[0].status == currently_exporting
 
     def test_update_company_with_export_countries_sync_company_fields(
@@ -2071,11 +2071,11 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
             ] for outer in data_items
         }
         current_countries_request = status_wise_items.get(
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+            CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             [],
         )
         future_countries_request = status_wise_items.get(
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+            CompanyExportCountry.Status.FUTURE_INTEREST,
             [],
         )
 
@@ -2134,11 +2134,11 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
             ] for outer in data_items
         }
         current_countries_request = status_wise_items.get(
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+            CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             [],
         )
         future_countries_request = status_wise_items.get(
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+            CompanyExportCountry.Status.FUTURE_INTEREST,
             [],
         )
 
@@ -2308,7 +2308,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         response_data = response.json()
         response_data['export_countries'].sort(key=lambda item: item['country']['name'])
         current_countries_request = status_wise_items.get(
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+            CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             [],
         )
         current_countries_response = [
@@ -2316,7 +2316,7 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         ]
 
         future_countries_request = status_wise_items.get(
-            CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+            CompanyExportCountry.Status.FUTURE_INTEREST,
             [],
         )
         future_countries_response = [

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -909,7 +909,7 @@ class TestUpdateCompany(APITestMixin):
             number_of_employees=95,
             is_number_of_employees_estimated=False,
             pending_dnb_investigation=True,
-            export_potential=Company.EXPORT_POTENTIAL_SCORES.very_high,
+            export_potential=Company.ExportPotentialScore.VERY_HIGH,
             great_profile_status=Company.GREAT_PROFILE_STATUSES.published,
         )
 
@@ -927,7 +927,7 @@ class TestUpdateCompany(APITestMixin):
                 'number_of_employees': 96,
                 'is_number_of_employees_estimated': True,
                 'pending_dnb_investigation': False,
-                'export_potential': Company.EXPORT_POTENTIAL_SCORES.very_low,
+                'export_potential': Company.ExportPotentialScore.VERY_LOW,
                 'great_profile_status': Company.GREAT_PROFILE_STATUSES.unpublished,
             },
         )
@@ -947,7 +947,7 @@ class TestUpdateCompany(APITestMixin):
         assert response_data['number_of_employees'] == 95
         assert not response_data['is_number_of_employees_estimated']
         assert response_data['pending_dnb_investigation']
-        assert response_data['export_potential'] == Company.EXPORT_POTENTIAL_SCORES.very_high
+        assert response_data['export_potential'] == Company.ExportPotentialScore.VERY_HIGH
         assert response_data['great_profile_status'] == Company.GREAT_PROFILE_STATUSES.published
 
     def test_cannot_update_dnb_readonly_fields_if_duns_number_is_set(self):

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -910,7 +910,7 @@ class TestUpdateCompany(APITestMixin):
             is_number_of_employees_estimated=False,
             pending_dnb_investigation=True,
             export_potential=Company.ExportPotentialScore.VERY_HIGH,
-            great_profile_status=Company.GREAT_PROFILE_STATUSES.published,
+            great_profile_status=Company.GreatProfileStatus.PUBLISHED,
         )
 
         url = reverse('api-v4:company:item', kwargs={'pk': company.pk})
@@ -928,7 +928,7 @@ class TestUpdateCompany(APITestMixin):
                 'is_number_of_employees_estimated': True,
                 'pending_dnb_investigation': False,
                 'export_potential': Company.ExportPotentialScore.VERY_LOW,
-                'great_profile_status': Company.GREAT_PROFILE_STATUSES.unpublished,
+                'great_profile_status': Company.GreatProfileStatus.UNPUBLISHED,
             },
         )
 
@@ -948,7 +948,7 @@ class TestUpdateCompany(APITestMixin):
         assert not response_data['is_number_of_employees_estimated']
         assert response_data['pending_dnb_investigation']
         assert response_data['export_potential'] == Company.ExportPotentialScore.VERY_HIGH
-        assert response_data['great_profile_status'] == Company.GREAT_PROFILE_STATUSES.published
+        assert response_data['great_profile_status'] == Company.GreatProfileStatus.PUBLISHED
 
     def test_cannot_update_dnb_readonly_fields_if_duns_number_is_set(self):
         """
@@ -1383,8 +1383,8 @@ class TestUpdateCompany(APITestMixin):
     @pytest.mark.parametrize(
         'profile_status',
         (
-            Company.GREAT_PROFILE_STATUSES.published,
-            Company.GREAT_PROFILE_STATUSES.unpublished,
+            Company.GreatProfileStatus.PUBLISHED,
+            Company.GreatProfileStatus.UNPUBLISHED,
             None,
         ),
     )

--- a/datahub/company/test/test_merge.py
+++ b/datahub/company/test/test_merge.py
@@ -272,7 +272,7 @@ class TestDuplicateCompanyMerger:
         )
         assert source_company.modified_by == user
         assert source_company.modified_on == merge_time
-        assert source_company.transfer_reason == Company.TRANSFER_REASONS.duplicate
+        assert source_company.transfer_reason == Company.TransferReason.DUPLICATE
         assert source_company.transferred_by == user
         assert source_company.transferred_on == merge_time
         assert source_company.transferred_to == target_company
@@ -350,7 +350,7 @@ class TestDuplicateCompanyMerger:
         )
         assert source_company.modified_by == user
         assert source_company.modified_on == merge_time
-        assert source_company.transfer_reason == Company.TRANSFER_REASONS.duplicate
+        assert source_company.transfer_reason == Company.TransferReason.DUPLICATE
         assert source_company.transferred_by == user
         assert source_company.transferred_on == merge_time
         assert source_company.transferred_to == target_company

--- a/datahub/company/test/test_signals.py
+++ b/datahub/company/test/test_signals.py
@@ -107,7 +107,7 @@ class TestNotifyDNBInvestigationPostSave:
         sets up a corresponding history record.
         """
         export_country = CompanyExportCountryFactory(
-            status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+            status=CompanyExportCountry.Status.FUTURE_INTEREST,
         )
         history = CompanyExportCountryHistory.objects.filter(id=export_country.id)
         assert len(history) == 1
@@ -117,7 +117,7 @@ class TestNotifyDNBInvestigationPostSave:
         assert history[0].status == export_country.status
         assert history[0].history_type == CompanyExportCountryHistory.HISTORY_TYPES.insert
 
-        export_country.status = CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting
+        export_country.status = CompanyExportCountry.Status.CURRENTLY_EXPORTING
         export_country.save()
         history = CompanyExportCountryHistory.objects.filter(
             id=export_country.id,
@@ -126,7 +126,7 @@ class TestNotifyDNBInvestigationPostSave:
         assert history[0].id == export_country.id
         assert history[0].company == export_country.company
         assert history[0].country == export_country.country
-        assert history[0].status == CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest
+        assert history[0].status == CompanyExportCountry.Status.FUTURE_INTEREST
         assert history[0].history_type == CompanyExportCountryHistory.HISTORY_TYPES.insert
         assert history[1].id == export_country.id
         assert history[1].company == export_country.company
@@ -140,7 +140,7 @@ class TestNotifyDNBInvestigationPostSave:
         sets up a corresponding history record.
         """
         export_country = CompanyExportCountryFactory(
-            status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+            status=CompanyExportCountry.Status.FUTURE_INTEREST,
         )
         history = CompanyExportCountryHistory.objects.filter(id=export_country.id)
         assert len(history) == 1
@@ -157,8 +157,8 @@ class TestNotifyDNBInvestigationPostSave:
         ).order_by('history_date')
         assert len(history) == 2
         assert history[0].id == export_country_id
-        assert history[0].status == CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest
+        assert history[0].status == CompanyExportCountry.Status.FUTURE_INTEREST
         assert history[0].history_type == CompanyExportCountryHistory.HISTORY_TYPES.insert
         assert history[1].id == export_country_id
-        assert history[1].status == CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest
+        assert history[1].status == CompanyExportCountry.Status.FUTURE_INTEREST
         assert history[1].history_type == CompanyExportCountryHistory.HISTORY_TYPES.delete

--- a/datahub/company/test/test_signals.py
+++ b/datahub/company/test/test_signals.py
@@ -99,7 +99,7 @@ class TestNotifyDNBInvestigationPostSave:
         assert history[0].company == export_country.company
         assert history[0].country == export_country.country
         assert history[0].status == export_country.status
-        assert history[0].history_type == CompanyExportCountryHistory.HISTORY_TYPES.insert
+        assert history[0].history_type == CompanyExportCountryHistory.HistoryType.INSERT
 
     def test_company_export_country_history_update(self):
         """
@@ -115,7 +115,7 @@ class TestNotifyDNBInvestigationPostSave:
         assert history[0].company == export_country.company
         assert history[0].country == export_country.country
         assert history[0].status == export_country.status
-        assert history[0].history_type == CompanyExportCountryHistory.HISTORY_TYPES.insert
+        assert history[0].history_type == CompanyExportCountryHistory.HistoryType.INSERT
 
         export_country.status = CompanyExportCountry.Status.CURRENTLY_EXPORTING
         export_country.save()
@@ -127,12 +127,12 @@ class TestNotifyDNBInvestigationPostSave:
         assert history[0].company == export_country.company
         assert history[0].country == export_country.country
         assert history[0].status == CompanyExportCountry.Status.FUTURE_INTEREST
-        assert history[0].history_type == CompanyExportCountryHistory.HISTORY_TYPES.insert
+        assert history[0].history_type == CompanyExportCountryHistory.HistoryType.INSERT
         assert history[1].id == export_country.id
         assert history[1].company == export_country.company
         assert history[1].country == export_country.country
         assert history[1].status == export_country.status
-        assert history[1].history_type == CompanyExportCountryHistory.HISTORY_TYPES.update
+        assert history[1].history_type == CompanyExportCountryHistory.HistoryType.UPDATE
 
     def test_company_export_country_history_delete(self):
         """
@@ -148,7 +148,7 @@ class TestNotifyDNBInvestigationPostSave:
         assert history[0].company == export_country.company
         assert history[0].country == export_country.country
         assert history[0].status == export_country.status
-        assert history[0].history_type == CompanyExportCountryHistory.HISTORY_TYPES.insert
+        assert history[0].history_type == CompanyExportCountryHistory.HistoryType.INSERT
 
         export_country_id = export_country.id
         export_country.delete()
@@ -158,7 +158,7 @@ class TestNotifyDNBInvestigationPostSave:
         assert len(history) == 2
         assert history[0].id == export_country_id
         assert history[0].status == CompanyExportCountry.Status.FUTURE_INTEREST
-        assert history[0].history_type == CompanyExportCountryHistory.HISTORY_TYPES.insert
+        assert history[0].history_type == CompanyExportCountryHistory.HistoryType.INSERT
         assert history[1].id == export_country_id
         assert history[1].status == CompanyExportCountry.Status.FUTURE_INTEREST
-        assert history[1].history_type == CompanyExportCountryHistory.HISTORY_TYPES.delete
+        assert history[1].history_type == CompanyExportCountryHistory.HistoryType.DELETE

--- a/datahub/dataset/investment_project/test/test_views.py
+++ b/datahub/dataset/investment_project/test/test_views.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def ist_adviser():
     """Provides IST adviser."""
-    team = TeamFactory(tags=[Team.TAGS.investment_services_team])
+    team = TeamFactory(tags=[Team.Tag.INVESTMENT_SERVICES_TEAM])
     yield AdviserFactory(dit_team_id=team.id)
 
 

--- a/datahub/dbmaintenance/management/commands/update_company_export_potential.py
+++ b/datahub/dbmaintenance/management/commands/update_company_export_potential.py
@@ -25,7 +25,7 @@ class Command(CSVBaseCommand):
 
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
-        score_dict = {value.lower(): key for key, value in Company.EXPORT_POTENTIAL_SCORES}
+        score_dict = {value.lower(): key for key, value in Company.ExportPotentialScore.choices}
 
         pk = parse_uuid(row['datahub_company_id'])
         company = Company.objects.get(pk=pk)

--- a/datahub/dbmaintenance/management/commands/update_company_great_profile_status.py
+++ b/datahub/dbmaintenance/management/commands/update_company_great_profile_status.py
@@ -34,9 +34,9 @@ class Command(CSVBaseCommand):
 
         profile_status = None
         if has_profile and is_published:
-            profile_status = Company.GREAT_PROFILE_STATUSES.published
+            profile_status = Company.GreatProfileStatus.PUBLISHED
         elif has_profile:
-            profile_status = Company.GREAT_PROFILE_STATUSES.unpublished
+            profile_status = Company.GreatProfileStatus.UNPUBLISHED
 
         if company.great_profile_status == profile_status:
             return

--- a/datahub/dbmaintenance/test/commands/test_update_company_export_potential.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_export_potential.py
@@ -21,11 +21,11 @@ def test_run(s3_stubber, caplog):
 
     with freeze_time(original_datetime):
         export_potential_scores = [
-            Company.EXPORT_POTENTIAL_SCORES.very_high,
-            Company.EXPORT_POTENTIAL_SCORES.medium,
-            Company.EXPORT_POTENTIAL_SCORES.low,
-            Company.EXPORT_POTENTIAL_SCORES.very_high,
-            Company.EXPORT_POTENTIAL_SCORES.high,
+            Company.ExportPotentialScore.VERY_HIGH,
+            Company.ExportPotentialScore.MEDIUM,
+            Company.ExportPotentialScore.LOW,
+            Company.ExportPotentialScore.VERY_HIGH,
+            Company.ExportPotentialScore.HIGH,
         ]
         companies = CompanyFactory.create_batch(
             5,
@@ -65,11 +65,11 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 2
 
     assert [company.export_potential for company in companies] == [
-        Company.EXPORT_POTENTIAL_SCORES.high,
-        Company.EXPORT_POTENTIAL_SCORES.very_high,
-        Company.EXPORT_POTENTIAL_SCORES.low,
-        Company.EXPORT_POTENTIAL_SCORES.high,
-        Company.EXPORT_POTENTIAL_SCORES.very_high,
+        Company.ExportPotentialScore.HIGH,
+        Company.ExportPotentialScore.VERY_HIGH,
+        Company.ExportPotentialScore.LOW,
+        Company.ExportPotentialScore.HIGH,
+        Company.ExportPotentialScore.VERY_HIGH,
     ]
     assert all(company.modified_on == original_datetime for company in companies)
 
@@ -79,11 +79,11 @@ def test_simulate(s3_stubber, caplog):
     caplog.set_level('ERROR')
 
     export_potential_scores = [
-        Company.EXPORT_POTENTIAL_SCORES.very_high,
-        Company.EXPORT_POTENTIAL_SCORES.medium,
-        Company.EXPORT_POTENTIAL_SCORES.low,
-        Company.EXPORT_POTENTIAL_SCORES.very_high,
-        Company.EXPORT_POTENTIAL_SCORES.high,
+        Company.ExportPotentialScore.VERY_HIGH,
+        Company.ExportPotentialScore.MEDIUM,
+        Company.ExportPotentialScore.LOW,
+        Company.ExportPotentialScore.VERY_HIGH,
+        Company.ExportPotentialScore.HIGH,
     ]
     companies = CompanyFactory.create_batch(
         5,
@@ -126,10 +126,10 @@ def test_simulate(s3_stubber, caplog):
 def test_audit_log(s3_stubber):
     """Test that reversion revisions are created."""
     company_without_change = CompanyFactory(
-        export_potential=Company.EXPORT_POTENTIAL_SCORES.high,
+        export_potential=Company.ExportPotentialScore.HIGH,
     )
     company_with_change = CompanyFactory(
-        export_potential=Company.EXPORT_POTENTIAL_SCORES.medium,
+        export_potential=Company.ExportPotentialScore.MEDIUM,
     )
 
     bucket = 'test_bucket'
@@ -153,12 +153,12 @@ def test_audit_log(s3_stubber):
     call_command('update_company_export_potential', bucket, object_key)
 
     company_without_change.refresh_from_db()
-    assert company_without_change.export_potential == Company.EXPORT_POTENTIAL_SCORES.high
+    assert company_without_change.export_potential == Company.ExportPotentialScore.HIGH
     versions = Version.objects.get_for_object(company_without_change)
     assert versions.count() == 0
 
     company_with_change.refresh_from_db()
-    assert company_with_change.export_potential == Company.EXPORT_POTENTIAL_SCORES.very_high
+    assert company_with_change.export_potential == Company.ExportPotentialScore.VERY_HIGH
     versions = Version.objects.get_for_object(company_with_change)
     assert versions.count() == 1
     assert versions[0].revision.get_comment() == 'Export potential updated.'

--- a/datahub/dbmaintenance/test/commands/test_update_company_great_profile_status.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_great_profile_status.py
@@ -20,12 +20,12 @@ def test_run(s3_stubber, caplog):
     original_datetime = datetime(2017, 1, 1, tzinfo=timezone.utc)
     with freeze_time(original_datetime):
         profile_statuses = [
-            Company.GREAT_PROFILE_STATUSES.unpublished,
+            Company.GreatProfileStatus.UNPUBLISHED,
             None,
-            Company.GREAT_PROFILE_STATUSES.published,
-            Company.GREAT_PROFILE_STATUSES.published,
-            Company.GREAT_PROFILE_STATUSES.unpublished,
-            Company.GREAT_PROFILE_STATUSES.published,
+            Company.GreatProfileStatus.PUBLISHED,
+            Company.GreatProfileStatus.PUBLISHED,
+            Company.GreatProfileStatus.UNPUBLISHED,
+            Company.GreatProfileStatus.PUBLISHED,
         ]
         companies = CompanyFactory.create_batch(
             6,
@@ -66,12 +66,12 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 2
 
     assert [company.great_profile_status for company in companies] == [
-        Company.GREAT_PROFILE_STATUSES.published,
-        Company.GREAT_PROFILE_STATUSES.unpublished,
+        Company.GreatProfileStatus.PUBLISHED,
+        Company.GreatProfileStatus.UNPUBLISHED,
         None,
         None,
-        Company.GREAT_PROFILE_STATUSES.unpublished,
-        Company.GREAT_PROFILE_STATUSES.published,
+        Company.GreatProfileStatus.UNPUBLISHED,
+        Company.GreatProfileStatus.PUBLISHED,
     ]
     assert all(company.modified_on == original_datetime for company in companies)
 
@@ -81,11 +81,11 @@ def test_simulate(s3_stubber, caplog):
     caplog.set_level('ERROR')
 
     profile_statuses = [
-        Company.GREAT_PROFILE_STATUSES.unpublished,
+        Company.GreatProfileStatus.UNPUBLISHED,
         None,
-        Company.GREAT_PROFILE_STATUSES.published,
-        Company.GREAT_PROFILE_STATUSES.published,
-        Company.GREAT_PROFILE_STATUSES.unpublished,
+        Company.GreatProfileStatus.PUBLISHED,
+        Company.GreatProfileStatus.PUBLISHED,
+        Company.GreatProfileStatus.UNPUBLISHED,
     ]
     companies = CompanyFactory.create_batch(
         5,
@@ -128,10 +128,10 @@ def test_simulate(s3_stubber, caplog):
 def test_audit_log(s3_stubber):
     """Test that reversion revisions are created."""
     company_without_change = CompanyFactory(
-        great_profile_status=Company.GREAT_PROFILE_STATUSES.published,
+        great_profile_status=Company.GreatProfileStatus.PUBLISHED,
     )
     company_with_change = CompanyFactory(
-        great_profile_status=Company.GREAT_PROFILE_STATUSES.unpublished,
+        great_profile_status=Company.GreatProfileStatus.UNPUBLISHED,
     )
 
     bucket = 'test_bucket'
@@ -155,12 +155,12 @@ def test_audit_log(s3_stubber):
     call_command('update_company_great_profile_status', bucket, object_key)
 
     company_without_change.refresh_from_db()
-    assert company_without_change.great_profile_status == Company.GREAT_PROFILE_STATUSES.published
+    assert company_without_change.great_profile_status == Company.GreatProfileStatus.PUBLISHED
     versions = Version.objects.get_for_object(company_without_change)
     assert versions.count() == 0
 
     company_with_change.refresh_from_db()
-    assert company_with_change.great_profile_status == Company.GREAT_PROFILE_STATUSES.published
+    assert company_with_change.great_profile_status == Company.GreatProfileStatus.PUBLISHED
     versions = Version.objects.get_for_object(company_with_change)
     assert versions.count() == 1
     assert versions[0].revision.get_comment() == 'GREAT profile status updated.'

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -352,7 +352,7 @@ class Interaction(ArchivableModel, BaseModel):
 class InteractionExportCountry(BaseModel):
     """
     Record `Interaction`'s exporting status to a `Country`.
-    Where `Status` is `CompanyExportCountry.EXPORT_INTEREST_STATUSES`
+    Where `status` is `CompanyExportCountry.Status`
 
     This data will help consolidate company level countries
     in `company.CompanyExportCountry`
@@ -374,7 +374,7 @@ class InteractionExportCountry(BaseModel):
     )
     status = models.CharField(
         max_length=settings.CHAR_FIELD_MAX_LENGTH,
-        choices=CompanyExportCountry.EXPORT_INTEREST_STATUSES,
+        choices=CompanyExportCountry.Status.choices,
     )
 
     class Meta:

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -185,7 +185,7 @@ class InteractionExportCountryFactory(factory.django.DjangoModelFactory):
 
     interaction = factory.SubFactory(CompanyInteractionFactory)
     country = factory.LazyFunction(lambda: random_obj_for_model(Country))
-    status = factory.Iterator(tuple(CompanyExportCountry.EXPORT_INTEREST_STATUSES._db_values))
+    status = factory.Iterator(CompanyExportCountry.Status.values)
     created_on = now()
     created_by = factory.SubFactory(AdviserFactory)
 

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -216,7 +216,7 @@ class TestAddInteraction(APITestMixin):
                             'name': Country.canada.value.name,
                         },
                         'status':
-                            CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                            CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                     },
                 ],
             },
@@ -230,7 +230,7 @@ class TestAddInteraction(APITestMixin):
                             'name': Country.canada.value.name,
                         },
                         'status':
-                            CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                            CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                     },
                 ],
             },
@@ -385,7 +385,7 @@ class TestAddInteraction(APITestMixin):
                         'id': Country.canada.value.id,
                     },
                     'status':
-                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                        CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                 },
             ],
         }
@@ -398,7 +398,7 @@ class TestAddInteraction(APITestMixin):
         export_countries = company.export_countries.all()
         assert export_countries.count() == 1
         assert str(export_countries[0].country.id) == Country.canada.value.id
-        currently_exporting = CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting
+        currently_exporting = CompanyExportCountry.Status.CURRENTLY_EXPORTING
         assert export_countries[0].status == currently_exporting
 
     @freeze_time('2017-04-18 13:25:30.986208')
@@ -410,27 +410,27 @@ class TestAddInteraction(APITestMixin):
             (
                 '2017-01-18',
                 '2017-04-18',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             ),
             # past dated interaction can't override existing newer status
             (
                 '2017-03-18',
                 '2017-02-18',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+                CompanyExportCountry.Status.NOT_INTERESTED,
             ),
             # future dated interaction, will be treated as current
             # and can't override existing much newer status
             (
                 '2017-05-18',
                 '2018-02-18',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+                CompanyExportCountry.Status.NOT_INTERESTED,
             ),
             # future dated interaction, will be treated as current
             # and will override existing older status
             (
                 '2017-03-18',
                 '2018-02-18',
-                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             ),
         ),
     )
@@ -453,7 +453,7 @@ class TestAddInteraction(APITestMixin):
                 CompanyExportCountryFactory(
                     company=company,
                     country=meta_models.Country.objects.get(id=Country.canada.value.id),
-                    status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+                    status=CompanyExportCountry.Status.NOT_INTERESTED,
                 ),
             ])
         contact = ContactFactory(company=company)
@@ -480,7 +480,7 @@ class TestAddInteraction(APITestMixin):
                         'id': Country.canada.value.id,
                     },
                     'status':
-                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                        CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                 },
             ],
         }
@@ -704,7 +704,7 @@ class TestAddInteraction(APITestMixin):
                                 'id': Country.canada.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -767,14 +767,14 @@ class TestAddInteraction(APITestMixin):
                                 'id': Country.canada.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                         {
                             'country': {
                                 'id': Country.canada.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                                CompanyExportCountry.Status.FUTURE_INTEREST,
                         },
                     ],
                 },
@@ -805,7 +805,7 @@ class TestAddInteraction(APITestMixin):
                     'export_countries': [
                         {
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -903,7 +903,7 @@ class TestAddInteraction(APITestMixin):
                                 'id': '1234',
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -937,7 +937,7 @@ class TestAddInteraction(APITestMixin):
                                 'id': '4dee26c2-799d-49a8-a533-c30c595c942c',
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -979,7 +979,7 @@ class TestAddInteraction(APITestMixin):
                                 'id': Country.canada.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -1267,7 +1267,7 @@ class TestAddInteraction(APITestMixin):
                         'id': Country.canada.value.id,
                     },
                     'status':
-                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                        CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                 },
             ],
         }
@@ -1868,7 +1868,7 @@ class TestUpdateInteraction(APITestMixin):
                                 'id': Country.greece.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -1885,7 +1885,7 @@ class TestUpdateInteraction(APITestMixin):
                                 'id': Country.greece.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -1942,7 +1942,7 @@ class TestUpdateInteraction(APITestMixin):
                                 'id': Country.greece.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -1959,7 +1959,7 @@ class TestUpdateInteraction(APITestMixin):
                                 'id': Country.greece.value.id,
                             },
                             'status':
-                                CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                                CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                         },
                     ],
                 },
@@ -1983,7 +1983,7 @@ class TestUpdateInteraction(APITestMixin):
         requester = create_test_user(permission_codenames=permissions)
         interaction = ExportCountriesInteractionFactory(
             export_countries__country_id=Country.canada.value.id,
-            export_countries__status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.not_interested,
+            export_countries__status=CompanyExportCountry.Status.NOT_INTERESTED,
         )
 
         assert len(Interaction.objects.get(pk=interaction.pk).export_countries.all()) > 0

--- a/datahub/investment/project/evidence/test/test_views.py
+++ b/datahub/investment/project/evidence/test/test_views.py
@@ -16,7 +16,8 @@ from datahub.investment.project.evidence.models import EvidenceDocument, Evidenc
 from datahub.investment.project.evidence.test.factories import EvidenceTagFactory
 from datahub.investment.project.evidence.test.utils import create_evidence_document
 from datahub.investment.project.test.factories import InvestmentProjectFactory
-from datahub.user_event_log.models import USER_EVENT_TYPES, UserEvent
+from datahub.user_event_log.constants import UserEventType
+from datahub.user_event_log.models import UserEvent
 
 pytestmark = pytest.mark.django_db
 
@@ -714,7 +715,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         user_event.data['tags'].sort(key=itemgetter('id'))
 
         assert user_event.adviser == user
-        assert user_event.type == USER_EVENT_TYPES.evidence_document_delete
+        assert user_event.type == UserEventType.EVIDENCE_DOCUMENT_DELETE
         assert user_event.timestamp == frozen_time
         assert user_event.api_url_path == url
         assert user_event.data == expected_user_event_data

--- a/datahub/investment/project/evidence/views.py
+++ b/datahub/investment/project/evidence/views.py
@@ -11,7 +11,7 @@ from datahub.investment.project.evidence.permissions import (
 from datahub.investment.project.evidence.serializers import EvidenceDocumentSerializer
 from datahub.investment.project.models import InvestmentProject
 from datahub.oauth.scopes import Scope
-from datahub.user_event_log.constants import USER_EVENT_TYPES
+from datahub.user_event_log.constants import UserEventType
 from datahub.user_event_log.utils import record_user_event
 
 
@@ -63,5 +63,5 @@ class EvidenceDocumentViewSet(BaseEntityDocumentModelViewSet):
         """Record delete event."""
         entity_document = self.get_object()
         data = self.serializer_class(entity_document).data
-        record_user_event(request, USER_EVENT_TYPES.evidence_document_delete, data=data)
+        record_user_event(request, UserEventType.EVIDENCE_DOCUMENT_DELETE, data=data)
         return super().destroy(request, *args, **kwargs)

--- a/datahub/investment/project/proposition/test/test_views.py
+++ b/datahub/investment/project/proposition/test/test_views.py
@@ -22,7 +22,8 @@ from datahub.investment.project.proposition.models import (
 from datahub.investment.project.proposition.test.factories import PropositionFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import TeamFactory
-from datahub.user_event_log.models import USER_EVENT_TYPES, UserEvent
+from datahub.user_event_log.constants import UserEventType
+from datahub.user_event_log.models import UserEvent
 
 NON_RESTRICTED_VIEW_PERMISSIONS = (
     (
@@ -2255,7 +2256,7 @@ class TestPropositionDocumentViews(APITestMixin):
 
         user_event = UserEvent.objects.first()
         assert user_event.adviser == user
-        assert user_event.type == USER_EVENT_TYPES.proposition_document_delete
+        assert user_event.type == UserEventType.PROPOSITION_DOCUMENT_DELETE
         assert user_event.timestamp == frozen_time
         assert user_event.api_url_path == url
         assert user_event.data == expected_user_event_data

--- a/datahub/investment/project/proposition/views.py
+++ b/datahub/investment/project/proposition/views.py
@@ -25,7 +25,7 @@ from datahub.investment.project.proposition.serializers import (
     PropositionSerializer,
 )
 from datahub.oauth.scopes import Scope
-from datahub.user_event_log.constants import USER_EVENT_TYPES
+from datahub.user_event_log.constants import UserEventType
 from datahub.user_event_log.utils import record_user_event
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -187,5 +187,5 @@ class PropositionDocumentViewSet(BaseEntityDocumentModelViewSet):
         entity_document = self.get_object()
         data = self.serializer_class(entity_document).data
         data['proposition_id'] = entity_document.proposition_id
-        record_user_event(request, USER_EVENT_TYPES.proposition_document_delete, data=data)
+        record_user_event(request, UserEventType.PROPOSITION_DOCUMENT_DELETE, data=data)
         return super().destroy(request, *args, **kwargs)

--- a/datahub/investment/project/report/spi.py
+++ b/datahub/investment/project/report/spi.py
@@ -145,7 +145,7 @@ class SPIReport:
         return (
             project_manager
             and project_manager.dit_team
-            and Team.TAGS.investment_services_team in project_manager.dit_team.tags
+            and Team.Tag.INVESTMENT_SERVICES_TEAM in project_manager.dit_team.tags
         )
 
     def _find_when_project_moved_to_won(self, investment_project):

--- a/datahub/investment/project/report/test/test_spi.py
+++ b/datahub/investment/project/report/test/test_spi.py
@@ -32,7 +32,7 @@ def spi_report():
 @pytest.fixture
 def ist_adviser():
     """Provides IST adviser."""
-    team = TeamFactory(tags=[Team.TAGS.investment_services_team])
+    team = TeamFactory(tags=[Team.Tag.INVESTMENT_SERVICES_TEAM])
     yield AdviserFactory(dit_team_id=team.id)
 
 

--- a/datahub/metadata/models.py
+++ b/datahub/metadata/models.py
@@ -152,9 +152,8 @@ class Team(BaseConstantModel):
         Comments: For when filtering by name__iexact
     """
 
-    TAGS = Choices(
-        ('investment_services_team', 'Investment Services Team'),
-    )
+    class Tag(models.TextChoices):
+        INVESTMENT_SERVICES_TEAM = ('investment_services_team', 'Investment Services Team')
 
     role = models.ForeignKey(
         TeamRole,
@@ -176,7 +175,7 @@ class Team(BaseConstantModel):
     )
     tags = MultipleChoiceField(
         max_length=settings.CHAR_FIELD_MAX_LENGTH,
-        choices=TAGS,
+        choices=Tag.choices,
         blank=True,
     )
 

--- a/datahub/metadata/models.py
+++ b/datahub/metadata/models.py
@@ -6,7 +6,6 @@ from django.contrib.postgres.indexes import GinIndex
 from django.db import models
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
-from model_utils import Choices
 from mptt.models import MPTTModel, TreeForeignKey
 
 from datahub.core.exceptions import DataHubException
@@ -218,28 +217,30 @@ class Service(MPTTModel, _MPTTObjectName, BaseOrderedConstantModel):
     Export Win
     """
 
-    CONTEXTS = Choices(
+    class Context(models.TextChoices):
         # Services that can be attached to an event
-        ('event', 'Event'),
+        EVENT = ('event', 'Event')
         # For interactions added to a company that are about export
-        ('export_interaction', 'Export interaction'),
+        EXPORT_INTERACTION = ('export_interaction', 'Export interaction')
         # For service deliveries added to a company that are about export
-        ('export_service_delivery', 'Export service delivery'),
+        EXPORT_SERVICE_DELIVERY = ('export_service_delivery', 'Export service delivery')
         # For interactions added to a company about investment (but not a
         # specific investment project)
-        ('investment_interaction', 'Investment interaction'),
+        INVESTMENT_INTERACTION = ('investment_interaction', 'Investment interaction')
         # For interactions added to a particular investment project
-        ('investment_project_interaction', 'Investment project interaction'),
+        INVESTMENT_PROJECT_INTERACTION = (
+            'investment_project_interaction',
+            'Investment project interaction',
+        )
         # For interactions added to a company that are about not about export or investment
-        ('other_interaction', 'Other interaction'),
+        OTHER_INTERACTION = ('other_interaction', 'Other interaction')
         # For service deliveries added to a company that are about not about export or investment
-        ('other_service_delivery', 'Other service delivery'),
+        OTHER_SERVICE_DELIVERY = ('other_service_delivery', 'Other service delivery')
 
         # TODO: Deprecated contexts  – remove once the front end has been updated to use
         # other contexts
-        ('interaction', 'Interaction (deprecated)'),
-        ('service_delivery', 'Service delivery (deprecated)'),
-    )
+        INTERACTION = ('interaction', 'Interaction (deprecated)')
+        SERVICE_DELIVERY = ('service_delivery', 'Service delivery (deprecated)')
 
     segment = models.CharField(max_length=settings.CHAR_FIELD_MAX_LENGTH)
 
@@ -253,7 +254,7 @@ class Service(MPTTModel, _MPTTObjectName, BaseOrderedConstantModel):
 
     contexts = MultipleChoiceField(
         max_length=settings.CHAR_FIELD_MAX_LENGTH,
-        choices=CONTEXTS,
+        choices=Context.choices,
         blank=True,
         help_text='Contexts are only valid on leaf nodes.',
     )

--- a/datahub/metadata/serializers.py
+++ b/datahub/metadata/serializers.py
@@ -69,7 +69,7 @@ class ServiceQuestionSerializer(serializers.ModelSerializer):
 class ServiceSerializer(ConstantModelSerializer):
     """Service serializer."""
 
-    contexts = serializers.MultipleChoiceField(choices=Service.CONTEXTS, read_only=True)
+    contexts = serializers.MultipleChoiceField(choices=Service.Context.choices, read_only=True)
     interaction_questions = ServiceQuestionSerializer(many=True, read_only=True)
 
 

--- a/datahub/metadata/test/factories.py
+++ b/datahub/metadata/test/factories.py
@@ -13,8 +13,8 @@ class ServiceFactory(factory.django.DjangoModelFactory):
 
     contexts = factory.LazyFunction(
         lambda: sample(
-            Service.CONTEXTS._db_values,
-            randrange(0, len(Service.CONTEXTS._db_values)),
+            Service.Context.values,
+            randrange(0, len(Service.Context.values)),
         ),
     )
 
@@ -29,8 +29,8 @@ class ChildServiceFactory(factory.django.DjangoModelFactory):
     parent = factory.SubFactory(ServiceFactory)
     contexts = factory.LazyFunction(
         lambda: sample(
-            Service.CONTEXTS._db_values,
-            randrange(0, len(Service.CONTEXTS._db_values)),
+            Service.Context.values,
+            randrange(0, len(Service.Context.values)),
         ),
     )
 

--- a/datahub/metadata/test/test_admin.py
+++ b/datahub/metadata/test/test_admin.py
@@ -14,13 +14,13 @@ from datahub.metadata.test.factories import ServiceFactory
 class TestServiceAdmin:
     """Tests for ServiceAdmin."""
 
-    @pytest.mark.parametrize('context', (Service.CONTEXTS.interaction, Service.CONTEXTS.event))
+    @pytest.mark.parametrize('context', (Service.Context.INTERACTION, Service.Context.EVENT))
     def test_context_filter(self, context):
         """Tests filtering by context."""
         test_data_contexts = (
-            [Service.CONTEXTS.interaction],
-            [Service.CONTEXTS.service_delivery],
-            [Service.CONTEXTS.interaction, Service.CONTEXTS.service_delivery],
+            [Service.Context.INTERACTION],
+            [Service.Context.SERVICE_DELIVERY],
+            [Service.Context.INTERACTION, Service.Context.SERVICE_DELIVERY],
         )
         ServiceFactory.create_batch(
             len(test_data_contexts),

--- a/datahub/metadata/test/test_views.py
+++ b/datahub/metadata/test/test_views.py
@@ -266,17 +266,17 @@ class TestServiceView:
     @pytest.mark.parametrize(
         'contexts',
         (
-            [Service.CONTEXTS.export_interaction],
+            [Service.Context.EXPORT_INTERACTION],
             ['non-existent-context'],
-            [Service.CONTEXTS.export_interaction, Service.CONTEXTS.export_service_delivery],
+            [Service.Context.EXPORT_INTERACTION, Service.Context.EXPORT_SERVICE_DELIVERY],
         ),
     )
     def test_list_filter_by_has_any(self, metadata_client, contexts):
         """Test listing services, filtered by context."""
         test_data_contexts = (
-            [Service.CONTEXTS.export_interaction],
-            [Service.CONTEXTS.export_service_delivery],
-            [Service.CONTEXTS.export_interaction, Service.CONTEXTS.export_service_delivery],
+            [Service.Context.EXPORT_INTERACTION],
+            [Service.Context.EXPORT_SERVICE_DELIVERY],
+            [Service.Context.EXPORT_INTERACTION, Service.Context.EXPORT_SERVICE_DELIVERY],
         )
 
         ServiceFactory.create_batch(

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -137,11 +137,11 @@ class Company(BaseESModel):
         ),
         'export_to_countries': lambda obj: [
             dict_utils.id_name_dict(o.country) for o in obj.export_countries.all()
-            if o.status == CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting
+            if o.status == CompanyExportCountry.Status.CURRENTLY_EXPORTING
         ],
         'future_interest_countries': lambda obj: [
             dict_utils.id_name_dict(o.country) for o in obj.export_countries.all()
-            if o.status == CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest
+            if o.status == CompanyExportCountry.Status.FUTURE_INTEREST
         ],
         'latest_interaction_date': lambda obj: obj.latest_interaction_date,
         'uk_address_postcode': lambda obj: obj.address_postcode if obj.uk_based else '',

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -63,19 +63,19 @@ def setup_data(es_with_collector):
     CompanyExportCountryFactory(
         company=company1,
         country_id=constants.Country.france.value.id,
-        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+        status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
     )
 
     CompanyExportCountryFactory(
         company=company1,
         country_id=constants.Country.japan.value.id,
-        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+        status=CompanyExportCountry.Status.FUTURE_INTEREST,
     )
 
     CompanyExportCountryFactory(
         company=company1,
         country_id=constants.Country.united_states.value.id,
-        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+        status=CompanyExportCountry.Status.FUTURE_INTEREST,
     )
 
     company2 = CompanyFactory(
@@ -90,19 +90,19 @@ def setup_data(es_with_collector):
     CompanyExportCountryFactory(
         company=company2,
         country_id=constants.Country.canada.value.id,
-        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+        status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
     )
 
     CompanyExportCountryFactory(
         company=company2,
         country_id=constants.Country.france.value.id,
-        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+        status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
     )
 
     CompanyExportCountryFactory(
         company=company2,
         country_id=constants.Country.japan.value.id,
-        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+        status=CompanyExportCountry.Status.FUTURE_INTEREST,
     )
 
     CompanyFactory(
@@ -991,9 +991,9 @@ class TestCompanyExportView(APITestMixin):
                 ),
                 status=factory.Iterator(
                     [
-                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
-                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
-                        CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                        CompanyExportCountry.Status.CURRENTLY_EXPORTING,
+                        CompanyExportCountry.Status.FUTURE_INTEREST,
+                        CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                     ],
                 ),
             )
@@ -1029,12 +1029,12 @@ class TestCompanyExportView(APITestMixin):
                 'UK region': get_attr_or_none(company, 'uk_region.name'),
                 'Countries exported to': ', '.join([
                     e.country.name for e in company.export_countries.filter(
-                        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.currently_exporting,
+                        status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                     ).order_by('country__name')
                 ]),
                 'Countries of interest':', '.join([
                     e.country.name for e in company.export_countries.filter(
-                        status=CompanyExportCountry.EXPORT_INTEREST_STATUSES.future_interest,
+                        status=CompanyExportCountry.Status.FUTURE_INTEREST,
                     ).order_by('country__name')
                 ]),
                 'Archived': company.archived,

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -189,8 +189,7 @@ class SearchCompanyExportAPIView(SearchCompanyAPIViewMixin, SearchExportAPIView)
             DBCompany,
             Case(
                 When(
-                    export_countries__status=CompanyExportCountry
-                    .EXPORT_INTEREST_STATUSES.currently_exporting,
+                    export_countries__status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                     then='export_countries__country__name',
                 ),
             ),
@@ -199,8 +198,7 @@ class SearchCompanyExportAPIView(SearchCompanyAPIViewMixin, SearchExportAPIView)
             DBCompany,
             Case(
                 When(
-                    export_countries__status=CompanyExportCountry
-                    .EXPORT_INTEREST_STATUSES.future_interest,
+                    export_countries__status=CompanyExportCountry.Status.FUTURE_INTEREST,
                     then='export_countries__country__name',
                 ),
             ),

--- a/datahub/search/export_country_history/test/test_signals.py
+++ b/datahub/search/export_country_history/test/test_signals.py
@@ -22,9 +22,9 @@ def test_new_export_country_history_synced(es_with_signals):
 def test_updated_interaction_synced(es_with_signals):
     """Test that when export country history is updated, it is synced to ES."""
     export_country_history = CompanyExportCountryHistoryFactory(
-        history_type=CompanyExportCountryHistory.HISTORY_TYPES.insert,
+        history_type=CompanyExportCountryHistory.HistoryType.INSERT,
     )
-    history_type = CompanyExportCountryHistory.HISTORY_TYPES.update
+    history_type = CompanyExportCountryHistory.HistoryType.UPDATE
     export_country_history.history_type = history_type
     export_country_history.save()
     es_with_signals.indices.refresh()

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -16,7 +16,7 @@ from datahub.omis.order.test.factories import OrderFactory
 from datahub.search.sync_object import sync_object
 from datahub.search.test.search_support.models import RelatedModel, SimpleModel
 from datahub.search.test.search_support.simplemodel import SimpleModelSearchApp
-from datahub.user_event_log.constants import USER_EVENT_TYPES
+from datahub.user_event_log.constants import UserEventType
 from datahub.user_event_log.models import UserEvent
 
 pytestmark = pytest.mark.django_db
@@ -515,7 +515,7 @@ class TestSearchExportAPIView(APITestMixin):
 
         user_event = UserEvent.objects.first()
         assert user_event.adviser == user
-        assert user_event.type == USER_EVENT_TYPES.search_export
+        assert user_event.type == UserEventType.SEARCH_EXPORT
         assert user_event.timestamp == frozen_time
         assert user_event.api_url_path == '/v3/search/simplemodel/export'
         assert user_event.data == {

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -33,7 +33,7 @@ from datahub.search.serializers import (
     EntitySearchQuerySerializer,
 )
 from datahub.search.utils import SearchOrdering
-from datahub.user_event_log.constants import USER_EVENT_TYPES
+from datahub.user_event_log.constants import UserEventType
 from datahub.user_event_log.utils import record_user_event
 
 
@@ -269,7 +269,7 @@ class SearchExportAPIView(SearchAPIView):
             'args': validated_data,
         }
 
-        record_user_event(request, USER_EVENT_TYPES.search_export, data=user_event_data)
+        record_user_event(request, UserEventType.SEARCH_EXPORT, data=user_event_data)
 
         return create_csv_response(db_queryset, self.field_titles, base_filename)
 

--- a/datahub/user_event_log/constants.py
+++ b/datahub/user_event_log/constants.py
@@ -1,7 +1,9 @@
-from model_utils import Choices
+from django.db import models
 
-USER_EVENT_TYPES = Choices(
-    ('search_export', 'Exported search results'),
-    ('proposition_document_delete', 'Deleted proposition document'),
-    ('evidence_document_delete', 'Deleted evidence document'),
-)
+
+class UserEventType(models.TextChoices):
+    """User event types."""
+
+    SEARCH_EXPORT = ('search_export', 'Exported search results')
+    PROPOSITION_DOCUMENT_DELETE = ('proposition_document_delete', 'Deleted proposition document')
+    EVIDENCE_DOCUMENT_DELETE = ('evidence_document_delete', 'Deleted evidence document')

--- a/datahub/user_event_log/models.py
+++ b/datahub/user_event_log/models.py
@@ -3,7 +3,7 @@ from django.contrib.postgres.fields import JSONField
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 
-from datahub.user_event_log.constants import USER_EVENT_TYPES
+from datahub.user_event_log.constants import UserEventType
 
 
 class UserEvent(models.Model):
@@ -24,7 +24,10 @@ class UserEvent(models.Model):
         on_delete=models.CASCADE,
         related_name='user_events',
     )
-    type = models.CharField(max_length=settings.CHAR_FIELD_MAX_LENGTH, choices=USER_EVENT_TYPES)
+    type = models.CharField(
+        max_length=settings.CHAR_FIELD_MAX_LENGTH,
+        choices=UserEventType.choices,
+    )
     api_url_path = models.CharField(verbose_name='API URL path', max_length=5000, db_index=True)
     data = JSONField(null=True, encoder=DjangoJSONEncoder)
 

--- a/datahub/user_event_log/test/test_utils.py
+++ b/datahub/user_event_log/test/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 from django.utils.timezone import utc
 
 from datahub.company.test.factories import AdviserFactory
-from datahub.user_event_log.constants import USER_EVENT_TYPES
+from datahub.user_event_log.constants import UserEventType
 from datahub.user_event_log.utils import record_user_event
 
 
@@ -35,10 +35,10 @@ def test_record_user_event(data, expected_data):
     """Test record_user_event() for various model and data values."""
     adviser = AdviserFactory()
     request = Mock(user=adviser, path='test-path')
-    event = record_user_event(request, USER_EVENT_TYPES.search_export, data=data)
+    event = record_user_event(request, UserEventType.SEARCH_EXPORT, data=data)
     event.refresh_from_db()
 
     assert event.adviser == adviser
-    assert event.type == USER_EVENT_TYPES.search_export
+    assert event.type == UserEventType.SEARCH_EXPORT
     assert event.api_url_path == 'test-path'
     assert event.data == expected_data


### PR DESCRIPTION
### Description of change

Following on from https://github.com/uktrade/data-hub-api/pull/2544, #2551, #2553 and #2554, this switches all remaining model fields from using [`model_utils.Choices`](https://django-model-utils.readthedocs.io/en/latest/utilities.html#choices) to [`django.db.models.TextChoices`](https://docs.djangoproject.com/en/3.0/ref/models/fields/#enumeration-types).

See https://github.com/uktrade/data-hub-api/pull/2544 for further background information.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
