### PR TITLE
Add global ultimate duns number to company admin

### DIFF
--- a/changelog/company/global-ultimate-duns-admin.feature.md
+++ b/changelog/company/global-ultimate-duns-admin.feature.md
@@ -1,0 +1,1 @@
+The global ultimate duns number field was added to the company admin change view.

--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -102,6 +102,7 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                     'company_number',
                     'vat_number',
                     'duns_number',
+                    'global_ultimate_duns_number',
                     'description',
                     'website',
                     'business_type',


### PR DESCRIPTION
### Description of change
The global ultimate duns number field was added to the company admin change view.


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
