### PR TITLE
D&B change-requests

### DIFF
--- a/changelog/company/dnb-change-request.feature.md
+++ b/changelog/company/dnb-change-request.feature.md
@@ -1,0 +1,14 @@
+The following endpoint was added to the Data Hub API for submitting change requests to D&B:
+
+- POST `/dnb/company-change-request/`
+
+The endpoint requires a json payload with a valid `duns_number` for a company that exists in Data Hub and requested `changes` like so:
+
+```
+{
+    'duns_number': '123456789',
+    'changes': {
+        'website': 'example.com',
+    },
+},
+```

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -231,3 +231,37 @@ class DNBCompanyLinkSerializer(DUNSNumberSerializer):
     """
 
     company_id = NestedRelatedField('company.Company', required=True)
+
+
+class DNBCompanyChangeRequestSerializer(serializers.Serializer):
+    """
+    Validate POST data for DNBCompanyChangeRequestView.
+    """
+
+    duns_number = serializers.CharField(
+        write_only=True,
+        max_length=9,
+        min_length=9,
+        validators=(integer_validator,),
+    )
+    changes = serializers.JSONField()
+
+    def validate_duns_number(self, duns_number):
+        """
+        A company with the given duns_number should exist in Data Hub.
+        """
+        if not Company.objects.filter(duns_number=duns_number).exists():
+            raise serializers.ValidationError(
+                f'Company with duns_number: {duns_number} does not exists in DataHub.',
+            )
+        return duns_number
+
+    def validate_changes(self, changes):
+        """
+        Empty changes is not valid.
+        """
+        if not changes:
+            raise serializers.ValidationError(
+                'No changes submitted.',
+            )
+        return changes

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from datahub.dnb_api.views import (
+    DNBCompanyChangeRequestView,
     DNBCompanyCreateInvestigationView,
     DNBCompanyCreateView,
     DNBCompanyLinkView,
@@ -27,5 +28,10 @@ urlpatterns = [
         'company-link',
         DNBCompanyLinkView.as_view(),
         name='company-link',
+    ),
+    path(
+        'company-change-request',
+        DNBCompanyChangeRequestView.as_view(),
+        name='company-change-request',
     ),
 ]


### PR DESCRIPTION
### Description of change

The following endpoint was added to the Data Hub API for submitting change requests to D&B:

  - POST `/dnb/company-change-request/`

The endpoint requires a json payload with a valid `duns_number` for a company that exists in Data Hub and requested `changes` like so:

  ```
 {
     'duns_number': '123456789',
     'changes': {
         'website': 'example.com',
     },
 },
 ```

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
