### PR TITLE
Stub dnb/company-change-request endpoint

### DIFF
--- a/changelog/company/dnb-change-request-view.feature.md
+++ b/changelog/company/dnb-change-request-view.feature.md
@@ -1,0 +1,5 @@
+The following endpoint was added the the Data Hub API:
+
+- POST `/dnb/company-change-request`
+
+At the moment, the endpoint returns HTTP 501 - Not Implemented. Following PRs would add the requisite functionality to the endpoint.

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from datahub.dnb_api.views import (
+    DNBCompanyChangeRequestView,
     DNBCompanyCreateInvestigationView,
     DNBCompanyCreateView,
     DNBCompanyLinkView,
@@ -27,5 +28,10 @@ urlpatterns = [
         'company-link',
         DNBCompanyLinkView.as_view(),
         name='company-link',
+    ),
+    path(
+        'company-change-request',
+        DNBCompanyChangeRequestView.as_view(),
+        name='company-change-request',
     ),
 ]

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -303,3 +303,26 @@ class DNBCompanyLinkView(APIView):
         return Response(
             CompanySerializer().to_representation(company),
         )
+
+
+class DNBCompanyChangeRequestView(APIView):
+    """
+    View for requesting change/s to DNB companies.
+    """
+
+    required_scopes = (Scope.internal_front_end,)
+
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        HasPermissions(
+            f'company.{CompanyPermission.view_company}',
+            f'company.{CompanyPermission.change_company}',
+        ),
+    )
+
+    @method_decorator(enforce_request_content_type('application/json'))
+    def post(self, request):
+        """
+        A thin wrapper around the dnb-service change request API.
+        """
+        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)


### PR DESCRIPTION
### Description of change

The following endpoint was added the the Data Hub API:

  - POST `/dnb/company-change-request`

  At the moment, the endpoint returns HTTP 501 - Not Implemented. Following PRs would add the requisite functionality to the endpoint.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
