### PR TITLE
Add support for referrals to admin site company merging tool

### DIFF
--- a/changelog/company/merge-tool-referrals.feature.md
+++ b/changelog/company/merge-tool-referrals.feature.md
@@ -1,0 +1,1 @@
+The company merging tool in the admin site now allows companies with referrals to be merged. (All referrals are moved to the company that’s retained.)

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -4,6 +4,7 @@ from typing import Callable, NamedTuple, Sequence, Type
 from django.db import models
 
 from datahub.company.models import Company, Contact
+from datahub.company_referral.models import CompanyReferral
 from datahub.core.exceptions import DataHubException
 from datahub.core.model_helpers import get_related_fields, get_self_referential_relations
 from datahub.interaction.models import Interaction
@@ -14,6 +15,7 @@ from datahub.user.company_list.models import CompanyListItem
 
 ALLOWED_RELATIONS_FOR_MERGING = {
     Company._meta.get_field('company_list_items').remote_field,
+    CompanyReferral.company.field,
     Contact.company.field,
     Interaction.company.field,
     InvestmentProject.investor_company.field,
@@ -69,6 +71,7 @@ class MergeConfiguration(NamedTuple):
 
 MERGE_CONFIGURATION = [
     MergeConfiguration(Interaction, ('company',)),
+    MergeConfiguration(CompanyReferral, ('company',)),
     MergeConfiguration(Contact, ('company',)),
     MergeConfiguration(InvestmentProject, INVESTMENT_PROJECT_COMPANY_FIELDS),
     MergeConfiguration(Order, ('company',)),

--- a/datahub/company/test/admin/merge/test_step_3.py
+++ b/datahub/company/test/admin/merge/test_step_3.py
@@ -227,23 +227,22 @@ class TestConfirmMergeViewPost(AdminTestMixin):
             'target_company': escape(str(target_company)),
         }
 
+        source_non_project_related_objects = [
+            *source_company_list_items,
+            *source_contacts,
+            *source_interactions,
+            *source_orders,
+            *source_referrals,
+        ]
         for obj in chain(
-            source_interactions,
-            source_contacts,
-            source_orders,
-            source_referrals,
+            source_non_project_related_objects,
             chain.from_iterable(source_investment_projects_by_field.values()),
         ):
             obj.refresh_from_db()
 
-        assert all(obj.company == target_company for obj in source_interactions)
-        assert all(obj.modified_on == creation_time for obj in source_interactions)
-        assert all(obj.company == target_company for obj in source_contacts)
-        assert all(obj.modified_on == creation_time for obj in source_contacts)
-        assert all(obj.company == target_company for obj in source_orders)
-        assert all(obj.modified_on == creation_time for obj in source_orders)
-        assert all(obj.company == target_company for obj in source_referrals)
-        assert all(obj.modified_on == creation_time for obj in source_referrals)
+        assert all(obj.company == target_company for obj in source_non_project_related_objects)
+        assert all(obj.modified_on == creation_time for obj in source_non_project_related_objects)
+
         for field, investment_projects in source_investment_projects_by_field.items():
             assert all(getattr(obj, field) == target_company for obj in investment_projects)
             assert all(obj.modified_on == creation_time for obj in investment_projects)

--- a/datahub/company/test/test_merge.py
+++ b/datahub/company/test/test_merge.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from itertools import chain
 from unittest.mock import patch
 
 import pytest
@@ -289,17 +288,19 @@ class TestDuplicateCompanyMerger:
             Order: {'company': len(source_orders)},
         }
 
-        for obj in chain(source_interactions, source_contacts, source_orders, source_referrals):
+        source_related_objects = [
+            *source_company_list_items,
+            *source_contacts,
+            *source_interactions,
+            *source_orders,
+            *source_referrals,
+        ]
+
+        for obj in source_related_objects:
             obj.refresh_from_db()
 
-        assert all(obj.company == target_company for obj in source_interactions)
-        assert all(obj.modified_on == creation_time for obj in source_interactions)
-        assert all(obj.company == target_company for obj in source_contacts)
-        assert all(obj.modified_on == creation_time for obj in source_contacts)
-        assert all(obj.company == target_company for obj in source_orders)
-        assert all(obj.modified_on == creation_time for obj in source_orders)
-        assert all(obj.company == target_company for obj in source_referrals)
-        assert all(obj.modified_on == creation_time for obj in source_referrals)
+        assert all(obj.company == target_company for obj in source_related_objects)
+        assert all(obj.modified_on == creation_time for obj in source_related_objects)
 
         source_company.refresh_from_db()
 


### PR DESCRIPTION
### Description of change

This adds support for company referrals to the company merging tool in the admin site.

Any referrals on the source company (the company to archive) are moved to the target company (the company to retain).

I also spotted that there were some missing assertions for company list items, so have added these in in the second commit.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
