### PR TITLE
Add delete_old_export_country_history management command

### DIFF
--- a/changelog/company/delete-old-export-country-history.feature.md
+++ b/changelog/company/delete-old-export-country-history.feature.md
@@ -1,0 +1,4 @@
+This adds a management command, `delete_old_export_country_history`, to delete `CompanyExportCountryHistory` older than a specified date.
+
+This is a temporary command to delete inaccurate `CompanyExportCountryHistory` objects
+that were accidentally created during the data migration from the previous `Company.export_to_countries` and `Company.future_interest_countries` fields.

--- a/datahub/dbmaintenance/management/commands/delete_old_export_country_history.py
+++ b/datahub/dbmaintenance/management/commands/delete_old_export_country_history.py
@@ -1,0 +1,65 @@
+from contextlib import ExitStack
+from logging import getLogger
+
+from dateutil.parser import isoparse
+from django.core.management import BaseCommand
+from django.db.transaction import atomic
+
+from datahub.company.models import CompanyExportCountryHistory
+from datahub.core.exceptions import SimulationRollback
+from datahub.search.deletion import update_es_after_deletions
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command to delete CompanyExportCountryHistory objects dated before a
+    specified timestamp.
+
+    This is a temporary command to delete inaccurate CompanyExportCountryHistory objects
+    that were accidentally created during the data migration.
+
+    TODO: Remove this command once we've used it in production.
+    """
+
+    help = """Deletes CompanyExportCountryHistory objects dated before a specified timestamp."""
+    requires_migrations_checks = True
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        parser.add_argument(
+            'timestamp',
+            type=isoparse,
+            help='An ISO timestamp. Records older than this will be deleted.',
+        )
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            help='Simulate the command by performing the deletions and rolling them back.',
+        )
+
+    def handle(self, *args, **options):
+        """Main logic for the actual command."""
+        is_simulation = options['simulate']
+        timestamp = options['timestamp']
+
+        queryset = CompanyExportCountryHistory.objects.filter(history_date__lt=timestamp)
+
+        try:
+            with ExitStack() as stack:
+                if not is_simulation:
+                    stack.enter_context(update_es_after_deletions())
+
+                stack.enter_context(atomic())
+                total_deleted, deletions_by_model = queryset.delete()
+
+                logger.info(f'{total_deleted} records deleted. Breakdown by model:')
+                for deletion_model, model_deletion_count in deletions_by_model.items():
+                    logger.info(f'{deletion_model}: {model_deletion_count}')
+
+                if is_simulation:
+                    logger.info(f'Rolling back deletions...')
+                    raise SimulationRollback()
+        except SimulationRollback:
+            logger.info(f'Deletions rolled back')

--- a/datahub/dbmaintenance/test/commands/test_delete_old_export_country_history.py
+++ b/datahub/dbmaintenance/test/commands/test_delete_old_export_country_history.py
@@ -1,0 +1,77 @@
+from datetime import datetime, timedelta
+
+import pytest
+from django.core.management import call_command
+from django.db.models import QuerySet
+from django.utils.timezone import utc
+from freezegun import freeze_time
+
+from datahub.company.models import CompanyExportCountryHistory
+from datahub.company.test.factories import CompanyExportCountryHistoryFactory
+from datahub.dbmaintenance.management.commands import delete_old_export_country_history
+from datahub.search.export_country_history import ExportCountryHistoryApp
+from datahub.search.test.utils import doc_count, doc_exists
+
+
+@pytest.mark.django_db
+class TestDeleteOldExportCountryHistory:
+    """Tests for the delete_old_export_country_history management command."""
+
+    def test_deletes_expected_records(self, es_with_signals):
+        """Test that the command deletes records only before the cut-off."""
+        deletion_cutoff = datetime(2020, 3, 1, 12, 0, 0)
+
+        with freeze_time(deletion_cutoff - timedelta(days=1)):
+            objects_to_delete = CompanyExportCountryHistoryFactory.create_batch(2)
+
+        with freeze_time(deletion_cutoff):
+            objects_to_keep = CompanyExportCountryHistoryFactory.create_batch(2)
+
+        es_with_signals.indices.refresh()
+
+        command = delete_old_export_country_history.Command()
+        call_command(command, deletion_cutoff.isoformat())
+
+        es_with_signals.indices.refresh()
+
+        for history_object in objects_to_delete:
+            assert not CompanyExportCountryHistory.objects.filter(pk=history_object.pk).exists()
+            assert not doc_exists(es_with_signals, ExportCountryHistoryApp, history_object.pk)
+
+        for history_object in objects_to_keep:
+            assert CompanyExportCountryHistory.objects.filter(pk=history_object.pk).exists()
+            assert doc_exists(es_with_signals, ExportCountryHistoryApp, history_object.pk)
+
+    def test_simulate(self, track_return_values, es_with_signals):
+        """Test that --simulate only simulates deletions."""
+        delete_return_value_tracker = track_return_values(QuerySet, 'delete')
+
+        deletion_cutoff = datetime(2020, 3, 1, 12, 0, 0, tzinfo=utc)
+
+        with freeze_time(deletion_cutoff - timedelta(days=1)):
+            objects_to_delete = CompanyExportCountryHistoryFactory.create_batch(2)
+
+        with freeze_time(deletion_cutoff):
+            CompanyExportCountryHistoryFactory.create_batch(2)
+
+        es_with_signals.indices.refresh()
+
+        assert CompanyExportCountryHistory.objects.count() == 4
+        assert doc_count(es_with_signals, ExportCountryHistoryApp) == 4
+
+        command = delete_old_export_country_history.Command()
+        call_command(command, deletion_cutoff.isoformat(), simulate=True)
+
+        es_with_signals.indices.refresh()
+
+        # Check that nothing has been deleted
+        assert CompanyExportCountryHistory.objects.count() == 4
+        assert doc_count(es_with_signals, ExportCountryHistoryApp) == 4
+
+        # Check which model objects were deleted prior to the rollback
+        return_values = delete_return_value_tracker.return_values
+        assert len(return_values) == 1
+        _, deletions_by_model = return_values[0]
+        assert deletions_by_model == {
+            CompanyExportCountryHistory._meta.label: len(objects_to_delete),
+        }

--- a/datahub/search/test/utils.py
+++ b/datahub/search/test/utils.py
@@ -28,10 +28,19 @@ def create_mock_search_app(
 def doc_exists(es_client, search_app, id_):
     """Checks if a document exists for a specified search app."""
     return es_client.exists(
-        index=search_app.es_model.get_write_index(),
+        index=search_app.es_model.get_read_alias(),
         doc_type=search_app.name,
         id=id_,
     )
+
+
+def doc_count(es_client, search_app):
+    """Return a document count for a specified search app."""
+    response = es_client.count(
+        index=search_app.es_model.get_read_alias(),
+        doc_type=search_app.name,
+    )
+    return response['count']
 
 
 def _create_mock_es_model(


### PR DESCRIPTION
### Description of change

This adds a management command, `delete_old_export_country_history`, to delete `CompanyExportCountryHistory` older than a specified date.

This is a temporary command to delete inaccurate `CompanyExportCountryHistory` objects
that were accidentally created during the data migration from the previous `Company.export_to_country` and `Company.future_interest_countries` fields.

The implementation of the command was based on `datahub.cleanup.management.commands._base_command.BaseCleanupCommand`.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
