### PR TITLE
Link company to D&B endpoint

### DIFF
--- a/changelog/company/company-link-endpoint.feature.md
+++ b/changelog/company/company-link-endpoint.feature.md
@@ -1,0 +1,5 @@
+The following endpoint was added to Data Hub API:
+
+- POST `/v4/dnb/company-link` {'company_id': <company_id>, 'duns_number': <duns_number>}
+
+This endpoint would link a Data Hub company to a D&B record given a valid Data Hub company ID and a `duns_number`.

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -9,7 +9,7 @@ from datahub.company.validators import (
     has_uk_establishment_number_prefix,
 )
 from datahub.core.constants import Country
-from datahub.core.serializers import PermittedFieldsModelSerializer
+from datahub.core.serializers import NestedRelatedField, PermittedFieldsModelSerializer
 from datahub.core.validators import EqualsRule, OperatorRule, RulesBasedValidator, ValidationRule
 from datahub.interaction.models import InteractionPermission
 
@@ -223,3 +223,11 @@ class DNBCompanyInvestigationSerializer(CompanySerializer):
 
     class Meta(CompanySerializer.Meta):
         fields = CompanySerializer.Meta.fields + ('dnb_investigation_data', )
+
+
+class DNBCompanyLinkSerializer(DUNSNumberSerializer):
+    """
+    Validate POST data for DNBCompanyLinkView.
+    """
+
+    company_id = NestedRelatedField('company.Company', required=True)

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1,6 +1,7 @@
 import json
 from unittest.mock import Mock
 from urllib.parse import urljoin
+from uuid import UUID
 
 import pytest
 from django.conf import settings
@@ -15,6 +16,8 @@ from datahub.company.models import Company, CompanyPermission
 from datahub.company.test.factories import CompanyFactory
 from datahub.core.serializers import AddressSerializer
 from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.dnb_api.constants import ALL_DNB_UPDATED_SERIALIZER_FIELDS
+from datahub.dnb_api.utils import format_dnb_company
 from datahub.interaction.models import InteractionPermission
 from datahub.metadata.models import Country
 
@@ -1075,16 +1078,6 @@ class TestCompanyLinkView(APITestMixin):
     Test POST `/dnb/company-link` endpoint.
     """
 
-    def test_200(self):
-        """
-        Test that POST `/dnb/company-link` returns 200.
-        """
-        response = self.api_client.post(
-            reverse('api-v4:dnb-api:company-link'),
-            data={},
-        )
-        assert response.status_code == status.HTTP_200_OK
-
     @pytest.mark.parametrize(
         'content_type,expected_status_code',
         (
@@ -1161,3 +1154,135 @@ class TestCompanyLinkView(APITestMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    @pytest.mark.parametrize(
+        'status_code',
+        (
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            status.HTTP_502_BAD_GATEWAY,
+        ),
+    )
+    def test_dnb_service_error(
+        self,
+        requests_mock,
+        status_code,
+    ):
+        """
+        Test if company-link endpoint returns 502 if the upstream
+        `dnb-service` returns an error.
+        """
+        company = CompanyFactory()
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=status_code,
+        )
+
+        response = self.api_client.post(
+            reverse('api-v4:dnb-api:company-link'),
+            data={
+                'company_id': company.id,
+                'duns_number': 123456789,
+            },
+        )
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+    def test_already_linked(self):
+        """
+        Test that the endpoint returns 400 for a company that is already linked.
+        """
+        company = CompanyFactory(duns_number='123456789')
+        response = self.api_client.post(
+            reverse('api-v4:dnb-api:company-link'),
+            data={
+                'company_id': company.pk,
+                'duns_number': '123456789',
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'duns_number': ['Company with duns_number: 123456789 already exists in DataHub.'],
+        }
+
+    def test_duplicate_duns_number(self):
+        """
+        Test that the endpoint returns 400 if we try to link a company to a D&B record
+        that has already been linked to a different company.
+        """
+        CompanyFactory(duns_number='123456789')
+        company = CompanyFactory()
+        response = self.api_client.post(
+            reverse('api-v4:dnb-api:company-link'),
+            data={
+                'company_id': company.pk,
+                'duns_number': '123456789',
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'duns_number': ['Company with duns_number: 123456789 already exists in DataHub.'],
+        }
+
+    def test_company_not_found(
+        self,
+        requests_mock,
+    ):
+        """
+        Test that when a duns_number does not return any company from
+        dnb-service, the endpoint returns 400 status.
+        """
+        company = CompanyFactory()
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=status.HTTP_200_OK,
+            json={'results': []},
+        )
+        response = self.api_client.post(
+            reverse('api-v4:dnb-api:company-link'),
+            data={
+                'company_id': company.pk,
+                'duns_number': '123456789',
+            },
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'detail': 'Cannot find a company with duns_number: 123456789',
+        }
+
+    def test_valid(
+        self,
+        requests_mock,
+        dnb_response_uk,
+    ):
+        """
+        Test that valid request to company-link endpoint returns 200.
+        """
+        company = CompanyFactory()
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=status.HTTP_200_OK,
+            json=dnb_response_uk,
+        )
+        response = self.api_client.post(
+            reverse('api-v4:dnb-api:company-link'),
+            data={
+                'company_id': company.pk,
+                'duns_number': '123456789',
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        dh_company = response.json()
+        dnb_company = format_dnb_company(dnb_response_uk['results'][0])
+        # TODO: The format for the payload returned via CompanySerializer and that returned via
+        # format_dnb_company is slightly different.
+        # format_dnb_company: {... 'country': UUID(...)}
+        # CompanySerializer: {... 'country': {'id': <uuid:str>}}
+        dh_company['address']['country'] = UUID(dh_company['address']['country']['id'])
+
+        for field in ALL_DNB_UPDATED_SERIALIZER_FIELDS:
+            assert dh_company[field] == dnb_company[field]

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1130,3 +1130,34 @@ class TestCompanyLinkView(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        'override',
+        (
+            {'duns_number': None},
+            {'duns_number': 'foobarbaz'},
+            {'duns_number': '12345678'},
+            {'duns_number': '1234567890'},
+            {'company_id': None},
+            {'company_id': 'does-not-exist'},
+            {'company_id': '11111111-2222-3333-4444-555555555555'},
+        ),
+    )
+    def test_invalid(
+        self,
+        override,
+    ):
+        """
+        Test that a query without a valid `duns_number` returns 400.
+        """
+        company = CompanyFactory()
+        response = self.api_client.post(
+            reverse('api-v4:dnb-api:company-link'),
+            data={
+                'company_id': company.pk,
+                **override,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from datahub.dnb_api.views import (
     DNBCompanyCreateInvestigationView,
     DNBCompanyCreateView,
+    DNBCompanyLinkView,
     DNBCompanySearchView,
 )
 
@@ -21,5 +22,10 @@ urlpatterns = [
         'company-create-investigation',
         DNBCompanyCreateInvestigationView.as_view(),
         name='company-create-investigation',
+    ),
+    path(
+        'company-link',
+        DNBCompanyLinkView.as_view(),
+        name='company-link',
     ),
 ]

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -249,3 +249,26 @@ class DNBCompanyCreateInvestigationView(APIView):
         return Response(
             company_serializer.to_representation(datahub_company),
         )
+
+
+class DNBCompanyLinkView(APIView):
+    """
+    View for linking a company to a DNB record.
+    """
+
+    required_scopes = (Scope.internal_front_end, )
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        HasPermissions(
+            f'company.{CompanyPermission.view_company}',
+            f'company.{CompanyPermission.change_company}',
+        ),
+    )
+
+    @method_decorator(enforce_request_content_type('application/json'))
+    def post(self, request):
+        """
+        Given a Data Hub Company ID and a duns-number, link the Data Hub
+        Company to the D&B record.
+        """
+        return Response(status.HTTP_200_OK)

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -17,6 +17,7 @@ from datahub.core.view_utils import enforce_request_content_type
 from datahub.dnb_api.queryset import get_company_queryset
 from datahub.dnb_api.serializers import (
     DNBCompanyInvestigationSerializer,
+    DNBCompanyLinkSerializer,
     DNBCompanySerializer,
     DNBMatchedCompanySerializer,
     DUNSNumberSerializer,
@@ -271,4 +272,14 @@ class DNBCompanyLinkView(APIView):
         Given a Data Hub Company ID and a duns-number, link the Data Hub
         Company to the D&B record.
         """
+        link_serializer = DNBCompanyLinkSerializer(data=request.data)
+
+        link_serializer.is_valid(raise_exception=True)
+
+        # This bit: validated_data['company_id'].id is weird but the alternative
+        # is to rename the field to `company_id` which would (1) still be weird
+        # and (2) leak the weirdness to the API
+        company_id = link_serializer.validated_data['company_id'].id
+        duns_number = link_serializer.validated_data['duns_number']
+
         return Response(status.HTTP_200_OK)


### PR DESCRIPTION
### Description of change

The following endpoint was added to Data Hub API:

POST `/v4/dnb/company-link` {'company_id': <company_id>, 'duns_number': <duns_number>}

This endpoint would link a Data Hub company to a D&B record given a valid Data Hub company ID and a duns_number.

I would recommend reviewing individual commits separately.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
