### PR TITLE
Add utility functions for D&B change-requests

### DIFF
--- a/changelog/company/dnb-request-changes.internal.md
+++ b/changelog/company/dnb-request-changes.internal.md
@@ -1,0 +1,1 @@
+Utility functions were added for making change-requests to the `dnb-service` as well as for formatting these change-requests to/from `dnb-service`.

--- a/datahub/dnb_api/constants.py
+++ b/datahub/dnb_api/constants.py
@@ -41,3 +41,19 @@ ALL_DNB_UPDATED_MODEL_FIELDS = (
     'global_ultimate_duns_number',
     'company_number',
 )
+
+CHANGE_REQUEST_FIELD_MAPPING = [
+    # (data-hub-api fields, dnb-service fields)
+    ('name', 'primary_name'),
+    ('trading_names', 'trading_names'),
+    ('number_of_employees', 'employee_number'),
+    ('turnover', 'annual_sales'),
+    ('turnover_currency', 'annual_sales_currency'),
+    ('address_line_1', 'address_line_1'),
+    ('address_line_2', 'address_line_2'),
+    ('address_town', 'address_town'),
+    ('address_county', 'address_county'),
+    ('address_country', 'address_country'),
+    ('address_postcode', 'address_postcode'),
+    ('website', 'domain'),
+]

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -780,6 +780,36 @@ class TestRequestChange:
                 },
             ),
 
+            # No website
+            (
+                # change_request
+                {
+                    'duns_number': '123456789',
+                    'changes': {
+                        'name': 'Foo Bar',
+                    },
+                },
+                # dnb_response
+                {
+                    'duns_number': '123456789',
+                    'id': '11111111-2222-3333-4444-555555555555',
+                    'status': 'pending',
+                    'created_on': '2020-01-05T11:00:00',
+                    'changes': {
+                        'primary_name': 'Foo Bar',
+                    },
+                },
+                # datahub_response
+                {
+                    'duns_number': '123456789',
+                    'id': '11111111-2222-3333-4444-555555555555',
+                    'status': 'pending',
+                    'created_on': '2020-01-05T11:00:00',
+                    'changes': {
+                        'name': 'Foo Bar',
+                    },
+                },
+            ),
         ),
     )
     def test_valid(


### PR DESCRIPTION
### Description of change

Utility functions were added for making change-requests to the `dnb-service` as well as for converting format to/from `dnb-service`.

I will hook this up to a view in a following PR that will have more tests.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
