### PR TITLE
Add type  to Company Referral Activity Stream payload

### DIFF
--- a/changelog/company/company-referrals-activity-stream.api.md
+++ b/changelog/company/company-referrals-activity-stream.api.md
@@ -1,0 +1,1 @@
+The activity-stream payload for Company Referral will now contain `type` to be consistent with other payloads.

--- a/datahub/activity_stream/company_referral/serializers.py
+++ b/datahub/activity_stream/company_referral/serializers.py
@@ -26,6 +26,7 @@ class CompanyReferralActivitySerializer(ActivitySerializer):
             'generator': self._get_generator(),
             'object': {
                 'id': company_referral_id,
+                'type': ['dit:CompanyReferral'],
                 'startTime': instance.created_on,
                 'dit:subject': instance.subject,
                 'dit:status': str(instance.status),

--- a/datahub/activity_stream/company_referral/test/test_views.py
+++ b/datahub/activity_stream/company_referral/test/test_views.py
@@ -38,6 +38,7 @@ def test_company_referral_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubCompanyReferral:{company_referral.id}',
+                    'type': ['dit:CompanyReferral'],
                     'startTime': format_date_or_datetime(company_referral.created_on),
                     'dit:subject': company_referral.subject,
                     'dit:status': str(company_referral.status),
@@ -118,6 +119,7 @@ def test_closed_company_referral_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubCompanyReferral:{company_referral.id}',
+                    'type': ['dit:CompanyReferral'],
                     'startTime': format_date_or_datetime(company_referral.created_on),
                     'dit:subject': company_referral.subject,
                     'dit:status': str(company_referral.status),
@@ -213,6 +215,7 @@ def test_complete_company_referral_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubCompanyReferral:{company_referral.id}',
+                    'type': ['dit:CompanyReferral'],
                     'startTime': format_date_or_datetime(company_referral.created_on),
                     'dit:subject': company_referral.subject,
                     'dit:status': str(company_referral.status),
@@ -310,6 +313,7 @@ def test_company_referral_activity_without_team_and_contact(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubCompanyReferral:{company_referral.id}',
+                    'type': ['dit:CompanyReferral'],
                     'startTime': format_date_or_datetime(company_referral.created_on),
                     'dit:subject': company_referral.subject,
                     'dit:status': str(company_referral.status),


### PR DESCRIPTION
### Description of change

This PR adds `type` field to the Activity Stream's Company Referrals payload. This is to be consistent with other objects and make it easy for the Front End to figure out the type of the object being parsed.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
