### PR TITLE
Add additional fields to referral responses

### DIFF
--- a/changelog/company/add-referral-response-fields.api.md
+++ b/changelog/company/add-referral-response-fields.api.md
@@ -1,0 +1,3 @@
+`GET /v4/company-referral`, `POST /v4/company-referral`, `GET /v4/company-referral/<id>`: The following read-only fields were added to responses:
+
+- `completed_by`

--- a/changelog/company/add-referral-response-fields.api.md
+++ b/changelog/company/add-referral-response-fields.api.md
@@ -1,3 +1,5 @@
 `GET /v4/company-referral`, `POST /v4/company-referral`, `GET /v4/company-referral/<id>`: The following read-only fields were added to responses:
 
+- `closed_by`
+- `closed_on`
 - `completed_by`

--- a/datahub/company_referral/models.py
+++ b/datahub/company_referral/models.py
@@ -22,6 +22,14 @@ class CompanyReferral(BaseModel):
         COMPLETE = ('complete', 'Complete')
 
     id = models.UUIDField(primary_key=True, default=uuid4)
+    closed_by = models.ForeignKey(
+        'company.Advisor',
+        null=True,
+        blank=True,
+        on_delete=models.CASCADE,
+        related_name='closed_referrals',
+    )
+    closed_on = models.DateTimeField(null=True, blank=True)
     company = models.ForeignKey(
         'company.Company',
         on_delete=models.CASCADE,

--- a/datahub/company_referral/serializers.py
+++ b/datahub/company_referral/serializers.py
@@ -10,6 +10,7 @@ class CompanyReferralSerializer(serializers.ModelSerializer):
 
     company = NestedRelatedField('company.Company')
     contact = NestedRelatedField('company.Contact', required=False, allow_null=True)
+    closed_by = NestedAdviserWithEmailAndTeamField(read_only=True)
     completed_by = NestedAdviserWithEmailAndTeamField(read_only=True)
     created_by = NestedAdviserWithEmailAndTeamField(read_only=True)
     recipient = NestedAdviserWithEmailAndTeamField()
@@ -18,6 +19,8 @@ class CompanyReferralSerializer(serializers.ModelSerializer):
         model = CompanyReferral
         fields = (
             'id',
+            'closed_by',
+            'closed_on',
             'company',
             'completed_by',
             'completed_on',
@@ -31,6 +34,7 @@ class CompanyReferralSerializer(serializers.ModelSerializer):
         )
         read_only_fields = (
             'id',
+            'closed_on',
             'completed_on',
             'created_on',
             'status',

--- a/datahub/company_referral/serializers.py
+++ b/datahub/company_referral/serializers.py
@@ -10,6 +10,7 @@ class CompanyReferralSerializer(serializers.ModelSerializer):
 
     company = NestedRelatedField('company.Company')
     contact = NestedRelatedField('company.Contact', required=False, allow_null=True)
+    completed_by = NestedAdviserWithEmailAndTeamField(read_only=True)
     created_by = NestedAdviserWithEmailAndTeamField(read_only=True)
     recipient = NestedAdviserWithEmailAndTeamField()
 
@@ -18,6 +19,7 @@ class CompanyReferralSerializer(serializers.ModelSerializer):
         fields = (
             'id',
             'company',
+            'completed_by',
             'completed_on',
             'contact',
             'created_by',

--- a/datahub/company_referral/test/factories.py
+++ b/datahub/company_referral/test/factories.py
@@ -20,6 +20,14 @@ class CompanyReferralFactory(factory.django.DjangoModelFactory):
         model = 'company_referral.CompanyReferral'
 
 
+class ClosedCompanyReferralFactory(CompanyReferralFactory):
+    """A factory for referrals that have been closed."""
+
+    status = CompanyReferral.Status.CLOSED
+    closed_by = factory.SubFactory(AdviserFactory)
+    closed_on = factory.Faker('past_datetime', tzinfo=utc)
+
+
 class CompleteCompanyReferralFactory(CompanyReferralFactory):
     """A factory for referrals that have been completed."""
 

--- a/datahub/company_referral/test/factories.py
+++ b/datahub/company_referral/test/factories.py
@@ -1,6 +1,8 @@
 import factory
+from django.utils.timezone import utc
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
+from datahub.company_referral.models import CompanyReferral
 
 
 class CompanyReferralFactory(factory.django.DjangoModelFactory):
@@ -16,3 +18,11 @@ class CompanyReferralFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'company_referral.CompanyReferral'
+
+
+class CompleteCompanyReferralFactory(CompanyReferralFactory):
+    """A factory for referrals that have been completed."""
+
+    status = CompanyReferral.Status.COMPLETE
+    completed_by = factory.SubFactory(AdviserFactory)
+    completed_on = factory.Faker('past_datetime', tzinfo=utc)

--- a/datahub/company_referral/test/test_views.py
+++ b/datahub/company_referral/test/test_views.py
@@ -79,30 +79,14 @@ class TestListCompanyListsView(APITestMixin):
                 'id': str(company_referral.company.pk),
                 'name': company_referral.company.name,
             },
-            'completed_on': format_date_or_datetime(company_referral.completed_on),
+            'completed_on': None,
             'contact': {
                 'id': str(company_referral.contact.pk),
                 'name': company_referral.contact.name,
             },
-            'created_by': {
-                'id': str(company_referral.created_by.pk),
-                'name': company_referral.created_by.name,
-                'contact_email': company_referral.created_by.contact_email,
-                'dit_team': {
-                    'id': str(company_referral.created_by.dit_team.pk),
-                    'name': company_referral.created_by.dit_team.name,
-                },
-            },
+            'created_by': _format_expected_adviser(company_referral.created_by),
             'created_on': format_date_or_datetime(company_referral.created_on),
-            'recipient': {
-                'id': str(company_referral.recipient.pk),
-                'name': company_referral.recipient.name,
-                'contact_email': company_referral.recipient.contact_email,
-                'dit_team': {
-                    'id': str(company_referral.recipient.dit_team.id),
-                    'name': company_referral.recipient.dit_team.name,
-                },
-            },
+            'recipient': _format_expected_adviser(company_referral.recipient),
             'status': company_referral.status,
             'subject': company_referral.subject,
             'notes': company_referral.notes,
@@ -242,27 +226,11 @@ class TestAddCompanyReferral(APITestMixin):
             },
             'completed_on': None,
             'contact': None,
-            'created_by': {
-                'contact_email': self.user.contact_email,
-                'dit_team': {
-                    'id': str(self.user.dit_team.pk),
-                    'name': self.user.dit_team.name,
-                },
-                'id': str(self.user.pk),
-                'name': self.user.name,
-            },
+            'created_by': _format_expected_adviser(self.user),
             'created_on': format_date_or_datetime(FROZEN_DATETIME),
             'id': ANY,
             'notes': '',
-            'recipient': {
-                'contact_email': recipient.contact_email,
-                'dit_team': {
-                    'id': str(recipient.dit_team.pk),
-                    'name': recipient.dit_team.name,
-                },
-                'id': str(recipient.pk),
-                'name': recipient.name,
-            },
+            'recipient': _format_expected_adviser(recipient),
             'status': CompanyReferral.Status.OUTSTANDING,
             'subject': subject,
         }
@@ -304,27 +272,11 @@ class TestAddCompanyReferral(APITestMixin):
                 'id': str(contact.pk),
                 'name': contact.name,
             },
-            'created_by': {
-                'contact_email': self.user.contact_email,
-                'dit_team': {
-                    'id': str(self.user.dit_team.pk),
-                    'name': self.user.dit_team.name,
-                },
-                'id': str(self.user.pk),
-                'name': self.user.name,
-            },
+            'created_by': _format_expected_adviser(self.user),
             'created_on': format_date_or_datetime(FROZEN_DATETIME),
             'id': ANY,
             'notes': notes,
-            'recipient': {
-                'contact_email': recipient.contact_email,
-                'dit_team': {
-                    'id': str(recipient.dit_team.pk),
-                    'name': recipient.dit_team.name,
-                },
-                'id': str(recipient.pk),
-                'name': recipient.name,
-            },
+            'recipient': _format_expected_adviser(recipient),
             'status': CompanyReferral.Status.OUTSTANDING,
             'subject': subject,
         }
@@ -421,35 +373,34 @@ class TestGetCompanyReferral(APITestMixin):
                 'id': str(referral.company.pk),
                 'name': referral.company.name,
             },
-            'completed_on': None,
+            'completed_on': format_date_or_datetime(referral.completed_on),
             'contact': {
                 'id': str(referral.contact.pk),
                 'name': referral.contact.name,
             },
-            'created_by': {
-                'contact_email': referral.created_by.contact_email,
-                'dit_team': {
-                    'id': str(referral.created_by.dit_team.pk),
-                    'name': referral.created_by.dit_team.name,
-                },
-                'id': str(referral.created_by.pk),
-                'name': referral.created_by.name,
-            },
+            'created_by': _format_expected_adviser(referral.created_by),
             'created_on': format_date_or_datetime(referral.created_on),
             'id': str(referral.pk),
             'notes': referral.notes,
-            'recipient': {
-                'contact_email': referral.recipient.contact_email,
-                'dit_team': {
-                    'id': str(referral.recipient.dit_team.pk),
-                    'name': referral.recipient.dit_team.name,
-                },
-                'id': str(referral.recipient.pk),
-                'name': referral.recipient.name,
-            },
+            'recipient': _format_expected_adviser(referral.recipient),
             'status': referral.status,
             'subject': referral.subject,
         }
+
+
+def _format_expected_adviser(adviser):
+    if not adviser:
+        return None
+
+    return {
+        'contact_email': adviser.contact_email,
+        'dit_team': {
+            'id': str(adviser.dit_team.pk),
+            'name': adviser.dit_team.name,
+        },
+        'id': str(adviser.pk),
+        'name': adviser.name,
+    }
 
 
 def _resolve_data(data):

--- a/datahub/company_referral/test/test_views.py
+++ b/datahub/company_referral/test/test_views.py
@@ -12,6 +12,7 @@ from rest_framework.reverse import reverse
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.company_referral.models import CompanyReferral
 from datahub.company_referral.test.factories import (
+    ClosedCompanyReferralFactory,
     CompanyReferralFactory,
     CompleteCompanyReferralFactory,
 )
@@ -78,6 +79,8 @@ class TestListCompanyListsView(APITestMixin):
         assert len(results) == 1
         assert results[0] == {
             'id': str(company_referral.pk),
+            'closed_by': None,
+            'closed_on': None,
             'company': {
                 'id': str(company_referral.company.pk),
                 'name': company_referral.company.name,
@@ -224,6 +227,8 @@ class TestAddCompanyReferral(APITestMixin):
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
         assert response_data == {
+            'closed_by': None,
+            'closed_on': None,
             'company': {
                 'id': str(company.pk),
                 'name': company.name,
@@ -268,6 +273,8 @@ class TestAddCompanyReferral(APITestMixin):
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
         assert response_data == {
+            'closed_by': None,
+            'closed_on': None,
             'company': {
                 'id': str(company.pk),
                 'name': company.name,
@@ -369,6 +376,7 @@ class TestGetCompanyReferral(APITestMixin):
         'factory',
         (
             CompanyReferralFactory,
+            ClosedCompanyReferralFactory,
             CompleteCompanyReferralFactory,
         ),
     )
@@ -382,6 +390,8 @@ class TestGetCompanyReferral(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data == {
+            'closed_by': _format_expected_adviser(referral.closed_by),
+            'closed_on': format_date_or_datetime(referral.closed_on),
             'company': {
                 'id': str(referral.company.pk),
                 'name': referral.company.name,

--- a/datahub/company_referral/test/test_views.py
+++ b/datahub/company_referral/test/test_views.py
@@ -353,6 +353,8 @@ class TestAddCompanyReferral(APITestMixin):
         referral_data = CompanyReferral.objects.values().get(pk=pk)
 
         assert referral_data == {
+            'closed_by_id': None,
+            'closed_on': None,
             'company_id': request_data['company']['id'],
             'completed_by_id': None,
             'completed_on': None,


### PR DESCRIPTION
### Description of change

This:

- corrects an oversight in fd7c9b78cc9c7a2f5298e029c6f308a961d61e17 where only the migration was committed for the new fields
- refactors the company referral tests slightly to reduce repetition
- adds `closed_by`, `closed_on` and `completed_by` to responses (as read-only fields)

I'd recommend reviewing the commits individually.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
