### PR TITLE
Improve dnb link tool error formatting

### DIFF
--- a/changelog/company/improve-dnb-link-tool-errors.feature.md
+++ b/changelog/company/improve-dnb-link-tool-errors.feature.md
@@ -1,0 +1,2 @@
+Formatting of the dnb link admin tool's validation errors were improved by
+splitting them across multiple flash messages.

--- a/datahub/company/admin/update_from_dnb.py
+++ b/datahub/company/admin/update_from_dnb.py
@@ -14,7 +14,7 @@ from rest_framework import serializers
 from datahub.company.admin.utils import (
     AdminException,
     format_company_diff,
-    redirect_with_message,
+    redirect_with_messages,
 )
 from datahub.dnb_api.utils import (
     DNBServiceException,
@@ -27,7 +27,7 @@ from datahub.dnb_api.utils import (
 logger = logging.getLogger(__name__)
 
 
-@redirect_with_message
+@redirect_with_messages
 @method_decorator(require_http_methods(['GET', 'POST']))
 @method_decorator(csrf_protect)
 def update_from_dnb(model_admin, request, object_id):
@@ -59,11 +59,11 @@ def update_from_dnb(model_admin, request, object_id):
 
     except DNBServiceInvalidRequest:
         message = 'No matching company found in D&B database.'
-        raise AdminException(message, company_change_page)
+        raise AdminException([message], company_change_page)
 
     except DNBServiceException:
         message = 'Something went wrong in an upstream service.'
-        raise AdminException(message, company_change_page)
+        raise AdminException([message], company_change_page)
 
     if request.method == 'GET':
         return TemplateResponse(
@@ -84,4 +84,4 @@ def update_from_dnb(model_admin, request, object_id):
         return HttpResponseRedirect(company_change_page)
     except serializers.ValidationError:
         message = 'Data from D&B did not pass the Data Hub validation checks.'
-        raise AdminException(message, company_change_page)
+        raise AdminException([message], company_change_page)

--- a/datahub/company/test/admin/dnb_link/test_review_changes.py
+++ b/datahub/company/test/admin/dnb_link/test_review_changes.py
@@ -48,27 +48,27 @@ class TestReviewChangesViewGet(AdminTestMixin):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(
-        'data_overrides,expected_error',
+        'data_overrides,expected_errors',
         (
             (
                 {'company': None, 'duns_number': None},  # No data
-                'Company: This field is required. duns_number: This field is required.',
+                ['Company: This field is required.', 'Duns_number: This field is required.'],
             ),
             (
                 {
                     'company': 'abc123',  # Invalid company ID
                 },
-                'Company: “abc123” is not a valid UUID.',
+                ['Company: “abc123” is not a valid UUID.'],
             ),
             (
                 {
                     'duns_number': '1',  # Invalid duns number
                 },
-                'Duns_number: Ensure this value has at least 9 characters (it has 1).',
+                ['Duns_number: Ensure this value has at least 9 characters (it has 1).'],
             ),
         ),
     )
-    def test_validation_errors_rendered(self, data_overrides, expected_error):
+    def test_validation_errors_rendered(self, data_overrides, expected_errors):
         """
         Test that validation errors are rendered as expected.
         """
@@ -86,7 +86,8 @@ class TestReviewChangesViewGet(AdminTestMixin):
         response = self.client.get(review_changes_url, follow=True)
 
         assert response.status_code == status.HTTP_200_OK
-        assert expected_error in response.rendered_content
+        for expected_error in expected_errors:
+            assert expected_error in response.rendered_content
 
     def test_dh_company_already_linked_renders_error(self):
         """


### PR DESCRIPTION
### Description of change
Formatting of the dnb link admin tool's validation errors were improved by splitting them across multiple flash messages.

Note that this approach necessitated a slight rework of `datahub.company.admin.utils.AdminError` and `datahub.company.admin.utils.redirect_with_message` so that errors can emit multiple django messages.


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
