### PR TITLE
Update missing ENV in README and fixed error class inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `CELERY_TASK_ALWAYS_EAGER` | No | Can be set to True when running the app locally to run Celery tasks started from the web process synchronously. Not for use in production. |
 | `CELERY_TASK_SEND_SENT_EVENT` | No | Whether Celery workers send the `task-sent` event (default=True). |
 | `CELERY_WORKER_TASK_EVENTS` | No | Whether Celery workers send task events (by default) for use by monitoring tools such as Flower (default=True). |
+| `COMPANY_MATCHING_SERVICE_BASE_URL` | No | The base url of the company matching service (default=None). |
+| `COMPANY_MATCHING_HAWK_ID` | No | The hawk id to use when making a request to the company matching service (default=None). |
+| `COMPANY_MATCHING_HAWK_KEY` | No | The hawk key to use when making a request to the company matching service (default=None). |
 | `CONSENT_SERVICE_BASE_URL` | No | The base url of the consent service, to post email consent preferences to  (default=None). |
 | `CONSENT_SERVICE_HAWK_ID` | No | The hawk id to use when making a request to the consent service (default=None). |
 | `CONSENT_SERVICE_HAWK_KEY` | No | The hawk key to use when making a request to the consent service (default=None). |

--- a/datahub/company/company_matching_api.py
+++ b/datahub/company/company_matching_api.py
@@ -17,9 +17,9 @@ class CompanyMatchingServiceException(Exception):
     """
 
 
-class CompanyMatchingServiceHTTPError(Exception):
+class CompanyMatchingServiceHTTPError(CompanyMatchingServiceException):
     """
-    Base exception class for Company matching service related errors.
+    Exception for when Company matching service returns an http error status.
     """
 
 


### PR DESCRIPTION
### Description of change
Realised that I should have update the README for env variables this PR add that and also notice that a 
CompanyMatchingServiceHTTPError was inherited `Exception` instead of the base exceptions `CompanyMatchingServiceException`

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
