### PR TITLE
Add missing ISO country code to Honduras

### DIFF
--- a/changelog/add-missing-iso-code-to-honduras.bugfix.md
+++ b/changelog/add-missing-iso-code-to-honduras.bugfix.md
@@ -1,0 +1,3 @@
+Add ISO country code to Honduras.
+
+Lack of the ISO code prevented users from adding a company from that country on the frontend.

--- a/datahub/metadata/migrations/0002_add_iso_code_to_honduras.py
+++ b/datahub/metadata/migrations/0002_add_iso_code_to_honduras.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def add_iso_code_to_honduras(apps, schema_editor):
+    Country = apps.get_model('metadata', 'Country')
+    Country.objects.filter(pk='eff682ac-5d95-e211-a939-e4115bead28a').update(iso_alpha2_code='HN')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0001_squashed_0010_auto_20180613_1553'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_iso_code_to_honduras, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
### Description of change

Add ISO country code to Honduras.

Lack of the ISO code prevented users from adding a company from that country on the frontend.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
