### PR TITLE
Fix adviser serialising in Investment Project Activity dataset endpoint

### DIFF
--- a/changelog/investment/investment-project-activity.bugfix.md
+++ b/changelog/investment/investment-project-activity.bugfix.md
@@ -1,0 +1,2 @@
+A bug was fixed in the `GET /v4/dataset/investment-projects-activity-dataset` endpoint so that the SPI report 
+can be serialised correctly.

--- a/datahub/dataset/investment_project/spi.py
+++ b/datahub/dataset/investment_project/spi.py
@@ -16,7 +16,7 @@ class SPIReportFormatter:
         'Data Hub ID': 'investment_project_id',
         'Enquiry processed': 'enquiry_processed',
         'Enquiry type': 'enquiry_type',
-        'Enquiry processed by': 'enquiry_processed_by_id',
+        'Enquiry processed by ID': 'enquiry_processed_by_id',
         'Assigned to IST': 'assigned_to_ist',
         'Project manager assigned': 'project_manager_assigned',
         'Project manager assigned by': 'project_manager_assigned_by_id',
@@ -26,8 +26,7 @@ class SPIReportFormatter:
     }
 
     required_fields_value_mapping = {
-        'Enquiry processed by': lambda adviser: str(adviser),
-        'Project manager assigned by': lambda adviser: str(adviser.id),
+        'Project manager assigned by': lambda adviser: str(adviser.id) if adviser else '',
     }
 
     def __init__(self):
@@ -37,7 +36,8 @@ class SPIReportFormatter:
     def filter_fields(self, result):
         """Filter results fields."""
         return {
-            self.required_fields_label_mapping[key]: value
+            self.required_fields_label_mapping[key]:
+                self.required_fields_value_mapping.get(key, lambda value: value)(value)
             for key, value in result.items()
             if key in self.required_fields_label_mapping
         }

--- a/datahub/dataset/investment_project/test/test_spi.py
+++ b/datahub/dataset/investment_project/test/test_spi.py
@@ -16,10 +16,10 @@ def test_spi_record_row_is_formatted():
         'Project created on': 'project_created_on',
         'Enquiry processed': 'enquiry_processed',
         'Enquiry type': 'enquiry_type',
-        'Enquiry processed by': str(AdviserFactory().id),
+        'Enquiry processed by ID': str(uuid4()),
         'Assigned to IST': 'assigned_to_ist',
         'Project manager assigned': 'project_manager_assigned',
-        'Project manager assigned by': str(AdviserFactory().id),
+        'Project manager assigned by': AdviserFactory(),
         'Propositions': [{
             'deadline': 'deadline',
             'status': 'status',
@@ -36,10 +36,10 @@ def test_spi_record_row_is_formatted():
     assert filtered_row == {
         'enquiry_processed': 'enquiry_processed',
         'enquiry_type': 'enquiry_type',
-        'enquiry_processed_by_id': spi_report_row['Enquiry processed by'],
+        'enquiry_processed_by_id': spi_report_row['Enquiry processed by ID'],
         'assigned_to_ist': 'assigned_to_ist',
         'project_manager_assigned': 'project_manager_assigned',
-        'project_manager_assigned_by_id': spi_report_row['Project manager assigned by'],
+        'project_manager_assigned_by_id': str(spi_report_row['Project manager assigned by'].id),
         'propositions': [{
             'deadline': 'deadline',
             'status': 'status',

--- a/datahub/investment/project/report/test/test_spi.py
+++ b/datahub/investment/project/report/test/test_spi.py
@@ -125,10 +125,12 @@ def test_interaction_would_end_spi1_or_not(spi_report, service_id, visible):
     if visible:
         assert rows[0]['Enquiry processed'] == interaction.created_on.isoformat()
         assert str(rows[0]['Enquiry processed by']) == interaction.created_by.name
+        assert str(rows[0]['Enquiry processed by ID']) == str(interaction.created_by.id)
         assert rows[0]['Enquiry type'] == interaction.service.name
     else:
         assert rows[0]['Enquiry processed'] == ''
         assert rows[0]['Enquiry processed by'] == ''
+        assert rows[0]['Enquiry processed by ID'] == ''
         assert rows[0]['Enquiry type'] == ''
 
 


### PR DESCRIPTION
### Description of change

The Investment Project Activity dataset endpoint was unable to serialise Advisers returned by the SPI report. This PR corrects that and adds a test to ensure all fields are being serialised.

The intent is still to remove legacy CSV SPI report generation once the dataset endpoint starts being consumed.

Previously if investment project had no propositions, an empty string was returned. This change also ensures an empty array is returned instead.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
