### PR TITLE
Record user event on introspection in SSOIntrospectionAuthentication

### DIFF
--- a/changelog/adviser/introspection-user-event.feature.md
+++ b/changelog/adviser/introspection-user-event.feature.md
@@ -1,0 +1,1 @@
+The new authentication class with SSO email user ID support now records user events whenever an introspection occurs. This new authentication class continues to be currently disabled by default.

--- a/changelog/adviser/user-events-admin.feature.md
+++ b/changelog/adviser/user-events-admin.feature.md
@@ -1,0 +1,1 @@
+It‘s now possible to search for user events in the admin site by API URL path prefix and adviser ID. The user event API URL path field filter was also removed due to the large number of entries in this filter.

--- a/datahub/user_event_log/admin.py
+++ b/datahub/user_event_log/admin.py
@@ -9,7 +9,7 @@ class UserEventAdmin(ViewOnlyAdmin):
     """Admin configuration for UserEvent."""
 
     list_display = ('timestamp', 'adviser', 'type', 'api_url_path')
-    list_filter = ('type', 'api_url_path')
+    list_filter = ('type',)
     list_select_related = ('adviser',)
     fields = (
         'id',
@@ -19,6 +19,7 @@ class UserEventAdmin(ViewOnlyAdmin):
         'api_url_path',
         'pretty_data',
     )
+    search_fields = ('^api_url_path', '=adviser__id')
     readonly_fields = fields
 
     def adviser_link(self, obj):

--- a/datahub/user_event_log/constants.py
+++ b/datahub/user_event_log/constants.py
@@ -7,3 +7,4 @@ class UserEventType(models.TextChoices):
     SEARCH_EXPORT = ('search_export', 'Exported search results')
     PROPOSITION_DOCUMENT_DELETE = ('proposition_document_delete', 'Deleted proposition document')
     EVIDENCE_DOCUMENT_DELETE = ('evidence_document_delete', 'Deleted evidence document')
+    OAUTH_TOKEN_INTROSPECTION = ('oauth_token_introspection', 'OAuth token introspection')

--- a/datahub/user_event_log/test/test_utils.py
+++ b/datahub/user_event_log/test/test_utils.py
@@ -10,35 +10,38 @@ from datahub.user_event_log.constants import UserEventType
 from datahub.user_event_log.utils import record_user_event
 
 
-@pytest.mark.parametrize(
-    'data,expected_data',
-    (
-        (None, None),
-        (
-            {'a': 'b'},
-            {'a': 'b'},
-        ),
-        (
-            {'a': datetime(2016, 10, 10, 1, 0, 2, tzinfo=utc)},
-            {'a': '2016-10-10T01:00:02Z'},
-        ),
-        (
-            {'a': UUID('73c18056-c592-478b-baf9-3b1322dd0dcf')},
-            {'a': '73c18056-c592-478b-baf9-3b1322dd0dcf'},
-        ),
-        ('string', 'string'),
-        ([0, 2, 3], [0, 2, 3]),
-    ),
-)
 @pytest.mark.django_db
-def test_record_user_event(data, expected_data):
-    """Test record_user_event() for various model and data values."""
-    adviser = AdviserFactory()
-    request = Mock(user=adviser, path='test-path')
-    event = record_user_event(request, UserEventType.SEARCH_EXPORT, data=data)
-    event.refresh_from_db()
+class TestRecordUserEvent:
+    """Test record_user_event()."""
 
-    assert event.adviser == adviser
-    assert event.type == UserEventType.SEARCH_EXPORT
-    assert event.api_url_path == 'test-path'
-    assert event.data == expected_data
+    @pytest.mark.parametrize(
+        'data,expected_data',
+        (
+            (None, None),
+            (
+                {'a': 'b'},
+                {'a': 'b'},
+            ),
+            (
+                {'a': datetime(2016, 10, 10, 1, 0, 2, tzinfo=utc)},
+                {'a': '2016-10-10T01:00:02Z'},
+            ),
+            (
+                {'a': UUID('73c18056-c592-478b-baf9-3b1322dd0dcf')},
+                {'a': '73c18056-c592-478b-baf9-3b1322dd0dcf'},
+            ),
+            ('string', 'string'),
+            ([0, 2, 3], [0, 2, 3]),
+        ),
+    )
+    def test_records_data(self, data, expected_data):
+        """Test various data values."""
+        adviser = AdviserFactory()
+        request = Mock(user=adviser, path='test-path')
+        event = record_user_event(request, UserEventType.SEARCH_EXPORT, data=data)
+        event.refresh_from_db()
+
+        assert event.adviser == adviser
+        assert event.type == UserEventType.SEARCH_EXPORT
+        assert event.api_url_path == 'test-path'
+        assert event.data == expected_data

--- a/datahub/user_event_log/test/test_utils.py
+++ b/datahub/user_event_log/test/test_utils.py
@@ -45,3 +45,12 @@ class TestRecordUserEvent:
         assert event.type == UserEventType.SEARCH_EXPORT
         assert event.api_url_path == 'test-path'
         assert event.data == expected_data
+
+    def test_can_override_adviser(self):
+        """Test that an explicitly provided adviser is used over the one in the request."""
+        adviser = AdviserFactory()
+        request = Mock(user=Mock(), path='test-path')
+        event = record_user_event(request, UserEventType.SEARCH_EXPORT, adviser=adviser)
+        event.refresh_from_db()
+
+        assert event.adviser == adviser

--- a/datahub/user_event_log/utils.py
+++ b/datahub/user_event_log/utils.py
@@ -1,10 +1,10 @@
 from datahub.user_event_log.models import UserEvent
 
 
-def record_user_event(request, type_, data=None):
+def record_user_event(request, type_, adviser=None, data=None):
     """Records a user event in the database."""
     return UserEvent.objects.create(
-        adviser=request.user,
+        adviser=adviser or request.user,
         type=type_,
         api_url_path=request.path,
         data=data,

--- a/datahub/user_event_log/utils.py
+++ b/datahub/user_event_log/utils.py
@@ -3,11 +3,9 @@ from datahub.user_event_log.models import UserEvent
 
 def record_user_event(request, type_, data=None):
     """Records a user event in the database."""
-    event = UserEvent(
+    return UserEvent.objects.create(
         adviser=request.user,
         type=type_,
         api_url_path=request.path,
         data=data,
     )
-    event.save()
-    return event


### PR DESCRIPTION
### Description of change

This updates `SSOIntrospectionAuthentication` to create a `UserEvent` whenever an SSO access token introspection occurs.

This is for reporting needs (where reports were previously inferring this information from `AccessToken` objects).

It also makes some minor changes to the `ModelAdmin` configuration for `UserEvent`.

I'd recommend reviewing the commits individually.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
