### PR TITLE
Replace use of deprecated exclude Elasticsearch search parameter

### DIFF
--- a/changelog/es-excludes.internal.md
+++ b/changelog/es-excludes.internal.md
@@ -1,0 +1,1 @@
+Global search queries were updated to use the `excludes` Elasticsearch search parameter instead of the deprecated `exclude` parameter.

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -66,7 +66,7 @@ def get_basic_search_query(
         '_score',
         'id',
     ).source(
-        exclude=fields_to_exclude,
+        excludes=fields_to_exclude,
     )
 
     search.aggs.bucket(


### PR DESCRIPTION
### Description of change

This updates global search queries to use the `excludes` Elasticsearch search parameter instead of the deprecated `exclude` parameter.

This fixes the following deprecation warning in Elasticsearch logs: `Deprecated field [exclude] used, expected [excludes] instead`.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
