### PR TITLE
Deprecate closed_by and closed_on company referral fields

### DIFF
--- a/changelog/company/closed-fields-referral-activity-feed.deprecation.md
+++ b/changelog/company/closed-fields-referral-activity-feed.deprecation.md
@@ -1,0 +1,6 @@
+`GET /v3/activity-stream/company-referral`: The following are deprecated and will be removed on or after 3 March 2020:
+
+- the nested field `object.dit:closedOn`
+- the `closer` value for the `object.attributedTo.dit:DataHubCompanyReferral:role` nested field
+
+This is as they are not in use.

--- a/changelog/company/closed-fields-referral-activity-stream.deprecation.md
+++ b/changelog/company/closed-fields-referral-activity-stream.deprecation.md
@@ -1,0 +1,6 @@
+`GET /v4/activity-feed`: For objects of type `dit:CompanyReferral`, the following are deprecated and will be removed on or after 3 March 2020:
+
+- the nested field `object.dit:closedOn`
+- the `closer` value for the `object.attributedTo.dit:DataHubCompanyReferral:role` nested field
+
+This is as they are not in use.

--- a/changelog/company/closed-fields-referral-db.deprecation.md
+++ b/changelog/company/closed-fields-referral-db.deprecation.md
@@ -1,0 +1,6 @@
+The following columns in the `company_referral_companyreferral` table are deprecated and will be removed on or after 3 March 2020:
+ 
+- `closed_on`
+- `closed_by_id`
+ 
+This is due to the fields not being in use.

--- a/changelog/company/closed-fields-referral-views.deprecation.md
+++ b/changelog/company/closed-fields-referral-views.deprecation.md
@@ -1,0 +1,6 @@
+`GET /v4/company-referral`, `POST /v4/company-referral`, `GET /v4/company-referral/<id>`: The following response fields are deprecated and will be removed on or after 3 March 2020:
+
+- `closed_on`
+- `closed_by`
+
+This is due to the fields not being in use.


### PR DESCRIPTION
### Description of change

This deprecates the `closed_by` and `closed_on` fields for company referrals are the related functionality is being reconsidered so leaving these fields in will only be misleading.

(The `closed` status remains as we may need this in the admin site.)

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
