### PR TITLE
Add admin site view for adding an adviser using Staff SSO 

### DIFF
--- a/changelog/adviser/add-adviser-from-sso.internal.md
+++ b/changelog/adviser/add-adviser-from-sso.internal.md
@@ -1,0 +1,1 @@
+A new admin site page for adding an adviser by looking up their details in Staff SSO was added. This page is currently only linked to if a feature flag is enabled.

--- a/changelog/adviser/admin-sso-email-user-id.feature.md
+++ b/changelog/adviser/admin-sso-email-user-id.feature.md
@@ -1,0 +1,1 @@
+The 'SSO email user ID' field is now displayed when editing advisers on the admin site. This field is read-only until existing values have been filled in.

--- a/datahub/company/admin/adviser.py
+++ b/datahub/company/admin/adviser.py
@@ -19,6 +19,7 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
             {
                 'fields': (
                     'email',
+                    'sso_email_user_id',
                     'password',
                 ),
             },
@@ -66,6 +67,7 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
             },
         ),
     )
+    readonly_fields = ('sso_email_user_id',)
     list_display = ('email', 'first_name', 'last_name', 'dit_team', 'is_active', 'is_staff')
     search_fields = (
         '=pk',

--- a/datahub/company/admin/adviser.py
+++ b/datahub/company/admin/adviser.py
@@ -4,7 +4,9 @@ from django.urls import path
 from reversion.admin import VersionAdmin
 
 from datahub.company.admin.adviser_forms import AddAdviserFromSSOForm
+from datahub.company.admin.constants import ADMIN_ADD_ADVISER_FROM_SSO_FEATURE_FLAG
 from datahub.company.models import Advisor
+from datahub.feature_flag.utils import is_feature_flag_active
 
 
 @admin.register(Advisor)
@@ -74,6 +76,21 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
         'dit_team__name',
     )
     ordering = ('email',)
+
+    def changelist_view(self, request, extra_context=None):
+        """
+        The changelist view.
+
+        Overridden to add the add adviser from SSO feature flag to the template context.
+
+        TODO: Remove this once the feature flag has been removed.
+        """
+        combined_extra_context = {
+            'show_add_from_sso':
+                is_feature_flag_active(ADMIN_ADD_ADVISER_FROM_SSO_FEATURE_FLAG),
+            **(extra_context or {}),
+        }
+        return super().changelist_view(request, combined_extra_context)
 
     def get_urls(self):
         """

--- a/datahub/company/admin/constants.py
+++ b/datahub/company/admin/constants.py
@@ -1,0 +1,1 @@
+ADMIN_ADD_ADVISER_FROM_SSO_FEATURE_FLAG = 'admin-add-adviser-from-sso'

--- a/datahub/company/templates/admin/company/advisor/add_from_sso.html
+++ b/datahub/company/templates/admin/company/advisor/add_from_sso.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_form.html" %}
+{% load i18n %}
+
+{% block form_top %}
+  {% blocktrans %}
+  <p>
+    Use this form to add a user that‘s already been set up in Staff SSO. Some of the user‘s details will
+    be automatically copied from their Staff SSO record.
+  <p>
+  </p>
+    Enter any of the user‘s email addresses, or their email user ID, as shown in Staff SSO.
+  </p>
+  {% endblocktrans %}
+{% endblock %}

--- a/datahub/company/templates/admin/company/advisor/change_list_object_tools.html
+++ b/datahub/company/templates/admin/company/advisor/change_list_object_tools.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_list_object_tools.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+  {% if has_add_permission and show_add_from_sso %}
+    <li>
+      {% url cl.opts|admin_urlname:'add-from-sso' as add_from_sso_url %}
+      <a href="{% add_preserved_filters add_from_sso_url is_popup to_field %}" class="addlink">
+        {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }} from SSO{% endblocktrans %}
+      </a>
+    </li>
+  {% endif %}
+  {{block.super}}
+{% endblock %}

--- a/datahub/company/test/admin/test_adviser.py
+++ b/datahub/company/test/admin/test_adviser.py
@@ -1,0 +1,98 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+from rest_framework import status
+
+from datahub.company.admin.adviser_forms import AddAdviserFromSSOForm, DUPLICATE_USER_MESSAGE
+from datahub.company.models import Advisor
+from datahub.company.test.factories import AdviserFactory
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+
+add_from_sso_url = reverse('admin:company_advisor_add-from-sso')
+
+
+FAKE_SSO_USER_DATA = {
+    'email': 'email@email.test',
+    'user_id': 'c2c1afce-e45e-4139-9913-88b350f7a546',
+    'email_user_id': 'test@id.test',
+    'first_name': 'Johnny',
+    'last_name': 'Cakeman',
+    'related_emails': [],
+    'contact_email': 'contact@email.test',
+    'groups': [],
+    'permitted_applications': [],
+    'access_profiles': [],
+}
+
+
+@pytest.mark.usefixtures('mock_get_user_by_email', 'mock_get_user_by_email_user_id')
+class TestAddAdviserFromSSO(AdminTestMixin):
+    """Tests for the add adviser from SSO view."""
+
+    @pytest.mark.parametrize('http_method', ('get', 'post'))
+    def test_redirects_to_login_page_if_not_logged_in(self, http_method):
+        """Test that the view redirects to the login page if the user isn't authenticated."""
+        client = Client()
+        response = client.generic(http_method, add_from_sso_url)
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(add_from_sso_url)
+
+    @pytest.mark.parametrize('http_method', ('get', 'post'))
+    def test_redirects_to_login_page_if_not_staff(self, http_method):
+        """Test that the view redirects to the login page if the user isn't a member of staff."""
+        user = create_test_user(is_staff=False, password=self.PASSWORD)
+
+        client = self.create_client(user=user)
+        response = client.generic(http_method, add_from_sso_url)
+
+        assert response.status_code == status.HTTP_302_FOUND
+        assert response['Location'] == self.login_url_with_redirect(add_from_sso_url)
+
+    @pytest.mark.parametrize('http_method', ('get', 'post'))
+    def test_permission_denied_if_staff_and_without_ad_permission(self, http_method):
+        """
+        Test that the view returns a 403 response if the staff user does not have the
+        add adviser permission.
+        """
+        user = create_test_user(
+            permission_codenames=('view_advisor',),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+
+        client = self.create_client(user=user)
+        response = client.generic(http_method, add_from_sso_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_displays_form(self):
+        """Test that the correct form is displayed."""
+        response = self.client.get(add_from_sso_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert 'Email or SSO email user ID' in response.rendered_content
+        assert response.template_name.endswith('/add_from_sso.html')
+        assert isinstance(response.context['adminform'].form, AddAdviserFromSSOForm)
+
+    def test_displays_error_when_validation_fails(self, mock_get_user_by_email_user_id):
+        """Test that an error is displayed when form validation fails."""
+        mock_get_user_by_email_user_id.return_value = FAKE_SSO_USER_DATA
+        AdviserFactory(sso_email_user_id=FAKE_SSO_USER_DATA['email_user_id'])
+
+        data = {'search_email': 'search-email@test.test'}
+        response = self.client.post(add_from_sso_url, data)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.context['errors'] == [[DUPLICATE_USER_MESSAGE]]
+
+    def test_adds_a_new_adviser(self, mock_get_user_by_email_user_id):
+        """Test that an adviser is created on success."""
+        mock_get_user_by_email_user_id.return_value = FAKE_SSO_USER_DATA
+
+        data = {'search_email': 'search-email@test.test'}
+        response = self.client.post(add_from_sso_url, data)
+
+        assert response.status_code == status.HTTP_302_FOUND
+
+        queryset = Advisor.objects.filter(sso_email_user_id=FAKE_SSO_USER_DATA['email_user_id'])
+        assert queryset.exists()


### PR DESCRIPTION
### Description of change

This follows on from #2727 and adds a new admin site page for adding an adviser by looking up their details in Staff SSO.

The new page is at `/admin/company/advisor/add-from-sso/ and is linked to from `/admin/company/advisor/` if a feature flag is enabled.

(Later on, this will probably be made the default add adviser form and a link to the old form added to this page.)

This 'SSO email user ID' field has also been to the change adviser form. It's currently read-only and will be made editable once existing values have been filled in.

This is deployed to UAT if anyone would like to give it a manual test.

### Screenshots

#### Change list link

![image](https://user-images.githubusercontent.com/12693549/77770650-84b51f80-703d-11ea-8630-1402ab6c8eb1.png)

#### Form

![image](https://user-images.githubusercontent.com/12693549/77770972-fa20f000-703d-11ea-9d17-bf693819ce09.png)

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
