### PR TITLE
ContactSerializer: lookup consent from consent service [4 of 4]

### DIFF
--- a/changelog/contact/contactserializer-lookup-from-consent-service.internal.md
+++ b/changelog/contact/contactserializer-lookup-from-consent-service.internal.md
@@ -1,0 +1,3 @@
+It is now possible to look up contact consent to email marketing from central Consent
+Service API if `GET_CONSENT_FROM_CONSENT_SERVICE` feature flag is
+active for the `ContactViewSet.detail` (`GET /v3/contact/<uuid:pk>`) endpoint.

--- a/datahub/company/test/serializers/test_contact_serializer.py
+++ b/datahub/company/test/serializers/test_contact_serializer.py
@@ -18,9 +18,9 @@ FROZEN_TIME = '2020-03-13T14:21:24.367265+00:00'
 @pytest.fixture
 def update_contact_task_mock(monkeypatch):
     """Mocks the apply_async method of the update_contact_consent celery task"""
-    m = Mock()
-    monkeypatch.setattr('datahub.company.serializers.update_contact_consent.apply_async', m)
-    yield m
+    mock = Mock()
+    monkeypatch.setattr('datahub.company.serializers.update_contact_consent.apply_async', mock)
+    yield mock
 
 
 @pytest.fixture

--- a/datahub/company/test/serializers/test_contact_serializer.py
+++ b/datahub/company/test/serializers/test_contact_serializer.py
@@ -158,8 +158,8 @@ class TestContactSerializer:
         consent_get_one_mock.return_value = has_consented
         FeatureFlagFactory(code=GET_CONSENT_FROM_CONSENT_SERVICE, is_active=True)
         contact = self._make_contact()
-        c = ContactSerializer(instance=contact)
-        assert c.data['accepts_dit_email_marketing'] == val
+        contact_serializer = ContactSerializer(instance=contact)
+        assert contact_serializer.data['accepts_dit_email_marketing'] == has_consented
         consent_get_one_mock.assert_called_once_with(
             c.instance.email,
         )

--- a/datahub/company/test/serializers/test_contact_serializer.py
+++ b/datahub/company/test/serializers/test_contact_serializer.py
@@ -155,7 +155,7 @@ class TestContactSerializer:
         When feature flag enabled ensure that value returned
         from consent service is reflected in `ContactSerializer.data`
         """
-        consent_get_one_mock.return_value = val
+        consent_get_one_mock.return_value = has_consented
         FeatureFlagFactory(code=GET_CONSENT_FROM_CONSENT_SERVICE, is_active=True)
         contact = self._make_contact()
         c = ContactSerializer(instance=contact)

--- a/datahub/company/test/serializers/test_contact_serializer.py
+++ b/datahub/company/test/serializers/test_contact_serializer.py
@@ -161,5 +161,5 @@ class TestContactSerializer:
         contact_serializer = ContactSerializer(instance=contact)
         assert contact_serializer.data['accepts_dit_email_marketing'] == has_consented
         consent_get_one_mock.assert_called_once_with(
-            c.instance.email,
+            contact_serializer.instance.email,
         )

--- a/datahub/company/test/serializers/test_contact_serializer.py
+++ b/datahub/company/test/serializers/test_contact_serializer.py
@@ -26,9 +26,9 @@ def update_contact_task_mock(monkeypatch):
 @pytest.fixture
 def consent_get_one_mock(monkeypatch):
     """Mocks the .get_one function of the `datahub.company.consent` module"""
-    m = Mock()
-    monkeypatch.setattr('datahub.company.consent.get_one', m)
-    yield m
+    mock = Mock()
+    monkeypatch.setattr('datahub.company.consent.get_one', mock)
+    yield mock
 
 
 @freeze_time(FROZEN_TIME)

--- a/datahub/company/test/serializers/test_contact_serializer.py
+++ b/datahub/company/test/serializers/test_contact_serializer.py
@@ -149,8 +149,8 @@ class TestContactSerializer:
         _ = c.data
         assert not consent_get_one_mock.called
 
-    @pytest.mark.parametrize('val', (True, False))
-    def test_to_representation_feature_flag_on(self, consent_get_one_mock, val):
+    @pytest.mark.parametrize('has_consented', (True, False))
+    def test_to_representation_feature_flag_on(self, consent_get_one_mock, has_consented):
         """
         When feature flag enabled ensure that value returned
         from consent service is reflected in `ContactSerializer.data`


### PR DESCRIPTION
### Description of change

Update ContactSerializer so that `ContactViewSet.detail` calls the consent service to determine if a contact `accepts_dit_email_marketing`. This lookup will only happen if the feature flag `GET_CONSENT_FROM_CONSENT_SERVICE` is active, otherwise this will not change the existing behaviour

depends on: https://github.com/uktrade/data-hub-api/pull/2657

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
