### PR TITLE
Standardise duns number validation

### DIFF
--- a/changelog/company/standardise-duns-number-validation.internal.md
+++ b/changelog/company/standardise-duns-number-validation.internal.md
@@ -1,0 +1,1 @@
+Duns number validation was standardised to use django's `integer_validator`.

--- a/datahub/company/admin/dnb_link/forms.py
+++ b/datahub/company/admin/dnb_link/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.core.exceptions import ValidationError
+from django.core.validators import integer_validator
 from django.utils.translation import gettext_lazy
 
 from datahub.company.models import Company
@@ -23,7 +24,11 @@ class SelectIdsToLinkForm(forms.Form):
         widget=RawIdWidget(Company),
         label='Data Hub Company',
     )
-    duns_number = forms.CharField(min_length=9, max_length=9)
+    duns_number = forms.CharField(
+        min_length=9,
+        max_length=9,
+        validators=(integer_validator,),
+    )
 
     def clean_company(self):
         """


### PR DESCRIPTION
### Description of change

Duns number validation was standardised to use django's `integer_validator`.


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
