### PR TITLE
Standardise resolve_data test utility function

### DIFF
--- a/datahub/company_referral/test/test_views.py
+++ b/datahub/company_referral/test/test_views.py
@@ -1,4 +1,3 @@
-from collections.abc import Mapping
 from datetime import datetime
 from unittest.mock import ANY
 from uuid import UUID, uuid4
@@ -16,7 +15,12 @@ from datahub.company_referral.test.factories import (
     CompanyReferralFactory,
     CompleteCompanyReferralFactory,
 )
-from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
+from datahub.core.test_utils import (
+    APITestMixin,
+    create_test_user,
+    format_date_or_datetime,
+    resolve_objects,
+)
 
 FROZEN_DATETIME = datetime(2020, 1, 24, 16, 26, 50, tzinfo=utc)
 
@@ -200,7 +204,7 @@ class TestAddCompanyReferral(APITestMixin):
     )
     def test_validates_input(self, request_data, expected_response_data):
         """Test validation for various scenarios."""
-        resolved_request_data = _resolve_data(request_data)
+        resolved_request_data = resolve_objects(request_data)
         response = self.api_client.post(collection_url, data=resolved_request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -433,16 +437,3 @@ def _format_expected_adviser(adviser):
         'id': str(adviser.pk),
         'name': adviser.name,
     }
-
-
-def _resolve_data(data):
-    """Resolve callables in values used in parametrised tests."""
-    if isinstance(data, Mapping):
-        return {key: _resolve_data(value) for key, value in data.items()}
-
-    if callable(data):
-        resolved_value = data()
-    else:
-        resolved_value = data
-
-    return getattr(resolved_value, 'pk', resolved_value)

--- a/datahub/core/test/test_hawk_receiver.py
+++ b/datahub/core/test/test_hawk_receiver.py
@@ -1,5 +1,4 @@
 import datetime
-from collections.abc import Mapping
 
 import mohawk
 import pytest
@@ -9,7 +8,7 @@ from rest_framework import status
 from rest_framework.test import APIRequestFactory
 
 from datahub.core.test.support.views import HawkViewWithScope
-from datahub.core.test_utils import create_test_user
+from datahub.core.test_utils import create_test_user, resolve_data
 
 
 def _url():
@@ -48,16 +47,6 @@ def _auth_sender(
         content=content,
         content_type=content_type,
     )
-
-
-def _resolve_value(value):
-    if isinstance(value, Mapping):
-        return {item_key: _resolve_value(item_value) for item_key, item_value in value.items()}
-
-    if callable(value):
-        return value()
-
-    return value
 
 
 @pytest.mark.django_db
@@ -142,7 +131,7 @@ class TestHawkAuthentication:
         """If the request isn't properly Hawk-authenticated, then a 401 is
         returned
         """
-        resolved_get_kwargs = _resolve_value(get_kwargs)
+        resolved_get_kwargs = resolve_data(get_kwargs)
         response = api_client.get(
             _url(),
             **resolved_get_kwargs,

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -1,5 +1,4 @@
 from collections import Counter
-from collections.abc import Mapping
 from datetime import date, datetime, time
 from unittest.mock import Mock
 
@@ -11,6 +10,7 @@ from rest_framework import serializers
 from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.company.test.factories import AdviserFactory, ContactFactory
 from datahub.core.exceptions import DataHubException
+from datahub.core.test_utils import resolve_data
 from datahub.event.test.factories import DisabledEventFactory, EventFactory
 from datahub.interaction.admin_csv_import.duplicate_checking import DuplicateTracker
 from datahub.interaction.admin_csv_import.row_form import (
@@ -382,7 +382,7 @@ class TestInteractionCSVRowFormValidation:
             'service': service.name,
             'communication_channel': communication_channel.name,
 
-            **_resolve_data(data),
+            **resolve_data(data),
         }
 
         form = InteractionCSVRowForm(data=resolved_data)
@@ -482,7 +482,7 @@ class TestInteractionCSVRowFormValidation:
         adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
         communication_channel = random_communication_channel()
 
-        resolved_row_data = _resolve_data(row_data)
+        resolved_row_data = resolve_data(row_data)
         resolved_existing_objects_data = [
             {
                 key: value(resolved_row_data)
@@ -609,7 +609,7 @@ class TestInteractionCSVRowFormValidation:
         adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
         communication_channel = random_communication_channel()
 
-        resolved_row_data = _resolve_data(row_data)
+        resolved_row_data = resolve_data(row_data)
         resolved_prior_rows = [
             {
                 key: value(resolved_row_data)
@@ -1435,14 +1435,3 @@ class TestInteractionCSVRowFormSaving:
             form.save(user, source=source)
 
         assert not Interaction.objects.exists()
-
-
-def _resolve_data(data):
-    """Resolve callables in values used in parametrised tests."""
-    if isinstance(data, Mapping):
-        return {key: _resolve_data(value) for key, value in data.items()}
-
-    if callable(data):
-        return data()
-
-    return data


### PR DESCRIPTION
### Description of change

There were various forms of the `resolve_data` test utility function in different tests.

This change replaces them all with a pair of standardised ones in `datahub.core.test_utils` to avoid having several slightly different versions scattered across the tests.

(The generic version is slightly more complex, but we now have one version of it rather than four.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
