### PR TITLE
Add OMIS invoice detail Hawk authenticated endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,10 +321,12 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `MI_DATABASE_SSLCERT` | No | base64 encoded client certificate for MI database connection. |
 | `MI_DATABASE_SSLKEY` | No | base64 encoded client private key for MI database connection. |
 | `MI_FDI_DASHBOARD_TASK_DURATION_WARNING_THRESHOLD` | No | Threshold (in seconds) for emitting warnings about long transfer duration (default=600). |
+| `OMIS_PUBLIC_ACCESS_KEY_ID` | No | A non-secret access key ID, corresponding to `OMIS_PUBLIC_SECRET_ACCESS_KEY`. The holder of the secret key can access the OMIS public endpoints by Hawk authentication. |
 | `OMIS_NOTIFICATION_ADMIN_EMAIL`  | Yes | |
 | `OMIS_NOTIFICATION_API_KEY`  | Yes | |
 | `OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL`  | No | |
 | `OMIS_PUBLIC_BASE_URL`  | Yes | |
+| `OMIS_PUBLIC_SECRET_ACCESS_KEY` | If `OMIS_PUBLIC_ACCESS_KEY_ID` is set | A secret key, corresponding to `OMIS_PUBLIC_ACCESS_KEY_ID`. The holder of this key can access the OMIS public endpoints by Hawk authentication. |
 | `PAAS_IP_WHITELIST` | No | IP addresses (comma-separated) that can access the Hawk-authenticated endpoints. |
 | `REDIS_BASE_URL`  | No | redis base URL without the db |
 | `REDIS_CACHE_DB`  | No | redis db for django cache (default 0) |

--- a/changelog/omis/omis-hawk-public-invoice.api.md
+++ b/changelog/omis/omis-hawk-public-invoice.api.md
@@ -1,0 +1,2 @@
+A new Hawk authenticated `GET /v3/public/omis/order/<public-token>/invoice` endpoint has been added.
+The new endpoint is functionally the same as `GET /v3/omis/public/order/<public-token>/invoice`.

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -46,11 +46,20 @@ v3_urls = [
     path('', include((investment_urls, 'investment'), namespace='investment')),
     path('', include((search_urls.urls_v3, 'search'), namespace='search')),
     path('omis/', include((omis_urls.internal_frontend_urls, 'omis'), namespace='omis')),
+    # TODO: remove `omis/public` path, once all views have been migrated to Hawk
+    # and deprecation period has passed.
     path(
         'omis/public/',
         include(
             (omis_urls.public_urls, 'omis-public'),
             namespace='omis-public',
+        ),
+    ),
+    path(
+        'public/omis/',
+        include(
+            (omis_urls.hawk_public_urls, 'public-omis'),
+            namespace='public-omis',
         ),
     ),
 ]

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -589,6 +589,12 @@ _add_hawk_credentials(
     (HawkScope.metadata, ),
 )
 
+_add_hawk_credentials(
+    'OMIS_PUBLIC_ACCESS_KEY_ID',
+    'OMIS_PUBLIC_SECRET_ACCESS_KEY',
+    (HawkScope.public_omis,),
+)
+
 # To read data from Activity Stream
 ACTIVITY_STREAM_OUTGOING_URL = env('ACTIVITY_STREAM_OUTGOING_URL', default=None)
 ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID = env('ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID', default=None)

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -104,6 +104,10 @@ HAWK_RECEIVER_CREDENTIALS = {
         'key': 'data-flow-api-key',
         'scopes': (HawkScope.data_flow_api, ),
     },
+    'omis-public-id': {
+        'key': 'omis-public-key',
+        'scopes': (HawkScope.public_omis,),
+    },
 }
 
 DOCUMENT_BUCKETS = {

--- a/config/settings/types.py
+++ b/config/settings/types.py
@@ -14,3 +14,4 @@ class HawkScope(Enum):
     public_company = auto()
     data_flow_api = auto()
     metadata = auto()
+    public_omis = auto()

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -66,6 +66,10 @@ class HawkAPITestClient:
         """Make a PATCH request with a JSON body."""
         return self.request('patch', path, json_=json_)
 
+    def delete(self, path, json_):
+        """Make a DELETE request with a JSON body."""
+        return self.request('delete', path, json_=json_)
+
     def request(self, method, path, params=None, json_=unset, content_type=''):
         """Make a request with a specified HTTP method."""
         params = urlencode(params) if params else ''

--- a/datahub/omis/invoice/legacy_public_views.py
+++ b/datahub/omis/invoice/legacy_public_views.py
@@ -1,0 +1,19 @@
+from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
+
+from datahub.oauth.scopes import Scope
+from datahub.omis.invoice.views import BaseInvoiceViewSet
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.models import Order
+
+
+class LegacyPublicInvoiceViewSet(BaseInvoiceViewSet):
+    """ViewSet for legacy public facing API."""
+
+    permission_classes = (IsAuthenticatedOrTokenHasScope,)
+    required_scopes = (Scope.public_omis_front_end,)
+
+    order_lookup_field = 'public_token'
+    order_lookup_url_kwarg = 'public_token'
+    order_queryset = Order.objects.publicly_accessible().exclude(
+        status=OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
+    )

--- a/datahub/omis/invoice/urls.py
+++ b/datahub/omis/invoice/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path
 
+from datahub.omis.invoice.legacy_public_views import LegacyPublicInvoiceViewSet
 from datahub.omis.invoice.views import InvoiceViewSet, PublicInvoiceViewSet
-
 
 # internal frontend API
 internal_frontend_urls = [
@@ -12,8 +12,17 @@ internal_frontend_urls = [
     ),
 ]
 
-# public facing API
-public_urls = [
+# legacy public facing API
+legacy_public_urls = [
+    re_path(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/invoice$',
+        LegacyPublicInvoiceViewSet.as_view({'get': 'retrieve'}),
+        name='detail',
+    ),
+]
+
+# Hawk authenticated public facing API
+hawk_public_urls = [
     re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/invoice$',
         PublicInvoiceViewSet.as_view({'get': 'retrieve'}),

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -20,7 +20,6 @@ internal_frontend_urls = [
 public_urls = [
     path('', include((order_urls.public_urls, 'order'), namespace='order')),
     path('', include((quote_urls.public_urls, 'quote'), namespace='quote')),
-    path('', include((invoice_urls.public_urls, 'invoice'), namespace='invoice')),
     path('', include((payment_urls.payment_public_urls, 'payment'), namespace='payment')),
     path(
         '',
@@ -29,4 +28,10 @@ public_urls = [
             namespace='payment-gateway-session',
         ),
     ),
+    path('', include((invoice_urls.legacy_public_urls, 'invoice'), namespace='invoice')),
+]
+
+# TODO: rename this to public_urls once all public urls have been migrated to Hawk
+hawk_public_urls = [
+    path('', include((invoice_urls.hawk_public_urls, 'invoice'), namespace='invoice')),
 ]


### PR DESCRIPTION
### Description of change

As a part of deeper Staff SSO integration work we need to change public OMIS endpoints that are currently being authenticated with OAuth, to use Hawk authentication instead.
This is the first of a number of PRs that will follow. This moves existing OMIS public invoice detail view to corresponding legacy files and creates new Hawk authenticated view with exactly the same functionality.
Once all views are re-created with Hawk authentication, the existing legacy views will be deprecated and public facing OMIS app will be updated to use new endpoints. The last step will be to remove all legacy OMIS endpoints.

New URLs for Hawk authenticated OMIS endpoints will have a following format:

`/v3/public/omis/...`

We have a pattern for "public" search endpoints that start with `/v4/public` prefix.

The endpoint has not been upgraded to `v4` because that may require additional changes in the public facing app to support `v4`'s address format. This work could be done once migration is completed.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
