### PR TITLE
Fix postgres docker-compose images

### DIFF
--- a/changelog/fix-postgres-with-docker.bugfix.md
+++ b/changelog/fix-postgres-with-docker.bugfix.md
@@ -1,0 +1,3 @@
+A fix was made for environments using docker-compose which enables the postgres
+image to start successfully. A `POSTGRES_PASSWORD` was added for each postgres
+image and configs were updated accordingly.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,12 +32,14 @@ services:
     restart: always
     environment:
       - POSTGRES_DB=datahub
+      - POSTGRES_PASSWORD=datahub
 
   mi-postgres:
     image: postgres:9.6
     restart: always
     environment:
       - POSTGRES_DB=mi
+      - POSTGRES_PASSWORD=mi
 
   es:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.8.2

--- a/sample.env
+++ b/sample.env
@@ -1,6 +1,6 @@
 # Environment variables specific to usage with docker-compose
-DATABASE_URL=postgresql://postgres@postgres/datahub
-MI_DATABASE_URL=postgresql://postgres@mi-postgres/mi
+DATABASE_URL=postgresql://postgres:datahub@postgres/datahub
+MI_DATABASE_URL=postgresql://postgres:mi@mi-postgres/mi
 POSTGRES_URL=tcp://postgres:5432
 MI_POSTGRES_URL=tcp://mi-postgres:5432
 DEBUG=True


### PR DESCRIPTION
### Description of change

Following on from #2596 

A fix was made for environments using docker-compose which enables the postgres image to start successfully. A `POSTGRES_PASSWORD` was added for each postgres image and configs were updated accordingly.

Note: Devs running the API under docker will need to do the following:
```
docker-compose down
docker-compose rm
# copy DATABASE_URL and MI_DATABASE_URL lines from sample.env to .env file
docker-compose up --build -d
```

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
