### PR TITLE
Add serializer for change-requests

### DIFF
--- a/changelog/company/dnb-change-request-serializer.feature.md
+++ b/changelog/company/dnb-change-request-serializer.feature.md
@@ -1,0 +1,1 @@
+A serializer was added for validating the change-requests submitted to `dnb/company-change-request` endpoint and translating these change requests to the `dnb-service` format.

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -18,6 +18,7 @@ from datahub.core.view_utils import enforce_request_content_type
 from datahub.dnb_api.link_company import CompanyAlreadyDNBLinkedException, link_company_with_dnb
 from datahub.dnb_api.queryset import get_company_queryset
 from datahub.dnb_api.serializers import (
+    DNBCompanyChangeRequestSerializer,
     DNBCompanyInvestigationSerializer,
     DNBCompanyLinkSerializer,
     DNBCompanySerializer,
@@ -325,4 +326,6 @@ class DNBCompanyChangeRequestView(APIView):
         """
         A thin wrapper around the dnb-service change request API.
         """
-        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)
+        change_request_serializer = DNBCompanyChangeRequestSerializer(data=request.data)
+        change_request_serializer.is_valid(raise_exception=True)
+        return Response(change_request_serializer.validated_data)


### PR DESCRIPTION
### Description of change

This enriches the stub `DNBCompanyChangeRequestView` introduced in #2678 with a Serializer for validating the change-requests translating them to the `dnb-service` format.

At the moment, the view returns validated and translated change-request payload. This is temporary & deliberate.

In the following PR, I will introduce utility functions that will send the change-requests over to `dnb-service` and return the response of the `dnb-service`.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
