### PR TITLE
Send change-requests to dnb-service

### DIFF
--- a/changelog/company/dnb-change-request-utils.feature.md
+++ b/changelog/company/dnb-change-request-utils.feature.md
@@ -1,0 +1,3 @@
+Utility functions were added to the Data Hub API for sending change-requests to dnb-service and returning the response back to the clients.
+
+The `request_change` utility function was hooked up to the `DNBCompanyChangeRequestView` and tests were added to ensure we are keeping to the agreed contract with the client as well as `dnb-service`.

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -389,3 +389,46 @@ def rollback_dnb_company_update(
         for field, value in fields.items():
             setattr(company, field, value)
         company.save(update_fields=fields)
+
+
+def _request_changes(payload):
+    """
+    Submit change request to dnb-service.
+    """
+    if not settings.DNB_SERVICE_BASE_URL:
+        raise ImproperlyConfigured('The setting DNB_SERVICE_BASE_URL has not been set')
+    response = api_client.request(
+        'POST',
+        'change-request/',
+        json=payload,
+        timeout=3.0,
+    )
+    return response
+
+
+def request_changes(duns_number, changes):
+    """
+    Submit change request for the company with the given duns_number
+    and changes to the dnb-service.
+    """
+    try:
+        dnb_response = _request_changes(
+            {
+                'duns_number': duns_number,
+                'changes': changes,
+            },
+        )
+
+    except ConnectionError as exc:
+        error_message = 'Encountered an error connecting to DNB service'
+        raise DNBServiceConnectionError(error_message) from exc
+
+    except Timeout as exc:
+        error_message = 'Encountered a timeout interacting with DNB service'
+        raise DNBServiceTimeoutError(error_message) from exc
+
+    if not dnb_response.ok:
+        error_message = f'DNB service returned an error status: {dnb_response.status_code}'
+        raise DNBServiceError(error_message, dnb_response.status_code)
+
+    return dnb_response.json()


### PR DESCRIPTION
### Description of change

This PR follows from #2685 which set up the Serializer for validating change-requests.

This PR adds utility functions for sending these change-requests to `dnb-service` and returning the response back to the client.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
