### PR TITLE
Use _document_type field in Elasticsearch queries

### DIFF
--- a/changelog/use-document-type-es.internal.md
+++ b/changelog/use-document-type-es.internal.md
@@ -1,0 +1,1 @@
+Elasticsearch queries were updated to use the custom `_document_type` field instead of the deprecated `_type` field.

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -391,7 +391,7 @@ def test_get_basic_search_query():
                 'should': [
                     {
                         'term': {
-                            '_type': 'company',
+                            '_document_type': 'company',
                         },
                     },
                 ],
@@ -400,7 +400,7 @@ def test_get_basic_search_query():
         'aggs': {
             'count_by_type': {
                 'terms': {
-                    'field': '_type',
+                    'field': '_document_type',
                 },
             },
         },

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -334,7 +334,7 @@ def test_get_basic_search_query():
                 'should': [
                     {
                         'term': {
-                            '_type': 'contact',
+                            '_document_type': 'contact',
                         },
                     },
                 ],
@@ -343,7 +343,7 @@ def test_get_basic_search_query():
         'aggs': {
             'count_by_type': {
                 'terms': {
-                    'field': '_type',
+                    'field': '_document_type',
                 },
             },
         },

--- a/datahub/search/export_country_history/views.py
+++ b/datahub/search/export_country_history/views.py
@@ -83,6 +83,6 @@ class ExportCountryHistoryView(SearchAPIView):
         base_query = super().get_base_query(request, validated_data)
 
         is_relevant_interaction = Term(were_countries_discussed=True)
-        is_relevant_history_entry = Term(_type=ExportCountryHistoryApp.name)
+        is_relevant_history_entry = Term(_document_type=ExportCountryHistoryApp.name)
 
         return base_query.filter(is_relevant_interaction | is_relevant_history_entry)

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -748,7 +748,7 @@ def test_get_basic_search_query():
                 'should': [
                     {
                         'term': {
-                            '_type': 'investment_project',
+                            '_document_type': 'investment_project',
                         },
                     },
                 ],
@@ -757,7 +757,7 @@ def test_get_basic_search_query():
         'aggs': {
             'count_by_type': {
                 'terms': {
-                    'field': '_type',
+                    'field': '_document_type',
                 },
             },
         },

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -60,7 +60,7 @@ def get_basic_search_query(
 
     search = search.post_filter(
         Bool(
-            should=Term(_type=entity._doc_type.name),
+            should=Term(_document_type=entity.get_app_name()),
         ),
     ).sort(
         '_score',
@@ -70,7 +70,7 @@ def get_basic_search_query(
     )
 
     search.aggs.bucket(
-        'count_by_type', 'terms', field='_type',
+        'count_by_type', 'terms', field='_document_type',
     )
 
     return search[offset:offset + limit]
@@ -214,7 +214,7 @@ def _build_global_permission_query(permission_filters_by_entity):
 
 def _build_global_permission_subqueries(permission_filters_by_entity):
     for entity, filter_args in permission_filters_by_entity.items():
-        query = Term(_type=entity)
+        query = Term(_document_type=entity)
         entity_condition = _build_entity_permission_query(filter_args)
 
         if entity_condition is not None:

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -130,7 +130,7 @@ class _ESModelChoiceField(serializers.Field):
 
     def to_representation(self, value):
         """Translates a model to a model name."""
-        return value._doc_type.name
+        return value.get_app_name()
 
 
 class BasicSearchQuerySerializer(BaseSearchQuerySerializer):

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -712,7 +712,7 @@ def test_get_basic_search_query(mocked_get_global_search_apps_as_mapping):
                                         'must': [
                                             {
                                                 'term': {
-                                                    '_type': search_app.name,
+                                                    '_document_type': search_app.name,
                                                 },
                                             },
                                         ],
@@ -731,7 +731,7 @@ def test_get_basic_search_query(mocked_get_global_search_apps_as_mapping):
                 'should': [
                     {
                         'term': {
-                            '_type': search_app.name,
+                            '_document_type': search_app.name,
                         },
                     },
                 ],
@@ -740,7 +740,7 @@ def test_get_basic_search_query(mocked_get_global_search_apps_as_mapping):
         'aggs': {
             'count_by_type': {
                 'terms': {
-                    'field': '_type',
+                    'field': '_document_type',
                 },
             },
         },

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -163,7 +163,7 @@ def _get_global_search_permission_filters(request):
             continue
 
         filter_args = app.get_permission_filters(request)
-        yield (app.es_model._doc_type.name, filter_args)
+        yield (app.es_model.get_app_name(), filter_args)
 
 
 class SearchAPIView(APIView):


### PR DESCRIPTION
### Description of change

This updates Elasticsearch queries to use the custom `_document_type` field instead of the deprecated `_type` field.

This follows on from the work in #2673.

The next steps will include:

- specifying `include_type_name=false` in certain requests (as this will be the default in Elaticsearch 7)
- reverting to the default mapping type name of `_doc` for all search models

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
