### PR TITLE
Add OMIS public order Hawk authenticated endpoint

### DIFF
--- a/changelog/omis/omis-hawk-public-order.api.md
+++ b/changelog/omis/omis-hawk-public-order.api.md
@@ -1,0 +1,2 @@
+A new Hawk authenticated `GET /v3/public/omis/order/<public-token>` endpoint has been added.
+The new endpoint is functionally the same as `GET /v3/omis/public/order/<public-token>`.

--- a/datahub/omis/order/legacy_public_views.py
+++ b/datahub/omis/order/legacy_public_views.py
@@ -1,0 +1,22 @@
+from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
+
+from datahub.core.viewsets import CoreViewSet
+from datahub.oauth.scopes import Scope
+from datahub.omis.order.models import Order
+from datahub.omis.order.serializers import PublicOrderSerializer
+
+
+class LegacyPublicOrderViewSet(CoreViewSet):
+    """ViewSet for legacy public facing order endpoint."""
+
+    lookup_field = 'public_token'
+
+    permission_classes = (IsAuthenticatedOrTokenHasScope,)
+    required_scopes = (Scope.public_omis_front_end,)
+    serializer_class = PublicOrderSerializer
+    queryset = Order.objects.publicly_accessible(
+        include_reopened=True,
+    ).select_related(
+        'company',
+        'contact',
+    )

--- a/datahub/omis/order/test/views/test_legacy_public_order_details.py
+++ b/datahub/omis/order/test/views/test_legacy_public_order_details.py
@@ -1,89 +1,21 @@
 import pytest
+from oauth2_provider.models import Application
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
-from datahub.core.test_utils import HawkAPITestClient
+from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import OrderFactory, OrderWithCancelledQuoteFactory
 from datahub.omis.quote.test.factories import QuoteFactory
+
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db
 
 
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
-
-
-@pytest.fixture
-def public_omis_api_client(hawk_api_client):
-    """Hawk API client fixture configured to use credentials with the OMIS scope."""
-    hawk_api_client.set_credentials(
-        'omis-public-id',
-        'omis-public-key',
-    )
-    yield hawk_api_client
-
-
 class TestViewPublicOrderDetails(APITestMixin):
-    """Tests for the pubic facing Hawk authenticated order endpoints."""
-
-    def test_without_credentials(self, api_client):
-        """Test that making a request without credentials returns an error."""
-        order = OrderFactory()
-
-        url = reverse(
-            'api-v3:public-omis:order:detail',
-            kwargs={'public_token': order.public_token},
-        )
-        response = api_client.get(url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_without_scope(self, hawk_api_client):
-        """Test that making a request without the correct Hawk scope returns an error."""
-        order = OrderFactory()
-
-        hawk_api_client.set_credentials(
-            'test-id-without-scope',
-            'test-key-without-scope',
-        )
-        url = reverse(
-            'api-v3:public-omis:order:detail',
-            kwargs={'public_token': order.public_token},
-        )
-        response = hawk_api_client.get(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_without_whitelisted_ip(self, public_omis_api_client):
-        """Test that making a request without the whitelisted client IP returns an error."""
-        order = OrderFactory()
-
-        url = reverse(
-            'api-v3:public-omis:order:detail',
-            kwargs={'public_token': order.public_token},
-        )
-        public_omis_api_client.set_http_x_forwarded_for('1.1.1.1')
-        response = public_omis_api_client.get(url)
-
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
-    def test_verbs_not_allowed(self, verb, public_omis_api_client):
-        """Test that makes sure the other verbs are not allowed."""
-        order = OrderFactory(
-            quote=QuoteFactory(),
-            status=OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
-        )
-
-        url = reverse(
-            'api-v3:public-omis:order:detail',
-            kwargs={'public_token': order.public_token},
-        )
-        response = getattr(public_omis_api_client, verb)(url, json_={})
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+    """Tests for the pubic facing order endpoints."""
 
     @pytest.mark.parametrize(
         'order_status',
@@ -94,7 +26,7 @@ class TestViewPublicOrderDetails(APITestMixin):
             OrderStatus.COMPLETE,
         ),
     )
-    def test_get(self, order_status, public_omis_api_client):
+    def test_get(self, order_status):
         """Test getting an existing order by `public_token`."""
         order = OrderFactory(
             quote=QuoteFactory(),
@@ -102,10 +34,14 @@ class TestViewPublicOrderDetails(APITestMixin):
         )
 
         url = reverse(
-            'api-v3:public-omis:order:detail',
+            'api-v3:omis-public:order:detail',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -157,25 +93,33 @@ class TestViewPublicOrderDetails(APITestMixin):
             'completed_on': None,
         }
 
-    def test_get_draft_with_cancelled_quote(self, public_omis_api_client):
+    def test_get_draft_with_cancelled_quote(self):
         """Test getting an order in draft with a cancelled quote is allowed."""
         order = OrderWithCancelledQuoteFactory()
 
         url = reverse(
-            'api-v3:public-omis:order:detail',
+            'api-v3:omis-public:order:detail',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
 
-    def test_404_with_invalid_public_token(self, public_omis_api_client):
+    def test_404_with_invalid_public_token(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse(
-            'api-v3:public-omis:order:detail',
+            'api-v3:omis-public:order:detail',
             kwargs={'public_token': ('1234-abcd-' * 5)},  # len(token) == 50
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -183,14 +127,59 @@ class TestViewPublicOrderDetails(APITestMixin):
         'order_status',
         (OrderStatus.DRAFT, OrderStatus.CANCELLED),
     )
-    def test_404_if_in_disallowed_status(self, order_status, public_omis_api_client):
+    def test_404_if_in_disallowed_status(self, order_status):
         """Test that if the order is not in an allowed state, the endpoint returns 404."""
         order = OrderFactory(status=order_status)
 
         url = reverse(
-            'api-v3:public-omis:order:detail',
+            'api-v3:omis-public:order:detail',
             kwargs={'public_token': order.public_token},
         )
-        response = public_omis_api_client.get(url)
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, verb):
+        """Test that makes sure the other verbs are not allowed."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
+        )
+
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = getattr(client, verb)(url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    @pytest.mark.parametrize(
+        'scope',
+        (s.value for s in Scope if s != Scope.public_omis_front_end.value),
+    )
+    def test_403_if_scope_not_allowed(self, scope):
+        """Test that other oauth2 scopes are not allowed."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
+        )
+
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=scope,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/omis/order/urls.py
+++ b/datahub/omis/order/urls.py
@@ -2,6 +2,7 @@
 
 from django.urls import path, re_path
 
+from datahub.omis.order.legacy_public_views import LegacyPublicOrderViewSet
 from datahub.omis.order.views import (
     AssigneeView,
     OrderViewSet,
@@ -45,8 +46,17 @@ internal_frontend_urls = [
 ]
 
 
-# public facing API
-public_urls = [
+# legacy public facing API
+legacy_public_urls = [
+    re_path(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})$',
+        LegacyPublicOrderViewSet.as_view({'get': 'retrieve'}),
+        name='detail',
+    ),
+]
+
+# Hawk authenticated public facing API
+hawk_public_urls = [
     re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})$',
         PublicOrderViewSet.as_view({'get': 'retrieve'}),

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -18,7 +18,7 @@ internal_frontend_urls = [
 ]
 
 public_urls = [
-    path('', include((order_urls.public_urls, 'order'), namespace='order')),
+    path('', include((order_urls.legacy_public_urls, 'order'), namespace='order')),
     path('', include((quote_urls.legacy_public_urls, 'quote'), namespace='quote')),
     path('', include((payment_urls.payment_public_urls, 'payment'), namespace='payment')),
     path(
@@ -33,6 +33,7 @@ public_urls = [
 
 # TODO: rename this to public_urls once all public urls have been migrated to Hawk
 hawk_public_urls = [
+    path('', include((order_urls.hawk_public_urls, 'order'), namespace='order')),
     path('', include((quote_urls.hawk_public_urls, 'quote'), namespace='quote')),
     path('', include((invoice_urls.hawk_public_urls, 'invoice'), namespace='invoice')),
 ]


### PR DESCRIPTION
### Description of change

This PR follows #2697 ~and it is branched off that PR.~ and it has been rebased.

It moves existing OMIS public order endpoint to its relevant legacy files and creates Hawk authenticated view with the same functionality.

For more details you can refer to the PR linked above.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
