### PR TITLE
Remove django-model-utils

### DIFF
--- a/datahub/company/migrations/0001_squashed_0096_company_global_ultimate_duns_number.py
+++ b/datahub/company/migrations/0001_squashed_0096_company_global_ultimate_duns_number.py
@@ -146,7 +146,7 @@ class Migration(migrations.Migration):
                 ('pending_dnb_investigation', models.BooleanField(default=False, help_text='Whether this company is to be investigated by DNB.')),
                 ('dnb_investigation_data', django.contrib.postgres.fields.jsonb.JSONField(blank=True, null=True)),
                 ('export_potential', models.CharField(blank=True, choices=[('very_high', 'Very High'), ('high', 'High'), ('medium', 'Medium'), ('low', 'Low'), ('very_low', 'Very Low')], help_text='Score that signifies export potential, imported from Data Science', max_length=255, null=True)),
-                ('great_profile_status', models.CharField(blank=True, choices=[('published', 'Published'), ('unpublished', 'Unpublished'), (None, 'No profile or not known')], help_text='Whether this company has a profile and agreed to be published or not', max_length=255, null=True)),
+                ('great_profile_status', models.CharField(blank=True, choices=[(None, 'No profile or not known'), ('published', 'Published'), ('unpublished', 'Unpublished')], help_text='Whether this company has a profile and agreed to be published or not', max_length=255, null=True)),
                 ('global_ultimate_duns_number', models.CharField(blank=True, db_index=True, help_text='Dun & Bradstreet unique identifier for global ultimate.', max_length=9, validators=[django.core.validators.MinLengthValidator(9), django.core.validators.MaxLengthValidator(9), django.core.validators.RegexValidator(re.compile('^-?\\d+\\Z'), code='invalid', message='Enter a valid integer.')])),
             ],
             options={

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -210,9 +210,9 @@ class CompanyExportCountryHistoryFactory(factory.django.DjangoModelFactory):
     id = factory.LazyFunction(uuid.uuid4)
     company = factory.SubFactory(CompanyFactory)
     country = factory.LazyFunction(lambda: random_obj_for_model(Country))
-    status = factory.fuzzy.FuzzyChoice(CompanyExportCountry.Status.choices)
+    status = factory.fuzzy.FuzzyChoice(CompanyExportCountry.Status.values)
     history_user = factory.SubFactory(AdviserFactory)
-    history_type = factory.fuzzy.FuzzyChoice(CompanyExportCountryHistory.HistoryType.choices)
+    history_type = factory.fuzzy.FuzzyChoice(CompanyExportCountryHistory.HistoryType.values)
 
     class Meta:
         model = 'company.CompanyExportCountryHistory'

--- a/datahub/core/model_helpers.py
+++ b/datahub/core/model_helpers.py
@@ -1,8 +1,8 @@
 """
 Contains various utilities and helper functions for working with models.
 
-(As we already use a third-party package called model_utils, this module is named model_helpers
-rather than model_utils.)
+(This module is named model_helpers rather than model_utils as we were previously
+using a third-party package called model_utils.)
 """
 
 

--- a/datahub/dbmaintenance/test/test_utils.py
+++ b/datahub/dbmaintenance/test/test_utils.py
@@ -1,32 +1,39 @@
 import pytest
-from model_utils import Choices
+from django.db import models
 from rest_framework import serializers
 
 from datahub.dbmaintenance.utils import parse_choice
 
-CHOICES = Choices(
-    ('one', 'One'),
-    (2, '_2', 'Two'),
-)
+
+class SampleTextChoice(models.TextChoices):
+    """Example text choices."""
+
+    ONE = ('one', 'One')
+
+
+class SampleIntegerChoice(models.IntegerChoices):
+    """Example integer choices."""
+
+    _2 = (2, 'Two')
 
 
 class TestParseChoiceValue:
     """Tests for parse_choice()."""
 
     @pytest.mark.parametrize(
-        'input_value,expected_value',
+        'input_value,choices,expected_value',
         (
-            ('one', CHOICES.one),
-            ('2', CHOICES._2),
+            ('one', SampleTextChoice.choices, SampleTextChoice.ONE),
+            ('2', SampleIntegerChoice.choices, SampleIntegerChoice._2),
         ),
     )
-    def test_accepts_and_transforms_valid_values(self, input_value, expected_value):
+    def test_accepts_and_transforms_valid_values(self, input_value, choices, expected_value):
         """Test that valid values are accepted and transformed to the internal value."""
-        assert parse_choice(input_value, CHOICES) == expected_value
+        assert parse_choice(input_value, choices) == expected_value
 
     def test_raises_error_on_invalid_value(self):
         """Test that an error is raised if an invalid value is passed."""
         with pytest.raises(serializers.ValidationError) as excinfo:
-            parse_choice('invalid', CHOICES)
+            parse_choice('invalid', SampleTextChoice)
 
         assert excinfo.value.detail == ['"invalid" is not a valid choice.']

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,6 @@ django-extensions==2.2.7
 django-filter==2.2.0
 django-reversion==3.0.5
 django-pglocks==1.0.4
-django-model-utils==4.0.0
 django-mptt==0.11.0
 django-oauth-toolkit==1.2.0
 oauthlib==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,6 @@ django-environ==0.4.5
 django-extensions==2.2.7
 django-filter==2.2.0
 django-js-asset==1.2.2    # via django-mptt
-django-model-utils==4.0.0
 django-mptt==0.11.0
 django-oauth-toolkit==1.2.0
 django-pglocks==1.0.4


### PR DESCRIPTION
### Description of change

This is no longer required as we were only using it for its `Choices` class, which is no longer needed as Django now has similar classes built-in.

(I also fixed a small problem where Django was generating an unneeded migration for `Company.great_profile_status`.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
