### PR TITLE
Test already-linked company with new duns_number

### DIFF
--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1200,12 +1200,13 @@ class TestCompanyLinkView(APITestMixin):
             reverse('api-v4:dnb-api:company-link'),
             data={
                 'company_id': company.pk,
-                'duns_number': '123456789',
+                'duns_number': '012345678',
             },
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            'duns_number': ['Company with duns_number: 123456789 already exists in DataHub.'],
+            'detail': f'Company {str(company.id)} is already linked '
+                      'with duns number 123456789',
         }
 
     def test_duplicate_duns_number(self):


### PR DESCRIPTION
### Description of change

I missed this which made this test fail on the same codepath as the one after it. 

TY @currycoder for catching this 🙏 

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
