### PR TITLE
Restore ability to merge companies that have export countries

### DIFF
--- a/changelog/company/merge-companies-with-export-countries.bugfix.md
+++ b/changelog/company/merge-companies-with-export-countries.bugfix.md
@@ -1,0 +1,1 @@
+The ability to merge companies (in the admin site) that have export countries was restored. Note that the merging tool doesn't modify export countries on either company; these can be manually updated after the merge if needed.

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -3,7 +3,12 @@ from typing import Callable, NamedTuple, Sequence, Type
 
 from django.db import models
 
-from datahub.company.models import Company, Contact
+from datahub.company.models import (
+    Company,
+    CompanyExportCountry,
+    CompanyExportCountryHistory,
+    Contact,
+)
 from datahub.company_referral.models import CompanyReferral
 from datahub.core.exceptions import DataHubException
 from datahub.core.model_helpers import get_related_fields, get_self_referential_relations
@@ -13,7 +18,11 @@ from datahub.omis.order.models import Order
 from datahub.user.company_list.models import CompanyListItem
 
 
+# Merging is not allowed if the source company has any relations that aren't in
+# this list. This is to avoid references to the source company being inadvertently
+# left behind.
 ALLOWED_RELATIONS_FOR_MERGING = {
+    # These relations are moved to the target company on merge
     Company._meta.get_field('company_list_items').remote_field,
     CompanyReferral.company.field,
     Contact.company.field,
@@ -22,6 +31,12 @@ ALLOWED_RELATIONS_FOR_MERGING = {
     InvestmentProject.intermediate_company.field,
     InvestmentProject.uk_company.field,
     Order.company.field,
+
+    # Merging is allowed if the source company has export countries, but note that
+    # they aren't moved to the target company (these can be manually moved in
+    # the front end if required)
+    CompanyExportCountry.company.field,
+    CompanyExportCountryHistory.company.field,
 }
 
 


### PR DESCRIPTION
### Description of change

This restores the ability to merge companies (in the admin site) that have export countries.

Note that this does not make any attempt to move the export countries from the source company to the target company. We agreed to just restore the previous behaviour (from when the export countries were stored in many-to-many fields rather than the `CompanyExportCountry` model), where merging was allowed but export countries were left alone.

(This is because merging them would be fairly complex, and can be manually done in the front end if needed.)

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
