### PR TITLE
Add kind field to export country history search responses

### DIFF
--- a/datahub/search/export_country_history/test/test_views.py
+++ b/datahub/search/export_country_history/test/test_views.py
@@ -176,6 +176,7 @@ class TestSearchExportCountryHistory(APITestMixin):
                 }
                 for export_country in interaction.export_countries.order_by('country__pk')
             ],
+            'kind': interaction.kind,
             'id': str(interaction.pk),
             'service': {
                 'id': str(interaction.service.pk),

--- a/datahub/search/export_country_history/views.py
+++ b/datahub/search/export_country_history/views.py
@@ -44,6 +44,7 @@ class ExportCountryHistoryView(SearchAPIView):
         'contacts',
         'dit_participants',
         'export_countries',
+        'kind',
         'service',
         'subject',
     )


### PR DESCRIPTION
### Description of change

This adds the `kind` interaction field to responses in export country history search (which was missed in #2664).

I haven't added a new news fragment as the the original PR hasn't been released yet.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
