### PR TITLE
Archive companies with no interaction in last 5y

### DIFF
--- a/changelog/company/auto-archive-5y.feature.md
+++ b/changelog/company/auto-archive-5y.feature.md
@@ -1,0 +1,3 @@
+The `automatic-company-archive` job was revised to new criteria approved by the Data Hub board.
+
+We are now archiving companies that do not have an interaction during last 5 years.

--- a/datahub/company/tasks/company.py
+++ b/datahub/company/tasks/company.py
@@ -16,7 +16,7 @@ logger = get_task_logger(__name__)
 
 def _automatic_company_archive(limit, simulate):
 
-    _8y_ago = timezone.now() - relativedelta(years=8)
+    _5y_ago = timezone.now() - relativedelta(years=5)
     _3m_ago = timezone.now() - relativedelta(months=3)
 
     latest_interaction = Interaction.objects.filter(
@@ -32,7 +32,7 @@ def _automatic_company_archive(limit, simulate):
             condition=Q(investor_investment_projects__status=InvestmentProject.Status.ONGOING),
         ),
     ).filter(
-        Q(latest_interaction_date__date__lt=_8y_ago) | Q(latest_interaction_date__isnull=True),
+        Q(latest_interaction_date__date__lt=_5y_ago) | Q(latest_interaction_date__isnull=True),
         archived=False,
         duns_number__isnull=True,
         orders__isnull=True,

--- a/datahub/company/test/tasks/test_company.py
+++ b/datahub/company/test/tasks/test_company.py
@@ -119,8 +119,8 @@ class TestAutomaticCompanyArchive:
         'interaction_date_delta, expected_archived',
         (
             (relativedelta(), False),
-            (relativedelta(years=8), False),
-            (relativedelta(years=8, days=1), True),
+            (relativedelta(years=5), False),
+            (relativedelta(years=5, days=1), True),
         ),
     )
     @freeze_time('2020-01-01-12:00:00')


### PR DESCRIPTION
### Description of change

The `automatic-company-archive` job was revised to [new criteria](https://docs.google.com/document/d/1IKuFHKkmSH_r4OAPpCmU5Hq0gjImy8PqOfinnG226xI/edit?usp=sharing) approved by the Data Hub board.

 We are now archiving companies that do not have an interaction during last 5 years.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
