### PR TITLE
Allow clients of interactions to set page size

### DIFF
--- a/changelog/interactions-endpoint-page-size.api.md
+++ b/changelog/interactions-endpoint-page-size.api.md
@@ -1,0 +1,1 @@
+`GET /v4/dataset/*`: enabled a `page_size` parameter that allows clients to change the default page size from 100, up to a maximum of 10,000.

--- a/datahub/dataset/core/pagination.py
+++ b/datahub/dataset/core/pagination.py
@@ -14,3 +14,10 @@ class DatasetCursorPagination(CursorPagination):
     # is greater than the `offset_cutoff` the `next_page` in the response would
     # point to the current page creating an infinite loop.
     offset_cutoff = None
+
+    # Allow clients to override the default page size (100) for paginated responses
+    page_size_query_param = 'page_size'
+
+    # Set a maximum page size that we'll allow, so clients can't do something
+    # completely outrageous.
+    max_page_size = 10_000


### PR DESCRIPTION
### Description of change
In data-flow, we scrape interactions from this API every morning -
approx 3 mil records as it stands currently. At the moment, this is
paginated in groups of 100 records at a time, which obviously results in
a significant amount of requests. By increasing page size we hope to
make the task generally run faster. At the moment each request seems to
take around 0.1s, so increasing page size by a factor of 10 should be
fine. A factor of 100 should be manageable, though we don't intend to
use that as a client yet.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
