### PR TITLE
Prepare for Elasticsearch _type field removal

### DIFF
--- a/changelog/add-type-search-field.internal.md
+++ b/changelog/add-type-search-field.internal.md
@@ -1,0 +1,1 @@
+A new `_document_type` field was added internally to all Elasticsearch documents as a replacement for the deprecated Elasticsearch `_type` field.

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -120,6 +120,20 @@ def get_search_app_by_model(model):
 
 
 @lru_cache(maxsize=None)
+def get_search_app_by_search_model(search_model):
+    """
+    :returns: a single search app (by django model)
+    :param search_model: search model for the search app
+    :raises LookupError: if it can't find the search app
+    """
+    for search_app in get_search_apps():
+        if search_app.es_model is search_model:
+            return search_app
+
+    raise LookupError(f'search app for {search_model} not found.')
+
+
+@lru_cache(maxsize=None)
 def _load_search_apps():
     """Loads and registers all search apps specified in `SEARCH_APPS`."""
     apps = (_load_search_app(cls_path) for cls_path in settings.SEARCH_APPS)

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -22,6 +22,9 @@ def test_mapping(es):
         'company': {
             'dynamic': 'false',
             'properties': {
+                '_document_type': {
+                    'type': 'keyword',
+                },
                 'archived': {'type': 'boolean'},
                 'archived_by': {
                     'properties': {
@@ -536,6 +539,7 @@ def test_indexed_doc(es):
 
     assert indexed_company['_id'] == str(company.pk)
     assert indexed_company['_source'].keys() == {
+        '_document_type',
         'archived',
         'archived_by',
         'archived_on',

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -22,6 +22,7 @@ class TestCompanyElasticModel:
         result = ESCompany.db_object_to_dict(company_qs)
 
         keys = {
+            '_document_type',
             'archived',
             'archived_by',
             'archived_on',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -19,6 +19,9 @@ def test_mapping(es):
     assert mapping.to_dict() == {
         'contact': {
             'properties': {
+                '_document_type': {
+                    'type': 'keyword',
+                },
                 'accepts_dit_email_marketing': {'type': 'boolean'},
                 'address_1': {'type': 'text'},
                 'address_2': {'type': 'text'},

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -14,6 +14,7 @@ def test_contact_dbmodel_to_dict(es):
     result = ESContact.db_object_to_dict(contact)
 
     keys = {
+        '_document_type',
         'id',
         'title',
         'company',

--- a/datahub/search/event/test/test_elasticsearch.py
+++ b/datahub/search/event/test/test_elasticsearch.py
@@ -14,6 +14,9 @@ def test_mapping(es):
         'event': {
             'dynamic': 'false',
             'properties': {
+                '_document_type': {
+                    'type': 'keyword',
+                },
                 'address_1': {'type': 'text'},
                 'address_2': {'type': 'text'},
                 'address_country': {

--- a/datahub/search/event/test/test_models.py
+++ b/datahub/search/event/test/test_models.py
@@ -13,6 +13,7 @@ def test_event_dbmodel_to_dict(es):
     result = ESEvent.db_object_to_dict(event)
 
     keys = {
+        '_document_type',
         'id',
         'event_type',
         'location_type',

--- a/datahub/search/export_country_history/test/test_models.py
+++ b/datahub/search/export_country_history/test/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 
 from datahub.company.test.factories import CompanyExportCountryHistoryFactory
+from datahub.search.export_country_history import ExportCountryHistoryApp
 from datahub.search.export_country_history.models import ExportCountryHistory
 
 pytestmark = pytest.mark.django_db
@@ -12,6 +13,7 @@ def test_export_country_history_to_dict(es):
     result = ExportCountryHistory.db_object_to_dict(export_country_history)
 
     assert result == {
+        '_document_type': ExportCountryHistoryApp.name,
         'id': export_country_history.pk,
         'company': {
             'id': str(export_country_history.company.pk),

--- a/datahub/search/export_country_history/test/test_signals.py
+++ b/datahub/search/export_country_history/test/test_signals.py
@@ -36,6 +36,7 @@ def test_updated_interaction_synced(es_with_signals):
     )
 
     assert result['_source'] == {
+        '_document_type': ExportCountryHistoryApp.name,
         'history_user': {
             'id': str(export_country_history.history_user.id),
             'name': export_country_history.history_user.name,

--- a/datahub/search/interaction/test/test_models.py
+++ b/datahub/search/interaction/test/test_models.py
@@ -9,6 +9,7 @@ from datahub.interaction.test.factories import (
     InvestmentProjectInteractionFactory,
     ServiceDeliveryFactory,
 )
+from datahub.search.interaction import InteractionSearchApp
 from datahub.search.interaction.models import Interaction
 
 pytestmark = pytest.mark.django_db
@@ -35,6 +36,7 @@ def test_interaction_to_dict(es, factory_cls):
     result['policy_issue_types'].sort(key=itemgetter('id'))
 
     assert result == {
+        '_document_type': InteractionSearchApp.name,
         'id': interaction.pk,
         'kind': interaction.kind,
         'date': interaction.date,
@@ -142,6 +144,7 @@ def test_service_delivery_to_dict(es):
     result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
 
     assert result == {
+        '_document_type': InteractionSearchApp.name,
         'id': interaction.pk,
         'kind': interaction.kind,
         'date': interaction.date,

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -19,6 +19,9 @@ def test_mapping(es):
         'investment_project': {
             'dynamic': 'false',
             'properties': {
+                '_document_type': {
+                    'type': 'keyword',
+                },
                 'actual_land_date': {'type': 'date'},
                 'actual_uk_regions': {
                     'properties': {

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -58,6 +58,7 @@ def test_investment_project_to_dict(es):
     result = ESInvestmentProject.db_object_to_dict(project)
 
     keys = {
+        '_document_type',
         'id',
         'allow_blank_estimated_land_date',
         'allow_blank_possible_uk_regions',

--- a/datahub/search/large_investor_profile/test/test_elasticsearch.py
+++ b/datahub/search/large_investor_profile/test/test_elasticsearch.py
@@ -23,6 +23,9 @@ def test_mapping(es):
     assert mapping.to_dict() == {
         'large-investor-profile': {
             'properties': {
+                '_document_type': {
+                    'type': 'keyword',
+                },
                 'asset_classes_of_interest': {
                     'properties': {
                         'id': {
@@ -323,6 +326,7 @@ def test_indexed_doc(es):
 
     assert indexed_large_investor_profile['_id'] == str(large_investor_profile.pk)
     assert indexed_large_investor_profile['_source'] == {
+        '_document_type': LargeInvestorProfileSearchApp.name,
         'id': str(large_investor_profile.pk),
         'asset_classes_of_interest': [],
         'country_of_origin': {

--- a/datahub/search/large_investor_profile/test/test_models.py
+++ b/datahub/search/large_investor_profile/test/test_models.py
@@ -17,6 +17,7 @@ class TestLargeInvestorProfileElasticModel:
 
         result = ESLargeInvestorProfile.db_object_to_dict(large_investor_profile)
         keys = {
+            '_document_type',
             'asset_classes_of_interest',
             'construction_risks',
             'country_of_origin',

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -23,6 +23,9 @@ def test_mapping(es):
         'order': {
             'dynamic': 'false',
             'properties': {
+                '_document_type': {
+                    'type': 'keyword',
+                },
                 'assignees': {
                     'properties': {
                         'dit_team': {
@@ -510,6 +513,7 @@ def test_indexed_doc(order_factory, es):
 
     assert indexed_order['_id'] == str(order.pk)
     assert indexed_order['_source'] == {
+        '_document_type': OrderSearchApp.name,
         'id': str(order.pk),
         'created_by': {
             'id': str(order.created_by.pk),

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -9,6 +9,7 @@ from datahub.omis.order.test.factories import (
     OrderSubscriberFactory,
     OrderWithAcceptedQuoteFactory,
 )
+from datahub.search.omis import OrderSearchApp
 from datahub.search.omis.models import Order as ESOrder
 
 pytestmark = pytest.mark.django_db
@@ -35,6 +36,7 @@ def test_order_to_dict(order_factory):
     result = ESOrder.db_object_to_dict(order)
 
     assert result == {
+        '_document_type': OrderSearchApp.name,
         'id': order.pk,
         'company': {
             'id': str(order.company.pk),

--- a/datahub/search/test/test_apps.py
+++ b/datahub/search/test/test_apps.py
@@ -2,7 +2,13 @@ from unittest import mock
 
 import pytest
 
-from datahub.search.apps import get_search_app, get_search_app_by_model
+from datahub.search.apps import (
+    get_search_app,
+    get_search_app_by_model,
+    get_search_app_by_search_model,
+)
+from datahub.search.test.search_support.simplemodel import SimpleModelSearchApp
+from datahub.search.test.search_support.simplemodel.models import ESSimpleModel
 
 
 @mock.patch('datahub.search.apps._load_search_apps')
@@ -59,5 +65,21 @@ class TestGetSearchAppByModel:
         mocked_load_search_apps.return_value = {
             'app1': mock.Mock(),
         }
+        with pytest.raises(LookupError):
+            get_search_app_by_model(mock.Mock())
+
+
+class TestGetSearchAppBySearchModel:
+    """Tests for `get_search_app_by_search_model`."""
+
+    def test_found(self):
+        """Test that the expected app is returned for a registered search model."""
+        assert get_search_app_by_search_model(ESSimpleModel) is SimpleModelSearchApp
+
+    def test_not_found(self):
+        """
+        Test that get_search_app_by_model raises LookupError if it
+        can't find the right search app for the search model passed in.
+        """
         with pytest.raises(LookupError):
             get_search_app_by_model(mock.Mock())

--- a/datahub/search/test/test_models.py
+++ b/datahub/search/test/test_models.py
@@ -22,6 +22,7 @@ class TestBaseESModel:
             include_source=include_source,
         )
         source = {
+            '_document_type': 'simplemodel',
             'id': obj.pk,
             'name': 'test-name',
             'date': None,
@@ -48,7 +49,7 @@ def test_validate_model_fields(search_app):
     db_model_properties = _get_object_properties(db_model)
     db_model_fields = _get_db_model_fields(db_model)
 
-    valid_fields = computed_fields | db_model_properties | db_model_fields
+    valid_fields = computed_fields | db_model_properties | db_model_fields | {'_document_type'}
     invalid_fields = fields - valid_fields
 
     assert not invalid_fields

--- a/datahub/search/utils.py
+++ b/datahub/search/utils.py
@@ -40,6 +40,7 @@ def get_model_non_mapped_field_names(es_model):
         get_model_field_names(es_model)
         - es_model.MAPPINGS.keys()
         - es_model.COMPUTED_MAPPINGS.keys()
+        - {'_document_type'}
     )
 
 


### PR DESCRIPTION
### Description of change

Mapping types in Elasticsearch are deprecated:

- https://www.elastic.co/guide/en/elasticsearch/reference/7.6/removal-of-types.html
- https://www.elastic.co/blog/removal-of-mapping-types-elasticsearch

One of the remaining parts of this that we haven't dealt with is the deprecation of the `_type` (mapping type name) field in Elasticsearch. We've been using this, mainly for the aggregations in global search and for some of the permission filtering, so we'll need a replacement for it.

This PR:

- removes some usages of the mapping type name where we don't need to reference it
- adds a new `type_` field that we can use instead of `_type` where we actually need it

This change will help with the upgrade to Elasticsearch 7.

The new `type_` field is deliberately excluded from API responses so that the API is unchanged.

Once the new `type_` field has been indexed in all environments, queries can be updated to use it (in place of `_type`).

I went with `type_` because `_type` conflicts with the existing field, and `type` could conflict with a model field, but it can be called anything if anyone has any other suggestions.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
