### PR TITLE
Configure company hierarchy rollout task to run without simulate flag

### DIFF
--- a/changelog/company/hierarchy-rollout-switch-off-simulate.feature.md
+++ b/changelog/company/hierarchy-rollout-switch-off-simulate.feature.md
@@ -1,0 +1,3 @@
+The daily company hierarchy rollout task was adjusted so that it is no longer
+in simulation mode. It will ingest a number of companies per night up to a limit
+configured by the `DAILY_HIERARCHY_ROLLOUT_LIMIT` environment variable.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -402,21 +402,24 @@ if REDIS_BASE_URL:
                 'simulate': False,
             }
         },
-        'dnb_heirarchies_backfill': {
+    }
+
+    if env.bool('ENABLE_DAILY_HIERARCHY_ROLLOUT', False):
+        CELERY_BEAT_SCHEDULE['dnb_heirarchies_backfill'] = {
             'task': 'datahub.dnb_api.tasks.sync_outdated_companies_with_dnb',
             'schedule': crontab(minute=0, hour=1,),
             'kwargs': {
-                # Backfill companies which were last updated before 24 October 2019 -
+                # Backfill companies which were last updated before 25 October 2019 -
                 # this is when we started recording the `global_ultimate_duns_number` field
                 'dnb_modified_on_before': datetime(
                     year=2019, month=10, day=24, hour=23, minute=59, second=59, tzinfo=utc,
                 ),
                 'fields_to_update': ['global_ultimate_duns_number',],
-                'limit': 100,
-                'simulate': True,
+                'limit': env.integer('DAILY_HIERARCHY_ROLLOUT_LIMIT', 10),
+                'simulate': False,
             },
-        },
-    }
+        }
+
     if env.bool('ENABLE_DAILY_ES_SYNC', False):
         CELERY_BEAT_SCHEDULE['sync_es'] = {
             'task': 'datahub.search.tasks.sync_all_models',


### PR DESCRIPTION
### Description of change
The daily company hierarchy rollout task was adjusted so that it is no longer in simulation mode. It will ingest a number of companies per night up to a limit configured by the `DAILY_HIERARCHY_ROLLOUT_LIMIT` environment variable.

A `ENABLE_DAILY_HIERARCHY_ROLLOUT` environment variable has been added so that we can limit this task to run in production only.  We observed that the simulated run ran on staging and production around the same time which might lead to us exceeding our rate limit.

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [X] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
