### PR TITLE
change history_type to be indexed, adding common date field for sorting

### DIFF
--- a/changelog/company/export-country-history.api.md
+++ b/changelog/company/export-country-history.api.md
@@ -1,0 +1,4 @@
+`POST /v4/search/export-country-history`
+
+Indexing `history_type` so that we can filter out results based on its values.
+Adding common `date` field, which will help sort results across entities, `company_export_history` and `interaction`

--- a/datahub/search/export_country_history/models.py
+++ b/datahub/search/export_country_history/models.py
@@ -12,11 +12,14 @@ class ExportCountryHistory(BaseESModel):
     id = Keyword()
     history_date = Date(index=False)
     history_user = fields.id_unindexed_name_field()
-    history_type = Keyword(index=False)
+    history_type = Keyword(index=True)
     country = fields.id_unindexed_name_field()
 
     company = fields.id_unindexed_name_field()
     status = Keyword(index=False)
+    # Adding `date` field, mapping to `history_date` for sorting across entities
+    # export_country_history and interaction.
+    date = Date()
 
     MAPPINGS = {
         'history_user': dict_utils.id_name_dict,
@@ -26,6 +29,7 @@ class ExportCountryHistory(BaseESModel):
 
     COMPUTED_MAPPINGS = {
         'id': lambda obj: obj.history_id,  # Id required for indexing
+        'date': lambda obj: obj.history_date,
     }
 
     class Meta:

--- a/datahub/search/export_country_history/test/test_models.py
+++ b/datahub/search/export_country_history/test/test_models.py
@@ -22,6 +22,7 @@ def test_export_country_history_to_dict(es):
             'name': export_country_history.country.name,
         },
         'history_date': export_country_history.history_date,
+        'date': export_country_history.history_date,
         'history_type': export_country_history.history_type,
         'history_user': {
             'id': str(export_country_history.history_user.pk),

--- a/datahub/search/export_country_history/test/test_signals.py
+++ b/datahub/search/export_country_history/test/test_signals.py
@@ -51,5 +51,6 @@ def test_updated_interaction_synced(es_with_signals):
         'id': str(export_country_history.pk),
         'history_type': export_country_history.history_type,
         'history_date': export_country_history.history_date.isoformat(),
+        'date': export_country_history.history_date.isoformat(),
         'status': str(export_country_history.status),
     }


### PR DESCRIPTION
### Description of change
Change `history_type` field to be indexed in `export_country_history` search model, so that it can queried.

Adding a common `date` field for sorting across entities `export_country_history` and `interaction`.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
