### PR TITLE
API endpoint to expose export wins for a company

### DIFF
--- a/changelog/company/export_wins.api.md
+++ b/changelog/company/export_wins.api.md
@@ -1,0 +1,3 @@
+A new endpoint, `GET /v4/company/<ID>/export-win`, was added to expose company's export wins.
+
+This facilitates proxying the response from Export Wins API that gives a list of export wins for given company match id. Match id is obtained from Company Matching Service.

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -5,10 +5,12 @@ from operator import attrgetter, itemgetter
 
 import factory
 import pytest
+from django.conf import settings
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.company.company_matching_api import CompanyMatchingServiceHTTPError
 from datahub.company.constants import BusinessTypeConstant
 from datahub.company.models import (
     Company,
@@ -29,6 +31,7 @@ from datahub.core.test_utils import (
     APITestMixin,
     create_test_user,
     format_date_or_datetime,
+    HawkMockJSONResponse,
 )
 from datahub.metadata.models import Country as CountryModel
 from datahub.metadata.test.factories import TeamFactory
@@ -1993,14 +1996,263 @@ class TestGetCompanyExportWins(APITestMixin):
         'permission_codenames,expected_status',
         (
             ([], status.HTTP_403_FORBIDDEN),
-            (['view_export_win'], status.HTTP_501_NOT_IMPLEMENTED),
+            (['view_company'], status.HTTP_403_FORBIDDEN),
         ),
     )
     def test_permission_checking(self, permission_codenames, expected_status):
-        """Test that the expected status is returned for various user permissions."""
+        """Test that a 403 is returned if the user has not enough permissions."""
         user = create_test_user(permission_codenames=permission_codenames)
         api_client = self.create_api_client(user=user)
         company = CompanyFactory()
         url = reverse('api-v4:company:export-win', kwargs={'pk': company.id})
         response = api_client.get(url)
         assert response.status_code == expected_status
+
+    @pytest.mark.parametrize(
+        'match_response',
+        [
+            pytest.param(
+                {},
+            ),
+            pytest.param(
+                {
+                    'matches': [],
+                },
+            ),
+            pytest.param(
+                {
+                    'matches': [
+                        {
+                            'id': 1,
+                            'similarity': '100000',
+                        },
+                    ],
+                },
+            ),
+            pytest.param(
+                {
+                    'matches': [
+                        {
+                            'id': 1,
+                            'match_id': None,
+                            'similarity': '100000',
+                        },
+                    ],
+                },
+            ),
+        ],
+    )
+    def test_no_match_id_404_conditions(
+        self,
+        requests_mock,
+        match_response,
+    ):
+        """Test that any issues with company matching service results in a 404."""
+        company_dynamic_response = HawkMockJSONResponse(
+            api_id=settings.COMPANY_MATCHING_HAWK_ID,
+            api_key=settings.COMPANY_MATCHING_HAWK_KEY,
+            response=match_response,
+        )
+        requests_mock.post(
+            '/api/v1/company/match/',
+            status_code=status.HTTP_200_OK,
+            text=company_dynamic_response,
+        )
+
+        user = create_test_user(
+            permission_codenames=(
+                CompanyPermission.view_export_win,
+            ),
+        )
+        api_client = self.create_api_client(user=user)
+        company = CompanyFactory()
+        url = reverse('api-v4:company:export-win', kwargs={'pk': company.id})
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json() == {'detail': 'Not found.'}
+
+    @pytest.mark.parametrize(
+        'response_status',
+        (
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+            status.HTTP_408_REQUEST_TIMEOUT,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
+    def test_company_matching_upstream_error_conditions(self, requests_mock, response_status):
+        """Test company matching service error conditions."""
+        requests_mock.post(
+            '/api/v1/company/match/',
+            status_code=response_status,
+        )
+        user = create_test_user(
+            permission_codenames=(
+                CompanyPermission.view_export_win,
+            ),
+        )
+        api_client = self.create_api_client(user=user)
+        company = CompanyFactory()
+        url = reverse('api-v4:company:export-win', kwargs={'pk': company.id})
+        with pytest.raises(CompanyMatchingServiceHTTPError):
+            response = api_client.get(url)
+            assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+    @pytest.mark.parametrize(
+        'response_status',
+        (
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_405_METHOD_NOT_ALLOWED,
+            status.HTTP_408_REQUEST_TIMEOUT,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
+    def test_export_wins_upstream_error_conditions(self, requests_mock, response_status):
+        """Test export wins service error conditions."""
+        company_matching_reponse = {
+            'matches': [
+                {
+                    'id': 1,
+                    'match_id': 1,
+                    'similarity': '100000',
+                },
+            ],
+        }
+        company_dynamic_response = HawkMockJSONResponse(
+            api_id=settings.COMPANY_MATCHING_HAWK_ID,
+            api_key=settings.COMPANY_MATCHING_HAWK_KEY,
+            response=company_matching_reponse,
+        )
+        requests_mock.post(
+            '/api/v1/company/match/',
+            status_code=200,
+            text=company_dynamic_response,
+        )
+
+        requests_mock.get(
+            '/wins/match/1/',
+            status_code=response_status,
+        )
+
+        user = create_test_user(
+            permission_codenames=(
+                CompanyPermission.view_export_win,
+            ),
+        )
+        api_client = self.create_api_client(user=user)
+        company = CompanyFactory()
+        url = reverse('api-v4:company:export-win', kwargs={'pk': company.id})
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+    def test_no_company_with_pk_raises_404(self):
+        """
+        Test if company pk provided in get parameters doesn't match,
+        404 is raised.
+        """
+        user = create_test_user(
+            permission_codenames=(
+                CompanyPermission.view_export_win,
+            ),
+        )
+        api_client = self.create_api_client(user=user)
+        dummy_company_id = uuid.uuid4()
+        url = reverse('api-v4:company:export-win', kwargs={'pk': dummy_company_id})
+        response = api_client.get(url)
+        assert response.status_code == 404
+
+    def test_get_export_wins_success(
+        self,
+        requests_mock,
+    ):
+        """Test get wins in a successful scenario."""
+        company_matching_reponse = {
+            'matches': [
+                {
+                    'id': 1,
+                    'match_id': 1,
+                    'similarity': '100000',
+                },
+            ],
+        }
+        company_dynamic_response = HawkMockJSONResponse(
+            api_id=settings.COMPANY_MATCHING_HAWK_ID,
+            api_key=settings.COMPANY_MATCHING_HAWK_KEY,
+            response=company_matching_reponse,
+        )
+        requests_mock.post(
+            '/api/v1/company/match/',
+            status_code=200,
+            text=company_dynamic_response,
+        )
+
+        export_wins_response = {
+            'count': 1,
+            'next': None,
+            'previous': None,
+            'results': [
+                {
+                    'id': 'e3013078-7b3e-4359-83d9-cd003a515521',
+                    'date': '2016-05-25',
+                    'created': '2020-02-18T15:36:02.782000Z',
+                    'country': 'CA',
+                    'sector': 251,
+                    'business_potential': 1,
+                    'business_type': '',
+                    'name_of_export': '',
+                    'officer': {
+                        'name': 'lead officer name',
+                        'email': '',
+                        'team': {
+                            'type': 'tcp',
+                            'sub_type': 'tcp:12',
+                        },
+                    },
+                    'contact': {
+                        'name': 'customer name',
+                        'email': 'noname@somecompany.com',
+                        'job_title': 'customer job title',
+                    },
+                    'value': {
+                        'export': {
+                            'value': 100000,
+                            'breakdowns': [],
+                        },
+                    },
+                    'customer': 'Some Company Limited',
+                    'response': None,
+                    'hvc': {
+                        'code': 'E24116',
+                        'name': 'AER-01',
+                    },
+                },
+            ],
+        }
+        export_wins_dynamic_response = HawkMockJSONResponse(
+            api_id=settings.EXPORT_WINS_HAWK_ID,
+            api_key=settings.EXPORT_WINS_HAWK_KEY,
+            response=export_wins_response,
+        )
+        requests_mock.get(
+            '/wins/match/1/',
+            status_code=200,
+            text=export_wins_dynamic_response,
+        )
+
+        user = create_test_user(
+            permission_codenames=(
+                CompanyPermission.view_export_win,
+            ),
+        )
+        api_client = self.create_api_client(user=user)
+        company = CompanyFactory()
+        url = reverse('api-v4:company:export-win', kwargs={'pk': company.id})
+        response = api_client.get(url)
+        assert response.status_code == 200
+        assert response.json() == export_wins_response

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -3,7 +3,7 @@ from django.urls import path
 from datahub.company.views import (
     CompanyAuditViewSet,
     CompanyViewSet,
-    export_wins_501_not_implemented,
+    ExportWinsForCompanyView,
     OneListGroupCoreTeamViewSet,
     PublicCompanyViewSet,
 )
@@ -74,7 +74,7 @@ urls = [
     ),
     path(
         'company/<uuid:pk>/export-win',
-        export_wins_501_not_implemented,
+        ExportWinsForCompanyView.as_view(),
         name='export-win',
     ),
     path('public/company/<uuid:pk>', public_company_item, name='public-item'),


### PR DESCRIPTION
### Description of change
#### Context
This PR is part of a bigger piece of work to extract export wins from the export-wins-data project and display them in DataHub.
See the presentation for more context on the approach.
https://docs.google.com/presentation/d/132Kzu0dW-nt0qVzszjV0EdJCcC87FqIAZcNslcFQOA0/edit?usp=sharing

#### Changes in this PR
A new endpoint, `GET /v4/company/<ID>/export-win`, was added to expose company's export wins.

The new view facilitates proxying the response from Export Wins API that gives a list of export wins for given company match id.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
