### PR TITLE
Switch on global ultimate number ingestion in simulation

### DIFF
--- a/changelog/company/start-sync-global-ultimate-duns.feature.md
+++ b/changelog/company/start-sync-global-ultimate-duns.feature.md
@@ -1,0 +1,3 @@
+A task was added to celery beat to run daily syncs of global ultimate duns numbers.
+Initially, this task is run with the simulation flag so that we can observe that
+it is behaving correctly.


### PR DESCRIPTION
### Description of change

A task was added to celery beat to run daily syncs of global ultimate duns numbers. Initially, this task is run with the simulation flag so that we can observe that it is behaving correctly.

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [X] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
