### PR TITLE
Add GitHub Actions workflow for publishing releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,38 @@
+# This workflow publishes a release on GitHub when
+# a release PR is merged to master.
+#
+# The published release will appear on
+# https://github.com/uktrade/data-hub-api/releases
+
+name: Publish release
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  publish_release:
+    if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.label, 'uktrade:release/')
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --progress-bar off -r scripts/requirements.txt -c requirements.txt
+
+      - name: Run publish release script
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/publish_release.py

--- a/docs/How to prepare a release.md
+++ b/docs/How to prepare a release.md
@@ -64,44 +64,26 @@ Double-check that the details are correct and that the base branch is set to `ma
 
 Add at least two developers as reviewers and click 'Create pull request'.
 
+After the PR has been reviewed, merge it into `master` and delete the merged branch.
+
 ## Deploy to staging
 
-After the PR has been reviewed, merge it into `master` and delete the merged branch.
-The release will be automatically deployed to staging via Jenkins.
+Following the merge of the release PR, the release will be automatically 
+deployed to staging via Jenkins.
+
 Check that everything looks fine before proceeding.
 
 ## Tag and publish the release on GitHub
 
-Following the automatic staging deployment, the next step is create a release on GitHub. To do this, you will need to [generate a GitHub personal access 
-token](https://github.com/settings/tokens) with the `public_repo` scope.
+The merging of the release PR will also trigger a GitHub Actions workflow
+that will automatically publish the release on GitHub.
 
-Once you have this, you can either set it in the `GITHUB_TOKEN` environment variable, or enter it when prompted.
+You can [check the status of the job on the Actions tab on GitHub](https://github.com/uktrade/data-hub-api/actions).
 
-When you have a token, run:
+Once the job is complete, the release should appear [on the releases tab](https://github.com/uktrade/data-hub-api/releases).
 
-```shell
-scripts/publish_release.py
-```
-
-This will tag, create and publish the release on GitHub and open it in your web browser. 
-
-<details>
-<summary>If you are unable to use the script</summary>
-
-If you can‘t use the script for some reason, you can still manually create and publish the release.
-
-In GitHub, [create a release](https://github.com/uktrade/data-hub-api/releases/new) with the following values:
-
-* **Tag version**: `v<version>` e.g. `v6.3.0`
-* **Target**: `master`
-* **Release title**: `v<version>` e.g. `v6.3.0`
-* **Describe this release**: copy/paste the notes from the compiled changelog.
-
-And click on _Publish release_.
-
-For more information see the [GitHub documentation](https://help.github.com/articles/creating-releases/).
-
-</details>
+(If something goes wrong, it’s also possible to run `scripts/publish_release.py` locally.
+To do that you, you’ll need to [generate a GitHub personal access token](https://github.com/settings/tokens) with the `public_repo` scope.)
 
 ## Deploy to production
 Deployment to production happens manually but after the release has been announced on Slack.

--- a/scripts/publish_release.py
+++ b/scripts/publish_release.py
@@ -7,7 +7,7 @@ This is a script that:
 - gets the version number from origin/master
 - extracts the changelog for that version from CHANGELOG.md
 - creates a release on GitHub for that version
-- opens your web browser to the created release
+- prints the URL for the created release
 
 The script will abort if:
 
@@ -22,7 +22,7 @@ A GitHub access token with the public_repo scope is required.
 import argparse
 import os
 import subprocess
-import webbrowser
+import sys
 from getpass import getpass
 
 import requests
@@ -85,9 +85,7 @@ def publish_release():
     response.raise_for_status()
     response_data = response.json()
 
-    webbrowser.open(response_data['html_url'])
-
-    return tag
+    return tag, response_data['html_url']
 
 
 def main():
@@ -95,15 +93,17 @@ def main():
     parser.parse_args()
 
     try:
-        tag = publish_release()
+        tag, url = publish_release()
     except (CommandError, HTTPError, subprocess.CalledProcessError) as exc:
         print_error(exc)
-        return
+        sys.exit(1)
 
-    print(  # noqa: T001
-        f'Release {tag} was published and opened in your web browser. If anything is wrong, edit '
-        f'the release on GitHub.',
-    )
+    msg = f"""Release {tag} was published at:
+{url}.
+
+If anything is wrong, edit the release on GitHub.
+"""
+    print(msg)  # noqa: T001
 
 
 if __name__ == '__main__':

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,15 @@
+# The minimal subset of requirements needed for scripts
+# in this directory.
+#
+# All these requirements should also be specified in
+# /requirements.in.
+#
+# Note: This file is intended to be used by GitHub Actions
+# with the main requirements file used as a constraints file.
+# E.g.:
+#
+# pip install -r scripts/requirements.txt -c requirements.txt
+
+requests
+semantic_version
+towncrier


### PR DESCRIPTION
### Description of change

This adds a GitHub Actions workflow that automatically publishes a release on GitHub following the merge of a release PR.

The workflow is triggered by the merging of a PR where the base branch is `master` and the head branch starts with `release/`.

The workflow runs the existing `scripts/publish_release.py` script. This script now outputs the URL of the newly published release, instead of opening a web browser window, to better accommodate GitHub Actions. It also now correctly sets the exit code on failure.

The workflow also only installs the few  dependencies required by the script instead of the full set of project dependencies. This was done by using the main `requirements.txt` as a constraints file.

Note: The workflow was tested in the `data-hub-api-actions-test` repo.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
