### PR TITLE
Add OMIS public quote Hawk authenticated endpoints

### DIFF
--- a/changelog/omis/omis-hawk-public-quote.api.md
+++ b/changelog/omis/omis-hawk-public-quote.api.md
@@ -1,0 +1,4 @@
+A new Hawk authenticated `GET /v3/public/omis/order/<public-token>/quote` and 
+`POST /v3/public/omis/order/<public-token>/quote/accept` endpoints have been added.
+The new endpoints are functionally the same as `GET /v3/omis/public/order/<public-token>/quote` 
+and `POST /v3/omis/public/order/<public-token>/invoice/accept`.

--- a/datahub/omis/quote/legacy_public_views.py
+++ b/datahub/omis/quote/legacy_public_views.py
@@ -1,0 +1,27 @@
+from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
+from rest_framework import status
+from rest_framework.response import Response
+
+from datahub.oauth.scopes import Scope
+from datahub.omis.order.models import Order
+from datahub.omis.quote.serializers import PublicQuoteSerializer
+from datahub.omis.quote.views import BaseQuoteViewSet
+
+
+class LegacyPublicQuoteViewSet(BaseQuoteViewSet):
+    """ViewSet for legacy public facing API."""
+
+    permission_classes = (IsAuthenticatedOrTokenHasScope,)
+    required_scopes = (Scope.public_omis_front_end,)
+    serializer_class = PublicQuoteSerializer
+
+    order_lookup_field = 'public_token'
+    order_lookup_url_kwarg = 'public_token'
+    order_queryset = Order.objects.publicly_accessible(include_reopened=True)
+
+    def accept(self, request, *args, **kwargs):
+        """Accept a quote."""
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.accept()
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/datahub/omis/quote/test/views/test_legacy_public_quote_details.py
+++ b/datahub/omis/quote/test/views/test_legacy_public_quote_details.py
@@ -1,92 +1,20 @@
 import pytest
 from django.utils.timezone import now
 from freezegun import freeze_time
+from oauth2_provider.models import Application
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
-from datahub.core.test_utils import HawkAPITestClient
+from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
-from datahub.omis.order.test.factories import (
-    OrderFactory,
-)
-from datahub.omis.order.test.factories import OrderWithOpenQuoteFactory
+from datahub.omis.order.test.factories import OrderFactory, OrderWithOpenQuoteFactory
 from datahub.omis.quote.models import TermsAndConditions
 from datahub.omis.quote.test.factories import QuoteFactory
 
 
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
-
-
-@pytest.fixture
-def public_omis_api_client(hawk_api_client):
-    """Hawk API client fixture configured to use credentials with the OMIS scope."""
-    hawk_api_client.set_credentials(
-        'omis-public-id',
-        'omis-public-key',
-    )
-    yield hawk_api_client
-
-
 class TestPublicGetQuote(APITestMixin):
     """Get public quote test case."""
-
-    def test_without_credentials(self, api_client):
-        """Test that making a request without credentials returns an error."""
-        order = OrderFactory()
-
-        url = reverse(
-            'api-v3:public-omis:quote:detail',
-            kwargs={'public_token': order.public_token},
-        )
-        response = api_client.post(url, data={})
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_without_scope(self, hawk_api_client):
-        """Test that making a request without the correct Hawk scope returns an error."""
-        order = OrderFactory()
-
-        hawk_api_client.set_credentials(
-            'test-id-without-scope',
-            'test-key-without-scope',
-        )
-        url = reverse(
-            'api-v3:public-omis:quote:detail',
-            kwargs={'public_token': order.public_token},
-        )
-        response = hawk_api_client.get(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_without_whitelisted_ip(self, public_omis_api_client):
-        """Test that making a request without the whitelisted client IP returns an error."""
-        order = OrderFactory()
-
-        url = reverse(
-            'api-v3:public-omis:quote:detail',
-            kwargs={'public_token': order.public_token},
-        )
-        public_omis_api_client.set_http_x_forwarded_for('1.1.1.1')
-        response = public_omis_api_client.get(url)
-
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
-    def test_verbs_not_allowed(self, verb, public_omis_api_client):
-        """Test that makes sure the other verbs are not allowed."""
-        order = OrderFactory(
-            quote=QuoteFactory(),
-            status=OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
-        )
-
-        url = reverse(
-            'api-v3:public-omis:quote:detail',
-            kwargs={'public_token': order.public_token},
-        )
-        response = getattr(public_omis_api_client, verb)(url, json_={})
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     @pytest.mark.parametrize(
         'order_status',
@@ -97,7 +25,7 @@ class TestPublicGetQuote(APITestMixin):
             OrderStatus.COMPLETE,
         ),
     )
-    def test_get(self, order_status, public_omis_api_client):
+    def test_get(self, order_status):
         """Test a successful call to get a quote."""
         order = OrderFactory(
             quote=QuoteFactory(accepted_on=now()),
@@ -105,10 +33,14 @@ class TestPublicGetQuote(APITestMixin):
         )
 
         url = reverse(
-            'api-v3:public-omis:quote:detail',
+            'api-v3:omis-public:quote:detail',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         quote = order.quote
         assert response.status_code == status.HTTP_200_OK
@@ -121,7 +53,7 @@ class TestPublicGetQuote(APITestMixin):
             'terms_and_conditions': TermsAndConditions.objects.first().content,
         }
 
-    def test_get_without_ts_and_cs(self, public_omis_api_client):
+    def test_get_without_ts_and_cs(self):
         """Test a successful call to get a quote without Ts and Cs."""
         order = OrderFactory(
             quote=QuoteFactory(accepted_on=now(), terms_and_conditions=None),
@@ -129,15 +61,19 @@ class TestPublicGetQuote(APITestMixin):
         )
 
         url = reverse(
-            'api-v3:public-omis:quote:detail',
+            'api-v3:omis-public:quote:detail',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['terms_and_conditions'] == ''
 
-    def test_get_draft_with_cancelled_quote(self, public_omis_api_client):
+    def test_get_draft_with_cancelled_quote(self):
         """Test getting a cancelled quote with order in draft is allowed."""
         order = OrderFactory(
             quote=QuoteFactory(cancelled_on=now()),
@@ -145,10 +81,14 @@ class TestPublicGetQuote(APITestMixin):
         )
 
         url = reverse(
-            'api-v3:public-omis:quote:detail',
+            'api-v3:omis-public:quote:detail',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         quote = order.quote
         assert response.status_code == status.HTTP_200_OK
@@ -161,26 +101,34 @@ class TestPublicGetQuote(APITestMixin):
             'terms_and_conditions': TermsAndConditions.objects.first().content,
         }
 
-    def test_404_if_order_doesnt_exist(self, public_omis_api_client):
+    def test_404_if_order_doesnt_exist(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse(
-            'api-v3:public-omis:quote:detail',
+            'api-v3:omis-public:quote:detail',
             kwargs={'public_token': ('1234-abcd-' * 5)},  # len(token) == 50
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
-    def test_404_if_quote_doesnt_exist(self, public_omis_api_client):
+    def test_404_if_quote_doesnt_exist(self):
         """Test that if the quote doesn't exist, the endpoint returns 404."""
         order = OrderFactory(status=OrderStatus.QUOTE_AWAITING_ACCEPTANCE)
         assert not order.quote
 
         url = reverse(
-            'api-v3:public-omis:quote:detail',
+            'api-v3:omis-public:quote:detail',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -188,68 +136,78 @@ class TestPublicGetQuote(APITestMixin):
         'order_status',
         (OrderStatus.DRAFT, OrderStatus.CANCELLED),
     )
-    def test_404_if_in_disallowed_status(self, order_status, public_omis_api_client):
+    def test_404_if_in_disallowed_status(self, order_status):
         """Test that if the order is not in an allowed state, the endpoint returns 404."""
         order = OrderFactory(status=order_status)
 
         url = reverse(
-            'api-v3:public-omis:quote:detail',
+            'api-v3:omis-public:order:detail',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, verb):
+        """Test that makes sure the other verbs are not allowed."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
+        )
+
+        url = reverse(
+            'api-v3:omis-public:quote:detail',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = getattr(client, verb)(url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    @pytest.mark.parametrize(
+        'scope',
+        (s.value for s in Scope if s != Scope.public_omis_front_end.value),
+    )
+    def test_403_if_scope_not_allowed(self, scope):
+        """Test that other oauth2 scopes are not allowed."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
+        )
+
+        url = reverse(
+            'api-v3:omis-public:quote:detail',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=scope,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 class TestAcceptOrder(APITestMixin):
     """Tests for accepting a quote."""
 
-    def test_without_credentials(self, api_client):
-        """Test that making a request without credentials returns an error."""
-        order = OrderFactory()
-
-        url = reverse(
-            'api-v3:public-omis:quote:accept',
-            kwargs={'public_token': order.public_token},
-        )
-        response = api_client.post(url, json_={})
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_without_scope(self, hawk_api_client):
-        """Test that making a request without the correct Hawk scope returns an error."""
-        order = OrderFactory()
-
-        hawk_api_client.set_credentials(
-            'test-id-without-scope',
-            'test-key-without-scope',
-        )
-        url = reverse(
-            'api-v3:public-omis:quote:accept',
-            kwargs={'public_token': order.public_token},
-        )
-        response = hawk_api_client.post(url, json_={})
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_without_whitelisted_ip(self, public_omis_api_client):
-        """Test that making a request without the whitelisted client IP returns an error."""
-        order = OrderFactory()
-
-        url = reverse(
-            'api-v3:public-omis:quote:accept',
-            kwargs={'public_token': order.public_token},
-        )
-        public_omis_api_client.set_http_x_forwarded_for('1.1.1.1')
-        response = public_omis_api_client.post(url, json_={})
-
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_404_if_order_doesnt_exist(self, public_omis_api_client):
+    def test_404_if_order_doesnt_exist(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse(
-            'api-v3:public-omis:quote:accept',
+            'api-v3:omis-public:quote:accept',
             kwargs={'public_token': ('1234-abcd-' * 5)},  # len(token) == 50
         )
-        response = public_omis_api_client.post(url, json_={})
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.post(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -262,12 +220,7 @@ class TestAcceptOrder(APITestMixin):
             (OrderStatus.COMPLETE, {}),
         ),
     )
-    def test_409_if_order_in_disallowed_status(
-        self,
-        disallowed_status,
-        quote_fields,
-        public_omis_api_client,
-    ):
+    def test_409_if_order_in_disallowed_status(self, disallowed_status, quote_fields):
         """
         Test that if the order is not in one of the allowed statuses, the endpoint
         returns 409.
@@ -279,10 +232,14 @@ class TestAcceptOrder(APITestMixin):
         )
 
         url = reverse(
-            'api-v3:public-omis:quote:accept',
+            f'api-v3:omis-public:quote:accept',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.post(url, json_={})
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.post(url)
 
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json() == {
@@ -292,18 +249,22 @@ class TestAcceptOrder(APITestMixin):
             ),
         }
 
-    def test_accept(self, public_omis_api_client):
+    def test_accept(self):
         """Test that a quote can get accepted."""
         order = OrderWithOpenQuoteFactory()
         quote = order.quote
 
         url = reverse(
-            'api-v3:public-omis:quote:accept',
+            f'api-v3:omis-public:quote:accept',
             kwargs={'public_token': order.public_token},
         )
 
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
         with freeze_time('2017-07-12 13:00'):
-            response = public_omis_api_client.post(url, json_={})
+            response = client.post(url)
 
             assert response.status_code == status.HTTP_200_OK
             assert response.json() == {

--- a/datahub/omis/quote/urls.py
+++ b/datahub/omis/quote/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path, re_path
 
+from datahub.omis.quote.legacy_public_views import LegacyPublicQuoteViewSet
 from datahub.omis.quote.views import PublicQuoteViewSet, QuoteViewSet
-
 
 # internal frontend API
 internal_frontend_urls = [
@@ -25,8 +25,22 @@ internal_frontend_urls = [
     ),
 ]
 
-# public facing API
-public_urls = [
+# legacy public facing API
+legacy_public_urls = [
+    re_path(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/quote$',
+        LegacyPublicQuoteViewSet.as_view({'get': 'retrieve'}),
+        name='detail',
+    ),
+    re_path(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/quote/accept$',
+        LegacyPublicQuoteViewSet.as_view({'post': 'accept'}),
+        name='accept',
+    ),
+]
+
+# Hawk authenticated public facing API
+hawk_public_urls = [
     re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/quote$',
         PublicQuoteViewSet.as_view({'get': 'retrieve'}),

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -19,7 +19,7 @@ internal_frontend_urls = [
 
 public_urls = [
     path('', include((order_urls.public_urls, 'order'), namespace='order')),
-    path('', include((quote_urls.public_urls, 'quote'), namespace='quote')),
+    path('', include((quote_urls.legacy_public_urls, 'quote'), namespace='quote')),
     path('', include((payment_urls.payment_public_urls, 'payment'), namespace='payment')),
     path(
         '',
@@ -33,5 +33,6 @@ public_urls = [
 
 # TODO: rename this to public_urls once all public urls have been migrated to Hawk
 hawk_public_urls = [
+    path('', include((quote_urls.hawk_public_urls, 'quote'), namespace='quote')),
     path('', include((invoice_urls.hawk_public_urls, 'invoice'), namespace='invoice')),
 ]


### PR DESCRIPTION
### Description of change

This PR follows https://github.com/uktrade/data-hub-api/pull/2697 and it is branched off that PR.

It moves existing OMIS public quote endpoints to its relevant legacy files and creates Hawk authenticated views with the same functionality.

For more details you can refer to the PR linked above.

More PRs with additional endpoints are going to follow.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
