### PR TITLE
Tidy-up Hawk client fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,6 +10,7 @@ from django.db.models.signals import post_save
 from elasticsearch.helpers.test import get_test_client
 from pytest_django.lazy_django import skip_if_no_django
 
+from datahub.core.test_utils import HawkAPITestClient
 from datahub.dnb_api.utils import format_dnb_company
 from datahub.documents.utils import get_s3_client_for_bucket
 from datahub.metadata.test.factories import SectorFactory
@@ -72,6 +73,12 @@ def api_client():
 
     from rest_framework.test import APIClient
     return APIClient()
+
+
+@pytest.fixture
+def hawk_api_client():
+    """Hawk API client fixture."""
+    yield HawkAPITestClient()
 
 
 class _ReturnValueTracker:

--- a/datahub/company/test/test_public_company_view.py
+++ b/datahub/company/test/test_public_company_view.py
@@ -7,13 +7,7 @@ from rest_framework.reverse import reverse
 from datahub.company.models import OneListTier
 from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core.constants import Country
-from datahub.core.test_utils import format_date_or_datetime, HawkAPITestClient
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
+from datahub.core.test_utils import format_date_or_datetime
 
 
 @pytest.fixture

--- a/datahub/dataset/conftest.py
+++ b/datahub/dataset/conftest.py
@@ -1,13 +1,5 @@
 import pytest
 
-from datahub.core.test_utils import HawkAPITestClient
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
-
 
 @pytest.fixture
 def data_flow_api_client(hawk_api_client):

--- a/datahub/metadata/test/test_views.py
+++ b/datahub/metadata/test/test_views.py
@@ -7,7 +7,7 @@ from django.core.exceptions import FieldDoesNotExist
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import format_date_or_datetime, HawkAPITestClient
+from datahub.core.test_utils import format_date_or_datetime
 from datahub.interaction.models import ServiceAnswerOption
 from datahub.metadata import urls
 from datahub.metadata.models import AdministrativeArea, Country, Sector, Service
@@ -16,12 +16,6 @@ from datahub.metadata.test.factories import ServiceFactory
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
 
 
 @pytest.fixture

--- a/datahub/omis/conftest.py
+++ b/datahub/omis/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture
+def public_omis_api_client(hawk_api_client):
+    """Hawk API client fixture configured to use credentials with the OMIS scope."""
+    hawk_api_client.set_credentials(
+        'omis-public-id',
+        'omis-public-key',
+    )
+    yield hawk_api_client

--- a/datahub/omis/invoice/test/views/test_public_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_public_invoice_details.py
@@ -3,7 +3,6 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
-from datahub.core.test_utils import HawkAPITestClient
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import (
     OrderCompleteFactory,
@@ -11,22 +10,6 @@ from datahub.omis.order.test.factories import (
     OrderPaidFactory,
     OrderWithAcceptedQuoteFactory,
 )
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
-
-
-@pytest.fixture
-def public_omis_api_client(hawk_api_client):
-    """Hawk API client fixture configured to use credentials with the OMIS scope."""
-    hawk_api_client.set_credentials(
-        'omis-public-id',
-        'omis-public-key',
-    )
-    yield hawk_api_client
 
 
 class TestPublicGetInvoice(APITestMixin):

--- a/datahub/omis/order/test/views/test_public_order_details.py
+++ b/datahub/omis/order/test/views/test_public_order_details.py
@@ -3,29 +3,12 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
-from datahub.core.test_utils import HawkAPITestClient
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import OrderFactory, OrderWithCancelledQuoteFactory
 from datahub.omis.quote.test.factories import QuoteFactory
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
-
-
-@pytest.fixture
-def public_omis_api_client(hawk_api_client):
-    """Hawk API client fixture configured to use credentials with the OMIS scope."""
-    hawk_api_client.set_credentials(
-        'omis-public-id',
-        'omis-public-key',
-    )
-    yield hawk_api_client
 
 
 class TestViewPublicOrderDetails(APITestMixin):

--- a/datahub/omis/quote/test/views/test_public_quote_details.py
+++ b/datahub/omis/quote/test/views/test_public_quote_details.py
@@ -5,7 +5,6 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
-from datahub.core.test_utils import HawkAPITestClient
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import (
     OrderFactory,
@@ -13,22 +12,6 @@ from datahub.omis.order.test.factories import (
 from datahub.omis.order.test.factories import OrderWithOpenQuoteFactory
 from datahub.omis.quote.models import TermsAndConditions
 from datahub.omis.quote.test.factories import QuoteFactory
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
-
-
-@pytest.fixture
-def public_omis_api_client(hawk_api_client):
-    """Hawk API client fixture configured to use credentials with the OMIS scope."""
-    hawk_api_client.set_credentials(
-        'omis-public-id',
-        'omis-public-key',
-    )
-    yield hawk_api_client
 
 
 class TestPublicGetQuote(APITestMixin):

--- a/datahub/search/company/test/test_public_search_view.py
+++ b/datahub/search/company/test/test_public_search_view.py
@@ -10,7 +10,6 @@ from rest_framework.reverse import reverse
 from datahub.company.models import Company
 from datahub.company.test.factories import CompanyFactory
 from datahub.core import constants
-from datahub.core.test_utils import HawkAPITestClient
 from datahub.search.company import CompanySearchApp
 
 # Index objects for this search app only
@@ -51,12 +50,6 @@ def setup_data(es_with_collector):
         archived=True,
     )
     es_with_collector.flush_and_refresh()
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
 
 
 @pytest.fixture


### PR DESCRIPTION
### Description of change

This tidies up tests that use Hawk client, so that the Hawk client fixtures are not repeated in each app.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
