### PR TITLE
Mechanism for syncing fields on outdated Data Hub company records with D&B

### DIFF
--- a/changelog/company/sync-outdated-company-with-dnb-task.feature.md
+++ b/changelog/company/sync-outdated-company-with-dnb-task.feature.md
@@ -1,0 +1,6 @@
+A celery task `datahub.dnb_api.tasks.sync_outdated_companies_with_dnb` was added
+which provides a mechanism for syncing fields on outdated Data Hub company records
+with D&B.
+This can be used to "backfill" older Company records with newly recorded D&B
+data; e.g. for rolling out company hierarchies to all D&B linked companies
+by syncing the `global_ultimate_duns_number` field.

--- a/datahub/dnb_api/tasks.py
+++ b/datahub/dnb_api/tasks.py
@@ -4,6 +4,7 @@ from celery import shared_task
 from celery.result import ResultSet
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from django.db.models import F, Max, Q
 from django.utils.timezone import now
 from django_pglocks import advisory_lock
 from rest_framework.status import is_server_error
@@ -78,6 +79,82 @@ def sync_company_with_dnb(
     if not update_descriptor:
         update_descriptor = f'celery:sync_company_with_dnb:{self.request.id}'
     _sync_company_with_dnb(company_id, fields_to_update, self, update_descriptor, retry_failures)
+
+
+@shared_task(
+    bind=True,
+    acks_late=True,
+    priority=9,
+    max_retries=3,
+    rate_limit=1,  # Run this task at most once per worker per second
+    queue='long-running',
+)
+def sync_company_with_dnb_rate_limited(
+    self,
+    company_id,
+    fields_to_update=None,
+    update_descriptor=None,
+    retry_failures=True,
+    simulate=False,
+):
+    """
+    A rate limited wrapper around the sync_company_with_dnb task. This task
+    can be used for bulk tasks to ensure that we do not exceed our agreed
+    rate limit with D&B.
+    """
+    message = f'Syncing dnb-linked company: {company_id}'
+    if simulate:
+        logger.info(f'[SIMULATION] {message}')
+        return
+    sync_company_with_dnb.apply(
+        kwargs={
+            'company_id': company_id,
+            'fields_to_update': fields_to_update,
+            'update_descriptor': update_descriptor,
+            'retry_failures': retry_failures,
+        },
+    )
+    logger.info(message)
+
+
+@shared_task(
+    bind=True,
+    acks_late=True,
+    priority=9,
+    queue='long-running',
+)
+def sync_outdated_companies_with_dnb(
+    self,
+    dnb_modified_on_before,
+    fields_to_update=None,
+    limit=100,
+    simulate=True,
+):
+    """
+    Sync company records with data sourced from DNB which are determined as outdated.
+    This task will filter dnb-matched companies which have a `dnb_modified_on` date which is before
+    `dnb_modified_on_before` and will then interact with dnb-service to get the latest data to sync
+    these companies.
+    """
+    company_ids = Company.objects.filter(
+        Q(dnb_modified_on__lte=dnb_modified_on_before) | Q(dnb_modified_on__isnull=True),
+        duns_number__isnull=False,
+    ).annotate(
+        most_recent_interaction_date=Max('interactions__date'),
+    ).order_by(
+        F('most_recent_interaction_date').desc(nulls_last=True),
+        'dnb_modified_on',
+    ).values_list('id', flat=True)[:limit]
+
+    for company_id in company_ids:
+        sync_company_with_dnb_rate_limited.apply_async(
+            kwargs={
+                'company_id': company_id,
+                'fields_to_update': fields_to_update,
+                'update_descriptor': 'celery:sync_outdated_companies_with_dnb:{self.request.id}',
+                'simulate': simulate,
+            },
+        )
 
 
 def _record_audit(update_results, producer_task, start_time):


### PR DESCRIPTION
### Description of change

A celery task `datahub.dnb_api.tasks.sync_outdated_companies_with_dnb` was added which provides a mechanism for syncing fields on outdated Data Hub company records with D&B.

This can be used to "backfill" older Company records with newly recorded D&B data; e.g. for rolling out company hierarchies to all D&B linked companies by syncing the `global_ultimate_duns_number` field.

The idea is that we will run this task nightly to roll out company hierarchies, with progressively increasing limits until we reach an agreed target (e.g. 250 calls per night).  This will slowly fill in the data that we need while keeping us well below our D&B API limits.

### Possible points of contention

- The rate limiting enforced by celery is not explicitly tested.  My understanding is that this would be hard for us to do with our current test suite set up due to the dependency on `CELERY_ALWAYS_EAGER`.  To mitigate this risk, we will firstly run the task in simulation mode and interrogate the log timestamps to ensure that they have 1 second gaps.
- `datahub/dnb_api/tasks.py` (and it's test file) is getting long.  I'll follow up this PR with a separate PR to break those files down.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
