### PR TITLE
Include interactions in export country history search

### DIFF
--- a/changelog/company/export-country-history-sorting.api.md
+++ b/changelog/company/export-country-history-sorting.api.md
@@ -1,0 +1,1 @@
+`POST /v4/search/export-country-history`: The `history_date` option for the `sortby` parameter was removed and replaced by `date`. 

--- a/changelog/company/export-country-history.api.md
+++ b/changelog/company/export-country-history.api.md
@@ -1,0 +1,3 @@
+`POST /v4/search/export-country-history`: Search results now additionally include interactions that have export countries associated with them.
+
+The endpoint now requires both the `company.view_companyexportcountry` and `interaction.view_all_interaction` permissions.

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -203,15 +203,11 @@ class InteractionExportCountryFactory(factory.django.DjangoModelFactory):
         model = 'interaction.InteractionExportCountry'
 
 
-class ExportCountriesInteractionFactory(InteractionFactoryBase):
+class ExportCountriesInteractionFactory(CompanyInteractionFactory):
     """Factory for creating an export interaction with export countries."""
 
-    kind = Interaction.Kind.INTERACTION
     theme = factory.Iterator([Interaction.Theme.EXPORT, Interaction.Theme.OTHER])
     were_countries_discussed = True
-    communication_channel = factory.LazyFunction(
-        lambda: random_obj_for_model(CommunicationChannel),
-    )
 
     @to_many_field
     def export_countries(self, **kwargs):
@@ -219,9 +215,19 @@ class ExportCountriesInteractionFactory(InteractionFactoryBase):
         Instances of InteractionExportCountryFactory.
         Defaults to one InteractionExportCountryFactory.
         """
-        return [
-            InteractionExportCountryFactory(
-                interaction=self,
-                **kwargs,
-            ),
-        ]
+        return [InteractionExportCountryFactory(interaction=self, **kwargs)]
+
+
+class ExportCountriesServiceDeliveryFactory(ServiceDeliveryFactory):
+    """Factory for creating an export service delivery with export countries."""
+
+    theme = factory.Iterator([Interaction.Theme.EXPORT, Interaction.Theme.OTHER])
+    were_countries_discussed = True
+
+    @to_many_field
+    def export_countries(self, **kwargs):
+        """
+        Instances of InteractionExportCountryFactory.
+        Defaults to one InteractionExportCountryFactory.
+        """
+        return [InteractionExportCountryFactory(interaction=self, **kwargs)]

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -234,3 +234,7 @@ class CompanyAutocompleteSearchListAPIView(
         'address',
         'registered_address',
     ]
+
+    def get_entities(self):
+        """Returns entities"""
+        return [self.search_app.es_model]

--- a/datahub/search/export_country_history/apps.py
+++ b/datahub/search/export_country_history/apps.py
@@ -1,6 +1,5 @@
 from datahub.company.models import (
     CompanyExportCountryHistory as DBCompanyExportCountryHistory,
-    CompanyPermission,
 )
 from datahub.search.apps import SearchApp
 from datahub.search.export_country_history.models import ExportCountryHistory
@@ -12,7 +11,6 @@ class ExportCountryHistoryApp(SearchApp):
     name = 'export-country-history'
     es_model = ExportCountryHistory
     exclude_from_global_search = True
-    view_permissions = (f'company.{CompanyPermission.view_company}',)
     queryset = DBCompanyExportCountryHistory.objects.select_related(
         'history_user',
         'country',

--- a/datahub/search/export_country_history/serializers.py
+++ b/datahub/search/export_country_history/serializers.py
@@ -18,10 +18,10 @@ class SearchExportCountryHistorySerializer(EntitySearchQuerySerializer):
         ),
     }
 
-    DEFAULT_ORDERING = SearchOrdering('history_date', SortDirection.desc)
+    DEFAULT_ORDERING = SearchOrdering('date', SortDirection.desc)
 
     SORT_BY_FIELDS = (
-        'history_date',
+        'date',
     )
 
     country = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/export_country_history/test/test_views.py
+++ b/datahub/search/export_country_history/test/test_views.py
@@ -195,8 +195,8 @@ class TestSearchExportCountryHistory(APITestMixin):
         (
             # default sorting
             ({}, True),
-            ({'sortby': 'history_date:asc'}, False),
-            ({'sortby': 'history_date:desc'}, True),
+            ({'sortby': 'date:asc'}, False),
+            ({'sortby': 'date:desc'}, True),
         ),
     )
     def test_sorts_results(self, es_with_collector, request_args, is_reversed):

--- a/datahub/search/export_country_history/test/test_views.py
+++ b/datahub/search/export_country_history/test/test_views.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from operator import attrgetter, itemgetter
 from uuid import uuid4
 
 import pytest
@@ -7,16 +8,22 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.company.models import CompanyExportCountryHistory, CompanyPermission
+from datahub.company.models import CompanyExportCountryHistory
 from datahub.company.test.factories import CompanyExportCountryHistoryFactory, CompanyFactory
 from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.interaction.models import InteractionPermission
+from datahub.interaction.test.factories import (
+    CompanyInteractionFactory,
+    ExportCountriesInteractionFactory,
+    ExportCountriesServiceDeliveryFactory,
+)
 from datahub.metadata.models import Country
 from datahub.search.export_country_history import ExportCountryHistoryApp
+from datahub.search.interaction import InteractionSearchApp
 
 pytestmark = [
     pytest.mark.django_db,
-    # Index objects for this search app only
-    pytest.mark.es_collector_apps.with_args(ExportCountryHistoryApp),
+    pytest.mark.es_collector_apps.with_args(ExportCountryHistoryApp, InteractionSearchApp),
 ]
 
 HistoryType = CompanyExportCountryHistory.HistoryType
@@ -34,7 +41,15 @@ class TestSearchExportCountryHistory(APITestMixin):
                 status.HTTP_403_FORBIDDEN,
             ),
             (
-                [CompanyPermission.view_company],
+                ['view_companyexportcountry'],
+                status.HTTP_403_FORBIDDEN,
+            ),
+            (
+                [InteractionPermission.view_all],
+                status.HTTP_403_FORBIDDEN,
+            ),
+            (
+                ['view_companyexportcountry', InteractionPermission.view_all],
                 status.HTTP_200_OK,
             ),
         ),
@@ -98,11 +113,84 @@ class TestSearchExportCountryHistory(APITestMixin):
             'status': history_object.status,
         }
 
+    def test_interaction_response_body(self, es_with_collector):
+        """Test the format of an interaction result in the response body."""
+        interaction = ExportCountriesInteractionFactory()
+        es_with_collector.flush_and_refresh()
+
+        response = self.api_client.post(
+            export_country_history_search_url,
+            data={
+                # The view requires a filter
+                'company': interaction.company.pk,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        results = response.json()['results']
+        assert len(results) == 1
+
+        result = results[0]
+        result['contacts'].sort(key=itemgetter('id'))
+        result['dit_participants'].sort(key=lambda participant: participant['adviser']['id'])
+        result['export_countries'].sort(key=lambda export_country: export_country['country']['id'])
+
+        assert result == {
+            'company': {
+                'id': str(interaction.company.pk),
+                'name': interaction.company.name,
+                'trading_names': interaction.company.trading_names,
+            },
+            'contacts': [
+                {
+                    'id': str(contact.pk),
+                    'first_name': contact.first_name,
+                    'name': contact.name,
+                    'last_name': contact.last_name,
+                }
+                for contact in sorted(interaction.contacts.all(), key=attrgetter('id'))
+            ],
+            'date': interaction.date.isoformat(),
+            'dit_participants': [
+                {
+                    'adviser': {
+                        'id': str(dit_participant.adviser.pk),
+                        'first_name': dit_participant.adviser.first_name,
+                        'name': dit_participant.adviser.name,
+                        'last_name': dit_participant.adviser.last_name,
+                    },
+                    'team': {
+                        'id': str(dit_participant.team.pk),
+                        'name': dit_participant.team.name,
+                    },
+                }
+                for dit_participant in interaction.dit_participants.order_by('adviser__pk')
+            ],
+            'export_countries': [
+                {
+                    'country': {
+                        'id': str(export_country.country.pk),
+                        'name': export_country.country.name,
+                    },
+                    'status': export_country.status,
+                }
+                for export_country in interaction.export_countries.order_by('country__pk')
+            ],
+            'id': str(interaction.pk),
+            'service': {
+                'id': str(interaction.service.pk),
+                'name': interaction.service.name,
+            },
+            'subject': interaction.subject,
+        }
+
     @pytest.mark.parametrize(
         'factory',
         (
             lambda: CompanyExportCountryHistoryFactory(history_type=HistoryType.INSERT),
             lambda: CompanyExportCountryHistoryFactory(history_type=HistoryType.DELETE),
+            ExportCountriesInteractionFactory,
+            ExportCountriesServiceDeliveryFactory,
         ),
     )
     def test_filtering_by_company_returns_matches(self, es_with_collector, factory):
@@ -126,8 +214,12 @@ class TestSearchExportCountryHistory(APITestMixin):
         """Test that filtering by company excludes non-matching objects."""
         company = CompanyFactory()
 
+        # Non-export country interactions should be excluded
+        CompanyInteractionFactory(company=company)
+
         # Unrelated companies should be excluded
         CompanyExportCountryHistoryFactory(history_type=HistoryType.INSERT)
+        ExportCountriesInteractionFactory()
 
         es_with_collector.flush_and_refresh()
 
@@ -150,7 +242,11 @@ class TestSearchExportCountryHistory(APITestMixin):
             lambda: CompanyExportCountryHistoryFactory(history_type=HistoryType.DELETE),
         ),
     )
-    def test_filtering_by_country_returns_matches(self, es_with_collector, factory):
+    def test_filtering_by_country_returns_matching_history_objects(
+        self,
+        es_with_collector,
+        factory,
+    ):
         """Test that filtering by country includes matching export country history objects."""
         obj = factory()
         es_with_collector.flush_and_refresh()
@@ -167,14 +263,42 @@ class TestSearchExportCountryHistory(APITestMixin):
         assert response_data['count'] == 1
         assert response_data['results'][0]['id'] == str(obj.pk)
 
+    @pytest.mark.parametrize(
+        'factory',
+        (
+            ExportCountriesInteractionFactory,
+            ExportCountriesServiceDeliveryFactory,
+        ),
+    )
+    def test_filtering_by_country_returns_matching_interactions(self, es_with_collector, factory):
+        """Test that filtering by country includes matching interactions."""
+        obj = factory()
+        es_with_collector.flush_and_refresh()
+
+        response = self.api_client.post(
+            export_country_history_search_url,
+            data={
+                'country': obj.export_countries.first().country.pk,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == 1
+        assert response_data['results'][0]['id'] == str(obj.pk)
+
     def test_filtering_by_country_excludes_non_matches(self, es_with_collector):
         """Test that filtering by country excludes non-matching objects."""
         countries = list(Country.objects.order_by('?')[:2])
         filter_country = countries[0]
         other_country = countries[1]
 
+        # Non-export country interactions should be excluded
+        CompanyInteractionFactory()
+
         # Unrelated countries should be excluded
         CompanyExportCountryHistoryFactory(country=other_country, history_type=HistoryType.INSERT)
+        ExportCountriesInteractionFactory(export_countries__country=other_country)
 
         es_with_collector.flush_and_refresh()
 
@@ -214,8 +338,10 @@ class TestSearchExportCountryHistory(APITestMixin):
         company = CompanyFactory()
 
         objects = [
-            _make_dated_export_country_history(datetime_, company=company)
-            for datetime_ in datetimes
+            ExportCountriesInteractionFactory(date=datetimes.pop(0), company=company),
+            _make_dated_export_country_history(datetimes.pop(0), company=company),
+            ExportCountriesInteractionFactory(date=datetimes.pop(0), company=company),
+            _make_dated_export_country_history(datetimes.pop(0), company=company),
         ]
 
         if is_reversed:

--- a/datahub/search/export_country_history/views.py
+++ b/datahub/search/export_country_history/views.py
@@ -1,9 +1,12 @@
+from elasticsearch_dsl.query import Term
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 
+from datahub.core.permissions import HasPermissions
+from datahub.interaction.models import InteractionPermission
 from datahub.oauth.scopes import Scope
 from datahub.search.export_country_history import ExportCountryHistoryApp
 from datahub.search.export_country_history.serializers import SearchExportCountryHistorySerializer
-from datahub.search.permissions import SearchPermissions
+from datahub.search.interaction.models import Interaction
 from datahub.search.views import register_v4_view, SearchAPIView
 
 
@@ -14,7 +17,37 @@ class ExportCountryHistoryView(SearchAPIView):
     required_scopes = (Scope.internal_front_end,)
     search_app = ExportCountryHistoryApp
 
-    permission_classes = (IsAuthenticatedOrTokenHasScope, SearchPermissions)
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        # Note: This search view does not use SearchPermissions, as it requires multiple
+        # permissions
+        HasPermissions(
+            f'company.view_companyexportcountry',
+            f'interaction.{InteractionPermission.view_all}',
+        ),
+    )
+
+    fields_to_include = (
+        # Fields common to interactions and export country history objects
+        'company',
+        'date',
+        'id',
+
+        # Export country history object fields
+        'country',
+        'history_date',
+        'history_type',
+        'history_user',
+        'status',
+
+        # Interaction fields
+        'contacts',
+        'dit_participants',
+        'export_countries',
+        'service',
+        'subject',
+    )
+
     FILTER_FIELDS = [
         'country',
         'company',
@@ -22,7 +55,33 @@ class ExportCountryHistoryView(SearchAPIView):
 
     REMAP_FIELDS = {
         'company': 'company.id',
-        'country': 'country.id',
+    }
+
+    COMPOSITE_FILTERS = {
+        'country': [
+            'country.id',
+            'export_countries.country.id',
+        ],
     }
 
     serializer_class = SearchExportCountryHistorySerializer
+
+    def get_entities(self):
+        """
+        Overriding to provide multiple entities
+        """
+        return [self.search_app.es_model, Interaction]
+
+    def get_base_query(self, request, validated_data):
+        """
+        Get the base query.
+
+        This is overridden to exclude UPDATE history items and interactions
+        without export countries.
+        """
+        base_query = super().get_base_query(request, validated_data)
+
+        is_relevant_interaction = Term(were_countries_discussed=True)
+        is_relevant_history_entry = Term(_type=ExportCountryHistoryApp.name)
+
+        return base_query.filter(is_relevant_interaction | is_relevant_history_entry)

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -3,6 +3,7 @@ from django.db.models import Prefetch
 from datahub.interaction.models import (
     Interaction as DBInteraction,
     InteractionDITParticipant,
+    InteractionExportCountry,
     InteractionPermission,
 )
 from datahub.search.apps import SearchApp
@@ -38,5 +39,9 @@ class InteractionSearchApp(SearchApp):
         Prefetch(
             'dit_participants',
             queryset=InteractionDITParticipant.objects.select_related('adviser', 'team'),
+        ),
+        Prefetch(
+            'export_countries',
+            queryset=InteractionExportCountry.objects.select_related('country'),
         ),
     )

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -36,6 +36,31 @@ def _dit_participant_list(dit_participant_manager):
     ]
 
 
+def _export_country_field():
+    return Object(
+        properties={
+            'id': Keyword(index=False),
+            'country': Object(
+                properties={
+                    'id': Keyword(),
+                    'name': Text(index=False),
+                },
+            ),
+            'status': Text(index=False),
+        },
+    )
+
+
+def _export_countries_list(export_countries):
+    return [
+        {
+            'country': dict_utils.id_name_dict(export_country.country),
+            'status': export_country.status,
+        }
+        for export_country in export_countries.all()
+    ]
+
+
 class _DITParticipant(InnerDoc):
     adviser = Object(Person)
     team = Object(IDNameTrigram)
@@ -72,12 +97,15 @@ class Interaction(BaseESModel):
         },
     )
     was_policy_feedback_provided = Boolean()
+    were_countries_discussed = Boolean()
+    export_countries = _export_country_field()
 
     MAPPINGS = {
         'company': dict_utils.company_dict,
         'communication_channel': dict_utils.id_name_dict,
         'contacts': dict_utils.contact_or_adviser_list_of_dicts,
         'dit_participants': _dit_participant_list,
+        'export_countries': _export_countries_list,
         'event': dict_utils.id_name_dict,
         'investment_project': dict_utils.id_name_dict,
         'policy_areas': dict_utils.id_name_list_of_dicts,

--- a/datahub/search/interaction/test/test_models.py
+++ b/datahub/search/interaction/test/test_models.py
@@ -5,6 +5,7 @@ import pytest
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
     CompanyInteractionFactoryWithPolicyFeedback,
+    ExportCountriesInteractionFactory,
     InvestmentProjectInteractionFactory,
     ServiceDeliveryFactory,
 )
@@ -19,6 +20,7 @@ pytestmark = pytest.mark.django_db
         CompanyInteractionFactory,
         InvestmentProjectInteractionFactory,
         CompanyInteractionFactoryWithPolicyFeedback,
+        ExportCountriesInteractionFactory,
     ),
 )
 def test_interaction_to_dict(es, factory_cls):
@@ -28,6 +30,7 @@ def test_interaction_to_dict(es, factory_cls):
     result = Interaction.db_object_to_dict(interaction)
     result['contacts'].sort(key=itemgetter('id'))
     result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
+    result['export_countries'].sort(key=lambda export_country: export_country['country']['id'])
     result['policy_areas'].sort(key=itemgetter('id'))
     result['policy_issue_types'].sort(key=itemgetter('id'))
 
@@ -114,6 +117,17 @@ def test_interaction_to_dict(es, factory_cls):
         'grant_amount_offered': None,
         'net_company_receipt': None,
         'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
+        'export_countries': [
+            {
+                'country': {
+                    'id': str(export_country.country.pk),
+                    'name': export_country.country.name,
+                },
+                'status': export_country.status,
+            }
+            for export_country in interaction.export_countries.order_by('country__pk')
+        ],
+        'were_countries_discussed': interaction.were_countries_discussed,
         'created_on': interaction.created_on,
         'modified_on': interaction.modified_on,
     }
@@ -191,6 +205,8 @@ def test_service_delivery_to_dict(es):
         'grant_amount_offered': interaction.grant_amount_offered,
         'net_company_receipt': interaction.net_company_receipt,
         'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
+        'export_countries': [],
+        'were_countries_discussed': None,
         'created_on': interaction.created_on,
         'modified_on': interaction.modified_on,
     }

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -23,6 +23,10 @@ class SearchInteractionAPIViewMixin:
     es_sort_by_remappings = {
         'company.name': 'company.name.keyword',
     }
+    fields_to_exclude = (
+        'export_countries',
+        'were_countries_discussed',
+    )
 
     FILTER_FIELDS = (
         'kind',

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -30,6 +30,7 @@ def get_basic_search_query(
         permission_filters_by_entity=None,
         offset=0,
         limit=100,
+        fields_to_exclude=None,
 ):
     """
     Performs basic search for the given term in the given entity using the SEARCH_FIELDS.
@@ -61,8 +62,13 @@ def get_basic_search_query(
         Bool(
             should=Term(_type=entity._doc_type.name),
         ),
+    ).sort(
+        '_score',
+        'id',
+    ).source(
+        exclude=fields_to_exclude,
     )
-    search = search.sort('_score', 'id')
+
     search.aggs.bucket(
         'count_by_type', 'terms', field='_type',
     )

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -51,13 +51,14 @@ class TestValidateViewAttributes:
 
     def test_validate_composite_filter_fields(self, search_view):
         """Validate that the values of COMPOSITE_FILTERS are valid field paths."""
-        mapping = search_view.search_app.es_model._doc_type.mapping
+        entities = search_view().get_entities()
+        mappings = [entity._doc_type.mapping for entity in entities]
 
         invalid_fields = {
             field
             for field_list in search_view.COMPOSITE_FILTERS.values()
             for field in field_list
-            if not mapping.resolve_field(field)
+            if not any(mapping.resolve_field(field) for mapping in mappings)
             and field not in search_view.search_app.es_model.PREVIOUS_MAPPING_FIELDS
         }
 

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -15,7 +15,7 @@ from rest_framework.views import APIView
 from datahub.core.csv import create_csv_response
 from datahub.core.exceptions import DataHubException
 from datahub.oauth.scopes import Scope
-from datahub.search.apps import get_search_apps
+from datahub.search.apps import get_global_search_apps_as_mapping
 from datahub.search.execute_query import execute_autocomplete_query, execute_search_query
 from datahub.search.permissions import (
     has_permissions_for_app,
@@ -126,7 +126,7 @@ class SearchBasicAPIView(APIView):
         query = get_basic_search_query(
             entity=validated_params['entity'],
             term=validated_params['term'],
-            permission_filters_by_entity=dict(_get_permission_filters(request)),
+            permission_filters_by_entity=dict(_get_global_search_permission_filters(request)),
             offset=validated_params['offset'],
             limit=validated_params['limit'],
             fields_to_exclude=self.fields_to_exclude,
@@ -144,14 +144,14 @@ class SearchBasicAPIView(APIView):
         return Response(data=response)
 
 
-def _get_permission_filters(request):
+def _get_global_search_permission_filters(request):
     """
     Gets the permissions filters that should be applied to each search entity (to enforce
-    permissions).
+    permissions) in global search.
 
-    Only entities that the user has access are returned.
+    Only global search entities that the user has access to are returned.
     """
-    for app in get_search_apps():
+    for app in get_global_search_apps_as_mapping().values():
         if not has_permissions_for_app(request, app):
             continue
 
@@ -191,6 +191,10 @@ class SearchAPIView(APIView):
         }
         return filters
 
+    def get_entities(self):
+        """Returns entities"""
+        return [self.search_app.es_model]
+
     def validate_data(self, data):
         """Validate and clean data."""
         serializer = self.serializer_class(data=data)
@@ -200,11 +204,12 @@ class SearchAPIView(APIView):
     def get_base_query(self, request, validated_data):
         """Gets a filtered Elasticsearch query for the provided search parameters."""
         filter_data = self._get_filter_data(validated_data)
+        entities = self.get_entities()
         permission_filters = self.search_app.get_permission_filters(request)
         ordering = _map_es_ordering(validated_data['sortby'], self.es_sort_by_remappings)
 
         return get_search_by_entities_query(
-            [self.search_app.es_model],
+            entities=entities,
             term=validated_data['original_query'],
             filter_data=filter_data,
             composite_field_mapping=self.COMPOSITE_FILTERS,

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -112,6 +112,11 @@ class SearchBasicAPIView(APIView):
     http_method_names = ('get',)
     schema = SearchBasicStubSchema()
 
+    fields_to_exclude = (
+        'export_countries',
+        'were_countries_discussed',
+    )
+
     def get(self, request, format=None):
         """Performs basic search."""
         serializer = BasicSearchQuerySerializer(data=request.query_params)
@@ -124,6 +129,7 @@ class SearchBasicAPIView(APIView):
             permission_filters_by_entity=dict(_get_permission_filters(request)),
             offset=validated_params['offset'],
             limit=validated_params['limit'],
+            fields_to_exclude=self.fields_to_exclude,
         )
 
         results = execute_search_query(query)


### PR DESCRIPTION
### Description of change

This updates `POST /v4/search/export-country-history` so that interactions with export countries are additionally included in results.

The endpoint now requires both the `company.view_companyexportcountry` and `interaction.view_all_interaction` permissions.

Export country history objects that are updates (as opposed to additions or deletions) are also no longer included in results.

This is split from #2632 and follows on from #2663.

I'd recommend looking at the commits individually.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
