### PR TITLE
Update django-oauth-toolkit to version 1.3.0

### DIFF
--- a/datahub/oauth/migrations/0001_add_oauth_app_scope.py
+++ b/datahub/oauth/migrations/0001_add_oauth_app_scope.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(oauth2_settings.APPLICATION_MODEL),
-        ('oauth2_provider', '0005_auto_20170514_1141'),
+        ('oauth2_provider', '0001_initial'),
     ]
 
     operations = [

--- a/datahub/oauth/test/test_scopes.py
+++ b/datahub/oauth/test/test_scopes.py
@@ -86,7 +86,7 @@ class TestOAuthScopeBackend:
             data=urlencode(data),
             content_type='application/x-www-form-urlencoded',
         )
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             'error': 'invalid_scope',
         }

--- a/requirements.in
+++ b/requirements.in
@@ -7,8 +7,7 @@ django-filter==2.2.0
 django-reversion==3.0.7
 django-pglocks==1.0.4
 django-mptt==0.11.0
-django-oauth-toolkit==1.2.0
-oauthlib==2.1.0
+django-oauth-toolkit==1.3.0
 uritemplate==3.0.1  # required for DRF schema features
 whitenoise==5.0.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ django-extensions==2.2.8  # via -r requirements.in
 django-filter==2.2.0      # via -r requirements.in
 django-js-asset==1.2.2    # via django-mptt
 django-mptt==0.11.0       # via -r requirements.in
-django-oauth-toolkit==1.2.0  # via -r requirements.in
+django-oauth-toolkit==1.3.0  # via -r requirements.in
 django-pglocks==1.0.4     # via -r requirements.in
 django-redis==4.11.0      # via -r requirements.in
 django-reversion==3.0.7   # via -r requirements.in
@@ -72,7 +72,7 @@ mohawk==1.1.0             # via -r requirements.in, requests-hawk
 monotonic==1.5            # via notifications-python-client
 more-itertools==8.0.2     # via pytest
 notifications-python-client==5.5.1  # via -r requirements.in
-oauthlib==2.1.0           # via -r requirements.in, django-oauth-toolkit
+oauthlib==3.1.0           # via django-oauth-toolkit
 packaging==20.0           # via pytest, pytest-sugar
 parso==0.5.2              # via jedi
 pathtools==0.1.2          # via watchdog


### PR DESCRIPTION
### Description of change

This updates django-oauth-toolkit to version 1.3.0.

(This wasn't picked up by dependabot as we'd pinned oauthlib, due to oauthlib 3.x being incompatible with django-oauth-toolkit 1.2.0.)

Changelogs:

- https://github.com/jazzband/django-oauth-toolkit/blob/master/CHANGELOG.md
- https://github.com/oauthlib/oauthlib/blob/master/CHANGELOG.rst

(The `invalid_scope` status code was changed from 401 to 400 in oauthlib 3.0.0.)

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
