### PR TITLE
Update refresh gross value added cmd 

### DIFF
--- a/changelog/investment/investment-gva-cmd.bugfix.md
+++ b/changelog/investment/investment-gva-cmd.bugfix.md
@@ -1,0 +1,1 @@
+The periodic task to refresh gross value added values has been updated to include projects that don't have a foreign equity investment value set.

--- a/datahub/investment/project/tasks.py
+++ b/datahub/investment/project/tasks.py
@@ -67,7 +67,6 @@ def get_investment_projects_to_refresh_gva_values():
     """Get investment projects. returns: All projects that GVA can be calculated for."""
     return InvestmentProject.objects.filter(
         investment_type_id=InvestmentTypeConstant.fdi.value.id,
-        foreign_equity_investment__isnull=False,
     ).filter(
         Q(
             sector__isnull=False,

--- a/datahub/investment/project/test/management/commands/test_refresh_gross_value_added_values.py
+++ b/datahub/investment/project/test/management/commands/test_refresh_gross_value_added_values.py
@@ -19,12 +19,15 @@ class TestRefreshGrossValueAddedCommand:
     """Test refreshing gross value added values command."""
 
     @pytest.mark.parametrize(
-        'investment_type,sector,business_activities,multiplier_value',
+        'investment_type,sector,business_activities,multiplier_value,foreign_equity_investment,'
+        'gross_value_added',
         (
             (
                 InvestmentTypeConstant.fdi.value.id,
                 None,
                 [],
+                None,
+                None,
                 None,
             ),
             (
@@ -34,6 +37,8 @@ class TestRefreshGrossValueAddedCommand:
                     InvestmentBusinessActivityConstant.retail.value.id,
                 ],
                 '0.0581',
+                1000,
+                '58',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
@@ -42,24 +47,32 @@ class TestRefreshGrossValueAddedCommand:
                     InvestmentBusinessActivityConstant.sales.value.id,
                 ],
                 '0.0581',
+                1000,
+                '58',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
                 SectorConstant.renewable_energy_wind.value.id,
                 [InvestmentBusinessActivityConstant.retail.value.id],
                 '0.0581',
+                1000,
+                '58',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
                 SectorConstant.renewable_energy_wind.value.id,
                 [],
                 '0.0325',
+                1000,
+                '33',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
                 SectorConstant.aerospace_assembly_aircraft.value.id,
                 [],
                 '0.0621',
+                1000,
+                '62',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
@@ -69,11 +82,26 @@ class TestRefreshGrossValueAddedCommand:
                     InvestmentBusinessActivityConstant.other.value.id,
                 ],
                 '0.0581',
+                1000,
+                '58',
+            ),
+            (
+                InvestmentTypeConstant.fdi.value.id,
+                SectorConstant.renewable_energy_wind.value.id,
+                [
+                    InvestmentBusinessActivityConstant.retail.value.id,
+                    InvestmentBusinessActivityConstant.other.value.id,
+                ],
+                '0.0581',
+                None,
+                None,
             ),
             (
                 InvestmentTypeConstant.commitment_to_invest.value.id,
                 SectorConstant.renewable_energy_wind.value.id,
                 [],
+                None,
+                1000,
                 None,
             ),
             (
@@ -82,6 +110,8 @@ class TestRefreshGrossValueAddedCommand:
                 [
                     InvestmentBusinessActivityConstant.retail.value.id,
                 ],
+                None,
+                1000,
                 None,
             ),
         ),
@@ -92,6 +122,8 @@ class TestRefreshGrossValueAddedCommand:
         sector,
         business_activities,
         multiplier_value,
+        foreign_equity_investment,
+        gross_value_added,
     ):
         """Test populating Gross value added data."""
         with mock.patch(
@@ -102,7 +134,7 @@ class TestRefreshGrossValueAddedCommand:
                 sector_id=sector,
                 business_activities=business_activities,
                 investment_type_id=investment_type,
-                foreign_equity_investment=1000,
+                foreign_equity_investment=foreign_equity_investment,
             )
 
         assert not project.gva_multiplier
@@ -112,6 +144,11 @@ class TestRefreshGrossValueAddedCommand:
             assert not project.gva_multiplier
         else:
             assert project.gva_multiplier.multiplier == Decimal(multiplier_value)
+
+        if not gross_value_added:
+            assert not project.gross_value_added
+        else:
+            assert project.gross_value_added == Decimal(gross_value_added)
 
     def _run_command(self):
         cmd = refresh_gross_value_added_values.Command()


### PR DESCRIPTION
### Description of change
This change updates the `refresh_gross_value_added_values` command to run over projects that don't have a foreign equity value set. 

It was noted in the current FDI investment projects download that 700 odd projects have sectors or the relevant business activity set yet don't have GVA multiplier set when others do. This is because when saving a project if a multiplier can be assigned to a project one is set. The 700 projects in question haven't been updated since the GVA feature went live. So updating the command will set the multiplier on these projects making behaviour consistent.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
