### PR TITLE
Log the number of dnb company updates available

### DIFF
--- a/changelog/company/log-dnb-company-updates-count.feature.md
+++ b/changelog/company/log-dnb-company-updates-count.feature.md
@@ -1,0 +1,3 @@
+Additional logging was added to the nightly automatic D&B company updates task
+in order to surface the total number of company updates each day. This will inform
+how the company updates limit is adjusted over time (currently at 2000).

--- a/datahub/dnb_api/tasks/update.py
+++ b/datahub/dnb_api/tasks/update.py
@@ -96,6 +96,9 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
         if next_page is None:
             break
 
+    update_count = response.get('count', 0)
+    logger.info(f'get_company_updates total update count: {update_count}')
+
     # Wait for all update tasks to finish...
     ResultSet(results=update_results).join(
         propagate=False,

--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -94,8 +94,10 @@ def dnb_company_updates_response_uk(dnb_response_uk):
     for dnb-service.
     """
     return {
-        **dnb_response_uk,
         'next': None,
+        'previous': None,
+        'count': 1,
+        **dnb_response_uk,
     }
 
 


### PR DESCRIPTION
### Description of change

Additional logging was added to the nightly automatic D&B company updates task in order to surface the total number of company updates each day. This will inform how the company updates limit is adjusted over time (currently at 2000).

It's now possible to log this following some dnb-service work to expose the count in the company updates API endpoint: https://github.com/uktrade/dnb-service/pull/41

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [X] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
