### PR TITLE
Add interaction body to complete company referral response

### DIFF
--- a/changelog/company/complete-company-referral.api.md
+++ b/changelog/company/complete-company-referral.api.md
@@ -1,0 +1,1 @@
+The `POST /v4/company-referral/<ID>/complete` endpoint now returns the body of Interaction that has been created.

--- a/datahub/company_referral/views.py
+++ b/datahub/company_referral/views.py
@@ -76,4 +76,4 @@ class CompanyReferralViewSet(CoreViewSet):
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()
-        return Response(status=status.HTTP_201_CREATED)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
### Description of change

Complete company referral endpoint accepts the same request body as `POST /v3/interaction` (except `company` as this is coming from the company referral) to create interaction that completes the referral. That endpoint only returned `HTTP_201_CREATED` HTTP status.

On the front end, once the referral is completed, user should be taken to the interaction details page.
Currently obtaining the interaction ID would require a call to the get company referral endpoint after completion and make the process unnecessarily complex.

This PR adds interaction body to the response of complete company referral endpoint, so that the interaction details view can be fed straight away.

The alternative way considered was to return the body of completed referral, however, the caller of this endpoint would have all information returned by this endpoint already (except the interaction id) and would have to make another call to get the body of just created interaction.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
