### PR TITLE
Check user active status in SSOIntrospectionAuthentication

### DIFF
--- a/changelog/sso-intro-is-active.bugfix.md
+++ b/changelog/sso-intro-is-active.bugfix.md
@@ -1,0 +1,1 @@
+The new authentication class with SSO email user ID support now correctly denies access for inactive users. This new authentication class continues to be currently disabled by default.

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -156,6 +156,11 @@ DNB_INVESTIGATION_NOTIFICATION_RECIPIENTS = ['notifyme@digital.trade.gov.uk']
 
 STAFF_SSO_BASE_URL = 'http://sso.test/'
 STAFF_SSO_AUTH_TOKEN = 'test-sso-token'
+# TODO: Remove this once SSOIntrospectionAuthentication is the default, django-oauth-toolkit
+# is removed and APITestMixin has been updated
+REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = [
+    'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+]
 
 ADMIN_OAUTH2_ENABLED = True
 ADMIN_OAUTH2_REQUEST_TIMEOUT = 15

--- a/datahub/oauth/auth.py
+++ b/datahub/oauth/auth.py
@@ -54,7 +54,7 @@ class SSOIntrospectionAuthentication(BaseAuthentication):
             raise AuthenticationFailed(INVALID_CREDENTIALS_MESSAGE)
 
         user = _look_up_adviser(token_data)
-        if not user:
+        if not (user and user.is_active):
             raise AuthenticationFailed(INVALID_CREDENTIALS_MESSAGE)
 
         return user, None


### PR DESCRIPTION
### Description of change

This adds an extra check to `SSOIntrospectionAuthentication` to deny access if the user is inactive.

It also corrects an incorrect docstring, and fixes test failures when `STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC`  is `True`.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
