### PR TITLE
Slack messaging for scheduled tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `DISABLE_PAAS_IP_CHECK` | No | Disable PaaS IP check for Hawk endpoints (default=False). |
 | `ENABLE_DAILY_ES_SYNC` | No | Whether to enable the daily ES sync (default=False). |
 | `ENABLE_EMAIL_INGESTION` | No | True or False.  Whether or not to activate the celery beat task for ingesting emails |
+| `ENABLE_SLACK_MESSAGING` | No | If present and truthy, enable the transmission of messages to Slack. Necessitates the specification of the other env vars `SLACK_API_TOKEN` and `SLACK_MESSAGE_CHANNEL` |
 | `ENABLE_SPI_REPORT_GENERATION` | No | Whether to enable daily SPI report (default=False). |
 | `ES_INDEX_PREFIX`  | Yes | Prefix to use for indices and aliases |
 | `ES_SEARCH_REQUEST_TIMEOUT` | No | Timeout (in seconds) for searches (default=20). |
@@ -340,6 +341,8 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `SENTRY_ENVIRONMENT`  | Yes | Value for the environment tag in Sentry. |
 | `SKIP_ES_MAPPING_MIGRATIONS` | No | If non-empty, skip applying Elasticsearch mapping type migrations on deployment. |
 | `SKIP_MI_DATABASE_MIGRATIONS` | No | If non-empty, skip applying MI database migrations on deployment. Used in environments without a working MI database. |
+| `SLACK_API_TOKEN` | No | (Required if `ENABLE_SLACK_MESSAGING` is truthy) Auth token for connection to Slack API for purposes of sending messages through the datahub.core.realtime_messaging module |
+| `SLACK_MESSAGE_CHANNEL` | No | (Required if `ENABLE_SLACK_MESSAGING` is truthy) Name (or preferably ID) of the channel into which datahub.core.realtime_messaging should send messages |
 | `SSO_ENABLED` | Yes | Whether single sign-on via RFC 7662 token introspection is enabled |
 | `STAFF_SSO_AUTH_TOKEN` | If SSO enabled | Access token for the Staff SSO API. (Used only when STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True). |
 | `STAFF_SSO_BASE_URL` | If SSO enabled | The base URL for the Staff SSO API. (Used only when STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True). |
@@ -350,8 +353,6 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `STATSD_PREFIX` | No | Prefix for metrics being pushed to StatsD. |
 | `VCAP_SERVICES` | No | Set by GOV.UK PaaS when using their backing services. Contains connection details for Elasticsearch and Redis. |
 | `WEB_CONCURRENCY` | No | Number of Gunicorn workers (set automatically by Heroku, otherwise defaults to 1). |
-| `ENABLE_EMAIL_INGESTION` | No | True or False.  Whether or not to activate the celery beat task for ingesting emails |
-| `DATAHUB_NOTIFICATION_API_KEY` | No | The GOVUK notify API key to use for the `datahub.notification` django app. |
 
 
 ## Management commands

--- a/changelog/company/slack-messaging-for-scheduled-tasks.feature.md
+++ b/changelog/company/slack-messaging-for-scheduled-tasks.feature.md
@@ -1,0 +1,1 @@
+Two scheduled tasks - "automatic company archive" and "get company updates" - will now send summary messages to a Slack channel upon completion.

--- a/changelog/realtime-messaging-with-slack.internal.md
+++ b/changelog/realtime-messaging-with-slack.internal.md
@@ -1,0 +1,1 @@
+The PyPI package "slackclient" was added to the requirements and a wrapper library `realtime_messaging` was created to abstract away its implementation.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -608,6 +608,16 @@ _add_hawk_credentials(
     (HawkScope.public_omis,),
 )
 
+# Sending messages to Slack
+ENABLE_SLACK_MESSAGING = env.bool('ENABLE_SLACK_MESSAGING', default=False)
+if ENABLE_SLACK_MESSAGING:
+    SLACK_API_TOKEN = env('SLACK_API_TOKEN')
+    SLACK_MESSAGE_CHANNEL = env('SLACK_MESSAGE_CHANNEL')
+else:
+    SLACK_API_TOKEN = None
+    SLACK_MESSAGE_CHANNEL = None
+SLACK_TIMEOUT_SECONDS = 10
+
 # To read data from Activity Stream
 ACTIVITY_STREAM_OUTGOING_URL = env('ACTIVITY_STREAM_OUTGOING_URL', default=None)
 ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID = env('ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID', default=None)

--- a/datahub/core/realtime_messaging.py
+++ b/datahub/core/realtime_messaging.py
@@ -1,0 +1,30 @@
+import logging
+
+from django.conf import settings
+from slack import WebClient
+from slack.errors import SlackClientError  # the base error class
+
+logger = logging.getLogger(__name__)
+
+
+def send_realtime_message(message_text):
+    """
+    Send a message to the realtime messaging system.
+
+    Do not attempt if the messaging config was not set up properly.
+    """
+    if not (settings.SLACK_API_TOKEN and settings.SLACK_MESSAGE_CHANNEL):
+        logger.info('Setup was incomplete. Message not attempted.')
+        return
+
+    client = WebClient(
+        timeout=settings.SLACK_TIMEOUT_SECONDS,
+        token=settings.SLACK_API_TOKEN,
+    )
+    try:
+        client.chat_postMessage(
+            channel=settings.SLACK_MESSAGE_CHANNEL,
+            text=message_text,
+        )
+    except SlackClientError:
+        logger.error('Slack post failed.', exc_info=True)

--- a/datahub/core/test/test_realtime_messaging.py
+++ b/datahub/core/test/test_realtime_messaging.py
@@ -1,0 +1,128 @@
+from unittest import mock
+
+from django.test import override_settings
+from slack.errors import SlackClientError  # the base error class
+
+from datahub.core.realtime_messaging import send_realtime_message
+
+
+class TestRealtimeMessaging():
+    """
+    Test the realtime messaging wrapper.
+    """
+
+    @override_settings(ENABLE_SLACK_MESSAGING=False)
+    def test_disabled_facility_aborts_message(self, caplog, monkeypatch):
+        """
+        Test that an disabling the facility setting aborts the send process gracefully.
+        """
+        caplog.set_level('INFO')
+        mock_web_client = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.core.realtime_messaging.WebClient',
+            mock_web_client,
+        )
+        send_realtime_message('some message')
+        expected_message = 'Setup was incomplete. Message not attempted.'
+        assert expected_message in caplog.text
+        mock_web_client().assert_not_called()
+
+    @override_settings(
+        SLACK_API_TOKEN=None,
+        SLACK_MESSAGE_CHANNEL='MESSAGE_CHANNEL',
+    )
+    def test_absent_api_token_aborts_message(self, caplog, monkeypatch):
+        """
+        Test that an absence of Slack API token aborts the send process gracefully.
+        """
+        caplog.set_level('INFO')
+        mock_web_client = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.core.realtime_messaging.WebClient',
+            mock_web_client,
+        )
+        send_realtime_message('some message')
+        expected_message = 'Setup was incomplete. Message not attempted.'
+        assert expected_message in caplog.text
+        mock_web_client().assert_not_called()
+
+    @override_settings(
+        SLACK_API_TOKEN='API_TOKEN',
+        SLACK_MESSAGE_CHANNEL=None,
+    )
+    def test_absent_message_channel_aborts_message(self, caplog, monkeypatch):
+        """
+        Test that an absence of a message channel aborts the send process gracefully.
+        """
+        caplog.set_level('INFO')
+        mock_web_client = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.core.realtime_messaging.WebClient',
+            mock_web_client,
+        )
+        send_realtime_message('some message')
+        expected_message = 'Setup was incomplete. Message not attempted.'
+        assert expected_message in caplog.text
+        mock_web_client.assert_not_called()
+
+    @override_settings(
+        SLACK_API_TOKEN='API_TOKEN',
+        SLACK_MESSAGE_CHANNEL='MESSAGE_CHANNEL',
+        SLACK_TIMEOUT_SECONDS=11,
+    )
+    def test_slack_client_initiated(self, monkeypatch):
+        """
+        Test that the Slack client gets passed the token and timeout from the config.
+        """
+        mock_web_client = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.core.realtime_messaging.WebClient',
+            mock_web_client,
+        )
+        send_realtime_message('some message')
+        mock_web_client.assert_called_once_with(
+            timeout=11,
+            token='API_TOKEN',
+        )
+
+    @override_settings(
+        SLACK_API_TOKEN='API_TOKEN',
+        SLACK_MESSAGE_CHANNEL='MESSAGE_CHANNEL',
+    )
+    def test_message_method_called(self, monkeypatch):
+        """
+        Test that the Slack client 'send' method is called appropriately.
+        """
+        mock_web_client = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.core.realtime_messaging.WebClient',
+            mock_web_client,
+        )
+        send_realtime_message('Hello!')
+        mock_web_client().chat_postMessage.assert_called_once_with(
+            channel='MESSAGE_CHANNEL',
+            text='Hello!',
+        )
+
+    @override_settings(
+        SLACK_API_TOKEN='API_TOKEN',
+        SLACK_MESSAGE_CHANNEL='MESSAGE_CHANNEL',
+    )
+    def test_slack_error_handled(
+        self,
+        caplog,
+        monkeypatch,
+    ):
+        """
+        Test that Slack client errors are caught and reported.
+        """
+        caplog.set_level('ERROR')
+        mock_web_client = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.core.realtime_messaging.WebClient',
+            mock_web_client,
+        )
+        mock_web_client().chat_postMessage.side_effect = SlackClientError
+        send_realtime_message('some message')
+        expected_message = 'Slack post failed.'
+        assert expected_message in caplog.text

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -493,11 +493,13 @@ class TestGetCompanyUpdates:
             kwargs=expected_kwargs,
         )
 
+    @mock.patch('datahub.dnb_api.tasks.update.send_realtime_message')
     @mock.patch('datahub.dnb_api.tasks.update.log_to_sentry')
     @freeze_time('2019-01-02T2:00:00')
     def test_updates_with_update_company_from_dnb_data(
         self,
         mocked_log_to_sentry,
+        mocked_send_realtime_message,
         caplog,
         monkeypatch,
         dnb_company_updates_response_uk,
@@ -533,14 +535,20 @@ class TestGetCompanyUpdates:
                 'end_time': '2019-01-02T02:00:00+00:00',
             },
         )
-
+        expected_message = (
+            'datahub.dnb_api.tasks.update.get_company_updates '
+            'updated: 1; failed to update: 0'
+        )
+        mocked_send_realtime_message.assert_called_once_with(expected_message)
         assert 'get_company_updates total update count: 1' in caplog.text
 
+    @mock.patch('datahub.dnb_api.tasks.update.send_realtime_message')
     @mock.patch('datahub.dnb_api.tasks.update.log_to_sentry')
     @freeze_time('2019-01-02T2:00:00')
     def test_updates_with_update_company_from_dnb_data_partial_fields(
         self,
         mocked_log_to_sentry,
+        mocked_send_realtime_message,
         monkeypatch,
         dnb_company_updates_response_uk,
     ):
@@ -574,12 +582,19 @@ class TestGetCompanyUpdates:
                 'end_time': '2019-01-02T02:00:00+00:00',
             },
         )
+        expected_message = (
+            'datahub.dnb_api.tasks.update.get_company_updates '
+            'updated: 1; failed to update: 0'
+        )
+        mocked_send_realtime_message.assert_called_once_with(expected_message)
 
+    @mock.patch('datahub.dnb_api.tasks.update.send_realtime_message')
     @mock.patch('datahub.dnb_api.tasks.update.log_to_sentry')
     @freeze_time('2019-01-02T2:00:00')
     def test_updates_with_update_company_from_dnb_data_with_failure(
         self,
         mocked_log_to_sentry,
+        mocked_send_realtime_message,
         monkeypatch,
         dnb_company_updates_response_uk,
     ):
@@ -619,6 +634,11 @@ class TestGetCompanyUpdates:
                 'end_time': '2019-01-02T02:00:00+00:00',
             },
         )
+        expected_message = (
+            'datahub.dnb_api.tasks.update.get_company_updates '
+            'updated: 1; failed to update: 1'
+        )
+        mocked_send_realtime_message.assert_called_once_with(expected_message)
 
 
 def test_get_company_updates_feature_flag_inactive_no_updates(

--- a/requirements.in
+++ b/requirements.in
@@ -30,6 +30,9 @@ statsd==3.3.0
 mail-parser==3.12.0
 icalendar==4.0.5
 
+# Slack
+slackclient==2.5.0
+
 # REDIS
 django-redis==4.11.0
 redis==3.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,6 +111,7 @@ semantic_version==2.8.4   # via -r requirements.in
 sentry_sdk==0.14.3        # via -r requirements.in
 simplejson==3.17.0        # via mail-parser
 six==1.14.0               # via django-extensions, django-pglocks, elasticsearch-dsl, flake8-print, freezegun, mail-parser, mohawk, packaging, pip-tools, piprot, pytest-xdist, python-dateutil, requests-mock, traitlets
+slackclient==2.5.0        # via -r requirements.in
 snowballstemmer==2.0.0    # via pydocstyle
 sqlparse==0.3.1           # via django, django-debug-toolbar
 statsd==3.3.0             # via -r requirements.in


### PR DESCRIPTION
### Description of change
Enable 2 of the scheduled tasks - "automatic company archive" and "get company updates" - to send summary messages to a Slack channel upon completion

### Checklist

* [Y] If this is a releasable change, has a news fragment been added?

* [Y] Has this branch been rebased on top of the current `develop` branch?

* [Y] Is the CircleCI build passing?
