### PR TITLE
Refactor export country history search tests

### DIFF
--- a/datahub/search/export_country_history/test/test_views.py
+++ b/datahub/search/export_country_history/test/test_views.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from uuid import uuid4
 
 import pytest
 from django.utils.timezone import utc
@@ -6,14 +7,10 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.company.models import CompanyExportCountryHistory, CompanyPermission
 from datahub.company.test.factories import CompanyExportCountryHistoryFactory, CompanyFactory
-from datahub.core.constants import Country as CountryConstant
-from datahub.core.test_utils import (
-    APITestMixin,
-    create_test_user,
-)
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.models import Country
-from datahub.metadata.test.factories import TeamFactory
 from datahub.search.export_country_history import ExportCountryHistoryApp
 
 pytestmark = [
@@ -22,200 +19,225 @@ pytestmark = [
     pytest.mark.es_collector_apps.with_args(ExportCountryHistoryApp),
 ]
 
-FROZEN_DATETIME_1 = datetime(2001, 1, 22, 1, 2, 3, tzinfo=utc).isoformat()
-FROZEN_DATETIME_2 = datetime(2002, 2, 23, 4, 5, 6, tzinfo=utc).isoformat()
-FROZEN_DATETIME_3 = datetime(2003, 3, 24, 7, 8, 9, tzinfo=utc).isoformat()
-
-
-@pytest.fixture
-def setup_data():
-    """Sets up data for the tests."""
-    benchmark_country_japan = Country.objects.get(
-        pk=CountryConstant.japan.value.id,
-    )
-
-    benchmark_country_canada = Country.objects.get(
-        pk=CountryConstant.canada.value.id,
-    )
-
-    benchmark_company = CompanyFactory()
-
-    with freeze_time(FROZEN_DATETIME_1):
-        CompanyExportCountryHistoryFactory(
-            country=benchmark_country_japan,
-            company=benchmark_company,
-        )
-        CompanyExportCountryHistoryFactory(
-            company=benchmark_company,
-            country=benchmark_country_canada,
-        )
-        CompanyExportCountryHistoryFactory(
-            country=benchmark_country_canada,
-        )
-        CompanyExportCountryHistoryFactory()
-
-    with freeze_time(FROZEN_DATETIME_2):
-        CompanyExportCountryHistoryFactory(
-            country=benchmark_country_japan,
-        )
-
-    with freeze_time(FROZEN_DATETIME_3):
-        CompanyExportCountryHistoryFactory(
-            country=benchmark_country_japan,
-        )
-
-    yield str(benchmark_company.id)
+HistoryType = CompanyExportCountryHistory.HistoryType
+export_country_history_search_url = reverse('api-v4:search:export-country-history')
 
 
 class TestSearchExportCountryHistory(APITestMixin):
     """Tests search views."""
 
-    def test_export_country_history_search_no_permissions(self):
-        """Should return 403"""
-        user = create_test_user(dit_team=TeamFactory())
+    @pytest.mark.parametrize(
+        'permission_codenames,expected_status',
+        (
+            (
+                [],
+                status.HTTP_403_FORBIDDEN,
+            ),
+            (
+                [CompanyPermission.view_company],
+                status.HTTP_200_OK,
+            ),
+        ),
+    )
+    @pytest.mark.usefixtures('es')
+    def test_permission_checking(self, permission_codenames, expected_status, api_client):
+        """Test that the expected status is returned for various user permissions."""
+        user = create_test_user(permission_codenames=permission_codenames, dit_team=None)
         api_client = self.create_api_client(user=user)
-        url = reverse('api-v4:search:export-country-history')
-        response = api_client.get(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        response = api_client.post(
+            export_country_history_search_url,
+            data={
+                'company': uuid4(),
+            },
+        )
+        assert response.status_code == expected_status
 
-    def test_export_country_history_search_with_empty_request(self, es_with_collector, setup_data):
+    def test_export_country_history_search_with_empty_request(self, es_with_collector):
         """Should return 400."""
         es_with_collector.flush_and_refresh()
         error_response = 'Request must include either country or company parameters'
 
-        url = reverse('api-v4:search:export-country-history')
-
-        response = self.api_client.post(
-            url,
-            data={},
-        )
+        response = self.api_client.post(export_country_history_search_url, data={})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()['non_field_errors'][0] == error_response
 
-    def test_filtering_by_country_on_export_country_history_search(
-        self,
-        es_with_collector,
-        setup_data,
-    ):
-        """
-        Test ExportCountryHistory search app with country param.
-        """
+    def test_export_country_history_response_body(self, es_with_collector):
+        """Test the format of an export country history result in the response body."""
+        history_object = CompanyExportCountryHistoryFactory(history_type=HistoryType.INSERT)
         es_with_collector.flush_and_refresh()
 
-        url = reverse('api-v4:search:export-country-history')
-
         response = self.api_client.post(
-            url,
+            export_country_history_search_url,
             data={
-                'country': CountryConstant.japan.value.id,
+                # The view requires a filter
+                'company': history_object.company.pk,
             },
         )
-
-        expected_data = {
-            'country': {
-                'id': CountryConstant.japan.value.id,
-            },
-        }
-
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()['count'] == 3
-        assert all(
-            result['country']['id'] == expected_data['country']['id']
-            for result in response.json()['results']
-        )
 
-    def test_filtering_by_company_on_export_country_history_search(
-        self,
-        es_with_collector,
-        setup_data,
-    ):
-        """
-        Test ExportCountryHistory search app with company param.
-        """
-        es_with_collector.flush_and_refresh()
-
-        url = reverse('api-v4:search:export-country-history')
-        company_id = setup_data
-
-        response = self.api_client.post(
-            url,
-            data={
-                'company': company_id,
-            },
-        )
-
-        expected_data = {
+        results = response.json()['results']
+        assert len(results) == 1
+        assert results[0] == {
             'company': {
-                'id': company_id,
-            },
-        }
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json()['count'] == 2
-        assert all(
-            result['company']['id'] == expected_data['company']['id']
-            for result in response.json()['results']
-        )
-
-    def test_filtering_by_company_and_country_on_export_country_history_search(
-        self,
-        es_with_collector,
-        setup_data,
-    ):
-        """
-        Test ExportCountryHistory search app with company param.
-        """
-        es_with_collector.flush_and_refresh()
-
-        url = reverse('api-v4:search:export-country-history')
-
-        response = self.api_client.post(
-            url,
-            data={
-                'company': setup_data,
-                'country': CountryConstant.canada.value.id,
-            },
-        )
-
-        expected_data = {
-            'company': {
-                'id': setup_data,
+                'id': str(history_object.company.pk),
+                'name': history_object.company.name,
             },
             'country': {
-                'id': CountryConstant.canada.value.id,
+                'id': str(history_object.country.pk),
+                'name': history_object.country.name,
             },
+            'date': history_object.history_date.isoformat(),
+            'history_date': history_object.history_date.isoformat(),
+            'history_type': history_object.history_type,
+            'history_user': {
+                'id': str(history_object.history_user.pk),
+                'name': history_object.history_user.name,
+            },
+            'id': str(history_object.pk),
+            'status': history_object.status,
         }
 
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json()['count'] == 1
-        assert all(
-            result['company']['id'] == expected_data['company']['id']
-            for result in response.json()['results']
-        )
-        assert all(
-            result['country']['id'] == expected_data['country']['id']
-            for result in response.json()['results']
-        )
-
-    def test_sorting_in_export_country_history(self, es_with_collector, setup_data):
-        """Tests the sorting of country history search response."""
+    @pytest.mark.parametrize(
+        'factory',
+        (
+            lambda: CompanyExportCountryHistoryFactory(history_type=HistoryType.INSERT),
+            lambda: CompanyExportCountryHistoryFactory(history_type=HistoryType.DELETE),
+        ),
+    )
+    def test_filtering_by_company_returns_matches(self, es_with_collector, factory):
+        """Test that filtering by company includes matching objects."""
+        obj = factory()
         es_with_collector.flush_and_refresh()
 
-        url = reverse('api-v4:search:export-country-history')
-
         response = self.api_client.post(
-            url,
+            export_country_history_search_url,
             data={
-                'country': CountryConstant.japan.value.id,
+                'company': obj.company.pk,
             },
         )
-
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()['count'] == 3
 
-        date_times = [
-            result['history_date'] for result in response.json()['results']
+        response_data = response.json()
+        assert response_data['count'] == 1
+        assert response_data['results'][0]['id'] == str(obj.pk)
+
+    def test_filtering_by_company_excludes_non_matches(self, es_with_collector):
+        """Test that filtering by company excludes non-matching objects."""
+        company = CompanyFactory()
+
+        # Unrelated companies should be excluded
+        CompanyExportCountryHistoryFactory(history_type=HistoryType.INSERT)
+
+        es_with_collector.flush_and_refresh()
+
+        response = self.api_client.post(
+            export_country_history_search_url,
+            data={
+                'company': company.pk,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == 0
+        assert response_data['results'] == []
+
+    @pytest.mark.parametrize(
+        'factory',
+        (
+            lambda: CompanyExportCountryHistoryFactory(history_type=HistoryType.INSERT),
+            lambda: CompanyExportCountryHistoryFactory(history_type=HistoryType.DELETE),
+        ),
+    )
+    def test_filtering_by_country_returns_matches(self, es_with_collector, factory):
+        """Test that filtering by country includes matching export country history objects."""
+        obj = factory()
+        es_with_collector.flush_and_refresh()
+
+        response = self.api_client.post(
+            export_country_history_search_url,
+            data={
+                'country': obj.country.pk,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == 1
+        assert response_data['results'][0]['id'] == str(obj.pk)
+
+    def test_filtering_by_country_excludes_non_matches(self, es_with_collector):
+        """Test that filtering by country excludes non-matching objects."""
+        countries = list(Country.objects.order_by('?')[:2])
+        filter_country = countries[0]
+        other_country = countries[1]
+
+        # Unrelated countries should be excluded
+        CompanyExportCountryHistoryFactory(country=other_country, history_type=HistoryType.INSERT)
+
+        es_with_collector.flush_and_refresh()
+
+        response = self.api_client.post(
+            export_country_history_search_url,
+            data={
+                'country': filter_country.pk,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == 0
+        assert response_data['results'] == []
+
+    @pytest.mark.parametrize(
+        'request_args,is_reversed',
+        (
+            # default sorting
+            ({}, True),
+            ({'sortby': 'history_date:asc'}, False),
+            ({'sortby': 'history_date:desc'}, True),
+        ),
+    )
+    def test_sorts_results(self, es_with_collector, request_args, is_reversed):
+        """
+        Test sorting in various cases.
+
+        Note that a filter is mandatory in this view, hence the test filters by company.
+        """
+        datetimes = [
+            datetime(2001, 1, 22, tzinfo=utc),
+            datetime(2002, 2, 23, 1, 2, 3, tzinfo=utc),
+            datetime(2003, 3, 24, tzinfo=utc),
+            datetime(2004, 4, 25, 1, 2, 3, tzinfo=utc),
+        ]
+        company = CompanyFactory()
+
+        objects = [
+            _make_dated_export_country_history(datetime_, company=company)
+            for datetime_ in datetimes
         ]
 
-        assert date_times == [FROZEN_DATETIME_3, FROZEN_DATETIME_2, FROZEN_DATETIME_1]
+        if is_reversed:
+            objects.reverse()
+
+        es_with_collector.flush_and_refresh()
+
+        response = self.api_client.post(
+            export_country_history_search_url,
+            data={
+                'company': company.pk,
+                **request_args,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        expected_result_ids = [str(obj.pk) for obj in objects]
+        actual_result_ids = [result['id'] for result in response.json()['results']]
+
+        assert actual_result_ids == expected_result_ids
+
+
+def _make_dated_export_country_history(history_date, **kwargs):
+    with freeze_time(history_date):
+        return CompanyExportCountryHistoryFactory(history_type=HistoryType.INSERT, **kwargs)


### PR DESCRIPTION
### Description of change

This refactors the company export country search tests in advance of adding interactions to the search results (without any change to functionality).

This is split from #2632.

The tests are structured in a way that will make it easier to add interactions into the mix. (They're also more direct, rather than relying on a generic fixture with a load of objects.)

Additionally. a test for the response body was added.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
