### PR TITLE
Bump auto-archive limit to 5000

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -396,6 +396,7 @@ if REDIS_BASE_URL:
             'task': 'datahub.company.tasks.automatic_company_archive',
             'schedule': crontab(minute=0, hour=20, day_of_week='SAT'),
             'kwargs': {
+                'limit': 5000,
                 'simulate': False,
             }
         },


### PR DESCRIPTION
### Description of change

We have audited samples of previous runs where limit was 1000. The outcomes seem sensible so we are looking to bump this to 5000.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
