### PR TITLE
Fixed a bug in django settings for company hierarchy rollout

### DIFF
--- a/changelog/company/fix-hierarchy-rollout-settings.bugfix.md
+++ b/changelog/company/fix-hierarchy-rollout-settings.bugfix.md
@@ -1,0 +1,2 @@
+A bug was fixed in `config/settings/common.py` relating to the celery beat config 
+for the company hierarchy rollout.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -415,7 +415,7 @@ if REDIS_BASE_URL:
                     year=2019, month=10, day=24, hour=23, minute=59, second=59, tzinfo=utc,
                 ),
                 'fields_to_update': ['global_ultimate_duns_number',],
-                'limit': env.integer('DAILY_HIERARCHY_ROLLOUT_LIMIT', 10),
+                'limit': env.int('DAILY_HIERARCHY_ROLLOUT_LIMIT', 10),
                 'simulate': False,
             },
         }


### PR DESCRIPTION
### Description of change
A bug was fixed in `config/settings/common.py` relating to the celery beat config for the company hierarchy rollout.

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [X] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
