### PR TITLE
Fix outdated company sync runtime errors

### DIFF
--- a/changelog/company/company-hierarchy-rollout-retry-failures.internal.md
+++ b/changelog/company/company-hierarchy-rollout-retry-failures.internal.md
@@ -1,0 +1,4 @@
+The company hierarchy rollout task -
+`datahub.dnb_api.tasks.sync_outdated_companies_with_dnb` - was adjusted so that
+any failed sync tasks are not retried. This fixes a `RuntimeError` raised by
+celery.

--- a/changelog/company/improve-outdated-company-sync-logging.internal.md
+++ b/changelog/company/improve-outdated-company-sync-logging.internal.md
@@ -1,0 +1,2 @@
+The logging for the `datahub.dnb_api.tasks.sync_outdated_companies_with_dnb`
+task was improved so that sync successes and failures are logged consistently.

--- a/datahub/dnb_api/tasks/sync.py
+++ b/datahub/dnb_api/tasks/sync.py
@@ -107,7 +107,7 @@ def sync_company_with_dnb_rate_limited(
             throw=True,
         )
     except Exception:
-        logger.error(f'{message} Failed')
+        logger.warning(f'{message} Failed')
         raise
 
     logger.info(f'{message} Succeeded')
@@ -149,5 +149,6 @@ def sync_outdated_companies_with_dnb(
                 'fields_to_update': fields_to_update,
                 'update_descriptor': 'celery:sync_outdated_companies_with_dnb:{self.request.id}',
                 'simulate': simulate,
+                'retry_failures': False,
             },
         )

--- a/datahub/dnb_api/tasks/sync.py
+++ b/datahub/dnb_api/tasks/sync.py
@@ -91,19 +91,26 @@ def sync_company_with_dnb_rate_limited(
     can be used for bulk tasks to ensure that we do not exceed our agreed
     rate limit with D&B.
     """
-    message = f'Syncing dnb-linked company: {company_id}'
+    message = f'Syncing dnb-linked company "{company_id}"'
     if simulate:
-        logger.info(f'[SIMULATION] {message}')
+        logger.info(f'[SIMULATION] {message} Succeeded')
         return
-    sync_company_with_dnb.apply(
-        kwargs={
-            'company_id': company_id,
-            'fields_to_update': fields_to_update,
-            'update_descriptor': update_descriptor,
-            'retry_failures': retry_failures,
-        },
-    )
-    logger.info(message)
+
+    try:
+        sync_company_with_dnb.apply(
+            kwargs={
+                'company_id': company_id,
+                'fields_to_update': fields_to_update,
+                'update_descriptor': update_descriptor,
+                'retry_failures': retry_failures,
+            },
+            throw=True,
+        )
+    except Exception:
+        logger.error(f'{message} Failed')
+        raise
+
+    logger.info(f'{message} Succeeded')
 
 
 @shared_task(

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -1161,10 +1161,12 @@ def test_sync_outdated_companies_simulation(caplog):
 
 
 @freeze_time('2019-01-01 11:12:13')
-def test_sync_outdated_companies_sync_task_fails(caplog, monkeypatch):
+def test_sync_outdated_companies_sync_task_failure_logs_error(caplog, monkeypatch):
     """
+    Test that when the sync_company_with_dnb sub-task fails, an error log is
+    generated.
     """
-    caplog.set_level('ERROR')
+    caplog.set_level('WARNING')
     company = CompanyFactory(
         duns_number='123456789',
         dnb_modified_on=now() - timedelta(days=5),


### PR DESCRIPTION
### Description of change

The company hierarchy rollout task - `datahub.dnb_api.tasks.sync_outdated_companies_with_dnb` - was adjusted so that any failed sync tasks are not retried. This fixes a `RuntimeError` raised by celery: https://sentry.ci.uktrade.io/dit/data-hub-api/issues/22055/?referrer=slack

In addition, the logging for the `datahub.dnb_api.tasks.sync_outdated_companies_with_dnb` task was improved so that sync successes and failures are logged consistently.  This will help us in visualising these logs on ELK/Kibana.

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [X] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
