### PR TITLE
Add new authentication class with SSO email user ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,9 +341,10 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `SKIP_ES_MAPPING_MIGRATIONS` | No | If non-empty, skip applying Elasticsearch mapping type migrations on deployment. |
 | `SKIP_MI_DATABASE_MIGRATIONS` | No | If non-empty, skip applying MI database migrations on deployment. Used in environments without a working MI database. |
 | `SSO_ENABLED` | Yes | Whether single sign-on via RFC 7662 token introspection is enabled |
-| `STAFF_SSO_AUTH_TOKEN` | If SSO enabled | Access token for the Staff SSO API. (This setting is not yet in use.) |
-| `STAFF_SSO_BASE_URL` | If SSO enabled | The base URL for the Staff SSO API. (This setting is not yet in use.) |
-| `STAFF_SSO_REQUEST_TIMEOUT` | No | Staff SSO API request timeout in seconds (default=5). (This setting is not yet in use.) |
+| `STAFF_SSO_AUTH_TOKEN` | If SSO enabled | Access token for the Staff SSO API. (Used only when STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True). |
+| `STAFF_SSO_BASE_URL` | If SSO enabled | The base URL for the Staff SSO API. (Used only when STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True). |
+| `STAFF_SSO_REQUEST_TIMEOUT` | No | Staff SSO API request timeout in seconds (default=5). (Used only when STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True). |
+| `STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC` | No | Whether to enable the new Staff SSO token introspection logic with email user ID support (default=False). |
 | `STATSD_HOST` | No | StatsD host url. |
 | `STATSD_PORT` | No | StatsD port number. |
 | `STATSD_PREFIX` | No | Prefix for metrics being pushed to StatsD. |

--- a/changelog/new-auth-class.feature.md
+++ b/changelog/new-auth-class.feature.md
@@ -1,0 +1,1 @@
+A new authentication class with SSO email user ID support was added. This is currently disabled by default.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -269,7 +269,15 @@ else:
     STAFF_SSO_BASE_URL = None
     STAFF_SSO_AUTH_TOKEN = None
 
+STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC = env.bool(
+    'STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC',
+    default=False,
+)
 STAFF_SSO_REQUEST_TIMEOUT = env.int('STAFF_SSO_REQUEST_TIMEOUT', default=5)  # seconds
+STAFF_SSO_USER_TOKEN_CACHING_PERIOD = env.int(
+    'STAFF_SSO_USER_TOKEN_CACHING_PERIOD',
+    default=60 * 60,  # One hour
+)
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/
@@ -282,13 +290,18 @@ STATIC_ROOT = str(CONFIG_DIR('staticfiles'))
 STATIC_URL = '/static/'
 
 # DRF
+if STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC:
+    _default_authentication_class = 'datahub.oauth.auth.SSOIntrospectionAuthentication'
+else:
+    _default_authentication_class = 'oauth2_provider.contrib.rest_framework.OAuth2Authentication'
+
 REST_FRAMEWORK = {
     'UNAUTHENTICATED_USER': None,
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'oauth2_provider.contrib.rest_framework.OAuth2Authentication'
+        _default_authentication_class,
     ],
     'DEFAULT_PERMISSION_CLASSES': [
         'oauth2_provider.contrib.rest_framework.IsAuthenticatedOrTokenHasScope',

--- a/datahub/oauth/test/test_auth.py
+++ b/datahub/oauth/test/test_auth.py
@@ -1,0 +1,222 @@
+from datetime import datetime, timedelta
+
+import pytest
+from django.conf import settings
+from django.core.cache import cache
+from django.utils.timezone import utc
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.oauth.auth import SSOIntrospectionAuthentication
+
+
+FROZEN_DATETIME = datetime(2020, 1, 1, 0, tzinfo=utc)
+STAFF_SSO_INTROSPECT_URL = f'{settings.STAFF_SSO_BASE_URL}o/introspect/'
+EXAMPLE_SSO_EMAIL_USER_ID = 'user_id@example.test'
+
+
+class IntrospectionAuthView(APIView):
+    """View using Hawk authentication."""
+
+    authentication_classes = (SSOIntrospectionAuthentication,)
+    permission_classes = ()
+
+    def get(self, request):
+        """Simple test view with fixed response."""
+        return Response({'content': 'introspection-test-view'})
+
+
+view = IntrospectionAuthView.as_view()
+
+
+def _make_introspection_data(**overrides):
+    return {
+        'active': True,
+        'username': 'username@example.test',
+        'email_user_id': EXAMPLE_SSO_EMAIL_USER_ID,
+        'exp': (FROZEN_DATETIME + timedelta(hours=10)).timestamp(),
+        **overrides,
+    }
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('local_memory_cache')
+@freeze_time(FROZEN_DATETIME)
+class TestSSOIntrospectionAuthentication:
+    """Tests for SSOIntrospectionAuthentication."""
+
+    @pytest.mark.parametrize(
+        'request_kwargs,expected_error',
+        (
+            pytest.param(
+                {},
+                'Authentication credentials were not provided.',
+                id='no-header',
+            ),
+            pytest.param(
+                {'HTTP_AUTHORIZATION': 'wrong-scheme-no-space'},
+                'Incorrect authentication scheme.',
+                id='wrong-scheme-no-space',
+            ),
+            pytest.param(
+                {'HTTP_AUTHORIZATION': 'wrong-scheme 8jol80DF'},
+                'Incorrect authentication scheme.',
+                id='wrong-scheme',
+            ),
+            pytest.param(
+                {'HTTP_AUTHORIZATION': 'bearer'},
+                'Authentication credentials were not provided.',
+                id='no-token',
+            ),
+        ),
+    )
+    def test_rejects_malformed_headers(
+        self,
+        api_request_factory,
+        request_kwargs,
+        expected_error,
+    ):
+        """Test that errors are returned for various header values."""
+        request = api_request_factory.get('/test-path', **request_kwargs)
+        response = view(request)
+
+        assert response['WWW-Authenticate'] == 'Bearer realm="api"'
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.data == {'detail': expected_error}
+        assert not request.user
+
+    @pytest.mark.parametrize(
+        'response_kwargs',
+        (
+            pytest.param(
+                {
+                    'status_code': status.HTTP_401_UNAUTHORIZED,
+                    'json': {'active': False},
+                },
+                id='invalid-token',
+            ),
+            pytest.param(
+                {
+                    'status_code': status.HTTP_200_OK,
+                    'json': {},
+                },
+                id='inactive-response',
+            ),
+            # Should not happen in reality
+            pytest.param(
+                {
+                    'status_code': status.HTTP_200_OK,
+                    'json': _make_introspection_data(active=False),
+                },
+                id='inactive-token',
+            ),
+            # Should not happen in reality
+            pytest.param(
+                {
+                    'status_code': status.HTTP_200_OK,
+                    'json': _make_introspection_data(exp=FROZEN_DATETIME.timestamp() - 1),
+                },
+                id='expired-token',
+            ),
+        ),
+    )
+    def test_authentication_fails_on_introspection_failure(
+        self,
+        response_kwargs,
+        api_request_factory,
+        requests_mock,
+    ):
+        """Test that authentication fails and an error is returned when introspection fails."""
+        AdviserFactory(sso_email_user_id='user_id@example.test')
+        requests_mock.post(STAFF_SSO_INTROSPECT_URL, **response_kwargs)
+
+        request = api_request_factory.get('/test-path', HTTP_AUTHORIZATION='Bearer token')
+        response = view(request)
+        assert not request.user
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.data == {'detail': 'Invalid authentication credentials.'}
+
+    def test_authenticates_if_noncached_token_provided(self, api_request_factory, requests_mock):
+        """Test that authentication is successful if a valid, non-cached token is provided."""
+        adviser = AdviserFactory(sso_email_user_id=EXAMPLE_SSO_EMAIL_USER_ID)
+        requests_mock.post(STAFF_SSO_INTROSPECT_URL, json=_make_introspection_data())
+
+        request = api_request_factory.get('/test-path', HTTP_AUTHORIZATION='Bearer token')
+        response = view(request)
+        assert request.user == adviser
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'content': 'introspection-test-view'}
+
+    def test_authenticates_if_token_is_cached(self, api_request_factory, requests_mock):
+        """Test that authentication is successful if a valid, cached token is provided."""
+        adviser = AdviserFactory(sso_email_user_id=EXAMPLE_SSO_EMAIL_USER_ID)
+        cache.set('access_token:token', _make_introspection_data())
+
+        request = api_request_factory.get('/test-path', HTTP_AUTHORIZATION='Bearer token')
+        response = view(request)
+        assert not requests_mock.called
+        assert request.user == adviser
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'content': 'introspection-test-view'}
+
+    def test_caches_token_with_timeout_on_introspection(self, api_request_factory, requests_mock):
+        """Test that after introspection, token data is cached with a timeout."""
+        AdviserFactory(sso_email_user_id=EXAMPLE_SSO_EMAIL_USER_ID)
+        introspection_data = _make_introspection_data()
+        requests_mock.post(STAFF_SSO_INTROSPECT_URL, json=introspection_data)
+
+        request = api_request_factory.get('/test-path', HTTP_AUTHORIZATION='Bearer token')
+        response = view(request)
+        assert response.status_code == status.HTTP_200_OK
+
+        # Check that the returned token data is cached
+        assert cache.get('access_token:token') == introspection_data
+
+        caching_period = settings.STAFF_SSO_USER_TOKEN_CACHING_PERIOD
+        post_expiry_time = FROZEN_DATETIME + timedelta(seconds=caching_period)
+
+        # Check that the cached token data expires after the caching period
+        with freeze_time(post_expiry_time):
+            assert not cache.get('access_token:token')
+
+    def test_falls_back_to_email_field(self, api_request_factory, requests_mock):
+        """
+        Test that advisers are looked up using the email field when a match using
+        sso_email_user_id is not found, and the adviser's sso_email_user_id is updated.
+        """
+        adviser = AdviserFactory(email='email@email.test', sso_email_user_id=None)
+
+        requests_mock.post(
+            STAFF_SSO_INTROSPECT_URL,
+            json=_make_introspection_data(username='email@email.test'),
+        )
+
+        request = api_request_factory.get('/test-path', HTTP_AUTHORIZATION='Bearer token')
+        response = view(request)
+
+        assert request.user == adviser
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'content': 'introspection-test-view'}
+
+        # Check that the sso_email_user_id was set on the user
+        adviser.refresh_from_db()
+        assert adviser.sso_email_user_id == 'user_id@example.test'
+
+    def test_authentication_fails_if_no_matching_user(self, api_request_factory, requests_mock):
+        """Test that authentication fails when there is no matching adviser in Data Hub."""
+        # Create an unrelated user that should not be returned
+        AdviserFactory(email='unrelated@email.test', sso_email_user_id='unrelated@id.test')
+        requests_mock.post(
+            STAFF_SSO_INTROSPECT_URL,
+            json=_make_introspection_data(username='email@email.test'),
+        )
+
+        request = api_request_factory.get('/test-path', HTTP_AUTHORIZATION='Bearer token')
+        response = view(request)
+
+        assert not request.user
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.data == {'detail': 'Invalid authentication credentials.'}


### PR DESCRIPTION
### Description of change

This adds a new Django Rest Framework authentication class (that uses OAuth token introspection with Staff SSO). This will eventually replace the currently used authentication class provided by Django OAuth Toolkit.

For further background [have a look at this document](https://docs.google.com/document/d/1n6aQXXyfX8auecUnF4dqQaX8-QJUgAhPwsbnkq0NobM).

The main reason for the new class to help us migrate to using the SSO email user ID to link advisers in Data Hub with users in Staff SSO.

Some behaviour of the new class:

- The new class has support for looking up advisers using the unique SSO email user ID rather than the user's primary application email address. It also contains some migration logic for users that do not have an SSO email user ID set.

- The new class also uses Redis to cache introspected access tokens rather than a Django model.

- The new class does not automatically create stub users at present. This will hopefully not be needed if a better add adviser flow is added to the admin site.

- The new class doesn't bother with OAuth scopes, as we no longer need them with machine-to-machine endpoints (that don't involve a user) now using Hawk.

The new class is disabled by default until further related functionality is also added. However, it can be enabled using the `STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC` setting.

This is deployed to the UAT environment (with `STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True`) so it can be tested there. (Testing locally with a real Staff SSO instance is more difficult, but if you'd like to, let me know and I'll try and help.)

[This is the main part of the equivalent code in Django OAuth Toolkit](https://github.com/jazzband/django-oauth-toolkit/blob/fd0a0d8a260f9ca41785d26a03925811c9462ad2/oauth2_provider/oauth2_validators.py#L271-L382) if you'd like to compare.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
