### PR TITLE
Add Hawk authenticated OMIS public payment endpoint

### DIFF
--- a/changelog/omis/omis-hawk-public-payment.api.md
+++ b/changelog/omis/omis-hawk-public-payment.api.md
@@ -1,0 +1,2 @@
+A new Hawk authenticated `POST /v3/public/omis/order/<public-token>/payment` endpoint has been added.
+The new endpoint is functionally the same as `POST /v3/omis/public/order/<public-token>/payment`.

--- a/datahub/omis/payment/legacy_public_views.py
+++ b/datahub/omis/payment/legacy_public_views.py
@@ -8,7 +8,18 @@ from datahub.omis.order.models import Order
 from datahub.omis.order.views import BaseNestedOrderViewSet
 from datahub.omis.payment.models import PaymentGatewaySession
 from datahub.omis.payment.serializers import PaymentGatewaySessionSerializer
-from datahub.omis.payment.views import CreatePaymentGatewaySessionThrottle
+from datahub.omis.payment.views import BasePaymentViewSet, CreatePaymentGatewaySessionThrottle
+
+
+class LegacyPublicPaymentViewSet(BasePaymentViewSet):
+    """ViewSet for legacy public facing API."""
+
+    permission_classes = (IsAuthenticatedOrTokenHasScope,)
+    required_scopes = (Scope.public_omis_front_end,)
+
+    order_lookup_field = 'public_token'
+    order_lookup_url_kwarg = 'public_token'
+    order_queryset = Order.objects.publicly_accessible()
 
 
 class LegacyPublicPaymentGatewaySessionViewSet(BaseNestedOrderViewSet):

--- a/datahub/omis/payment/test/views/test_legacy_public_payments.py
+++ b/datahub/omis/payment/test/views/test_legacy_public_payments.py
@@ -1,0 +1,122 @@
+import pytest
+from oauth2_provider.models import Application
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.core.test_utils import APITestMixin, format_date_or_datetime
+from datahub.oauth.scopes import Scope
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.test.factories import OrderFactory, OrderPaidFactory
+from datahub.omis.payment.test.factories import PaymentFactory
+
+
+class TestPublicGetPayments(APITestMixin):
+    """Public get payments test case."""
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (
+            OrderStatus.QUOTE_AWAITING_ACCEPTANCE,
+            OrderStatus.QUOTE_ACCEPTED,
+            OrderStatus.PAID,
+            OrderStatus.COMPLETE,
+        ),
+    )
+    def test_get(self, order_status):
+        """Test a successful call to get a list of payments."""
+        order = OrderFactory(status=order_status)
+        PaymentFactory.create_batch(2, order=order)
+        PaymentFactory.create_batch(5)  # create some extra ones not linked to `order`
+
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == [
+            {
+                'created_on': format_date_or_datetime(payment.created_on),
+                'reference': payment.reference,
+                'transaction_reference': payment.transaction_reference,
+                'additional_reference': payment.additional_reference,
+                'amount': payment.amount,
+                'method': payment.method,
+                'received_on': payment.received_on.isoformat(),
+            }
+            for payment in order.payments.all()
+        ]
+
+    def test_404_if_order_doesnt_exist(self):
+        """Test that if the order doesn't exist, the endpoint returns 404."""
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': ('1234-abcd-' * 5)},  # len(token) == 50
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (OrderStatus.DRAFT, OrderStatus.CANCELLED),
+    )
+    def test_404_if_in_disallowed_status(self, order_status):
+        """Test that if the order is not in an allowed state, the endpoint returns 404."""
+        order = OrderFactory(status=order_status)
+
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, verb):
+        """Test that makes sure the other verbs are not allowed."""
+        order = OrderPaidFactory()
+
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = getattr(client, verb)(url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    @pytest.mark.parametrize(
+        'scope',
+        (s.value for s in Scope if s != Scope.public_omis_front_end.value),
+    )
+    def test_403_if_scope_not_allowed(self, scope):
+        """Test that other oauth2 scopes are not allowed."""
+        order = OrderPaidFactory()
+
+        url = reverse(
+            'api-v3:omis-public:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        client = self.create_api_client(
+            scope=scope,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/omis/payment/test/views/test_public_payments.py
+++ b/datahub/omis/payment/test/views/test_public_payments.py
@@ -1,10 +1,8 @@
 import pytest
-from oauth2_provider.models import Application
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
-from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import OrderFactory, OrderPaidFactory
 from datahub.omis.payment.test.factories import PaymentFactory
@@ -12,6 +10,57 @@ from datahub.omis.payment.test.factories import PaymentFactory
 
 class TestPublicGetPayments(APITestMixin):
     """Public get payments test case."""
+
+    def test_without_credentials(self, api_client):
+        """Test that making a request without credentials returns an error."""
+        order = OrderFactory()
+
+        url = reverse(
+            'api-v3:public-omis:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        response = api_client.post(url, data={})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_without_scope(self, hawk_api_client):
+        """Test that making a request without the correct Hawk scope returns an error."""
+        order = OrderFactory()
+
+        hawk_api_client.set_credentials(
+            'test-id-without-scope',
+            'test-key-without-scope',
+        )
+        url = reverse(
+            'api-v3:public-omis:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        response = hawk_api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_without_whitelisted_ip(self, public_omis_api_client):
+        """Test that making a request without the whitelisted client IP returns an error."""
+        order = OrderFactory()
+
+        url = reverse(
+            'api-v3:public-omis:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        public_omis_api_client.set_http_x_forwarded_for('1.1.1.1')
+        response = public_omis_api_client.get(url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, verb, public_omis_api_client):
+        """Test that makes sure the other verbs are not allowed."""
+        order = OrderPaidFactory()
+
+        url = reverse(
+            'api-v3:public-omis:payment:collection',
+            kwargs={'public_token': order.public_token},
+        )
+        response = getattr(public_omis_api_client, verb)(url, json_={})
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     @pytest.mark.parametrize(
         'order_status',
@@ -22,21 +71,17 @@ class TestPublicGetPayments(APITestMixin):
             OrderStatus.COMPLETE,
         ),
     )
-    def test_get(self, order_status):
+    def test_get(self, order_status, public_omis_api_client):
         """Test a successful call to get a list of payments."""
         order = OrderFactory(status=order_status)
         PaymentFactory.create_batch(2, order=order)
         PaymentFactory.create_batch(5)  # create some extra ones not linked to `order`
 
         url = reverse(
-            'api-v3:omis-public:payment:collection',
+            'api-v3:public-omis:payment:collection',
             kwargs={'public_token': order.public_token},
         )
-        client = self.create_api_client(
-            scope=Scope.public_omis_front_end,
-            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
-        )
-        response = client.get(url)
+        response = public_omis_api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
@@ -52,17 +97,13 @@ class TestPublicGetPayments(APITestMixin):
             for payment in order.payments.all()
         ]
 
-    def test_404_if_order_doesnt_exist(self):
+    def test_404_if_order_doesnt_exist(self, public_omis_api_client):
         """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse(
-            'api-v3:omis-public:payment:collection',
+            'api-v3:public-omis:payment:collection',
             kwargs={'public_token': ('1234-abcd-' * 5)},  # len(token) == 50
         )
-        client = self.create_api_client(
-            scope=Scope.public_omis_front_end,
-            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
-        )
-        response = client.get(url)
+        response = public_omis_api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -70,53 +111,14 @@ class TestPublicGetPayments(APITestMixin):
         'order_status',
         (OrderStatus.DRAFT, OrderStatus.CANCELLED),
     )
-    def test_404_if_in_disallowed_status(self, order_status):
+    def test_404_if_in_disallowed_status(self, order_status, public_omis_api_client):
         """Test that if the order is not in an allowed state, the endpoint returns 404."""
         order = OrderFactory(status=order_status)
 
         url = reverse(
-            'api-v3:omis-public:payment:collection',
+            'api-v3:public-omis:payment:collection',
             kwargs={'public_token': order.public_token},
         )
-        client = self.create_api_client(
-            scope=Scope.public_omis_front_end,
-            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
-        )
-        response = client.get(url)
+        response = public_omis_api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
-    def test_verbs_not_allowed(self, verb):
-        """Test that makes sure the other verbs are not allowed."""
-        order = OrderPaidFactory()
-
-        url = reverse(
-            'api-v3:omis-public:payment:collection',
-            kwargs={'public_token': order.public_token},
-        )
-        client = self.create_api_client(
-            scope=Scope.public_omis_front_end,
-            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
-        )
-        response = getattr(client, verb)(url)
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-
-    @pytest.mark.parametrize(
-        'scope',
-        (s.value for s in Scope if s != Scope.public_omis_front_end.value),
-    )
-    def test_403_if_scope_not_allowed(self, scope):
-        """Test that other oauth2 scopes are not allowed."""
-        order = OrderPaidFactory()
-
-        url = reverse(
-            'api-v3:omis-public:payment:collection',
-            kwargs={'public_token': order.public_token},
-        )
-        client = self.create_api_client(
-            scope=scope,
-            grant_type=Application.GRANT_CLIENT_CREDENTIALS,
-        )
-        response = client.get(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/omis/payment/urls.py
+++ b/datahub/omis/payment/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path, re_path
 
-from datahub.omis.payment.legacy_public_views import LegacyPublicPaymentGatewaySessionViewSet
+from datahub.omis.payment.legacy_public_views import (
+    LegacyPublicPaymentGatewaySessionViewSet,
+    LegacyPublicPaymentViewSet,
+)
 from datahub.omis.payment.views import (
     PaymentViewSet,
     PublicPaymentGatewaySessionViewSet,
@@ -20,10 +23,10 @@ payment_internal_frontend_urls = [
 ]
 
 # public facing API
-payment_public_urls = [
+legacy_payment_public_urls = [
     re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/payment$',
-        PublicPaymentViewSet.as_view({'get': 'list'}),
+        LegacyPublicPaymentViewSet.as_view({'get': 'list'}),
         name='collection',
     ),
 ]
@@ -41,6 +44,14 @@ legacy_payment_gateway_session_public_urls = [
         ),
         LegacyPublicPaymentGatewaySessionViewSet.as_view({'get': 'retrieve'}),
         name='detail',
+    ),
+]
+
+hawk_payment_public_urls = [
+    re_path(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/payment$',
+        PublicPaymentViewSet.as_view({'get': 'list'}),
+        name='collection',
     ),
 ]
 

--- a/datahub/omis/payment/views.py
+++ b/datahub/omis/payment/views.py
@@ -1,4 +1,3 @@
-from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework import status
 from rest_framework.response import Response
 
@@ -53,10 +52,11 @@ class PaymentViewSet(BasePaymentViewSet):
 
 
 class PublicPaymentViewSet(BasePaymentViewSet):
-    """ViewSet for public facing API."""
+    """ViewSet for Hawk authenticated public facing API."""
 
-    permission_classes = (IsAuthenticatedOrTokenHasScope,)
-    required_scopes = (Scope.public_omis_front_end,)
+    authentication_classes = (PaaSIPAuthentication, HawkAuthentication)
+    permission_classes = (HawkScopePermission, )
+    required_hawk_scope = HawkScope.public_omis
 
     order_lookup_field = 'public_token'
     order_lookup_url_kwarg = 'public_token'

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -20,7 +20,7 @@ internal_frontend_urls = [
 public_urls = [
     path('', include((order_urls.legacy_public_urls, 'order'), namespace='order')),
     path('', include((quote_urls.legacy_public_urls, 'quote'), namespace='quote')),
-    path('', include((payment_urls.payment_public_urls, 'payment'), namespace='payment')),
+    path('', include((payment_urls.legacy_payment_public_urls, 'payment'), namespace='payment')),
     path(
         '',
         include(
@@ -35,6 +35,7 @@ public_urls = [
 hawk_public_urls = [
     path('', include((order_urls.hawk_public_urls, 'order'), namespace='order')),
     path('', include((quote_urls.hawk_public_urls, 'quote'), namespace='quote')),
+    path('', include((payment_urls.hawk_payment_public_urls, 'payment'), namespace='payment')),
     path(
         '',
         include(


### PR DESCRIPTION
### Description of change

This PR follows #2697 and it is one of the series of PRs that changes authentication of existing public OMIS endpoints to use Hawk protocol.

This moves existing OMIS public payment endpoints to its relevant legacy files and creates Hawk authenticated view with the same functionality.

For more details you can refer to the PR linked above.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
