### PR TITLE
Moving data workspace export country datasets to new model

### DIFF
--- a/changelog/company/company-export-to-countries.api.md
+++ b/changelog/company/company-export-to-countries.api.md
@@ -1,0 +1,3 @@
+`GET /v4/dataset/company-export-to-countries-dataset`
+
+This endpoint now exposes `CURRENTLY_EXPORTING` countries from new export country model instead of old `export_to_countries` field, which will be deprecated shortly.

--- a/changelog/company/company-future-interest-countries.api.md
+++ b/changelog/company/company-future-interest-countries.api.md
@@ -1,0 +1,3 @@
+`GET /v4/dataset/company-future-interest-countries-dataset`
+
+This endpoint now exposes `FUTURE_INTEREST` countries from new export country model instead of old `future_interest_countries` field, which will be deprecated shortly.

--- a/datahub/dataset/company_export_to_country/pagination.py
+++ b/datahub/dataset/company_export_to_country/pagination.py
@@ -1,9 +1,0 @@
-from datahub.dataset.core.pagination import DatasetCursorPagination
-
-
-class CompanyExportToCountriesDatasetViewCursorPagination(DatasetCursorPagination):
-    """
-    Cursor Pagination for CompanyExportToCountries
-    """
-
-    ordering = ('id', )

--- a/datahub/dataset/company_export_to_country/test/test_views.py
+++ b/datahub/dataset/company_export_to_country/test/test_views.py
@@ -1,39 +1,33 @@
-import factory
 import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from datahub.company.models import Company
-from datahub.company.test.factories import CompanyFactory
-from datahub.core import constants
+from datahub.company.models import CompanyExportCountry
+from datahub.company.test.factories import CompanyExportCountryFactory, CompanyFactory
 from datahub.core.test.factories import to_many_field
 from datahub.dataset.core.test import BaseDatasetViewTest
-from datahub.metadata.models import Country
-
-
-class CompanyExportToCountriesFactory(factory.django.DjangoModelFactory):
-    """Returns a company-export_to_country relationship"""
-
-    company = factory.SubFactory(CompanyFactory)
-    country_id = constants.Country.united_kingdom.value.id
-
-    class Meta:
-        model = Company.export_to_countries.through
 
 
 class CompanyWithExportToCountriesFactory(CompanyFactory):
     """Extends Company Factory to provide a export_to_countries"""
 
     @to_many_field
-    def export_to_countries(self):
-        """Return stubbed countries"""
-        return list(Country.objects.all()[:1])
+    def export_countries(self):
+        """Return stubbed export countries"""
+        return [
+            CompanyExportCountryFactory(
+                status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
+            ),
+        ]
 
 
 def get_expected_data_from_company(company):
-    """Returns company export_to_countries data as a list of dictionaries"""
-    values = company.export_to_countries.through.objects.filter(
-        company_id=company.id,
+    """
+    Returns company export_countries data with status `currently_exporting`
+    as a list of dictionaries
+    """
+    values = company.export_countries.filter(
+        status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
     ).values(
         'id',
         'company_id',
@@ -44,7 +38,7 @@ def get_expected_data_from_company(company):
     for value in values:
         expected.append(
             {
-                'id': value['id'],
+                'id': str(value['id']),
                 'company_id': str(value['company_id']),
                 'country__name': value['country__name'],
                 'country__iso_alpha2_code': value['country__iso_alpha2_code'],
@@ -60,7 +54,7 @@ class TestCompanyExportToCountriesDatasetViewSet(BaseDatasetViewTest):
     Tests for CompanyExportToCountriesDatasetView
     """
 
-    factory = CompanyExportToCountriesFactory
+    factory = CompanyExportCountryFactory
     view_url = reverse('api-v4:dataset:company-export-to-countries-dataset')
 
     @pytest.mark.parametrize(
@@ -75,20 +69,24 @@ class TestCompanyExportToCountriesDatasetViewSet(BaseDatasetViewTest):
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
         response_results = response.json()['results']
-        result = response_results
         expected_result = get_expected_data_from_company(company)
-        assert result == expected_result
+        assert response_results == expected_result
 
     def test_with_multiple_records(self, data_flow_api_client):
         """Test that endpoint returns correct number of records"""
-        countries = Country.objects.all()[:3]
         company1 = CompanyFactory()
-        company2 = CompanyFactory(export_to_countries=countries[:2])
-        company3 = CompanyFactory(export_to_countries=countries[:1])
+        company2 = CompanyFactory()
+
+        CompanyExportCountryFactory.create_batch(2, company=company2)
+        company3 = CompanyFactory()
+
+        CompanyExportCountryFactory.create(company=company3)
         company4 = CompanyFactory()
+
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
         response_results = response.json()['results']
+        response_results = sorted(response_results, key=lambda x: x['id'])
         assert len(response_results) == 3
 
         companies = [company1, company2, company3, company4]

--- a/datahub/dataset/company_export_to_country/views.py
+++ b/datahub/dataset/company_export_to_country/views.py
@@ -1,4 +1,4 @@
-from datahub.company.models import Company
+from datahub.company.models import CompanyExportCountry
 from datahub.dataset.company_export_to_country.pagination import (
     CompanyExportToCountriesDatasetViewCursorPagination,
 )
@@ -17,7 +17,9 @@ class CompanyExportToCountriesDatasetView(BaseDatasetView):
 
     def get_dataset(self):
         """Returns list of company_export_to_countries records"""
-        return Company.export_to_countries.through.objects.values(
+        return CompanyExportCountry.objects.filter(
+            status=CompanyExportCountry.Status.CURRENTLY_EXPORTING,
+        ).values(
             'id',
             'company_id',
             'country__name',

--- a/datahub/dataset/company_export_to_country/views.py
+++ b/datahub/dataset/company_export_to_country/views.py
@@ -1,7 +1,4 @@
 from datahub.company.models import CompanyExportCountry
-from datahub.dataset.company_export_to_country.pagination import (
-    CompanyExportToCountriesDatasetViewCursorPagination,
-)
 from datahub.dataset.core.views import BaseDatasetView
 
 
@@ -13,8 +10,6 @@ class CompanyExportToCountriesDatasetView(BaseDatasetView):
     then be queried to create custom reports for users.
     """
 
-    pagination_class = CompanyExportToCountriesDatasetViewCursorPagination
-
     def get_dataset(self):
         """Returns list of company_export_to_countries records"""
         return CompanyExportCountry.objects.filter(
@@ -24,4 +19,5 @@ class CompanyExportToCountriesDatasetView(BaseDatasetView):
             'company_id',
             'country__name',
             'country__iso_alpha2_code',
+            'created_on',
         )

--- a/datahub/dataset/company_future_interest_countries/pagination.py
+++ b/datahub/dataset/company_future_interest_countries/pagination.py
@@ -1,9 +1,0 @@
-from datahub.dataset.core.pagination import DatasetCursorPagination
-
-
-class CompanyFutureInterestCountriesDatasetViewCursorPagination(DatasetCursorPagination):
-    """
-    Cursor Pagination for CompanyFutureInterestCountries
-    """
-
-    ordering = ('id', )

--- a/datahub/dataset/company_future_interest_countries/test/test_views.py
+++ b/datahub/dataset/company_future_interest_countries/test/test_views.py
@@ -1,39 +1,34 @@
-import factory
 import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from datahub.company.models import Company
-from datahub.company.test.factories import CompanyFactory
-from datahub.core import constants
+from datahub.company.models import CompanyExportCountry
+from datahub.company.test.factories import CompanyExportCountryFactory, CompanyFactory
 from datahub.core.test.factories import to_many_field
 from datahub.dataset.core.test import BaseDatasetViewTest
 from datahub.metadata.models import Country
-
-
-class CompanyFutureInterestCountriesFactory(factory.django.DjangoModelFactory):
-    """Returns a company-future_interest_country relationship"""
-
-    company = factory.SubFactory(CompanyFactory)
-    country_id = constants.Country.united_kingdom.value.id
-
-    class Meta:
-        model = Company.future_interest_countries.through
 
 
 class CompanyWithFutureInterestCountriesFactory(CompanyFactory):
     """Overrides Company Factory to provide a future interest country"""
 
     @to_many_field
-    def future_interest_countries(self):
-        """Return stubbed countries"""
-        return list(Country.objects.all()[:1])
+    def export_countries(self):
+        """Return stubbed export countries"""
+        return [
+            CompanyExportCountryFactory(
+                status=CompanyExportCountry.Status.FUTURE_INTEREST,
+            ),
+        ]
 
 
 def get_expected_data_from_company(company):
-    """Returns company future interest countries data as a list of dictionaries"""
-    values = company.future_interest_countries.through.objects.filter(
-        company_id=company.id,
+    """
+    Returns company export_countries data with status `future_interest`
+    as a list of dictionaries
+    """
+    values = company.export_countries.filter(
+        status=CompanyExportCountry.Status.FUTURE_INTEREST,
     ).values(
         'id',
         'company_id',
@@ -44,7 +39,7 @@ def get_expected_data_from_company(company):
     for value in values:
         expected.append(
             {
-                'id': value['id'],
+                'id': str(value['id']),
                 'company_id': str(value['company_id']),
                 'country__name': value['country__name'],
                 'country__iso_alpha2_code': value['country__iso_alpha2_code'],
@@ -60,7 +55,7 @@ class TestCompanyFutureinterestCountriesDatasetViewSet(BaseDatasetViewTest):
     Tests for CompanyFutureInterestCountriesDatasetView
     """
 
-    factory = CompanyFutureInterestCountriesFactory
+    factory = CompanyWithFutureInterestCountriesFactory
     view_url = reverse('api-v4:dataset:company-future-interest-countries-dataset')
 
     @pytest.mark.parametrize(
@@ -75,21 +70,35 @@ class TestCompanyFutureinterestCountriesDatasetViewSet(BaseDatasetViewTest):
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
         response_results = response.json()['results']
-        result = response_results
         expected_result = get_expected_data_from_company(company)
-        assert result == expected_result
+        assert response_results == expected_result
 
     def test_with_multiple_records(self, data_flow_api_client):
         """Test that endpoint returns correct number of records"""
-        countries = Country.objects.all()[:3]
+        countries = Country.objects.all()[:2]
         company1 = CompanyFactory()
-        company2 = CompanyFactory(future_interest_countries=countries[:2])
-        company3 = CompanyFactory(future_interest_countries=countries[:1])
+
+        company2 = CompanyFactory()
+        CompanyExportCountryFactory(
+            company=company2,
+            country=countries[0],
+            status=CompanyExportCountry.Status.FUTURE_INTEREST,
+        )
+
+        company3 = CompanyFactory()
+        CompanyExportCountryFactory(
+            company=company3,
+            country=countries[1],
+            status=CompanyExportCountry.Status.FUTURE_INTEREST,
+        )
+
         company4 = CompanyFactory()
+
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
         response_results = response.json()['results']
-        assert len(response_results) == 3
+        response_results = sorted(response_results, key=lambda x: x['id'])
+        assert len(response_results) == 2
 
         companies = [company1, company2, company3, company4]
         expected_results = []

--- a/datahub/dataset/company_future_interest_countries/test/test_views.py
+++ b/datahub/dataset/company_future_interest_countries/test/test_views.py
@@ -1,108 +1,86 @@
 import pytest
 from django.urls import reverse
+from freezegun import freeze_time
 from rest_framework import status
 
 from datahub.company.models import CompanyExportCountry
-from datahub.company.test.factories import CompanyExportCountryFactory, CompanyFactory
-from datahub.core.test.factories import to_many_field
+from datahub.company.test.factories import CompanyExportCountryFactory
+from datahub.core.test_utils import format_date_or_datetime
 from datahub.dataset.core.test import BaseDatasetViewTest
-from datahub.metadata.models import Country
 
 
-class CompanyWithFutureInterestCountriesFactory(CompanyFactory):
-    """Overrides Company Factory to provide a future interest country"""
+class FutureInterestExportCountryFactory(CompanyExportCountryFactory):
+    """Future interest company export country."""
 
-    @to_many_field
-    def export_countries(self):
-        """Return stubbed export countries"""
-        return [
-            CompanyExportCountryFactory(
-                status=CompanyExportCountry.Status.FUTURE_INTEREST,
-            ),
-        ]
+    status = CompanyExportCountry.Status.FUTURE_INTEREST
 
 
-def get_expected_data_from_company(company):
+def get_expected_data_from_export_country(export_country):
     """
     Returns company export_countries data with status `future_interest`
     as a list of dictionaries
     """
-    values = company.export_countries.filter(
-        status=CompanyExportCountry.Status.FUTURE_INTEREST,
-    ).values(
-        'id',
-        'company_id',
-        'country__name',
-        'country__iso_alpha2_code',
-    )
-    expected = []
-    for value in values:
-        expected.append(
-            {
-                'id': str(value['id']),
-                'company_id': str(value['company_id']),
-                'country__name': value['country__name'],
-                'country__iso_alpha2_code': value['country__iso_alpha2_code'],
-            },
-        )
-    expected = sorted(expected, key=lambda x: x['id'])
-    return expected
+    return {
+        'id': str(export_country.pk),
+        'company_id': str(export_country.company_id),
+        'country__name': export_country.country.name,
+        'country__iso_alpha2_code': export_country.country.iso_alpha2_code,
+        'created_on': format_date_or_datetime(export_country.created_on),
+    }
 
 
 @pytest.mark.django_db
-class TestCompanyFutureinterestCountriesDatasetViewSet(BaseDatasetViewTest):
+class TestCompanyFutureInterestCountriesDatasetViewSet(BaseDatasetViewTest):
     """
     Tests for CompanyFutureInterestCountriesDatasetView
     """
 
-    factory = CompanyWithFutureInterestCountriesFactory
+    factory = FutureInterestExportCountryFactory
     view_url = reverse('api-v4:dataset:company-future-interest-countries-dataset')
 
+    def test_response_body(self, data_flow_api_client):
+        """Test that endpoint returns the expected data for a single export country."""
+        export_country = self.factory()
+        response = data_flow_api_client.get(self.view_url)
+        assert response.status_code == status.HTTP_200_OK
+        response_results = response.json()['results']
+        assert len(response_results) == 1
+        result = response_results[0]
+        expected_result = get_expected_data_from_export_country(export_country)
+        assert result == expected_result
+
     @pytest.mark.parametrize(
-        'company_factory', (
-            CompanyFactory,
-            CompanyWithFutureInterestCountriesFactory,
+        'export_country_status',
+        (
+            CompanyExportCountry.Status.CURRENTLY_EXPORTING,
+            CompanyExportCountry.Status.NOT_INTERESTED,
         ),
     )
-    def test_company_with_no_interest(self, data_flow_api_client, company_factory):
-        """Test that endpoint returns with expected data for a single company"""
-        company = company_factory()
+    def test_excludes_other_statuses(self, data_flow_api_client, export_country_status):
+        """Test that endpoint excludes other export country statuses."""
+        CompanyExportCountry(status=export_country_status)
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
-        response_results = response.json()['results']
-        expected_result = get_expected_data_from_company(company)
-        assert response_results == expected_result
+        assert response.json()['results'] == []
 
     def test_with_multiple_records(self, data_flow_api_client):
-        """Test that endpoint returns correct number of records"""
-        countries = Country.objects.all()[:2]
-        company1 = CompanyFactory()
-
-        company2 = CompanyFactory()
-        CompanyExportCountryFactory(
-            company=company2,
-            country=countries[0],
-            status=CompanyExportCountry.Status.FUTURE_INTEREST,
-        )
-
-        company3 = CompanyFactory()
-        CompanyExportCountryFactory(
-            company=company3,
-            country=countries[1],
-            status=CompanyExportCountry.Status.FUTURE_INTEREST,
-        )
-
-        company4 = CompanyFactory()
+        """Test the ordering of results."""
+        with freeze_time('2019-01-01 12:30:00'):
+            export_country_1 = self.factory()
+        with freeze_time('2019-01-03 12:00:00'):
+            export_country_2 = self.factory()
+        with freeze_time('2019-01-01 12:00:00'):
+            export_country_3 = self.factory()
+            export_country_4 = self.factory()
 
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
         response_results = response.json()['results']
-        response_results = sorted(response_results, key=lambda x: x['id'])
-        assert len(response_results) == 2
-
-        companies = [company1, company2, company3, company4]
-        expected_results = []
-        for company in companies:
-            expected_results.extend(get_expected_data_from_company(company))
-        expected_results = sorted(expected_results, key=lambda x: x['id'])
-        assert response_results == expected_results
+        assert len(response_results) == 4
+        expected_results = [
+            *sorted([export_country_3, export_country_4], key=lambda x: x.pk),
+            export_country_1,
+            export_country_2,
+        ]
+        for index, export_country in enumerate(expected_results):
+            assert str(export_country.id) == response_results[index]['id']

--- a/datahub/dataset/company_future_interest_countries/views.py
+++ b/datahub/dataset/company_future_interest_countries/views.py
@@ -1,4 +1,4 @@
-from datahub.company.models import Company
+from datahub.company.models import CompanyExportCountry
 from datahub.dataset.company_future_interest_countries.pagination import (
     CompanyFutureInterestCountriesDatasetViewCursorPagination,
 )
@@ -17,7 +17,9 @@ class CompanyFutureInterestCountriesDatasetView(BaseDatasetView):
 
     def get_dataset(self):
         """Returns list of Company Future Interest Countries  records"""
-        return Company.future_interest_countries.through.objects.values(
+        return CompanyExportCountry.objects.filter(
+            status=CompanyExportCountry.Status.FUTURE_INTEREST,
+        ).values(
             'id',
             'company_id',
             'country__name',

--- a/datahub/dataset/company_future_interest_countries/views.py
+++ b/datahub/dataset/company_future_interest_countries/views.py
@@ -1,7 +1,4 @@
 from datahub.company.models import CompanyExportCountry
-from datahub.dataset.company_future_interest_countries.pagination import (
-    CompanyFutureInterestCountriesDatasetViewCursorPagination,
-)
 from datahub.dataset.core.views import BaseDatasetView
 
 
@@ -13,8 +10,6 @@ class CompanyFutureInterestCountriesDatasetView(BaseDatasetView):
     then be queried to create custom reports for users.
     """
 
-    pagination_class = CompanyFutureInterestCountriesDatasetViewCursorPagination
-
     def get_dataset(self):
         """Returns list of Company Future Interest Countries  records"""
         return CompanyExportCountry.objects.filter(
@@ -24,4 +19,5 @@ class CompanyFutureInterestCountriesDatasetView(BaseDatasetView):
             'company_id',
             'country__name',
             'country__iso_alpha2_code',
+            'created_on',
         )


### PR DESCRIPTION
### Description of change
As the implementation of new company export country model, replacing `Company` fields for export countries (`currently_exporting_to` and `future_interest_countries`), is now complete and deployed, this is to move data workspace datasets API from reading old fields to new model. This will enable us to remove old fields soon.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
