### PR TITLE
track correct user for deleted export country

### DIFF
--- a/changelog/company/delete-export-country.bugfix.md
+++ b/changelog/company/delete-export-country.bugfix.md
@@ -1,0 +1,1 @@
+`POST /v4/company/update_export_detail`: will now track correct user that deleted export country instead of user who last updated it.

--- a/datahub/company/signal_receivers.py
+++ b/datahub/company/signal_receivers.py
@@ -1,0 +1,4 @@
+from django.dispatch import Signal
+
+export_country_update_signal = Signal(providing_args=['instance', 'created', 'by'])
+export_country_delete_signal = Signal(providing_args=['instance', 'by'])

--- a/datahub/company/signals.py
+++ b/datahub/company/signals.py
@@ -2,7 +2,7 @@ import logging
 from functools import partial
 
 from django.db import transaction
-from django.db.models.signals import post_migrate, post_save, pre_delete
+from django.db.models.signals import post_migrate, post_save
 from django.dispatch import receiver
 
 from datahub.company.constants import BusinessTypeConstant
@@ -12,6 +12,10 @@ from datahub.company.models import (
     CompanyExportCountryHistory,
 )
 from datahub.company.notify import notify_new_dnb_investigation
+from datahub.company.signal_receivers import (
+    export_country_delete_signal,
+    export_country_update_signal,
+)
 from datahub.core.utils import load_constants_to_database
 from datahub.metadata.models import BusinessType
 
@@ -56,46 +60,42 @@ def _notify_dnb_investigation_post_save(instance):
 
 
 @receiver(
-    post_save,
+    export_country_update_signal,
     sender=CompanyExportCountry,
     dispatch_uid='record_export_country_history_update',
 )
-def record_export_country_history_update(sender, instance, created, raw, **kwargs):
+def record_export_country_history_update(sender, instance, created, by, **kwargs):
     """
     Record export country changes to history.
     """
-    if raw:
-        return
-
     action = CompanyExportCountryHistory.HistoryType.UPDATE
     if created:
         action = CompanyExportCountryHistory.HistoryType.INSERT
 
-    _record_export_country_history(instance, action)
+    _record_export_country_history(instance, action, by)
 
 
 @receiver(
-    pre_delete,
+    export_country_delete_signal,
     sender=CompanyExportCountry,
     dispatch_uid='record_export_country_history_delete',
 )
-def record_export_country_history_delete(sender, instance, **kwargs):
+def record_export_country_history_delete(sender, instance, by, **kwargs):
     """
     Record export country deletions to history.
     """
     action = CompanyExportCountryHistory.HistoryType.DELETE
+    _record_export_country_history(instance, action, by)
 
-    _record_export_country_history(instance, action)
 
-
-def _record_export_country_history(export_country, action):
+def _record_export_country_history(export_country, action, adviser):
     """
     Records each change made to `CompanyExportCountry` model
     into companion log model, `CompanyExportCountryHistory`.
     Along with type of change, insert, update or delete.
     """
     CompanyExportCountryHistory.objects.create(
-        history_user=export_country.modified_by,
+        history_user=adviser,
         history_type=action,
         id=export_country.id,
         company=export_country.company,


### PR DESCRIPTION
### Description of change
This fix will make sure correct user is added to export country history when one of them was deleted. This was achieved by a declaring a custom signal. To keep things consistent, tracking export country creates/updates into history are also managed by custom signal now.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
