### PR TITLE
Use default mapping type alias when indexing Elasticsearch documents

### DIFF
--- a/changelog/es-bulk-default-mapping-type-name.internal.md
+++ b/changelog/es-bulk-default-mapping-type-name.internal.md
@@ -1,0 +1,1 @@
+Elasticsearch document indexing and deletion operations were updated to use the default mapping type alias. This is to allow us to stop using custom mapping type names (which are deprecated).

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -738,9 +738,8 @@ def test_run(
 
     if has_search_app:
         search_app = get_search_app_by_model(model)
-        doc_type = search_app.name
         read_alias = search_app.es_model.get_read_alias()
-        assert es_with_signals.count(read_alias, doc_type=doc_type)['count'] == total_model_records
+        assert es_with_signals.count(read_alias)['count'] == total_model_records
 
     assert model.objects.count() == total_model_records
 
@@ -752,7 +751,7 @@ def test_run(
     assert model.objects.count() == total_model_records - num_expired_records
 
     if has_search_app:
-        assert es_with_signals.count(read_alias, doc_type=doc_type)['count'] == (
+        assert es_with_signals.count(read_alias)['count'] == (
             total_model_records
             - num_expired_records
         )
@@ -808,7 +807,7 @@ def test_simulate(
     if has_search_app:
         search_app = get_search_app_by_model(model)
         read_alias = search_app.es_model.get_read_alias()
-        assert es_with_signals.count(read_alias, doc_type=search_app.name)['count'] == 3
+        assert es_with_signals.count(read_alias)['count'] == 3
 
     assert model.objects.count() == 3
 
@@ -833,7 +832,7 @@ def test_simulate(
     assert model.objects.count() == 3
 
     if has_search_app:
-        assert es_with_signals.count(read_alias, doc_type=search_app.name)['count'] == 3
+        assert es_with_signals.count(read_alias)['count'] == 3
 
 
 @freeze_time(FROZEN_TIME)

--- a/datahub/cleanup/test/commands/test_delete_orphans.py
+++ b/datahub/cleanup/test/commands/test_delete_orphans.py
@@ -241,11 +241,10 @@ def test_run(
 
     model = apps.get_model(model_name)
     search_app = get_search_app_by_model(model)
-    doc_type = search_app.name
     read_alias = search_app.es_model.get_read_alias()
 
     assert model.objects.count() == total_model_records
-    assert es_with_signals.count(read_alias, doc_type=doc_type)['count'] == total_model_records
+    assert es_with_signals.count(read_alias)['count'] == total_model_records
 
     # Run the command
     management.call_command(command, model_name)
@@ -253,7 +252,7 @@ def test_run(
 
     # Check that the records have been deleted
     assert model.objects.count() == total_model_records - 1
-    assert es_with_signals.count(read_alias, doc_type=doc_type)['count'] == total_model_records - 1
+    assert es_with_signals.count(read_alias)['count'] == total_model_records - 1
 
     # Check which models were actually deleted
     return_values = delete_return_value_tracker.return_values
@@ -302,7 +301,7 @@ def test_simulate(
     read_alias = search_app.es_model.get_read_alias()
 
     assert model.objects.count() == 3
-    assert es_with_signals.count(read_alias, doc_type=search_app.name)['count'] == 3
+    assert es_with_signals.count(read_alias)['count'] == 3
 
     # Run the command
     management.call_command(command, model_name, simulate=True)
@@ -323,7 +322,7 @@ def test_simulate(
 
     # Check that nothing has actually been deleted
     assert model.objects.count() == 3
-    assert es_with_signals.count(read_alias, doc_type=search_app.name)['count'] == 3
+    assert es_with_signals.count(read_alias)['count'] == 3
 
 
 @freeze_time(FROZEN_TIME)

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -4,6 +4,7 @@ from elasticsearch_dsl import Mapping
 from datahub.company.test.factories import CompanyFactory
 from datahub.search.company import CompanySearchApp
 from datahub.search.company.models import Company as ESCompany
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.query_builder import (
     get_basic_search_query,
     get_search_by_entities_query,
@@ -523,7 +524,7 @@ def test_indexed_doc(es):
 
     indexed_company = es.get(
         index=CompanySearchApp.es_model.get_write_index(),
-        doc_type=CompanySearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=company.pk,
     )
 

--- a/datahub/search/company/test/test_signals.py
+++ b/datahub/search/company/test/test_signals.py
@@ -5,6 +5,7 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.search.company.apps import CompanySearchApp
 from datahub.search.company.models import Company
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.query_builder import get_basic_search_query
 from datahub.search.test.utils import get_documents_by_ids
 
@@ -102,7 +103,7 @@ def test_adding_interaction_updates_company(es_with_signals):
 
     doc = es_with_signals.get(
         index=CompanySearchApp.es_model.get_read_alias(),
-        doc_type=CompanySearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=company.pk,
     )
     assert doc['_source']['name'] == test_name
@@ -117,7 +118,7 @@ def test_adding_interaction_updates_company(es_with_signals):
 
     updated_doc = es_with_signals.get(
         index=CompanySearchApp.es_model.get_read_alias(),
-        doc_type=CompanySearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=company.pk,
     )
     assert updated_doc['_source']['name'] == test_name

--- a/datahub/search/event/test/test_signals.py
+++ b/datahub/search/event/test/test_signals.py
@@ -2,6 +2,7 @@ import pytest
 
 from datahub.event.test.factories import EventFactory
 from datahub.search.event.apps import EventSearchApp
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 
 pytestmark = pytest.mark.django_db
 
@@ -13,7 +14,7 @@ def test_new_event_synced(es_with_signals):
 
     assert es_with_signals.get(
         index=EventSearchApp.es_model.get_write_index(),
-        doc_type=EventSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=event.pk,
     )
 
@@ -28,7 +29,7 @@ def test_updated_event_synced(es_with_signals):
 
     result = es_with_signals.get(
         index=EventSearchApp.es_model.get_write_index(),
-        doc_type=EventSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=event.pk,
     )
     assert result['_source']['name'] == new_name

--- a/datahub/search/export_country_history/test/test_signals.py
+++ b/datahub/search/export_country_history/test/test_signals.py
@@ -3,6 +3,7 @@ import pytest
 from datahub.company.models import CompanyExportCountryHistory
 from datahub.company.test.factories import CompanyExportCountryHistoryFactory
 from datahub.search.export_country_history.apps import ExportCountryHistoryApp
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 
 pytestmark = pytest.mark.django_db
 
@@ -14,7 +15,7 @@ def test_new_export_country_history_synced(es_with_signals):
 
     assert es_with_signals.get(
         index=ExportCountryHistoryApp.es_model.get_write_index(),
-        doc_type=ExportCountryHistoryApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=company_export_country_history.pk,
     )
 
@@ -31,7 +32,7 @@ def test_updated_interaction_synced(es_with_signals):
 
     result = es_with_signals.get(
         index=ExportCountryHistoryApp.es_model.get_write_index(),
-        doc_type=ExportCountryHistoryApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=export_country_history.pk,
     )
 

--- a/datahub/search/interaction/test/test_signals.py
+++ b/datahub/search/interaction/test/test_signals.py
@@ -7,6 +7,7 @@ from datahub.interaction.test.factories import (
     InvestmentProjectInteractionFactory,
 )
 from datahub.search.interaction.apps import InteractionSearchApp
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 
 pytestmark = pytest.mark.django_db
 
@@ -18,7 +19,7 @@ def test_new_interaction_synced(es_with_signals):
 
     assert es_with_signals.get(
         index=InteractionSearchApp.es_model.get_write_index(),
-        doc_type=InteractionSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=interaction.pk,
     )
 
@@ -33,7 +34,7 @@ def test_updated_interaction_synced(es_with_signals):
 
     result = es_with_signals.get(
         index=InteractionSearchApp.es_model.get_write_index(),
-        doc_type=InteractionSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=interaction.pk,
     )
     assert result['_source']['subject'] == new_subject
@@ -49,7 +50,7 @@ def test_deleted_interaction_deleted_from_es(es_with_signals):
 
     assert es_with_signals.get(
         index=InteractionSearchApp.es_model.get_write_index(),
-        doc_type=InteractionSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=interaction.pk,
     )
 
@@ -60,7 +61,7 @@ def test_deleted_interaction_deleted_from_es(es_with_signals):
     with pytest.raises(NotFoundError):
         assert es_with_signals.get(
             index=InteractionSearchApp.es_model.get_write_index(),
-            doc_type=InteractionSearchApp.name,
+            doc_type=DEFAULT_MAPPING_TYPE,
             id=interaction_id,
         ) is None
 
@@ -72,7 +73,7 @@ def test_interaction_synced_when_dit_participant_added(es_with_signals):
 
     doc = es_with_signals.get(
         index=InteractionSearchApp.es_model.get_read_alias(),
-        doc_type=InteractionSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=interaction.pk,
     )
     assert doc['_source']['dit_participants'] == []
@@ -82,7 +83,7 @@ def test_interaction_synced_when_dit_participant_added(es_with_signals):
 
     updated_doc = es_with_signals.get(
         index=InteractionSearchApp.es_model.get_read_alias(),
-        doc_type=InteractionSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=interaction.pk,
     )
     actual_dit_participants = updated_doc['_source']['dit_participants']
@@ -101,7 +102,7 @@ def test_updating_company_name_updates_interaction(es_with_signals):
 
     result = es_with_signals.get(
         index=InteractionSearchApp.es_model.get_write_index(),
-        doc_type=InteractionSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=interaction.pk,
     )
     assert result['_source']['company']['name'] == new_company_name
@@ -120,7 +121,7 @@ def test_updating_contact_name_updates_interaction(es_with_signals):
 
     result = es_with_signals.get(
         index=InteractionSearchApp.es_model.get_write_index(),
-        doc_type=InteractionSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=interaction.pk,
     )
     assert result['_source']['contacts'][0] == {
@@ -144,7 +145,7 @@ def test_updating_project_name_updates_interaction(es_with_signals):
 
     result = es_with_signals.get(
         index=InteractionSearchApp.es_model.get_write_index(),
-        doc_type=InteractionSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=interaction.pk,
     )
     assert result['_source']['investment_project']['name'] == new_project_name

--- a/datahub/search/large_investor_profile/apps.py
+++ b/datahub/search/large_investor_profile/apps.py
@@ -3,16 +3,13 @@ from datahub.investment.investor_profile.models import (
 )
 from datahub.investment.investor_profile.permissions import InvestorProfilePermission
 from datahub.search.apps import SearchApp
-from datahub.search.large_investor_profile.models import (
-    DOC_TYPE as LARGE_INVESTOR_PROFILE_DOC_TYPE,
-    LargeInvestorProfile,
-)
+from datahub.search.large_investor_profile.models import LargeInvestorProfile
 
 
 class LargeInvestorProfileSearchApp(SearchApp):
     """SearchApp for large investor profile."""
 
-    name = LARGE_INVESTOR_PROFILE_DOC_TYPE
+    name = 'large-investor-profile'
     es_model = LargeInvestorProfile
     view_permissions = (f'investor_profile.{InvestorProfilePermission.view_investor_profile}',)
     export_permission = f'investor_profile.{InvestorProfilePermission.export}'

--- a/datahub/search/large_investor_profile/test/test_elasticsearch.py
+++ b/datahub/search/large_investor_profile/test/test_elasticsearch.py
@@ -9,7 +9,7 @@ from datahub.search.large_investor_profile import LargeInvestorProfileSearchApp
 from datahub.search.large_investor_profile.models import (
     LargeInvestorProfile as ESLargeInvestorProfile,
 )
-
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 
 pytestmark = pytest.mark.django_db
 
@@ -320,7 +320,7 @@ def test_indexed_doc(es):
 
     indexed_large_investor_profile = es.get(
         index=ESLargeInvestorProfile.get_write_index(),
-        doc_type=LargeInvestorProfileSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=large_investor_profile.pk,
     )
 

--- a/datahub/search/large_investor_profile/test/test_signals.py
+++ b/datahub/search/large_investor_profile/test/test_signals.py
@@ -6,6 +6,7 @@ from elasticsearch.exceptions import NotFoundError
 from datahub.company.test.factories import CompanyFactory
 from datahub.investment.investor_profile.test.factories import LargeCapitalInvestorProfileFactory
 from datahub.search.large_investor_profile.apps import LargeInvestorProfileSearchApp
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 
 pytestmark = pytest.mark.django_db
 
@@ -13,7 +14,7 @@ pytestmark = pytest.mark.django_db
 def _get_es_document(setup_es, pk):
     return setup_es.get(
         index=LargeInvestorProfileSearchApp.es_model.get_read_alias(),
-        doc_type=LargeInvestorProfileSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=pk,
     )
 

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -17,6 +17,9 @@ from datahub.search.utils import get_model_non_mapped_field_names, serialise_map
 
 logger = getLogger(__name__)
 
+# TODO: Remove this and all usages once we have upgraded to Elasticsearch 7
+DEFAULT_MAPPING_TYPE = '_doc'
+
 
 class BaseESModel(Document):
     """Helps convert Django models to dictionaries."""
@@ -146,7 +149,7 @@ class BaseESModel(Document):
         aren't required (e.g. when using `datahub.search.deletion.delete_documents()`).
         """
         doc = {
-            '_type': cls._doc_type.name,
+            '_type': DEFAULT_MAPPING_TYPE,
             '_id': db_object.pk,
         }
 

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -9,6 +9,7 @@ from datahub.omis.order.test.factories import (
     OrderWithAcceptedQuoteFactory,
 )
 from datahub.search import elasticsearch
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.omis import OrderSearchApp
 from datahub.search.omis.models import Order as ESOrder
 
@@ -507,7 +508,7 @@ def test_indexed_doc(order_factory, es):
 
     indexed_order = es.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
 

--- a/datahub/search/omis/test/test_signals.py
+++ b/datahub/search/omis/test/test_signals.py
@@ -6,6 +6,7 @@ from datahub.omis.order.test.factories import (
     OrderSubscriberFactory,
     OrderWithOpenQuoteFactory,
 )
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.omis import OrderSearchApp
 
 pytestmark = pytest.mark.django_db
@@ -18,7 +19,7 @@ def test_creating_order_syncs_to_es(es_with_signals):
 
     assert es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
 
@@ -33,7 +34,7 @@ def test_updating_order_updates_es(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
     assert result['_source']['description'] == new_description
@@ -49,7 +50,7 @@ def test_accepting_quote_updates_es(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
     assert not result['_source']['payment_due_date']
@@ -59,7 +60,7 @@ def test_accepting_quote_updates_es(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
     assert result['_source']['payment_due_date'] == order.invoice.payment_due_date.isoformat()
@@ -76,7 +77,7 @@ def test_adding_subscribers_syncs_order_to_es(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
 
@@ -98,7 +99,7 @@ def test_removing_subscribers_syncs_order_to_es(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
 
@@ -119,7 +120,7 @@ def test_adding_assignees_syncs_order_to_es(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
 
@@ -141,7 +142,7 @@ def test_removing_assignees_syncs_order_to_es(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
 
@@ -161,7 +162,7 @@ def test_updating_company_name_updates_orders(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
     assert result['_source']['company']['name'] == new_company_name
@@ -181,7 +182,7 @@ def test_updating_contact_name_updates_orders(es_with_signals):
 
     result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
-        doc_type=OrderSearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=order.pk,
     )
     assert result['_source']['contact'] == {

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -7,6 +7,7 @@ from datahub.company.test.factories import CompanyFactory
 from datahub.core.test_utils import MockQuerySet
 from datahub.search.bulk_sync import sync_app, sync_objects
 from datahub.search.company import CompanySearchApp
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.signals import disable_search_signal_receivers
 from datahub.search.test.utils import create_mock_search_app
 
@@ -89,7 +90,7 @@ def test_sync_app_uses_latest_data(monkeypatch, es):
     company = mock_sync_objects.call_args_list[1][0][1][0]
     fetched_company = es.get(
         index=CompanySearchApp.es_model.get_read_alias(),
-        doc_type=CompanySearchApp.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=company.pk,
     )
     assert fetched_company['_source']['name'] == 'new name'

--- a/datahub/search/test/test_deletion.py
+++ b/datahub/search/test/test_deletion.py
@@ -12,6 +12,7 @@ from datahub.search.deletion import (
     delete_documents,
     update_es_after_deletions,
 )
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.sync_object import sync_object
 from datahub.search.test.search_support.models import SimpleModel
 from datahub.search.test.search_support.simplemodel import SimpleModelSearchApp
@@ -25,9 +26,9 @@ def test_delete_documents(es_bulk, mock_es_client):
 
     index = 'test-index'
     es_docs = [
-        {'_type': 'model', '_id': 1},
-        {'_type': 'model', '_id': 2},
-        {'_type': 'model', '_id': 3},
+        {'_type': DEFAULT_MAPPING_TYPE, '_id': 1},
+        {'_type': DEFAULT_MAPPING_TYPE, '_id': 2},
+        {'_type': DEFAULT_MAPPING_TYPE, '_id': 3},
     ]
     delete_documents(index, es_docs)
 
@@ -60,7 +61,7 @@ def test_delete_documents_with_errors(es_bulk, mock_es_client):
     )
 
     index = 'test-index'
-    es_docs = [{'_type': 'model', '_id': 1}]
+    es_docs = [{'_type': DEFAULT_MAPPING_TYPE, '_id': 1}]
 
     with pytest.raises(DataHubException) as excinfo:
         delete_documents(index, es_docs)
@@ -126,12 +127,12 @@ def test_collector(monkeypatch, es_with_signals):
     read_alias = ESSimpleModel.get_read_alias()
 
     assert SimpleModel.objects.count() == 0
-    assert es_with_signals.count(read_alias, doc_type=SimpleModelSearchApp.name)['count'] == 1
+    assert es_with_signals.count(read_alias)['count'] == 1
 
     collector.delete_from_es()
 
     es_with_signals.indices.refresh()
-    assert es_with_signals.count(read_alias, doc_type=SimpleModelSearchApp.name)['count'] == 0
+    assert es_with_signals.count(read_alias)['count'] == 0
 
 
 @pytest.mark.django_db
@@ -149,10 +150,10 @@ def test_update_es_after_deletions(es_with_signals):
     read_alias = ESSimpleModel.get_read_alias()
 
     assert SimpleModel.objects.count() == 1
-    assert es_with_signals.count(read_alias, doc_type=SimpleModelSearchApp.name)['count'] == 1
+    assert es_with_signals.count(read_alias)['count'] == 1
 
     with update_es_after_deletions():
         obj.delete()
 
     es_with_signals.indices.refresh()
-    assert es_with_signals.count(read_alias, doc_type=SimpleModelSearchApp.name)['count'] == 0
+    assert es_with_signals.count(read_alias)['count'] == 0

--- a/datahub/search/test/test_models.py
+++ b/datahub/search/test/test_models.py
@@ -3,6 +3,7 @@ import inspect
 import pytest
 from django.utils.functional import cached_property
 
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.test.search_support.models import SimpleModel
 from datahub.search.test.search_support.simplemodel.models import ESSimpleModel
 from datahub.search.utils import get_model_field_names
@@ -30,7 +31,7 @@ class TestBaseESModel:
 
         expected_doc = {
             '_id': obj.pk,
-            '_type': 'simplemodel',
+            '_type': DEFAULT_MAPPING_TYPE,
             **({'_index': ESSimpleModel.get_write_alias()} if include_index else {}),
             **({'_source': source} if include_source else {}),
         }

--- a/datahub/search/test/utils.py
+++ b/datahub/search/test/utils.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+from datahub.search.models import DEFAULT_MAPPING_TYPE
+
 
 def create_mock_search_app(
         current_mapping_hash='mapping-hash',
@@ -29,17 +31,14 @@ def doc_exists(es_client, search_app, id_):
     """Checks if a document exists for a specified search app."""
     return es_client.exists(
         index=search_app.es_model.get_read_alias(),
-        doc_type=search_app.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         id=id_,
     )
 
 
 def doc_count(es_client, search_app):
     """Return a document count for a specified search app."""
-    response = es_client.count(
-        index=search_app.es_model.get_read_alias(),
-        doc_type=search_app.name,
-    )
+    response = es_client.count(index=search_app.es_model.get_read_alias())
     return response['count']
 
 
@@ -78,7 +77,7 @@ def get_documents_by_ids(es_client, app, ids):
     """Get given search app documents by supplied ids."""
     return es_client.mget(
         index=app.es_model.get_read_alias(),
-        doc_type=app.name,
+        doc_type=DEFAULT_MAPPING_TYPE,
         body={
             'ids': ids,
         },


### PR DESCRIPTION
### Description of change

This follows on from #2745 and changes Elasticsearch document indexing and deletion to use the `_doc` alias for the mapping type in place of the real mapping type name.

`_doc` became an alias in Elasticsearch 6.7: https://github.com/elastic/elasticsearch/pull/39505

This will allow us to seamlessly change mapping type names from their current values to `_doc` without incurring downtime.

(I also took the opportunity to update various similar operations in tests.)

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
