### PR TITLE
Add complete a company referral endpoint

### DIFF
--- a/changelog/company/complete-referral.api.md
+++ b/changelog/company/complete-referral.api.md
@@ -1,0 +1,3 @@
+A new endpoint, `POST /v4/company-referral/<ID>/complete`, was added for completing a company referral.
+
+The request body is in the same format as `POST /v3/interaction`, except that the `company` field is not used as this comes from the referral object.

--- a/datahub/company_referral/models.py
+++ b/datahub/company_referral/models.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 from django.conf import settings
 from django.db import models
+from django.utils.timezone import now
 
 from datahub.core.models import BaseModel
 from datahub.core.utils import get_front_end_url
@@ -76,3 +77,11 @@ class CompanyReferral(BaseModel):
     def get_absolute_url(self):
         """URL to the object in the Data Hub internal front end."""
         return get_front_end_url(self)
+
+    def mark_as_complete(self, interaction, user):
+        """Mark this referral as complete."""
+        self.status = CompanyReferral.Status.COMPLETE
+        self.interaction = interaction
+        self.modified_by = user
+        self.completed_by = user
+        self.completed_on = now()

--- a/datahub/company_referral/test/test_complete_view.py
+++ b/datahub/company_referral/test/test_complete_view.py
@@ -1,0 +1,377 @@
+from datetime import datetime
+from uuid import uuid4
+
+import pytest
+from django.utils.timezone import utc
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
+from datahub.company_referral.models import CompanyReferral
+from datahub.company_referral.test.factories import (
+    ClosedCompanyReferralFactory,
+    CompanyReferralFactory,
+    CompleteCompanyReferralFactory,
+)
+from datahub.core.test_utils import (
+    APITestMixin,
+    create_test_user,
+    random_obj_for_model,
+    resolve_objects,
+)
+from datahub.event.test.factories import EventFactory
+from datahub.interaction.models import CommunicationChannel, Interaction
+from datahub.interaction.test.utils import random_service
+
+
+FROZEN_DATETIME = datetime(2020, 1, 24, 16, 26, 50, tzinfo=utc)
+
+
+def _complete_url(pk):
+    return reverse('api-v4:company-referral:complete', kwargs={'pk': pk})
+
+
+class TestCompleteCompanyReferral(APITestMixin):
+    """
+    Tests for the complete a company referral view.
+
+    There is some overlap between these and the tests for adding an interaction. However,
+    these are subtly different, as the company field is not required here, and the referral
+    object is (of course) also updated.
+    """
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if the user is unauthenticated."""
+        referral = CompanyReferralFactory()
+        url = _complete_url(referral.pk)
+        response = api_client.post(url, data={})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames,expected_status',
+        (
+            ([], status.HTTP_403_FORBIDDEN),
+            (['change_companyreferral'], status.HTTP_201_CREATED),
+        ),
+    )
+    def test_permission_checking(self, permission_codenames, expected_status, api_client):
+        """Test that the expected status is returned depending on the permissions the user has."""
+        user = create_test_user(permission_codenames=permission_codenames)
+        api_client = self.create_api_client(user=user)
+
+        referral = CompanyReferralFactory()
+        url = _complete_url(referral.pk)
+        request_data = _sample_valid_request_data(referral)
+
+        response = api_client.post(url, data=request_data)
+        assert response.status_code == expected_status
+
+    def test_returns_404_for_non_existent_referral(self):
+        """Test that a 404 is returned for a non-existent referral ID."""
+        url = _complete_url(uuid4())
+        response = self.api_client.post(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        'factory',
+        (
+            ClosedCompanyReferralFactory,
+            CompleteCompanyReferralFactory,
+        ),
+    )
+    def test_fails_if_referral_not_outstanding(self, factory):
+        """Test that a an error is returned if the referral is closed or already complete."""
+        referral = factory()
+        url = _complete_url(referral.pk)
+
+        request_data = _sample_valid_request_data(referral)
+        response = self.api_client.post(url, data=request_data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'non_field_errors': [
+                'This referral can’t be completed as it’s not in the outstanding status',
+            ],
+        }
+
+    @pytest.mark.parametrize(
+        'request_data,expected_response_data',
+        (
+            pytest.param(
+                {},
+                {
+                    'contacts': ['This field is required.'],
+                    'date': ['This field is required.'],
+                    'dit_participants': ['This field is required.'],
+                    'kind': ['This field is required.'],
+                    'subject': ['This field is required.'],
+                    'was_policy_feedback_provided': ['This field is required.'],
+                },
+                id='omitted-fields',
+            ),
+            pytest.param(
+                {
+                    'contacts': None,
+                    'date': None,
+                    'dit_participants': None,
+                    'kind': None,
+                    'subject': None,
+                    'was_policy_feedback_provided': None,
+                },
+                {
+                    'contacts': ['This field may not be null.'],
+                    'date': ['This field may not be null.'],
+                    'dit_participants': ['This field may not be null.'],
+                    'kind': ['This field may not be null.'],
+                    'subject': ['This field may not be null.'],
+                    'was_policy_feedback_provided': ['This field may not be null.'],
+                },
+                id='non-null-fields',
+            ),
+            pytest.param(
+                {
+                    # These fields shouldn't be allowed to be blank
+                    'kind': '',
+                    'subject': '',
+
+                    # Provide values for other required fields (so we don't get errors for them)
+                    'was_policy_feedback_provided': False,
+                    'date': '2020-01-01',
+                    'contacts': [ContactFactory],
+                    'dit_participants': [
+                        {
+                            'adviser': AdviserFactory,
+                        },
+                    ],
+                },
+                {
+                    'kind': ['"" is not a valid choice.'],
+                    'subject': ['This field may not be blank.'],
+                },
+                id='non-blank-fields',
+            ),
+            pytest.param(
+                {
+                    # These fields shouldn't be allowed to be empty
+                    'contacts': [],
+                    'dit_participants': [],
+
+                    # Provide values for other required fields (so we don't get errors for them)
+                    'kind': Interaction.Kind.INTERACTION,
+                    'subject': 'Test subject',
+                    'was_policy_feedback_provided': False,
+                    'date': '2020-01-01',
+                },
+                {
+                    'contacts': ['This list may not be empty.'],
+                    'dit_participants': {
+                        'non_field_errors': ['This list may not be empty.'],
+                    },
+                },
+                id='non-empty-fields',
+            ),
+            pytest.param(
+                {
+                    # These fields shouldn't be allowed to be blank for interactions
+                    'communication_channel': None,
+                    'service': None,
+
+                    # Fill in the standard fields to test interaction validation
+                    'kind': Interaction.Kind.INTERACTION,
+                    'subject': 'test subject',
+                    'was_policy_feedback_provided': False,
+                    'date': '2020-01-01',
+                    'contacts': [ContactFactory],
+                    'dit_participants': [
+                        {
+                            'adviser': AdviserFactory,
+                        },
+                    ],
+                },
+                {
+                    'communication_channel': ['This field is required.'],
+                    'service': ['This field is required.'],
+                },
+                id='interaction-non-blank-fields',
+            ),
+            pytest.param(
+                {
+                    # These fields shouldn't be allowed to be blank for service deliveries
+                    'is_event': None,
+                    'service': None,
+
+                    # Fill in the standard fields to test interaction validation
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
+                    'subject': 'test subject',
+                    'was_policy_feedback_provided': False,
+                    'date': '2020-01-01',
+                    'contacts': [ContactFactory],
+                    'dit_participants': [
+                        {
+                            'adviser': AdviserFactory,
+                        },
+                    ],
+                },
+                {
+                    'is_event': ['This field is required.'],
+                    'service': ['This field is required.'],
+                },
+                id='service-delivery-non-blank-fields',
+            ),
+        ),
+    )
+    def test_body_validation(self, request_data, expected_response_data):
+        """Test validation of the request body in various cases."""
+        referral = CompanyReferralFactory()
+        url = _complete_url(referral.pk)
+
+        resolved_data = resolve_objects(request_data)
+        response = self.api_client.post(url, data=resolved_data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_response_data
+
+    def test_updates_referral_status(self):
+        """Test that the status of the referral is updated on success."""
+        referral = CompanyReferralFactory()
+        url = _complete_url(referral.pk)
+
+        request_data = _sample_valid_request_data(referral)
+
+        with freeze_time(FROZEN_DATETIME):
+            response = self.api_client.post(url, data=request_data)
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        referral.refresh_from_db()
+
+        assert referral.status == CompanyReferral.Status.COMPLETE
+        assert referral.completed_by == self.user
+        assert referral.completed_on == FROZEN_DATETIME
+        assert referral.modified_by == self.user
+        assert referral.modified_on == FROZEN_DATETIME
+
+    @pytest.mark.parametrize(
+        'extra_data',
+        (
+            pytest.param(
+                {
+                    'kind': Interaction.Kind.INTERACTION,
+                    'communication_channel': lambda: random_obj_for_model(CommunicationChannel),
+                },
+                id='interaction',
+            ),
+            pytest.param(
+                {
+                    'kind': Interaction.Kind.INTERACTION,
+                    'communication_channel': lambda: random_obj_for_model(CommunicationChannel),
+                    # Any company in the request body should be ignored
+                    'company': CompanyFactory,
+                },
+                id='company-is-ignored',
+            ),
+            pytest.param(
+                {
+                    'kind': Interaction.Kind.SERVICE_DELIVERY,
+                    'is_event': True,
+                    'event': EventFactory,
+                },
+                id='service-delivery',
+            ),
+        ),
+    )
+    def test_creates_an_interaction(self, extra_data):
+        """Test that an interaction is created on success."""
+        referral = CompanyReferralFactory()
+        url = _complete_url(referral.pk)
+
+        contact = ContactFactory(company=referral.company)
+        service = random_service()
+
+        request_data = {
+            'kind': Interaction.Kind.INTERACTION,
+            'subject': 'test subject',
+            'date': '2020-02-03',
+            'dit_participants': [
+                {'adviser': self.user},
+            ],
+            'contacts': [contact],
+            'service': service,
+            'was_policy_feedback_provided': False,
+            **extra_data,
+        }
+
+        resolved_request_data = resolve_objects(request_data)
+
+        with freeze_time(FROZEN_DATETIME):
+            response = self.api_client.post(url, data=resolved_request_data)
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        referral.refresh_from_db()
+
+        assert referral.interaction_id
+        interaction_data = Interaction.objects.values().get(pk=referral.interaction_id)
+        assert interaction_data == {
+            # Automatically set fields
+            'company_id': referral.company_id,
+            'created_by_id': self.user.pk,
+            'created_on': FROZEN_DATETIME,
+            'id': referral.interaction_id,
+            'modified_by_id': self.user.pk,
+            'modified_on': FROZEN_DATETIME,
+
+            # Fields specified in the request body
+            'communication_channel_id': resolved_request_data.get('communication_channel'),
+            'date': datetime(2020, 2, 3, tzinfo=utc),
+            'event_id': resolved_request_data.get('event'),
+            'grant_amount_offered': None,
+            'investment_project_id': None,
+            'kind': resolved_request_data['kind'],
+            'net_company_receipt': None,
+            'notes': '',
+            'policy_feedback_notes': '',
+            'service_answers': None,
+            'service_delivery_status_id': None,
+            'service_id': service.pk,
+            'source': None,
+            'status': Interaction.Status.COMPLETE,
+            'subject': resolved_request_data['subject'],
+            'theme': None,
+            'was_policy_feedback_provided': resolved_request_data['was_policy_feedback_provided'],
+            'were_countries_discussed': None,
+
+            # Other fields
+            'archived': False,
+            'archived_by_id': None,
+            'archived_documents_url_path': '',
+            'archived_on': None,
+            'archived_reason': None,
+        }
+
+        assert list(referral.interaction.contacts.all()) == [contact]
+
+        participant = referral.interaction.dit_participants.get()
+        assert participant.adviser == self.user
+        assert participant.team == self.user.dit_team
+
+
+def _sample_valid_request_data(referral):
+    adviser = AdviserFactory()
+    contact = ContactFactory(company=referral.company)
+    communication_channel = random_obj_for_model(CommunicationChannel)
+    service = random_service()
+
+    return {
+        'kind': Interaction.Kind.INTERACTION,
+        'communication_channel': communication_channel.pk,
+        'subject': 'test subject',
+        'date': '2020-02-03',
+        'dit_participants': [
+            {'adviser': adviser.pk},
+        ],
+        'contacts': [contact.pk],
+        'service': service.pk,
+        'was_policy_feedback_provided': False,
+    }

--- a/datahub/company_referral/urls.py
+++ b/datahub/company_referral/urls.py
@@ -22,4 +22,9 @@ urlpatterns = [
         ),
         name='item',
     ),
+    path(
+        'company-referral/<uuid:pk>/complete',
+        CompanyReferralViewSet.as_action_view('complete'),
+        name='complete',
+    ),
 ]

--- a/datahub/company_referral/views.py
+++ b/datahub/company_referral/views.py
@@ -1,7 +1,15 @@
 from django.db.models import Q
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
 from datahub.company_referral.models import CompanyReferral
-from datahub.company_referral.serializers import CompanyReferralSerializer
+from datahub.company_referral.serializers import (
+    CompanyReferralSerializer,
+    CompleteCompanyReferralSerializer,
+)
+from datahub.core.permissions import HasPermissions
+from datahub.core.schemas import StubSchema
 from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
 
@@ -32,3 +40,41 @@ class CompanyReferralViewSet(CoreViewSet):
             )
 
         return super().get_queryset()
+
+    @action(
+        methods=['post'],
+        detail=True,
+        schema=StubSchema(),
+        permission_classes=[
+            HasPermissions('company_referral.change_companyreferral'),
+        ],
+    )
+    def complete(self, request, **kwargs):
+        """
+        View for completing a referral.
+
+        Completing a referral involves creating an interaction and linking the referral and
+        interaction together. Hence, this view creates an interaction and updates the referral
+        object accordingly.
+        """
+        referral = self.get_object()
+        context = {
+            **self.get_serializer_context(),
+            # Used by HasAssociatedInvestmentProjectValidator
+            'check_association_permissions': False,
+            'referral': referral,
+            'user': request.user,
+        }
+        data = {
+            **request.data,
+            'company': {
+                'id': referral.company.pk,
+            },
+        }
+        serializer = CompleteCompanyReferralSerializer(
+            data=data,
+            context=context,
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+        return Response(status=status.HTTP_201_CREATED)

--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -252,7 +252,7 @@ class InteractionCSVRowForm(forms.Form):
             return
 
         transformed_data = self.cleaned_data_as_serializer_dict()
-        serializer = InteractionSerializer(context={'is_bulk_import': True})
+        serializer = InteractionSerializer(context={'check_association_permissions': False})
 
         try:
             serializer.run_validators(transformed_data)

--- a/datahub/interaction/email_processors/processors.py
+++ b/datahub/interaction/email_processors/processors.py
@@ -163,7 +163,10 @@ class CalendarInteractionEmailProcessor(EmailProcessor):
         Returns the instantiated serializer.
         """
         transformed_data = self._to_serializer_format(data)
-        serializer = InteractionSerializer(context={'is_bulk_import': True}, data=transformed_data)
+        serializer = InteractionSerializer(
+            context={'check_association_permissions': False},
+            data=transformed_data,
+        )
         serializer.is_valid(raise_exception=True)
         return serializer
 

--- a/datahub/interaction/permissions.py
+++ b/datahub/interaction/permissions.py
@@ -86,10 +86,10 @@ class HasAssociatedInvestmentProjectValidator:
 
         :param attrs:   Serializer data (post-field-validation/processing)
         """
-        # If the validator is being called from the admin site import interactions tool
-        # do nothing, as the logic below is irrelevant for admin site users, and is only
-        # functional for API requests via DRF views
-        if serializer.context.get('is_bulk_import'):
+        # If the validator is being called from e.g. the admin site import interactions tool
+        # do nothing, as the logic below is only really relevant for standard users directly
+        # creating or editing interactions
+        if not serializer.context.get('check_association_permissions', True):
             return
 
         if serializer.instance:


### PR DESCRIPTION
### Description of change

This adds a new view at `POST /v4/company-referral/<ID>/complete` for completing a company referral.

Completing a company referral involves creating an interaction (as well as updating the status of the referral).

(The view itself is relatively simple – most of the additions are tests.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
