### PR TITLE
Set PostgreSQL password in CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,8 +29,8 @@ job_defaults: &job_defaults
     ADMIN_OAUTH2_LOGOUT_PATH: '/o/logout'
     ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
     ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
-    DATABASE_URL: postgresql://postgres@localhost/datahub
-    MI_DATABASE_URL: postgresql://postgres@mi-postgres/mi
+    DATABASE_URL: postgresql://postgres:datahub@postgres/datahub
+    MI_DATABASE_URL: postgresql://postgres:datahub@mi-postgres/mi
     DEBUG: 'True'
     DJANGO_SECRET_KEY: changeme
     DJANGO_SETTINGS_MODULE: config.settings.local
@@ -56,13 +56,16 @@ job_defaults: &job_defaults
     - image: <<parameters.es_image>>
 
     - image: <<parameters.postgres_image>>
+      name: postgres
       environment:
-        POSTGRES_DB=datahub
+        POSTGRES_DB: datahub
+        POSTGRES_PASSWORD: datahub
 
     - image: <<parameters.mi_postgres_image>>
       name: mi-postgres
       environment:
-        POSTGRES_DB=mi
+        POSTGRES_DB: mi
+        POSTGRES_PASSWORD: datahub
 
   steps:
     - checkout


### PR DESCRIPTION
### Description of change

The `postgres` Docker image now requires a password to be set. This change sets a password in the CircleCI build to meet that requirement.

See https://github.com/docker-library/postgres/issues/681 for more information.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
