### PR TITLE
Add `created_by_id` field to the interactions dataset response

### DIFF
--- a/changelog/interaction/dataset-api-endpoint-add-created-by.api.md
+++ b/changelog/interaction/dataset-api-endpoint-add-created-by.api.md
@@ -1,0 +1,1 @@
+`GET /v4/dataset/interactions-dataset`: The field `created_by_id` was added to the interactions dataset endpoint.

--- a/datahub/dataset/interaction/test/test_views.py
+++ b/datahub/dataset/interaction/test/test_views.py
@@ -27,6 +27,7 @@ def get_expected_data_from_interaction(interaction):
         ),
         'company_id': str(interaction.company.id),
         'contact_ids': [str(x.id) for x in interaction.contacts.all().order_by('pk')],
+        'created_by_id': str(interaction.created_by_id),
         'created_on': format_date_or_datetime(interaction.created_on),
         'date': format_date_or_datetime(interaction.date),
         'event_id': (

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -48,6 +48,7 @@ class InteractionsDatasetView(BaseDatasetView):
             'communication_channel__name',
             'company_id',
             'contact_ids',
+            'created_by_id',
             'created_on',
             'date',
             'event_id',


### PR DESCRIPTION
### Description of change

Add `created_by_id` field to the interaction dataset response. T

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
