### PR TITLE
Add populate_adviser_sso_email_user_id management command

### DIFF
--- a/changelog/adviser/populate-sso-email-user-id-command.feature.md
+++ b/changelog/adviser/populate-sso-email-user-id-command.feature.md
@@ -1,0 +1,3 @@
+A new management command, `populate_adviser_sso_email_user_id`, was added. This fills in blank adviser SSO email user IDs by querying Staff SSO.
+
+This is a temporary command and will be removed once no longer required.

--- a/datahub/dbmaintenance/management/commands/populate_adviser_sso_email_user_id.py
+++ b/datahub/dbmaintenance/management/commands/populate_adviser_sso_email_user_id.py
@@ -1,0 +1,63 @@
+from logging import getLogger
+
+from django.core.management import BaseCommand
+
+from datahub.company.models import Advisor
+from datahub.oauth.sso_api_client import get_user_by_email, SSOUserDoesNotExist
+from datahub.search.signals import disable_search_signal_receivers
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Command to fill in black Advisor.sso_email_user_id by querying Staff SSO.
+
+    This is a temporary command and will be removed once no longer required.
+
+    TODO: Remove this command once it has been run in production and
+    the new introspection logic is live.
+    """
+
+    help = """Populates adviser SSO email user IDs by querying Staff SSO."""
+    requires_migrations_checks = True
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            help='Simulate the command by querying Staff SSO but not saving changes.',
+        )
+
+    @disable_search_signal_receivers(Advisor)
+    def handle(self, *args, **options):
+        """Main logic for the actual command."""
+        is_simulation = options['simulate']
+        num_skipped = 0
+        num_updated = 0
+
+        queryset = Advisor.objects.filter(is_active=True, sso_email_user_id__isnull=True)
+        for adviser in queryset.iterator():
+            try:
+                sso_user_data = get_user_by_email(adviser.email)
+            except SSOUserDoesNotExist:
+                logger.warning(f'No SSO user found for adviser ID {adviser.pk}')
+                num_skipped += 1
+                continue
+
+            # Only do the update if the primary emails match (otherwise this is a
+            # duplicate or redundant adviser record)
+            if adviser.email.lower() != sso_user_data['email'].lower():
+                logger.warning(f'SSO primary email didn’t match for adviser ID {adviser.pk}')
+                num_skipped += 1
+                continue
+
+            adviser.sso_email_user_id = sso_user_data['email_user_id']
+            if not is_simulation:
+                adviser.save(update_fields=('sso_email_user_id',))
+
+            logger.info(f'SSO email user ID updated for adviser ID {adviser.pk}')
+            num_updated += 1
+
+        logger.info(f'{num_updated} advisers updated; {num_skipped} advisers skipped')

--- a/datahub/dbmaintenance/test/commands/test_populate_adviser_sso_email_user_id.py
+++ b/datahub/dbmaintenance/test/commands/test_populate_adviser_sso_email_user_id.py
@@ -1,0 +1,163 @@
+from unittest.mock import Mock
+
+import pytest
+from django.core.management import call_command
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.dbmaintenance.management.commands import populate_adviser_sso_email_user_id
+from datahub.oauth.sso_api_client import SSOUserDoesNotExist
+from datahub.search.investment.signals import investment_project_sync_es_adviser_change
+
+
+FAKE_SSO_USER_DATA = {
+    'email': 'EMAil@email.test',
+    'user_id': 'c2c1afce-e45e-4139-9913-88b350f7a546',
+    'email_user_id': 'id@id.test',
+    'first_name': 'Johnny',
+    'last_name': 'Cakeman',
+    'related_emails': [],
+    'contact_email': 'contact@email.test',
+    'groups': [],
+    'permitted_applications': [],
+    'access_profiles': [],
+}
+
+
+@pytest.mark.django_db
+class TestPopulateAdviserSSOEmailUserIDCommand:
+    """Tests for the populate_adviser_sso_email_user_id management command."""
+
+    @pytest.mark.parametrize(
+        'adviser_factory,get_user_by_email_mock,expected_sso_email_user_id,expected_log_message',
+        (
+            # If sso_email_user_id is None and SSO returns a user with a matching
+            # primary email (ignoring case), sso_email_user_id should be updated
+            pytest.param(
+                lambda: AdviserFactory(email='Email@email.test', sso_email_user_id=None),
+                Mock(return_value=FAKE_SSO_USER_DATA),
+                FAKE_SSO_USER_DATA['email_user_id'],
+                '1 advisers updated; 0 advisers skipped',
+                id='match-with-matching-email',
+            ),
+            # If sso_email_user_id is None and SSO returns a user with a non-matching
+            # primary email, sso_email_user_id should be unchanged
+            pytest.param(
+                lambda: AdviserFactory(email='alternative@email.test', sso_email_user_id=None),
+                Mock(return_value=FAKE_SSO_USER_DATA),
+                None,
+                '0 advisers updated; 1 advisers skipped',
+                id='match-with-unmatching-email',
+            ),
+            # If sso_email_user_id is None and there is no matching user in SSO,
+            # sso_email_user_id should be unchanged
+            pytest.param(
+                lambda: AdviserFactory(email='alternative@email.test', sso_email_user_id=None),
+                Mock(side_effect=SSOUserDoesNotExist()),
+                None,
+                '0 advisers updated; 1 advisers skipped',
+                id='no-match',
+            ),
+            # If sso_email_user_id is None and the user is inactive, no change should
+            # be attempted
+            pytest.param(
+                lambda: AdviserFactory(
+                    email='email@email.test',
+                    sso_email_user_id=None,
+                    is_active=False,
+                ),
+                Mock(return_value=FAKE_SSO_USER_DATA),
+                None,
+                '0 advisers updated; 0 advisers skipped',
+                id='adviser-is-inactive',
+            ),
+            # If sso_email_user_id is not None, no change should be attempted
+            pytest.param(
+                lambda: AdviserFactory(
+                    email='email@email.test',
+                    sso_email_user_id='existing@id.test',
+                ),
+                Mock(return_value=FAKE_SSO_USER_DATA),
+                'existing@id.test',
+                '0 advisers updated; 0 advisers skipped',
+                id='adviser-already-has-sso-email-user-id',
+            ),
+        ),
+    )
+    def test_updates_sso_email_user_if_appropriate(
+        self,
+        adviser_factory,
+        get_user_by_email_mock,
+        expected_sso_email_user_id,
+        expected_log_message,
+        monkeypatch,
+        caplog,
+    ):
+        """Test adviser SSO email user ID updating in various different cases."""
+        caplog.set_level('INFO')
+
+        monkeypatch.setattr(
+            populate_adviser_sso_email_user_id,
+            'get_user_by_email',
+            get_user_by_email_mock,
+        )
+
+        adviser = adviser_factory()
+
+        command = populate_adviser_sso_email_user_id.Command()
+        call_command(command)
+
+        adviser.refresh_from_db()
+
+        assert adviser.sso_email_user_id == expected_sso_email_user_id
+        assert expected_log_message in caplog.text
+
+    def test_simulate_does_not_save_changes(self, monkeypatch, caplog):
+        """Test that simulate does not save model object changes."""
+        caplog.set_level('INFO')
+
+        monkeypatch.setattr(
+            populate_adviser_sso_email_user_id,
+            'get_user_by_email',
+            Mock(return_value=FAKE_SSO_USER_DATA),
+        )
+
+        adviser = AdviserFactory(email='email@email.test', sso_email_user_id=None)
+
+        command = populate_adviser_sso_email_user_id.Command()
+        call_command(command, simulate=True)
+
+        adviser.refresh_from_db()
+
+        assert not adviser.sso_email_user_id
+        assert '1 advisers updated; 0 advisers skipped' in caplog.text
+
+    def test_does_not_resync_search_investment_project_documents(self, monkeypatch):
+        """
+        Test that investment projects are not resynced to Elasticsearch when an adviser is
+        updated.
+
+        This is due to the use of the disable_search_signal_receivers decorator.
+        """
+        monkeypatch.setattr(
+            populate_adviser_sso_email_user_id,
+            'get_user_by_email',
+            Mock(return_value=FAKE_SSO_USER_DATA),
+        )
+
+        investment_project_sync_es_adviser_change_mock = Mock(
+            wraps=investment_project_sync_es_adviser_change,
+        )
+        monkeypatch.setattr(
+            'datahub.search.investment.signals.investment_project_sync_es_adviser_change',
+            investment_project_sync_es_adviser_change_mock,
+        )
+
+        adviser = AdviserFactory(email='email@email.test', sso_email_user_id=None)
+
+        command = populate_adviser_sso_email_user_id.Command()
+        call_command(command)
+
+        adviser.refresh_from_db()
+
+        assert adviser.sso_email_user_id == FAKE_SSO_USER_DATA['email_user_id']
+        assert not investment_project_sync_es_adviser_change_mock.called


### PR DESCRIPTION
### Description of change

This adds a management command to fill in blank adviser SSO email user IDs by querying Staff SSO.

This is a temporary command and will be removed once no longer required.

The command queries Staff SSO for each active adviser without an SSO email user ID in Data Hub. If a match is found, with the same primary email address, the Data Hub adviser is updated.

Adviser search signal receivers are disabled as there is no need to resync search documents due to this change, and it would cause a significant amount of resyncing.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
