### PR TITLE
Add admin site form for adding an adviser using Staff SSO

### DIFF
--- a/changelog/adviser/add-adviser-from-sso.internal.md
+++ b/changelog/adviser/add-adviser-from-sso.internal.md
@@ -1,0 +1,1 @@
+Some preparatory work was performed for new admin site functionality that will let advisers be added by looking up their details in Staff SSO.

--- a/datahub/company/admin/adviser_forms.py
+++ b/datahub/company/admin/adviser_forms.py
@@ -1,0 +1,124 @@
+from django import forms
+from django.contrib.admin import widgets
+from django.core.exceptions import ValidationError
+from django.db.models import Q
+from django.utils.translation import gettext_lazy
+
+from datahub.company.models import Advisor
+from datahub.oauth.sso_api_client import (
+    get_user_by_email,
+    get_user_by_email_user_id,
+    SSORequestError,
+    SSOUserDoesNotExist,
+)
+
+NO_MATCHING_USER_MESSAGE = gettext_lazy(
+    'No matching user was found in Staff SSO. Double-check the entered details and check if the '
+    'user has Data Hub access in Staff SSO.',
+)
+SSO_REQUEST_ERROR_MESSAGE = gettext_lazy(
+    'There was an error communicating with Staff SSO: %(error)s. Please try again.',
+)
+DUPLICATE_USER_MESSAGE = gettext_lazy('This user has already been added to Data Hub.')
+
+SSO_ADVISER_FIELD_MAPPING = {
+    'first_name': 'first_name',
+    'last_name': 'last_name',
+    'sso_email_user_id': 'email_user_id',
+    'email': 'email',
+    'contact_email': 'contact_email',
+}
+
+
+class AddAdviserFromSSOForm(forms.ModelForm):
+    """
+    Form for adding an adviser by looking the user up in Staff SSO.
+
+    Note: This form is designed so that it can be used as a ModelAdmin add_form.
+
+    This is the main reason it‘s using ModelForm.
+    """
+
+    search_email = forms.EmailField(
+        label='Email or SSO email user ID',
+        widget=widgets.AdminEmailInputWidget,
+    )
+
+    class Meta:
+        model = Advisor
+        fields = ()
+
+    def clean(self):
+        """Validate the search email and fetch user details from Staff SSO."""
+        data = super().clean()
+        search_email = data.get('search_email')
+
+        if not search_email:
+            return data
+
+        sso_user_data = self._get_user_data_from_sso(search_email)
+        if sso_user_data:
+            data['user_data'] = self._clean_sso_user_data(sso_user_data)
+
+        return data
+
+    def save(self, commit=True):
+        """Create the adviser using looked-up information."""
+        adviser = super().save(commit=False)
+        user_data = self.cleaned_data['user_data']
+
+        for field, value in user_data.items():
+            setattr(adviser, field, value)
+
+        if commit:
+            adviser.save()
+            # No many-to-many fields are currently set above, but this is
+            # included for completeness
+            self.save_m2m()
+
+        return adviser
+
+    def _clean_sso_user_data(self, sso_user_data):
+        mapped_user_data = {
+            model_field: sso_user_data[sso_field]
+            for model_field, sso_field in SSO_ADVISER_FIELD_MAPPING.items()
+        }
+        is_duplicate = self._check_if_duplicate(mapped_user_data)
+
+        if is_duplicate:
+            return None
+
+        return mapped_user_data
+
+    def _get_user_data_from_sso(self, email):
+        try:
+            return _fetch_user_data_from_sso(email)
+        except SSOUserDoesNotExist:
+            error = ValidationError(NO_MATCHING_USER_MESSAGE, code='no_matching_user')
+            self.add_error(None, error)
+        except SSORequestError as exc:
+            error = ValidationError(
+                SSO_REQUEST_ERROR_MESSAGE,
+                code='request_error',
+                params={'error': exc},
+            )
+            self.add_error(None, error)
+
+        return None
+
+    def _check_if_duplicate(self, user_data):
+        q = Q(email=user_data['email']) | Q(sso_email_user_id=user_data['sso_email_user_id'])
+        is_duplicate = Advisor.objects.filter(q).exists()
+
+        if is_duplicate:
+            error = ValidationError(DUPLICATE_USER_MESSAGE, code='duplicate_user')
+            self.add_error(None, error)
+
+        return is_duplicate
+
+
+def _fetch_user_data_from_sso(email):
+    try:
+        return get_user_by_email_user_id(email)
+    except SSOUserDoesNotExist:
+        return get_user_by_email(email)

--- a/datahub/company/test/admin/conftest.py
+++ b/datahub/company/test/admin/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 
@@ -35,3 +37,19 @@ def dnb_response():
             },
         ],
     }
+
+
+@pytest.fixture
+def mock_get_user_by_email(monkeypatch):
+    """Mock get_user_by_email()."""
+    mock = Mock()
+    monkeypatch.setattr('datahub.company.admin.adviser_forms.get_user_by_email', mock)
+    yield mock
+
+
+@pytest.fixture
+def mock_get_user_by_email_user_id(monkeypatch):
+    """Mock get_user_by_email_user_id()."""
+    mock = Mock()
+    monkeypatch.setattr('datahub.company.admin.adviser_forms.get_user_by_email_user_id', mock)
+    yield mock

--- a/datahub/company/test/admin/test_adviser_forms.py
+++ b/datahub/company/test/admin/test_adviser_forms.py
@@ -1,0 +1,140 @@
+import pytest
+from django.core.exceptions import NON_FIELD_ERRORS
+
+from datahub.company.admin.adviser_forms import (
+    AddAdviserFromSSOForm,
+    DUPLICATE_USER_MESSAGE,
+    NO_MATCHING_USER_MESSAGE,
+)
+from datahub.company.test.factories import AdviserFactory
+from datahub.oauth.sso_api_client import SSORequestError, SSOUserDoesNotExist
+
+
+FAKE_SSO_USER_DATA = {
+    'email': 'email@email.test',
+    'user_id': 'c2c1afce-e45e-4139-9913-88b350f7a546',
+    'email_user_id': 'test@id.test',
+    'first_name': 'Johnny',
+    'last_name': 'Cakeman',
+    'related_emails': [],
+    'contact_email': 'contact@email.test',
+    'groups': [],
+    'permitted_applications': [],
+    'access_profiles': [],
+}
+
+
+@pytest.mark.usefixtures('mock_get_user_by_email', 'mock_get_user_by_email_user_id')
+@pytest.mark.django_db
+class TestAddAdviserFromSSOForm:
+    """Tests for the add adviser from SSO form."""
+
+    def test_validation_fails_when_no_search_email_entered(self):
+        """Test that validation fails if no search email is entered."""
+        data = {'search_email': ''}
+        form = AddAdviserFromSSOForm(data=data)
+
+        assert form.errors == {
+            'search_email': ['This field is required.'],
+        }
+
+    @pytest.mark.parametrize(
+        'factory_kwargs',
+        (
+            {'sso_email_user_id': FAKE_SSO_USER_DATA['email_user_id']},
+            {'email': FAKE_SSO_USER_DATA['email']},
+        ),
+    )
+    def test_validation_fails_when_adviser_already_exists(
+        self,
+        factory_kwargs,
+        mock_get_user_by_email_user_id,
+    ):
+        """
+        Test that validation fails if there's an existing adviser with the same SSO email user
+        ID or email (username).
+        """
+        mock_get_user_by_email_user_id.return_value = FAKE_SSO_USER_DATA
+        AdviserFactory(**factory_kwargs)
+
+        data = {'search_email': 'search-email@test.test'}
+        form = AddAdviserFromSSOForm(data=data)
+
+        assert form.errors == {
+            NON_FIELD_ERRORS: [DUPLICATE_USER_MESSAGE],
+        }
+
+    def test_validation_fails_when_adviser_not_in_sso(
+        self,
+        mock_get_user_by_email,
+        mock_get_user_by_email_user_id,
+    ):
+        """
+        Test that validation fails if there's no matching adviser in Staff SSO.
+        """
+        mock_get_user_by_email.side_effect = SSOUserDoesNotExist()
+        mock_get_user_by_email_user_id.side_effect = SSOUserDoesNotExist()
+
+        data = {'search_email': 'search-email@test.test'}
+        form = AddAdviserFromSSOForm(data=data)
+
+        assert form.errors == {
+            NON_FIELD_ERRORS: [NO_MATCHING_USER_MESSAGE],
+        }
+
+    def test_validation_fails_when_there_is_a_request_error(self, mock_get_user_by_email_user_id):
+        """
+        Test that validation fails if there's an error communicating with Staff SSO.
+        """
+        mock_get_user_by_email_user_id.side_effect = SSORequestError('Test error')
+
+        data = {'search_email': 'search-email@test.test'}
+        form = AddAdviserFromSSOForm(data=data)
+
+        assert form.errors == {
+            NON_FIELD_ERRORS: [
+                'There was an error communicating with Staff SSO: Test error. Please try again.',
+            ],
+        }
+
+    def test_can_create_an_adviser_by_email_user_id(self, mock_get_user_by_email_user_id):
+        """Test that an adviser can be created using its SSO email user ID."""
+        mock_get_user_by_email_user_id.return_value = FAKE_SSO_USER_DATA
+
+        data = {'search_email': 'search-email@test.test'}
+        form = AddAdviserFromSSOForm(data=data)
+
+        assert not form.errors
+
+        adviser = form.save()
+
+        assert adviser.email == FAKE_SSO_USER_DATA['email']
+        assert adviser.sso_email_user_id == FAKE_SSO_USER_DATA['email_user_id']
+        assert adviser.contact_email == FAKE_SSO_USER_DATA['contact_email']
+        assert adviser.first_name == FAKE_SSO_USER_DATA['first_name']
+        assert adviser.last_name == FAKE_SSO_USER_DATA['last_name']
+
+    def test_can_create_an_adviser_by_email(
+        self,
+        mock_get_user_by_email_user_id,
+        mock_get_user_by_email,
+    ):
+        """
+        Test that an adviser can be created using its SSO email (when there is no match on
+        email user ID).
+        """
+        mock_get_user_by_email_user_id.side_effect = SSOUserDoesNotExist()
+        mock_get_user_by_email.return_value = FAKE_SSO_USER_DATA
+
+        data = {'search_email': 'search-email@test.test'}
+        form = AddAdviserFromSSOForm(data=data)
+
+        assert not form.errors
+
+        adviser = form.save()
+
+        assert adviser.email == FAKE_SSO_USER_DATA['email']
+        assert adviser.sso_email_user_id == FAKE_SSO_USER_DATA['email_user_id']
+        assert adviser.contact_email == FAKE_SSO_USER_DATA['contact_email']
+        assert adviser.first_name == FAKE_SSO_USER_DATA['first_name']
+        assert adviser.last_name == FAKE_SSO_USER_DATA['last_name']


### PR DESCRIPTION
### Description of change

This adds a new add adviser form that can be used to add an adviser that's been set up in Staff SSO using their SSO email user ID or SSO primary application email address.

This is implemented using a `ModelForm` so it can be used as an `add_form` in a `ModelAdmin` (and avoid having to reimplement the view).

A search is first attempted using the SSO email user ID. If no match is found, a search using the on email is then done. On saving, some details are pulled through from Staff SSO automatically.

The view will be added separately.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
