### PR TITLE
update elastic search query builder to support multiple entities

### DIFF
--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -6,7 +6,7 @@ from datahub.search.company import CompanySearchApp
 from datahub.search.company.models import Company as ESCompany
 from datahub.search.query_builder import (
     get_basic_search_query,
-    get_search_by_entity_query,
+    get_search_by_entities_query,
     limit_search_query,
 )
 from datahub.search.sync_object import sync_object
@@ -419,8 +419,8 @@ def test_limited_get_search_by_entity_query():
         'archived_before': date,
         'archived_after': date,
     }
-    query = get_search_by_entity_query(
-        ESCompany,
+    query = get_search_by_entities_query(
+        [ESCompany],
         term='test',
         filter_data=filter_data,
     )
@@ -435,10 +435,6 @@ def test_limited_get_search_by_entity_query():
             'bool': {
                 'must': [
                     {
-                        'term': {
-                            '_type': 'company',
-                        },
-                    }, {
                         'bool': {
                             'should': [
                                 {

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -4,7 +4,7 @@ from datahub.search.contact import ContactSearchApp
 from datahub.search.contact.models import Contact as ESContact
 from datahub.search.query_builder import (
     get_basic_search_query,
-    get_search_by_entity_query,
+    get_search_by_entities_query,
     limit_search_query,
 )
 
@@ -362,8 +362,8 @@ def test_get_limited_search_by_entity_query():
         'archived_before': date,
         'archived_after': date,
     }
-    query = get_search_by_entity_query(
-        ESContact,
+    query = get_search_by_entities_query(
+        [ESContact],
         term='test',
         filter_data=filter_data,
     )
@@ -378,10 +378,6 @@ def test_get_limited_search_by_entity_query():
             'bool': {
                 'must': [
                     {
-                        'term': {
-                            '_type': 'contact',
-                        },
-                    }, {
                         'bool': {
                             'should': [
                                 {

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -3,7 +3,7 @@ from elasticsearch_dsl import Mapping
 from datahub.search.investment.models import InvestmentProject as ESInvestmentProject
 from datahub.search.query_builder import (
     get_basic_search_query,
-    get_search_by_entity_query,
+    get_search_by_entities_query,
     limit_search_query,
 )
 
@@ -775,8 +775,8 @@ def test_limited_get_search_by_entity_query():
         'estimated_land_date_after': date,
         'estimated_land_date_before': date,
     }
-    query = get_search_by_entity_query(
-        ESInvestmentProject,
+    query = get_search_by_entities_query(
+        [ESInvestmentProject],
         term='test',
         filter_data=filter_data,
     )
@@ -791,10 +791,6 @@ def test_limited_get_search_by_entity_query():
             'bool': {
                 'must': [
                     {
-                        'term': {
-                            '_type': 'investment_project',
-                        },
-                    }, {
                         'bool': {
                             'should': [
                                 {

--- a/datahub/search/investment/test/test_signals.py
+++ b/datahub/search/investment/test/test_signals.py
@@ -8,7 +8,7 @@ from datahub.investment.project.test.factories import (
 from datahub.metadata.test.factories import TeamFactory
 from datahub.search.investment.models import InvestmentProject
 from datahub.search.query_builder import (
-    get_search_by_entity_query,
+    get_search_by_entities_query,
 )
 
 pytestmark = pytest.mark.django_db
@@ -22,8 +22,8 @@ def test_investment_project_auto_sync_to_es(es_with_signals):
     )
     es_with_signals.indices.refresh()
 
-    result = get_search_by_entity_query(
-        InvestmentProject,
+    result = get_search_by_entities_query(
+        [InvestmentProject],
         term='',
         filter_data={'name': test_name},
     ).execute()
@@ -39,8 +39,8 @@ def test_investment_project_auto_updates_to_es(es_with_signals):
     project.save()
     es_with_signals.indices.refresh()
 
-    result = get_search_by_entity_query(
-        InvestmentProject,
+    result = get_search_by_entities_query(
+        [InvestmentProject],
         term='',
         filter_data={'name': new_test_name},
     ).execute()
@@ -58,8 +58,8 @@ def test_investment_project_team_member_added_sync_to_es(es_with_signals, team_m
     """Tests if investment project gets synced to Elasticsearch when a team member is added."""
     es_with_signals.indices.refresh()
 
-    results = get_search_by_entity_query(
-        InvestmentProject,
+    results = get_search_by_entities_query(
+        [InvestmentProject],
         term='',
         filter_data={},
     ).execute()
@@ -78,8 +78,8 @@ def test_investment_project_team_member_updated_sync_to_es(es_with_signals, team
     team_member.save()
     es_with_signals.indices.refresh()
 
-    results = get_search_by_entity_query(
-        InvestmentProject,
+    results = get_search_by_entities_query(
+        [InvestmentProject],
         term='',
         filter_data={},
     ).execute()
@@ -96,8 +96,8 @@ def test_investment_project_team_member_deleted_sync_to_es(es_with_signals, team
     team_member.delete()
     es_with_signals.indices.refresh()
 
-    results = get_search_by_entity_query(
-        InvestmentProject,
+    results = get_search_by_entities_query(
+        [InvestmentProject],
         term='',
         filter_data={},
     ).execute()
@@ -130,8 +130,8 @@ def test_investment_project_syncs_when_adviser_changes(es_with_signals, field):
 
     es_with_signals.indices.refresh()
 
-    result = get_search_by_entity_query(
-        InvestmentProject,
+    result = get_search_by_entities_query(
+        [InvestmentProject],
         term='',
         filter_data={'id': project.pk},
     ).execute()
@@ -153,8 +153,8 @@ def test_investment_project_syncs_when_team_member_adviser_changes(es_with_signa
 
     es_with_signals.indices.refresh()
 
-    result = get_search_by_entity_query(
-        InvestmentProject,
+    result = get_search_by_entities_query(
+        [InvestmentProject],
         term='',
         filter_data={'id': team_member.investment_project.pk},
     ).execute()

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -24,7 +24,7 @@ from datahub.search.permissions import (
 )
 from datahub.search.query_builder import (
     get_basic_search_query,
-    get_search_by_entity_query,
+    get_search_by_entities_query,
     limit_search_query,
 )
 from datahub.search.serializers import (
@@ -197,8 +197,8 @@ class SearchAPIView(APIView):
         permission_filters = self.search_app.get_permission_filters(request)
         ordering = _map_es_ordering(validated_data['sortby'], self.es_sort_by_remappings)
 
-        return get_search_by_entity_query(
-            self.search_app.es_model,
+        return get_search_by_entities_query(
+            [self.search_app.es_model],
             term=validated_data['original_query'],
             filter_data=filter_data,
             composite_field_mapping=self.COMPOSITE_FILTERS,


### PR DESCRIPTION
### Description of change
This is an enabler PR for to show export country history, where we need to show company export country edits on export tab as well as export countries tagged with interaction.

By enabling elastic search query builder to search across entities, we can then obtain results from company export country history and interaction at the same time.

Exact change is to convert `get_search_by_entity_query` to `get_search_by_entities_query` and instead of taking one `entity` into consideration, take multiple `entities`.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
