### PR TITLE
DNB investigation api stub

### DIFF
--- a/changelog/company/company-dnb-investigation.api.md
+++ b/changelog/company/company-dnb-investigation.api.md
@@ -1,0 +1,5 @@
+A new API endpoint `POST /v4/dnb/company-investigation` was added which will eventually
+replace `/v4/dnb/company-create-investigation` for creating new company record investigations
+with D&B.  Right now the endpoint does some rudimentary validation of input, but otherwise 
+responds with 501 NOT IMPLEMENTED.
+The endpoint will be further fleshed out in subsequent work.

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -176,7 +176,7 @@ class DUNSNumberSerializer(serializers.Serializer):
 
 
 # TODO: Remove this once the D&B investigations endpoint has been released
-class DNBInvestigationDataSerializer(serializers.Serializer):
+class LegacyDNBInvestigationDataSerializer(serializers.Serializer):
     """
     Serializer for DNBInvestigationData - a JSON field that contains
     auxuliary data needed for submitting to DNB for investigation.
@@ -190,7 +190,7 @@ class DNBInvestigationDataSerializer(serializers.Serializer):
 
 
 # TODO: Refactor this once the D&B investigations endpoint has been released
-class DNBCompanyInvestigationSerializer(CompanySerializer):
+class LegacyDNBCompanyInvestigationSerializer(CompanySerializer):
     """
     For creating Company record to be investigated by DNB.
 
@@ -209,7 +209,7 @@ class DNBCompanyInvestigationSerializer(CompanySerializer):
         """
         if dnb_investigation_data in (None, ''):
             return None
-        serializer = DNBInvestigationDataSerializer(data=dnb_investigation_data)
+        serializer = LegacyDNBInvestigationDataSerializer(data=dnb_investigation_data)
         serializer.is_valid(raise_exception=True)
         return serializer.validated_data
 

--- a/datahub/dnb_api/test/test_serializers.py
+++ b/datahub/dnb_api/test/test_serializers.py
@@ -5,8 +5,8 @@ import pytest
 from datahub.company.models import Company
 from datahub.company.test.factories import CompanyFactory
 from datahub.dnb_api.serializers import (
-    DNBCompanyInvestigationSerializer,
     DNBCompanySerializer,
+    LegacyDNBCompanyInvestigationSerializer,
     SerializerNotPartial,
 )
 from datahub.dnb_api.utils import format_dnb_company_investigation
@@ -81,7 +81,7 @@ def test_investigation_serializer_valid(
             **investigation_payload_override,
         },
     )
-    serializer = DNBCompanyInvestigationSerializer(data=data)
+    serializer = LegacyDNBCompanyInvestigationSerializer(data=data)
     assert serializer.is_valid()
 
     company = serializer.save()
@@ -121,7 +121,7 @@ def test_investigation_serializer_null_fields_valid(
             investigation_payload_override,
         ),
     )
-    serializer = DNBCompanyInvestigationSerializer(data=data)
+    serializer = LegacyDNBCompanyInvestigationSerializer(data=data)
     assert serializer.is_valid()
 
     company = serializer.save()
@@ -154,7 +154,7 @@ def test_investigation_serializer_no_investigation_data_valid(
         ),
         investigation_data_override,
     )
-    serializer = DNBCompanyInvestigationSerializer(data=data)
+    serializer = LegacyDNBCompanyInvestigationSerializer(data=data)
     assert serializer.is_valid()
 
 
@@ -185,7 +185,7 @@ def test_investigation_serializer_null_fields_invalid(
             investigation_payload_override,
         ),
     )
-    serializer = DNBCompanyInvestigationSerializer(data=data)
+    serializer = LegacyDNBCompanyInvestigationSerializer(data=data)
     assert not serializer.is_valid()
     assert serializer.errors == {
         'non_field_errors': [
@@ -234,7 +234,7 @@ def test_investigation_serializer_invalid(
     """
     Test if DNBCompanyInvestigationSerializer fails given an invalid payload.
     """
-    serializer = DNBCompanyInvestigationSerializer(
+    serializer = LegacyDNBCompanyInvestigationSerializer(
         data=format_dnb_company_investigation(
             {**investigation_payload, **investigation_payload_override},
         ),

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -2,10 +2,11 @@ from django.urls import path
 
 from datahub.dnb_api.views import (
     DNBCompanyChangeRequestView,
-    LegacyDNBCompanyCreateInvestigationView,
     DNBCompanyCreateView,
+    DNBCompanyInvestigationView,
     DNBCompanyLinkView,
     DNBCompanySearchView,
+    LegacyDNBCompanyCreateInvestigationView,
 )
 
 urlpatterns = [
@@ -33,5 +34,10 @@ urlpatterns = [
         'company-change-request',
         DNBCompanyChangeRequestView.as_view(),
         name='company-change-request',
+    ),
+    path(
+        'company-investigation',
+        DNBCompanyInvestigationView.as_view(),
+        name='company-investigation',
     ),
 ]

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 
 from datahub.dnb_api.views import (
     DNBCompanyChangeRequestView,
-    DNBCompanyCreateInvestigationView,
+    LegacyDNBCompanyCreateInvestigationView,
     DNBCompanyCreateView,
     DNBCompanyLinkView,
     DNBCompanySearchView,
@@ -21,7 +21,7 @@ urlpatterns = [
     ),
     path(
         'company-create-investigation',
-        DNBCompanyCreateInvestigationView.as_view(),
+        LegacyDNBCompanyCreateInvestigationView.as_view(),
         name='company-create-investigation',
     ),
     path(

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -19,6 +19,7 @@ from datahub.dnb_api.link_company import CompanyAlreadyDNBLinkedException, link_
 from datahub.dnb_api.queryset import get_company_queryset
 from datahub.dnb_api.serializers import (
     DNBCompanyChangeRequestSerializer,
+    DNBCompanyInvestigationSerializer,
     DNBCompanyLinkSerializer,
     DNBCompanySerializer,
     DNBMatchedCompanySerializer,
@@ -344,3 +345,29 @@ class DNBCompanyChangeRequestView(APIView):
             raise APIUpstreamException(str(exc))
 
         return Response(response)
+
+
+class DNBCompanyInvestigationView(APIView):
+    """
+    View for creating a new investigation to get D&B to investigate and create a company record.
+    """
+
+    required_scopes = (Scope.internal_front_end,)
+
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        HasPermissions(
+            f'company.{CompanyPermission.view_company}',
+            f'company.{CompanyPermission.change_company}',
+        ),
+    )
+
+    @method_decorator(enforce_request_content_type('application/json'))
+    def post(self, request):
+        """
+        A wrapper around the investigation API endpoint for dnb-service.
+        """
+        investigation_serializer = DNBCompanyInvestigationSerializer(data=request.data)
+        investigation_serializer.is_valid(raise_exception=True)
+
+        return Response(status=status.HTTP_501_NOT_IMPLEMENTED)

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -19,11 +19,11 @@ from datahub.dnb_api.link_company import CompanyAlreadyDNBLinkedException, link_
 from datahub.dnb_api.queryset import get_company_queryset
 from datahub.dnb_api.serializers import (
     DNBCompanyChangeRequestSerializer,
-    DNBCompanyInvestigationSerializer,
     DNBCompanyLinkSerializer,
     DNBCompanySerializer,
     DNBMatchedCompanySerializer,
     DUNSNumberSerializer,
+    LegacyDNBCompanyInvestigationSerializer,
 )
 from datahub.dnb_api.utils import (
     DNBServiceConnectionError,
@@ -207,7 +207,9 @@ class DNBCompanyCreateView(APIView):
         )
 
 
-class DNBCompanyCreateInvestigationView(APIView):
+# TODO: Remove this API endpoint when the new company investigation proxy
+# endpoint is available
+class LegacyDNBCompanyCreateInvestigationView(APIView):
     """
     View for creating a company for DNB to investigate.
 
@@ -232,7 +234,7 @@ class DNBCompanyCreateInvestigationView(APIView):
         create a Company record in DataHub.
         """
         formatted_company_data = format_dnb_company_investigation(request.data)
-        company_serializer = DNBCompanyInvestigationSerializer(data=formatted_company_data)
+        company_serializer = LegacyDNBCompanyInvestigationSerializer(data=formatted_company_data)
 
         try:
             company_serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
### Description of change

A new API endpoint `POST /v4/dnb/company-investigation` was added which will eventually replace the part of `/v4/dnb/company-create-investigation` which creates new company record investigations with D&B.  Right now the endpoint does some rudimentary validation of input, but otherwise responds with 501 NOT IMPLEMENTED.

The endpoint will be further fleshed out in subsequent work.

### Background
For further background info on this feature, please look at the description for this PR: #2729 

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [X] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [X] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
