### PR TITLE
Fix changelog for removal of `dnb_match` app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,8 @@
 
 - The IP restriction functionality provided by `django-admin-ip-restrictor` was removed as it was not in use as we're using private networking and other mechanisms within GOV.UK PaaS instead.
 
+- The `dnb_match` app has been removed from Data Hub.
+
 ## Features
 
 - It is now possible to perform queries to search endpoints in the API browser.
@@ -306,10 +308,6 @@
 
 
 # Data Hub API 26.2.0 (2020-01-14)
-
-## Removals
-
-- The `dnb_match` app has been removed from Data Hub.
 
 ## Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -307,6 +307,9 @@
 
 # Data Hub API 26.2.0 (2020-01-14)
 
+## Removals
+
+- The `dnb_match` app has been removed from Data Hub.
 
 ## Internal changes
 

--- a/datahub/remove-dnb-match.internal.md
+++ b/datahub/remove-dnb-match.internal.md
@@ -1,1 +1,0 @@
-The `dnb_match` app has been removed from Data Hub.


### PR DESCRIPTION
### Description of change

This was put in the wrong directory and never made it to the changelog.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
