### PR TITLE
[POC] Add endpoint for parsing interaction from mail body

### DIFF
--- a/datahub/interaction/test/views/test_mail.py
+++ b/datahub/interaction/test/views/test_mail.py
@@ -1,0 +1,85 @@
+from pathlib import PurePath
+
+import pytest
+from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from datahub.company.test.factories import AdviserFactory, ContactFactory
+from datahub.interaction.email_processors.parsers import _get_top_company_from_contacts
+from datahub.interaction.email_processors.processors import _filter_contacts_to_single_company
+
+
+client = APIClient()
+
+
+class TestICALViewSet():
+    """
+    Tests for the .ical views.
+    """
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        'mailpath, adviser_email, contact_emails, date',
+        (
+            (
+                'email_processors/email_samples/valid/outlook_online/sample.eml',
+                'adviser1@trade.gov.uk',
+                ['bill.adama@example.net'],
+                '2019-03-29T12:00:00+00:00',
+            ),
+            (
+                'email_processors/email_samples/valid/gmail/no_vcalendar.eml',
+                'adviser1@trade.gov.uk',
+                ['bill.adama@example.net'],
+                '2019-03-29T16:30:00+00:00',
+            ),
+            (
+                'email_processors/email_samples/valid/gmail/sample.eml',
+                'Correspondence3@digital.trade.gov.uk',
+                ['bill.adama@example.net'],
+                '2019-03-29T16:30:00+00:00',
+            ),
+            (
+                'email_processors/email_samples/valid/outlook_desktop/sample.eml',
+                'example@trade.gov.uk',
+                ['adviser1@digital.trade.gov.uk', 'meetings.dev@example.net'],
+                '2019-05-15T11:00:00+00:00',
+            ),
+            (
+                'email_processors/email_samples/valid/outlook_iphone/sample.eml',
+                'example@trade.gov.uk',
+                ['meetings.dev@example.net'],
+                '2019-05-19T00:00:00+00:00',
+            ),
+        ),
+    )
+    def test_valid(self, mailpath, adviser_email, contact_emails, date):
+        """
+        Endpoint should return 200 and parsed contents from the Mail message.
+        """
+        adviser = AdviserFactory(email=adviser_email)
+        contacts = [ContactFactory(email=contact_email) for contact_email in contact_emails]
+        mailpath = PurePath(__file__).parent.parent / mailpath
+        with open(mailpath, 'rb') as email_file:
+            message = email_file.read()
+        response = client.get(
+            reverse('api-v3:interaction:mail'),
+            data={'message': message},
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        # Subject is hard to test
+        data.pop('subject')
+        company = _get_top_company_from_contacts(contacts)
+        contacts = _filter_contacts_to_single_company(contacts, company)
+
+        assert data == {
+            'company': str(company.id),
+            'contacts': [str(contact.id) for contact in contacts],
+            'date': date,
+            'dit_participants': [str(adviser.id)],
+            'kind': 'interaction',
+            'status': 'draft',
+            'was_policy_feedback_provided': False,
+        }

--- a/datahub/interaction/test/views/test_mail.py
+++ b/datahub/interaction/test/views/test_mail.py
@@ -13,7 +13,7 @@ from datahub.interaction.email_processors.processors import _filter_contacts_to_
 client = APIClient()
 
 
-class TestICALViewSet(APITestMixin):
+class TestMailViewSet(APITestMixin):
     """
     Tests for the .ical views.
     """
@@ -63,7 +63,7 @@ class TestICALViewSet(APITestMixin):
         mailpath = PurePath(__file__).parent.parent / mailpath
         with open(mailpath, 'rb') as email_file:
             message = email_file.read()
-        response = client.get(
+        response = client.post(
             reverse('api-v3:interaction:mail'),
             data={'message': message},
         )

--- a/datahub/interaction/urls.py
+++ b/datahub/interaction/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from datahub.interaction.views import InteractionViewSet
+from datahub.interaction.views import InteractionViewSet, MailViewSet
 
 collection = InteractionViewSet.as_view({
     'get': 'list',
@@ -28,5 +28,10 @@ urlpatterns = [
         'interaction/<uuid:pk>/unarchive',
         unarchive_item,
         name='unarchive-item',
+    ),
+    path(
+        'interaction/mail',
+        MailViewSet.as_view(),
+        name='mail',
     ),
 ]

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -1,9 +1,22 @@
+import mailparser
 from django_filters.rest_framework import DjangoFilterBackend
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
+from rest_framework import serializers
 from rest_framework.filters import OrderingFilter
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.viewsets import CoreViewSet
+from datahub.interaction.email_processors.exceptions import InvalidInviteError
+from datahub.interaction.email_processors.parsers import CalendarInteractionEmailParser
+from datahub.interaction.email_processors.processors import (
+    _filter_contacts_to_single_company,
+    _get_meeting_subject,
+    CalendarInteractionEmailProcessor,
+)
+from datahub.interaction.models import Interaction
 from datahub.interaction.permissions import (
     InteractionModelPermissions,
     IsAssociatedToInvestmentProjectInteractionFilter,
@@ -45,3 +58,83 @@ class InteractionViewSet(ArchivableViewSetMixin, CoreViewSet):
         'subject',
     )
     ordering = ('-date', '-created_on')
+
+
+class NoSaveProcessor(CalendarInteractionEmailProcessor):
+    """
+    Does exactly what the parent class does except for saving an
+    interaction.
+    """
+
+    def _get_interaction_dict(self, data):
+        return {
+            'company': str(data['company'].id),
+            'contacts': [str(contact.id) for contact in data['contacts']],
+            'date': data['date'].isoformat(),
+            'dit_participants': [
+                str(participant['adviser'].id)
+                for participant in data['dit_participants']
+            ],
+            'kind': data['kind'],
+            'status': data['status'],
+            'subject': data['subject'],
+            'was_policy_feedback_provided': data['was_policy_feedback_provided'],
+        }
+
+    def process_email(self, message):
+        """
+        Review the metadata and calendar attachment (if present) of an email
+        message to see if it fits the our criteria of a valid Data Hub meeting
+        request.  If it does, return a serialised representation.
+        """
+        try:
+            email_parser = CalendarInteractionEmailParser(message)
+            interaction_data = email_parser.extract_interaction_data_from_email()
+        except InvalidInviteError as exc:
+            raise serializers.ValidationError(str(exc))
+
+        # Make the same-company check easy to remove later if we allow Interactions
+        # to have contacts from more than one company
+        sanitised_contacts = _filter_contacts_to_single_company(
+            interaction_data['contacts'],
+            interaction_data['top_company'],
+        )
+        interaction_data['contacts'] = sanitised_contacts
+
+        # Replace the meeting invite subject with one which details the people attending
+        interaction_data['subject'] = _get_meeting_subject(
+            interaction_data['sender'],
+            interaction_data['contacts'],
+            interaction_data['secondary_advisers'],
+        )
+
+        # Get a serializer for the interaction data
+        serialiser = self.validate_with_serializer(interaction_data)
+
+        # For our initial iteration of this feature, we are ignoring meeting updates
+        matching_interactions = Interaction.objects.filter(
+            source__contains={'meeting': {'id': interaction_data['meeting_details']['uid']}},
+        )
+        if matching_interactions.exists():
+            raise serializers.ValidationError('Interaction already exists.')
+
+        return self._get_interaction_dict(serialiser.validated_data)
+
+
+class MailViewSet(APIView):
+    """
+    Takes a mail body and return parsed content.
+    """
+
+    permission_classes = (
+        AllowAny,
+    )
+
+    def get(self, request):
+        """
+        Receive an .ical file, parse it and return the
+        parsed content in the response.
+        """
+        message = mailparser.parse_from_string(request.query_params.get('message'))
+        data = NoSaveProcessor().process_email(message)
+        return Response(data)

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -130,11 +130,11 @@ class MailViewSet(APIView):
         AllowAny,
     )
 
-    def get(self, request):
+    def post(self, request):
         """
         Receive an .ical file, parse it and return the
         parsed content in the response.
         """
-        message = mailparser.parse_from_string(request.query_params.get('message'))
+        message = mailparser.parse_from_string(request.data.get('message'))
         data = NoSaveProcessor().process_email(message)
         return Response(data)


### PR DESCRIPTION
### Description of change

This adds an endpoint that takes a mail body and parses it to produce content that can then be sent over to `POST /interaction`.

This was written as part of the fire break week and is not production-ready. 

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
