### PR TITLE
Add workaround for Django 3 memory leak under gevent

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `GUNICORN_ACCESS_LOG_FORMAT`  | No |  |
 | `GUNICORN_ENABLE_ASYNC_PSYCOPG2` | No | Whether to enable asynchronous psycopg2 when the worker class is 'gevent' (default=True). |
 | `GUNICORN_ENABLE_STATSD` | No | Whether to enable Gunicorn StatD instrumentation (default=False). |
+| `GUNICORN_PATCH_ASGIREF` | No | Whether to enable a workaround for https://github.com/django/asgiref/issues/144 when the worker class is 'gevent' (default=False). |
 | `GUNICORN_WORKER_CLASS`  | No | [Type of Gunicorn worker.](http://docs.gunicorn.org/en/stable/settings.html#worker-class) Uses async workers via gevent by default. |
 | `GUNICORN_WORKER_CONNECTIONS`  | No | Maximum no. of connections for async workers (default=10). |
 | `INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE` | No | Maximum file size in bytes for interaction admin CSV uploads (default=2MB). |

--- a/changelog/django-3-gevent-workaround.internal.md
+++ b/changelog/django-3-gevent-workaround.internal.md
@@ -1,0 +1,1 @@
+A workaround was added for a memory leak when using Django 3 with gevent. This is inactive by default.

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -41,6 +41,9 @@ worker_connections = os.environ.get('GUNICORN_WORKER_CONNECTIONS', '10')
 _enable_async_psycopg2 = (
     os.environ.get('GUNICORN_ENABLE_ASYNC_PSYCOPG2', 'true').lower() in ('true', '1')
 )
+_patch_asgiref = (
+    os.environ.get('GUNICORN_PATCH_ASGIREF', 'false').lower() in ('true', '1')
+)
 
 
 def post_fork(server, worker):
@@ -49,6 +52,19 @@ def post_fork(server, worker):
 
     Enables async processing in Psycopg2 if GUNICORN_ENABLE_ASYNC_PSYCOPG2 is set.
     """
-    if worker_class == 'gevent' and _enable_async_psycopg2:
-        patch_psycopg()
-        worker.log.info('Enabled async Psycopg2')
+    if worker_class == 'gevent':
+        if _enable_async_psycopg2:
+            patch_psycopg()
+            worker.log.info('Enabled async Psycopg2')
+
+        # Temporary workaround for https://github.com/django/asgiref/issues/144.
+        # Essentially reverts part of
+        # https://github.com/django/django/commit/a415ce70bef6d91036b00dd2c8544aed7aeeaaed.
+        #
+        # TODO: Remove once there is a better fix for https://github.com/django/asgiref/issues/144.
+        if _patch_asgiref:
+            import asgiref.local
+            import threading
+
+            asgiref.local.Local = lambda **kwargs: threading.local()
+            worker.log.info('Patched asgiref.local.Local')


### PR DESCRIPTION
### Description of change

We've been suffering from a problematic memory leak since upgrading to Django 3 which is believed to be caused by https://github.com/django/asgiref/issues/144:

![image](https://user-images.githubusercontent.com/12693549/76442002-2ab72780-63b8-11ea-8d36-06e49060fd4e.png)

The memory leak is causing Gunicorn worker processes to exhaust available memory and crash and restart.

This adds a workaround which is inactive by default. This is so it can be we can verify that it fixes the problem in e.g. the dev environment.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
