### PR TITLE
Use SSO email user ID for user lookup

### DIFF
--- a/changelog/adviser/admin-sso-use-email-user-id.feature.md
+++ b/changelog/adviser/admin-sso-use-email-user-id.feature.md
@@ -1,0 +1,1 @@
+The (currently inactive) Staff SSO integration for Django was updated to use the SSO email user id to lookup users. This replaces lookup by primary email, which could change over time.

--- a/datahub/oauth/admin/test/test_utils.py
+++ b/datahub/oauth/admin/test/test_utils.py
@@ -93,7 +93,7 @@ def test_get_sso_user_profile(requests_mock):
     requests_mock.get(
         settings.ADMIN_OAUTH2_USER_PROFILE_PATH,
         status_code=status.HTTP_200_OK,
-        json={'email': 'what@email'},
+        json={'email': 'what@email', 'email_user_id': 'what-123@email'},
     )
 
     sso_user_profile = get_sso_user_profile('1234')
@@ -101,7 +101,7 @@ def test_get_sso_user_profile(requests_mock):
     assert requests_mock.call_count == 1
     assert requests_mock.request_history[-1].url == settings.ADMIN_OAUTH2_USER_PROFILE_PATH
 
-    assert sso_user_profile == {'email': 'what@email'}
+    assert sso_user_profile == {'email': 'what@email', 'email_user_id': 'what-123@email'}
 
 
 def test_get_sso_user_profile_error(requests_mock):
@@ -122,14 +122,14 @@ def test_get_adviser_by_sso_user_profile_no_staff_email_id():
     AdviserFactory(is_staff=True, is_active=True)
 
     with pytest.raises(AuthenticationFailed) as excinfo:
-        get_adviser_by_sso_user_profile({'sso_email_user_id': 'some-123@email'})
+        get_adviser_by_sso_user_profile({'email_user_id': 'some-123@email'})
     assert excinfo.value.detail == 'User not found.'
 
 
 def test_get_adviser_by_sso_user_profile_email_id():
-    """Test that adviser is returned if staff SSO user email id matches."""
+    """Test that adviser is returned if staff SSO email user id matches."""
     adviser = AdviserFactory(sso_email_user_id='some-123@email', is_staff=True, is_active=True)
-    sso_adviser = get_adviser_by_sso_user_profile({'sso_email_user_id': 'some-123@email'})
+    sso_adviser = get_adviser_by_sso_user_profile({'email_user_id': 'some-123@email'})
 
     assert sso_adviser.pk == adviser.pk
     assert sso_adviser.sso_email_user_id == 'some-123@email'
@@ -145,11 +145,11 @@ def test_get_adviser_by_sso_user_profile_email_id():
 )
 def test_get_adviser_by_sso_email_id_non_staff_or_active(flags):
     """
-    Test that AuthenticationFailed is raised if SSO email id matches and user has neither
+    Test that AuthenticationFailed is raised if SSO email user id matches and user has neither
     is_staff nor is_active flags set.
     """
     AdviserFactory(sso_email_user_id='some-123@email', **flags)
     with pytest.raises(AuthenticationFailed) as excinfo:
-        get_adviser_by_sso_user_profile({'sso_email_user_id': 'some-123@email'})
+        get_adviser_by_sso_user_profile({'email_user_id': 'some-123@email'})
 
     assert excinfo.value.detail == 'User not found.'

--- a/datahub/oauth/admin/test/test_utils.py
+++ b/datahub/oauth/admin/test/test_utils.py
@@ -117,22 +117,22 @@ def test_get_sso_user_profile_error(requests_mock):
     assert excinfo.value.detail == 'Cannot get user profile.'
 
 
-def test_get_adviser_by_sso_user_profile_no_staff_email():
-    """Test that AuthenticationFailed is raised if staff SSO email doesn't match."""
+def test_get_adviser_by_sso_user_profile_no_staff_email_id():
+    """Test that AuthenticationFailed is raised if staff SSO email user id doesn't match."""
     AdviserFactory(is_staff=True, is_active=True)
 
     with pytest.raises(AuthenticationFailed) as excinfo:
-        get_adviser_by_sso_user_profile({'email': 'some@email'})
+        get_adviser_by_sso_user_profile({'sso_email_user_id': 'some-123@email'})
     assert excinfo.value.detail == 'User not found.'
 
 
-def test_get_adviser_by_sso_user_profile_email():
-    """Test that adviser is returned if staff SSO user email matches."""
-    adviser = AdviserFactory(email='some@email', is_staff=True, is_active=True)
-    sso_adviser = get_adviser_by_sso_user_profile({'email': 'some@email'})
+def test_get_adviser_by_sso_user_profile_email_id():
+    """Test that adviser is returned if staff SSO user email id matches."""
+    adviser = AdviserFactory(sso_email_user_id='some-123@email', is_staff=True, is_active=True)
+    sso_adviser = get_adviser_by_sso_user_profile({'sso_email_user_id': 'some-123@email'})
 
     assert sso_adviser.pk == adviser.pk
-    assert sso_adviser.email == 'some@email'
+    assert sso_adviser.sso_email_user_id == 'some-123@email'
 
 
 @pytest.mark.parametrize(
@@ -143,13 +143,13 @@ def test_get_adviser_by_sso_user_profile_email():
         {'is_staff': False, 'is_active': False},
     ),
 )
-def test_get_adviser_by_sso_email_non_staff_or_active(flags):
+def test_get_adviser_by_sso_email_id_non_staff_or_active(flags):
     """
-    Test that AuthenticationFailed is raised if SSO email matches and user has neither
+    Test that AuthenticationFailed is raised if SSO email id matches and user has neither
     is_staff nor is_active flags set.
     """
-    AdviserFactory(email='some@email', **flags)
+    AdviserFactory(sso_email_user_id='some-123@email', **flags)
     with pytest.raises(AuthenticationFailed) as excinfo:
-        get_adviser_by_sso_user_profile({'email': 'some@email'})
+        get_adviser_by_sso_user_profile({'sso_email_user_id': 'some-123@email'})
 
     assert excinfo.value.detail == 'User not found.'

--- a/datahub/oauth/admin/test/test_views.py
+++ b/datahub/oauth/admin/test/test_views.py
@@ -150,7 +150,7 @@ def test_callback_without_access_code():
 def test_callback_requests_sso_profile_no_user(get_sso_user_profile, get_access_token):
     """Test that if SSO user is not found then no access is granted."""
     get_access_token.return_value = {'access_token': 'access-token', 'expires_in': 3600}
-    get_sso_user_profile.return_value = {'email': 'some@email'}
+    get_sso_user_profile.return_value = {'sso_email_user_id': 'some-123@email'}
 
     fake_state_id = token_urlsafe(settings.ADMIN_OAUTH2_TOKEN_BYTE_LENGTH)
 
@@ -189,7 +189,7 @@ def test_callback_requests_sso_profile_valid_non_staff_user_by_email(
     AdviserFactory(email='some@email', **flags)
 
     get_access_token.return_value = {'access_token': 'access-token'}
-    get_sso_user_profile.return_value = {'email': 'some@email'}
+    get_sso_user_profile.return_value = {'sso_email_user_id': 'some-123@email'}
 
     request = get_request_with_session('/oauth/callback/?state=original&code=code')
     request.session['oauth.state'] = 'original'
@@ -211,10 +211,10 @@ def test_callback_requests_sso_profile_valid_email(get_sso_user_profile, get_acc
     Test that if SSO user has a matching email (and relevant flags), then the access is granted.
     """
     fake_state_id = token_urlsafe(settings.ADMIN_OAUTH2_TOKEN_BYTE_LENGTH)
-    adviser = AdviserFactory(email='some@email', is_staff=True, is_active=True)
+    adviser = AdviserFactory(sso_email_user_id='some-123@email', is_staff=True, is_active=True)
 
     get_access_token.return_value = {'access_token': 'access-token', 'expires_in': 3600}
-    get_sso_user_profile.return_value = {'email': 'some@email'}
+    get_sso_user_profile.return_value = {'sso_email_user_id': 'some-123@email'}
 
     request = get_request_with_session(f'/oauth/callback/?state={fake_state_id}&code=code')
 
@@ -233,10 +233,10 @@ def test_callback_requests_sso_profile_valid_email(get_sso_user_profile, get_acc
 def test_callback_redirects_to_next_url(get_sso_user_profile, get_access_token):
     """Test that successful login redirects user to `next_url`."""
     fake_state_id = token_urlsafe(settings.ADMIN_OAUTH2_TOKEN_BYTE_LENGTH)
-    AdviserFactory(email='some@email', is_staff=True, is_active=True)
+    AdviserFactory(sso_email_user_id='some-123@email', is_staff=True, is_active=True)
 
     get_access_token.return_value = {'access_token': 'access-token', 'expires_in': 3600}
-    get_sso_user_profile.return_value = {'email': 'some@email'}
+    get_sso_user_profile.return_value = {'sso_email_user_id': 'some-123@email'}
 
     request = get_request_with_session(
         f'/oauth/callback/?next=/some-location&state={fake_state_id}&code=code',
@@ -262,10 +262,10 @@ def test_callback_redirects_to_next_url(get_sso_user_profile, get_access_token):
 def test_callback_validates_next_url(get_sso_user_profile, get_access_token, dangerous_redirect):
     """Test that successful login redirects user to `next_url`."""
     fake_state_id = token_urlsafe(settings.ADMIN_OAUTH2_TOKEN_BYTE_LENGTH)
-    AdviserFactory(email='some@email', is_staff=True, is_active=True)
+    AdviserFactory(sso_email_user_id='some-123@email', is_staff=True, is_active=True)
 
     get_access_token.return_value = {'access_token': 'access-token', 'expires_in': 3600}
-    get_sso_user_profile.return_value = {'email': 'some@email'}
+    get_sso_user_profile.return_value = {'sso_email_user_id': 'some-123@email'}
 
     request = get_request_with_session(
         f'/oauth/callback/?next={dangerous_redirect}&state={fake_state_id}&code=code',

--- a/datahub/oauth/admin/utils.py
+++ b/datahub/oauth/admin/utils.py
@@ -53,7 +53,7 @@ def get_adviser_by_sso_user_profile(sso_user_profile):
     """Get adviser by sso user profile details."""
     try:
         user = Advisor.objects.get(
-            sso_email_user_id=sso_user_profile['sso_email_user_id'],
+            sso_email_user_id=sso_user_profile['email_user_id'],
             is_staff=True,
             is_active=True,
         )

--- a/datahub/oauth/admin/utils.py
+++ b/datahub/oauth/admin/utils.py
@@ -52,7 +52,11 @@ def get_sso_user_profile(access_token):
 def get_adviser_by_sso_user_profile(sso_user_profile):
     """Get adviser by sso user profile details."""
     try:
-        user = Advisor.objects.get(email=sso_user_profile['email'], is_staff=True, is_active=True)
+        user = Advisor.objects.get(
+            sso_email_user_id=sso_user_profile['sso_email_user_id'],
+            is_staff=True,
+            is_active=True,
+        )
     except Advisor.DoesNotExist:
         raise AuthenticationFailed('User not found.')
 


### PR DESCRIPTION
### Description of change

This changes how users are looked up in Data Hub using the (currently inactive) Staff SSO integration. 
Instead of using the user's primary email address, which may not be permanent, this uses the SSO email user ID to find a specific adviser.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
