### PR TITLE
Lock celery version to 4.4

### DIFF
--- a/changelog/lock-celery-version.internal.md
+++ b/changelog/lock-celery-version.internal.md
@@ -1,0 +1,3 @@
+A bug was fixed on the nightly company updates task which manifested as a result
+of using the latest celery library. Celery, kombu and billiard dependencies have
+been locked until this is resolved with a new celery release.

--- a/requirements.in
+++ b/requirements.in
@@ -40,9 +40,9 @@ elasticsearch==6.4.0
 elasticsearch-dsl==6.3.1
 
 # Celery
-celery[redis]==4.4.1
-billiard==3.6.3.0  # Not used directly, but pinned as it has been a source of breakage in the past
-kombu==4.6.8  # Not used directly, but pinned as it has been a source of breakage in the past
+celery[redis]==4.4 # Pinned until this is released in 4.4.2 https://github.com/celery/celery/pull/5985
+billiard==3.6.2.0  # Not used directly, but pinned as it has been a source of breakage in the past
+kombu==4.6.7  # Not used directly, but pinned as it has been a source of breakage in the past
 
 # Testing and dev
 pytest==5.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ argh==0.26.2              # via watchdog
 asgiref==3.2.3            # via django
 attrs==19.3.0             # via flake8-bugbear, pytest
 backcall==0.1.0           # via ipython
-billiard==3.6.3.0         # via -r requirements.in (line 44), celery
+billiard==3.6.2.0         # via -r requirements.in (line 44), celery
 boto3==1.12.11            # via -r requirements.in (line 23)
 botocore==1.15.11         # via boto3, s3transfer
-celery[redis]==4.4.1      # via -r requirements.in (line 43)
+celery[redis]==4.4        # via -r requirements.in (line 43)
 certifi==2019.11.28       # via requests, sentry-sdk
 chardet==3.0.4            # via -r requirements.in (line 15), requests
 click==7.0                # via pip-tools, towncrier
@@ -64,7 +64,7 @@ ipython==7.13.0           # via -r requirements.in (line 53)
 jedi==0.15.2              # via ipython
 jinja2==2.10.3            # via towncrier
 jmespath==0.9.4           # via boto3, botocore
-kombu==4.6.8              # via -r requirements.in (line 45), celery
+kombu==4.6.7              # via -r requirements.in (line 45), celery
 mail-parser==3.12.0       # via -r requirements.in (line 31)
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8


### PR DESCRIPTION
### Description of change

A bug was fixed on the nightly company updates task which manifested as a result of using the latest celery library. Celery, kombu and billiard dependencies have been locked until this is resolved with a new celery release.

The celery bug in question: https://github.com/celery/celery/pull/5985
Which results in the following error on data hub API: https://sentry.ci.uktrade.io/dit/data-hub-api/issues/22305/?referrer=slack

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [X] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
