### PR TITLE
ContactsDatasetView can lookup external consent info [2 of 4]

### DIFF
--- a/changelog/contact/contactdatasetview-consent-from-consent-service.internal.md
+++ b/changelog/contact/contactdatasetview-consent-from-consent-service.internal.md
@@ -1,0 +1,5 @@
+It is now possible to set `GET_CONSENT_FROM_CONSENT_SERVICE` feature flag to active
+to enable looking up `Contact.accepts_dit_email_marketing` from central Consent
+Service API when making a call to ContactsDataView
+(`GET /v4/dataset/contacts-dataset`) which is used for exporting Data Hub's entire
+list of contacts to Data Workspace.

--- a/datahub/company/constants.py
+++ b/datahub/company/constants.py
@@ -8,6 +8,7 @@ NOTIFY_DNB_INVESTIGATION_FEATURE_FLAG = 'notify-dnb-investigations'
 AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG = 'automatic-company-archive'
 EXPORT_COUNTRIES_FEATURE_FLAG = 'export-countries-switch'
 UPDATE_CONSENT_SERVICE_FEATURE_FLAG = 'update-consent-service'
+GET_CONSENT_FROM_CONSENT_SERVICE = 'get-consent-from-consent-service'
 
 CONSENT_SERVICE_EMAIL_CONSENT_TYPE = 'email_marketing'
 

--- a/datahub/dataset/core/views.py
+++ b/datahub/dataset/core/views.py
@@ -26,7 +26,16 @@ class BaseDatasetView(HawkResponseSigningMixin, APIView):
         dataset = self.get_dataset()
         paginator = self.pagination_class()
         page = paginator.paginate_queryset(dataset, request, view=self)
+        self._enrich_data(page)
         return paginator.get_paginated_response(page)
+
+    def _enrich_data(self, dataset):
+        """
+        Hook for enriching the paged dataset before returning a response.
+        By default it does nothing but can be changed in subclasses to make
+        calls to external APIs if required.
+        """
+        return dataset
 
     def get_dataset(self):
         """Return a list of records"""


### PR DESCRIPTION
### Description of change

This is an increment of the consent service / data-hub integration work and follows on from:
https://github.com/uktrade/data-hub-api/pull/2648

Hooks into the `ContactsDatasetView` to lookup consent status for current page
from the consent service.

This is to prepare for the `accepts_dit_email_marketing` field being removed
from the datahub database eventually. For now this will be behind a feature flag `datahub.dataset.constants.GET_CONSENT_FROM_CONSENT_SERVICE`.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
