### PR TITLE
Add OMIS public payment Hawk authenticated endpoints

### DIFF
--- a/changelog/omis/omis-hawk-public-payments.api.md
+++ b/changelog/omis/omis-hawk-public-payments.api.md
@@ -1,0 +1,11 @@
+The following new Hawk endpoints have been added:
+
+`POST /v3/public/omis/order/<public-token>/payment-gateway-session`
+`GET /v3/public/omis/order/<public-token>/payment-gateway-session/<session-id>` 
+`POST /v3/public/omis/order/<public-token>/payment`
+
+The new endpoints is functionally the same as their following counterparts:
+
+`POST /v3/omis/public/order/<public-token>/payment-gateway-session`
+`GET /v3/omis/public/order/<public-token>/payment-gateway-session/<session-id>` 
+`POST /v3/omis/public/order/<public-token>/payment`

--- a/changelog/omis/omis-hawk-public-payments.api.md
+++ b/changelog/omis/omis-hawk-public-payments.api.md
@@ -4,7 +4,7 @@ The following new Hawk endpoints have been added:
 `GET /v3/public/omis/order/<public-token>/payment-gateway-session/<session-id>` 
 `POST /v3/public/omis/order/<public-token>/payment`
 
-The new endpoints is functionally the same as their following counterparts:
+The new endpoints are functionally the same as their following counterparts:
 
 `POST /v3/omis/public/order/<public-token>/payment-gateway-session`
 `GET /v3/omis/public/order/<public-token>/payment-gateway-session/<session-id>` 

--- a/datahub/omis/payment/legacy_public_views.py
+++ b/datahub/omis/payment/legacy_public_views.py
@@ -1,81 +1,32 @@
-from rest_framework import status
+from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework.response import Response
 
-from config.settings.types import HawkScope
-from datahub.core.auth import PaaSIPAuthentication
 from datahub.core.exceptions import APIConflictException
-from datahub.core.hawk_receiver import (
-    HawkAuthentication,
-    HawkScopePermission,
-)
-from datahub.core.throttling import PathRateThrottle
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.models import Order
 from datahub.omis.order.views import BaseNestedOrderViewSet
-from datahub.omis.payment.models import Payment, PaymentGatewaySession
-from datahub.omis.payment.serializers import PaymentGatewaySessionSerializer, PaymentSerializer
+from datahub.omis.payment.models import PaymentGatewaySession
+from datahub.omis.payment.serializers import PaymentGatewaySessionSerializer
+from datahub.omis.payment.views import BasePaymentViewSet, CreatePaymentGatewaySessionThrottle
 
 
-class BasePaymentViewSet(BaseNestedOrderViewSet):
-    """Base Payment ViewSet."""
+class LegacyPublicPaymentViewSet(BasePaymentViewSet):
+    """ViewSet for legacy public facing API."""
 
-    queryset = Payment.objects.all()
-    serializer_class = PaymentSerializer
-    pagination_class = None
-
-    def get_queryset(self):
-        """
-        :returns: the queryset with payments related to the order.
-        """
-        return super().get_queryset().filter(order=self.get_order())
-
-
-class PaymentViewSet(BasePaymentViewSet):
-    """Payment ViewSet."""
-
-    required_scopes = (Scope.internal_front_end,)
-
-    def create_list(self, request, *args, **kwargs):
-        """Create a list of payments."""
-        serializer = self.get_serializer(
-            data=request.data,
-            many=True,
-        )
-        serializer.is_valid(raise_exception=True)
-        serializer.save()
-
-        headers = self.get_success_headers(serializer.data)
-        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
-
-
-class PublicPaymentViewSet(BasePaymentViewSet):
-    """ViewSet for Hawk authenticated public facing API."""
-
-    authentication_classes = (PaaSIPAuthentication, HawkAuthentication)
-    permission_classes = (HawkScopePermission, )
-    required_hawk_scope = HawkScope.public_omis
+    permission_classes = (IsAuthenticatedOrTokenHasScope,)
+    required_scopes = (Scope.public_omis_front_end,)
 
     order_lookup_field = 'public_token'
     order_lookup_url_kwarg = 'public_token'
     order_queryset = Order.objects.publicly_accessible()
 
 
-class CreatePaymentGatewaySessionThrottle(PathRateThrottle):
-    """
-    Implementation of PathRateThrottle with a specific scope.
-    This is to make it clear that it's for the create payment session only.
-    """
+class LegacyPublicPaymentGatewaySessionViewSet(BaseNestedOrderViewSet):
+    """Payment Gateway Session ViewSet for legacy public facing API."""
 
-    scope = 'payment_gateway_session.create'
-
-
-class PublicPaymentGatewaySessionViewSet(BaseNestedOrderViewSet):
-    """Payment Gateway Session ViewSet for Hawk authenticated public facing API."""
-
-    authentication_classes = (PaaSIPAuthentication, HawkAuthentication)
-    permission_classes = (HawkScopePermission, )
-    required_hawk_scope = HawkScope.public_omis
+    permission_classes = (IsAuthenticatedOrTokenHasScope,)
+    required_scopes = (Scope.public_omis_front_end,)
 
     order_lookup_field = 'public_token'
     order_lookup_url_kwarg = 'public_token'

--- a/datahub/omis/payment/test/views/test_legacy_public_payments.py
+++ b/datahub/omis/payment/test/views/test_legacy_public_payments.py
@@ -1,0 +1,122 @@
+import pytest
+from oauth2_provider.models import Application
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.core.test_utils import APITestMixin, format_date_or_datetime
+from datahub.oauth.scopes import Scope
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.test.factories import OrderFactory, OrderPaidFactory
+from datahub.omis.payment.test.factories import PaymentFactory
+
+
+class TestPublicGetPayments(APITestMixin):
+    """Public get payments test case."""
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (
+            OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
+            OrderStatus.QUOTE_ACCEPTED,
+            OrderStatus.PAID,
+            OrderStatus.COMPLETE,
+        ),
+    )
+    def test_get(self, order_status):
+        """Test a successful call to get a list of payments."""
+        order = OrderFactory(status=order_status)
+        PaymentFactory.create_batch(2, order=order)
+        PaymentFactory.create_batch(5)  # create some extra ones not linked to `order`
+
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == [
+            {
+                'created_on': format_date_or_datetime(payment.created_on),
+                'reference': payment.reference,
+                'transaction_reference': payment.transaction_reference,
+                'additional_reference': payment.additional_reference,
+                'amount': payment.amount,
+                'method': payment.method,
+                'received_on': payment.received_on.isoformat(),
+            }
+            for payment in order.payments.all()
+        ]
+
+    def test_404_if_order_doesnt_exist(self):
+        """Test that if the order doesn't exist, the endpoint returns 404."""
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': ('1234-abcd-' * 5)},  # len(token) == 50
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (OrderStatus.DRAFT, OrderStatus.CANCELLED),
+    )
+    def test_404_if_in_disallowed_status(self, order_status):
+        """Test that if the order is not in an allowed state, the endpoint returns 404."""
+        order = OrderFactory(status=order_status)
+
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, verb):
+        """Test that makes sure the other verbs are not allowed."""
+        order = OrderPaidFactory()
+
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = getattr(client, verb)(url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    @pytest.mark.parametrize(
+        'scope',
+        (s.value for s in Scope if s != Scope.public_omis_front_end.value),
+    )
+    def test_403_if_scope_not_allowed(self, scope):
+        """Test that other oauth2 scopes are not allowed."""
+        order = OrderPaidFactory()
+
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=scope,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/omis/payment/test/views/test_public_payment_gateway_sessions.py
+++ b/datahub/omis/payment/test/views/test_public_payment_gateway_sessions.py
@@ -8,10 +8,7 @@ from rest_framework.reverse import reverse
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.core.test_utils import HawkAPITestClient
 from datahub.omis.order.constants import OrderStatus
-from datahub.omis.order.test.factories import (
-    OrderFactory,
-    OrderWithAcceptedQuoteFactory,
-)
+from datahub.omis.order.test.factories import OrderFactory, OrderWithAcceptedQuoteFactory
 from datahub.omis.payment.constants import PaymentGatewaySessionStatus
 from datahub.omis.payment.govukpay import govuk_url
 from datahub.omis.payment.models import Payment, PaymentGatewaySession

--- a/datahub/omis/payment/urls.py
+++ b/datahub/omis/payment/urls.py
@@ -1,11 +1,14 @@
 from django.urls import path, re_path
 
+from datahub.omis.payment.legacy_public_views import (
+    LegacyPublicPaymentGatewaySessionViewSet,
+    LegacyPublicPaymentViewSet,
+)
 from datahub.omis.payment.views import (
     PaymentViewSet,
     PublicPaymentGatewaySessionViewSet,
     PublicPaymentViewSet,
 )
-
 
 # internal frontend API
 payment_internal_frontend_urls = [
@@ -19,8 +22,33 @@ payment_internal_frontend_urls = [
     ),
 ]
 
-# public facing API
-payment_public_urls = [
+# legacy public facing API
+legacy_payment_public_urls = [
+    re_path(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/payment$',
+        LegacyPublicPaymentViewSet.as_view({'get': 'list'}),
+        name='collection',
+    ),
+]
+
+legacy_payment_gateway_session_public_urls = [
+    re_path(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/payment-gateway-session$',
+        LegacyPublicPaymentGatewaySessionViewSet.as_view({'post': 'create'}),
+        name='collection',
+    ),
+    re_path(
+        (
+            r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/'
+            r'payment-gateway-session/(?P<pk>[0-9a-z-]{36})$'
+        ),
+        LegacyPublicPaymentGatewaySessionViewSet.as_view({'get': 'retrieve'}),
+        name='detail',
+    ),
+]
+
+# Hawk authenticated public facing API
+hawk_payment_public_urls = [
     re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/payment$',
         PublicPaymentViewSet.as_view({'get': 'list'}),
@@ -28,7 +56,7 @@ payment_public_urls = [
     ),
 ]
 
-payment_gateway_session_public_urls = [
+hawk_payment_gateway_session_public_urls = [
     re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/payment-gateway-session$',
         PublicPaymentGatewaySessionViewSet.as_view({'post': 'create'}),

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -20,11 +20,11 @@ internal_frontend_urls = [
 public_urls = [
     path('', include((order_urls.public_urls, 'order'), namespace='order')),
     path('', include((quote_urls.public_urls, 'quote'), namespace='quote')),
-    path('', include((payment_urls.payment_public_urls, 'payment'), namespace='payment')),
+    path('', include((payment_urls.legacy_payment_public_urls, 'payment'), namespace='payment')),
     path(
         '',
         include(
-            (payment_urls.payment_gateway_session_public_urls, 'payment-gateway-session'),
+            (payment_urls.legacy_payment_gateway_session_public_urls, 'payment-gateway-session'),
             namespace='payment-gateway-session',
         ),
     ),
@@ -33,5 +33,13 @@ public_urls = [
 
 # TODO: rename this to public_urls once all public urls have been migrated to Hawk
 hawk_public_urls = [
+    path('', include((payment_urls.hawk_payment_public_urls, 'payment'), namespace='payment')),
+    path(
+        '',
+        include(
+            (payment_urls.hawk_payment_gateway_session_public_urls, 'payment-gateway-session'),
+            namespace='payment-gateway-session',
+        ),
+    ),
     path('', include((invoice_urls.hawk_public_urls, 'invoice'), namespace='invoice')),
 ]


### PR DESCRIPTION
### Description of change

This PR follows #2697 ~and it is branched off that PR.~ and it has been rebased.

It moves existing OMIS public payment endpoints to its relevant legacy files and creates Hawk authenticated views with the same functionality.

For more details you can refer to the PR linked above.

More PRs with additional endpoints are going to follow.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
