### PR TITLE
Deprecate company autocomplete endpoint

### DIFF
--- a/changelog/company/company-autocomplete.deprecation.md
+++ b/changelog/company/company-autocomplete.deprecation.md
@@ -1,0 +1,5 @@
+The following endpoint is deprecated and will be removed on or after 1 April 2020:
+
+- `GET /v4/search/company/autocomplete`
+
+This is because it‘s not in use and isn‘t compatible with Elasticsearch 7 in its current form.


### PR DESCRIPTION
### Description of change

This deprecates the `GET /v4/search/company/autocomplete` endpoint as it's not compatible with Elasticsearch 7 as it is (as that doesn't allow optional contexts for these kind of searches), and also as it has problems with ordering results.

I've checked this with @debitan and @saruniitr.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
