### PR TITLE
Add utility functions for getting user details from Staff SSO

### DIFF
--- a/changelog/adviser/get-user-by-email.internal.md
+++ b/changelog/adviser/get-user-by-email.internal.md
@@ -1,1 +1,1 @@
-An internal utility function to get details of a user from Staff SSO was added. This will initially be used as part of enhanced admin site functionality.
+Some internal utility functions for getting details of a user from Staff SSO were added. These will initially be used as part of enhanced admin site functionality.

--- a/changelog/adviser/get-user-by-email.internal.md
+++ b/changelog/adviser/get-user-by-email.internal.md
@@ -1,0 +1,1 @@
+An internal utility function to get details of a user from Staff SSO was added. This will initially be used as part of enhanced admin site functionality.

--- a/datahub/oauth/sso_api_client.py
+++ b/datahub/oauth/sso_api_client.py
@@ -58,8 +58,17 @@ def get_user_by_email(email):
 
     Any of a user's email addresses can be specified.
     """
+    return _get_user(email=email)
+
+
+def get_user_by_email_user_id(email_user_id):
+    """Look up details about a user in Staff SSO using their unique email user ID."""
+    return _get_user(email_user_id=email_user_id)
+
+
+def _get_user(**params):
     try:
-        return _request('get', 'api/v1/user/introspect/', params={'email': email})
+        return _request('get', 'api/v1/user/introspect/', params=params)
     except SSORequestError as exc:
         if exc.response is not None and exc.response.status_code == status.HTTP_404_NOT_FOUND:
             raise SSOUserDoesNotExist()

--- a/datahub/oauth/test/test_sso_api_client.py
+++ b/datahub/oauth/test/test_sso_api_client.py
@@ -1,10 +1,38 @@
+from urllib.parse import urlencode
+
 import pytest
 from django.conf import settings
 from requests.exceptions import ConnectionError
 from rest_framework import status
 
 
-from datahub.oauth.sso_api_client import introspect_token, SSORequestError, SSOTokenDoesNotExist
+from datahub.oauth.sso_api_client import (
+    get_user_by_email,
+    introspect_token,
+    SSORequestError,
+    SSOTokenDoesNotExist,
+    SSOUserDoesNotExist,
+)
+
+
+FAKE_SSO_USER_DATA = {
+    'email': 'email@email.test',
+    'user_id': 'c2c1afce-e45e-4139-9913-88b350f7a546',
+    'email_user_id': 'test@id.test',
+    'first_name': 'Johnny',
+    'last_name': 'Cakeman',
+    'related_emails': ['related@email.test'],
+    'contact_email': 'contact@email.test',
+    'groups': [],
+    'permitted_applications': [
+        {
+            'key': 'an-app',
+            'url': 'https://app.invalid',
+            'name': 'An app',
+        },
+    ],
+    'access_profiles': ['an-access-profile'],
+}
 
 
 class TestIntrospectToken:
@@ -64,3 +92,47 @@ class TestIntrospectToken:
         )
         assert introspect_token('test-token') == mock_data
         assert requests_mock.last_request.text == 'token=test-token'
+
+
+class TestGetUserByEmail:
+    """Tests for get_user_by_email()."""
+
+    @pytest.mark.parametrize(
+        'mock_kwargs,expected_exception',
+        (
+            (
+                {'status_code': status.HTTP_400_BAD_REQUEST},
+                SSORequestError('SSO request failed'),
+            ),
+            (
+                {'status_code': status.HTTP_404_NOT_FOUND},
+                SSOUserDoesNotExist(),
+            ),
+            (
+                {'exc': ConnectionError},
+                SSORequestError('SSO request failed'),
+            ),
+            (
+                {'text': '{"invalid-json}'},
+                SSORequestError('SSO response parsing failed'),
+            ),
+        ),
+    )
+    def test_error_handling(self, requests_mock, mock_kwargs, expected_exception):
+        """Test that various errors are handled as expected."""
+        params = {'email': 'email@email.test'}
+        request_url = f'{settings.STAFF_SSO_BASE_URL}api/v1/user/introspect/?{urlencode(params)}'
+        requests_mock.get(request_url, **mock_kwargs)
+
+        with pytest.raises(expected_exception.__class__) as excinfo:
+            get_user_by_email('email@email.test')
+
+        assert str(excinfo.value) == str(expected_exception)
+
+    def test_returns_data_on_success(self, requests_mock):
+        """Test that user data is returned on success."""
+        params = {'email': 'email@email.test'}
+        request_url = f'{settings.STAFF_SSO_BASE_URL}api/v1/user/introspect/?{urlencode(params)}'
+        requests_mock.get(request_url, json=FAKE_SSO_USER_DATA)
+
+        assert get_user_by_email('email@email.test') == FAKE_SSO_USER_DATA


### PR DESCRIPTION
### Description of change

This adds two utility functions for getting details of a user from Staff SSO using either one of the user's email addresses or the user's email user ID.

The plan is to use these as part of a better add user form in the admin site (so a user can be added using either an email address or their email user ID and are details are pulled through from Staff SSO automatically).

Note: The first commit is from #2705.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
