### PR TITLE
Remove pytest-sugar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ job_defaults: &job_defaults
 
     - run:
         name: Run tests
-        command: python -m pytest -n 4 -p no:sugar --cov --junitxml=test-reports/junit.xml --durations 25
+        command: python -m pytest -n 4 --cov --junitxml=test-reports/junit.xml --durations 25
 
     - store_test_results:
         path: test-reports

--- a/requirements.in
+++ b/requirements.in
@@ -46,7 +46,6 @@ kombu==4.6.8  # Not used directly, but pinned as it has been a source of breakag
 # Testing and dev
 pytest==5.4.1
 pytest-django==3.8.0
-pytest-sugar==0.9.2
 pytest-cov==2.8.1
 pytest-xdist==1.31.0
 ipython==7.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,7 +73,7 @@ monotonic==1.5            # via notifications-python-client
 more-itertools==8.2.0     # via pytest
 notifications-python-client==5.5.1  # via -r requirements.in
 oauthlib==3.1.0           # via django-oauth-toolkit
-packaging==20.3           # via pytest, pytest-sugar
+packaging==20.3           # via pytest
 parso==0.6.2              # via jedi
 pathtools==0.1.2          # via watchdog
 pep8-naming==0.10.0       # via -r requirements.in
@@ -96,9 +96,8 @@ pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements.in
 pytest-django==3.8.0      # via -r requirements.in
 pytest-forked==1.1.3      # via pytest-xdist
-pytest-sugar==0.9.2       # via -r requirements.in
 pytest-xdist==1.31.0      # via -r requirements.in
-pytest==5.4.1             # via -r requirements.in, pytest-cov, pytest-django, pytest-forked, pytest-sugar, pytest-xdist
+pytest==5.4.1             # via -r requirements.in, pytest-cov, pytest-django, pytest-forked, pytest-xdist
 python-dateutil==2.8.1    # via -r requirements.in, botocore, elasticsearch-dsl, faker, freezegun, icalendar
 pytz==2019.3              # via celery, django, icalendar
 pyyaml==5.3.1             # via -r requirements.in, watchdog
@@ -115,7 +114,6 @@ six==1.14.0               # via django-extensions, django-pglocks, elasticsearch
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django, django-debug-toolbar
 statsd==3.3.0             # via -r requirements.in
-termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.3       # via faker
 toml==0.10.0              # via towncrier
 towncrier==19.2.0         # via -r requirements.in


### PR DESCRIPTION
### Description of change

This removes py-test sugar as:

- it has been broken for a couple of weeks due to https://github.com/Teemu/pytest-sugar/issues/187
- it was disabled on CircleCI (due to compatibility problems), which meant we didn't immediately notice it being broken
- the default output of pytest has improved since pytest-sugar was added to this project, making pytest-sugar less useful

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
