### PR TITLE
Add company referral by interaction ID endpoint

### DIFF
--- a/changelog/interaction/interaction-company-referral-detail.api.md
+++ b/changelog/interaction/interaction-company-referral-detail.api.md
@@ -1,0 +1,2 @@
+A new endpoint, `GET /v4/interaction/<uuid:interaction_id>/company-referral` has been added. It returns the details
+of completed company referral. Refer to the API documentation for the schema.

--- a/datahub/company_referral/test/test_views.py
+++ b/datahub/company_referral/test/test_views.py
@@ -461,14 +461,18 @@ class TestGetCompanyReferralByInteractionID(APITestMixin):
         response = api_client.get(url)
         assert response.status_code == expected_status
 
-    def test_returns_404_for_non_existent_referral(self):
-        """Test that a 404 is returned for a non-existent referral ID."""
+    def test_returns_404_for_non_existent_interaction(self):
+        """Test that a 404 is returned for a non-existent interaction."""
         url = _item_by_interaction_id_url(uuid4())
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_retrieve_a_complete_referral(self):
-        """Test that a complete referral can be retrieved by interaction ID."""
+        """
+        Test that a complete referral can be retrieved by interaction ID.
+
+        Only complete referral has interaction assigned.
+        """
         referral = CompleteCompanyReferralFactory()
         url = _item_by_interaction_id_url(referral.interaction.pk)
 

--- a/datahub/company_referral/urls.py
+++ b/datahub/company_referral/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
-from datahub.company_referral.views import CompanyReferralViewSet
+from datahub.company_referral.views import (
+    CompanyReferralByInteractionIDViewSet,
+    CompanyReferralViewSet,
+)
 
 urlpatterns = [
     path(
@@ -26,5 +29,14 @@ urlpatterns = [
         'company-referral/<uuid:pk>/complete',
         CompanyReferralViewSet.as_action_view('complete'),
         name='complete',
+    ),
+    path(
+        'interaction/<uuid:interaction_id>/company-referral',
+        CompanyReferralByInteractionIDViewSet.as_view(
+            {
+                'get': 'retrieve',
+            },
+        ),
+        name='item-by-interaction-id',
     ),
 ]

--- a/datahub/company_referral/views.py
+++ b/datahub/company_referral/views.py
@@ -14,8 +14,8 @@ from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
 
 
-class CompanyReferralViewSet(CoreViewSet):
-    """Company referral view set."""
+class CompanyReferralBaseViewSet(CoreViewSet):
+    """Company referral base view set."""
 
     serializer_class = CompanyReferralSerializer
     required_scopes = (Scope.internal_front_end,)
@@ -28,6 +28,10 @@ class CompanyReferralViewSet(CoreViewSet):
         'interaction',
         'recipient__dit_team',
     )
+
+
+class CompanyReferralViewSet(CompanyReferralBaseViewSet):
+    """Company referral view set."""
 
     def get_queryset(self):
         """
@@ -78,3 +82,9 @@ class CompanyReferralViewSet(CoreViewSet):
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(status=status.HTTP_201_CREATED)
+
+
+class CompanyReferralByInteractionIDViewSet(CompanyReferralBaseViewSet):
+    """Company referral by interaction ID view set."""
+
+    lookup_field = 'interaction_id'


### PR DESCRIPTION
### Description of change

This adds a new endpoint that helps the front-end display company referral detail when the viewed interaction has been created as a result of referral completion.
There is 1:1 relation between completed referral and interaction.
The endpoint is under the following URL:

`GET /v4/interaction/<uuid:interaction_id>/company-referral`

The response is the same as with the company referral item endpoint.

Only a completed referral can have assigned interaction, so the endpoint is only able to return complete one, otherwise the result will be 404.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
