### PR TITLE
Fix SPI report CSV writer

### DIFF
--- a/changelog/investment/investment-spi-report-csv.bugfix.md
+++ b/changelog/investment/investment-spi-report-csv.bugfix.md
@@ -1,0 +1,1 @@
+A bug causing the daily SPI report task to fail was fixed.

--- a/datahub/investment/project/report/spi.py
+++ b/datahub/investment/project/report/spi.py
@@ -60,10 +60,24 @@ def format_date(d):
     return d.isoformat()
 
 
+def _filter_row_dicts(rows, field_titles):
+    """Filter row dicts to exclude keys which are not present in field_titles."""
+    for row in rows:
+        yield {
+            key: value
+            for key, value in row.items()
+            if key in field_titles
+        }
+
+
 def write_report(file):
     """Write CSV report."""
     spi_report = SPIReport()
-    for line in csv_iterator(spi_report.rows(), spi_report.field_titles):
+    # ensure that rows only contain keys defined in field_titles
+    for line in csv_iterator(
+        _filter_row_dicts(spi_report.rows(), spi_report.field_titles),
+        spi_report.field_titles,
+    ):
         file.write(line)
 
 


### PR DESCRIPTION
### Description of change

The fix for SPI report (Investment Project Activity) dataset endpoint introduced a bug, where additional field in the returned row would upset `csv_iterator` as the field was not included in the `field_titles`. The additional field must not be included in the CSV report. The fix ensures that only fields defined in `field_titles` are sent to `csv_iterator`.
Additional test has been added to ensure the CSV file is being generated.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
