### PR TITLE
Turn simulation off for automatic-company-archive

### DIFF
--- a/changelog/company/auto-archive-simulate-false.feature.md
+++ b/changelog/company/auto-archive-simulate-false.feature.md
@@ -1,0 +1,3 @@
+The `automatic-company-archive` Celery job will now run with simulation mode turned off.
+
+We ran this job in simulation mode in order to audit the list of companies that would be archived. This is now done and so we are ready to turn off the simulation.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -395,6 +395,9 @@ if REDIS_BASE_URL:
         'automatic_company_archive': {
             'task': 'datahub.company.tasks.automatic_company_archive',
             'schedule': crontab(minute=0, hour=20, day_of_week='SAT'),
+            'kwargs': {
+                'simulate': False,
+            }
         },
     }
     if env.bool('ENABLE_DAILY_ES_SYNC', False):


### PR DESCRIPTION
### Description of change

The `automatic-company-archive` Celery job will now run with simulation mode turned off.

We ran this job in simulation mode in order to audit the list of companies that would be archived. This is now done and so we are ready to turn off the simulation.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
