### PR TITLE
Deprecate company export fields

### DIFF
--- a/changelog/company/company-export-to-countries-deprecation.db.md
+++ b/changelog/company/company-export-to-countries-deprecation.db.md
@@ -1,0 +1,3 @@
+The table `company_company_export_to_countries` is deprecated and will be removed on or after 23 April.
+
+It is replaced by the `currently_exporting` status in the `company_companyexportcountry` table.

--- a/changelog/company/company-export-to-countries-deprication.api.md
+++ b/changelog/company/company-export-to-countries-deprication.api.md
@@ -1,0 +1,4 @@
+`GET /v4/company`, `GET, PATCH /v4/company/{id}`, `POST /v3/search/company` and `POST /v4/search/company`:
+the field `export_to_countries` is deprecated and will be removed on or after 23 April.
+
+It is replaced by the `export_countries` field.

--- a/changelog/company/company-export-to-countries.deprecation.md
+++ b/changelog/company/company-export-to-countries.deprecation.md
@@ -1,0 +1,3 @@
+The field `export_to_countries` is deprecated and will be removed on or after 23 April. Please check the API and Database schema categories for more details.
+
+It is replaced by the `export_countries` field.

--- a/changelog/company/company-future-interest-countries-deprecation.api.md
+++ b/changelog/company/company-future-interest-countries-deprecation.api.md
@@ -1,0 +1,4 @@
+`GET /v4/company`, `GET, PATCH /v4/company/{id}`, `POST /v3/search/company` and `POST /v4/search/company`:
+the field `future_interest_countries` is deprecated and will be removed on or after 23 April.
+
+It is replaced by the `export_countries` field.

--- a/changelog/company/company-future-interest-countries-deprecation.db.md
+++ b/changelog/company/company-future-interest-countries-deprecation.db.md
@@ -1,0 +1,3 @@
+The table `company_company_future_interest_countries` is deprecated and will be removed on or after 23 April.
+
+It is replaced by the `future_interest` status in the `company_companyexportcountry` table.

--- a/changelog/company/company-future-interest-countries.deprecation.md
+++ b/changelog/company/company-future-interest-countries.deprecation.md
@@ -1,0 +1,3 @@
+The field `future_interest_countries` is deprecated and will be removed on or after 23 April. Please check the API and Database schema categories for more details.
+
+It is replaced by the `export_countries` field.


### PR DESCRIPTION
### Description of change

This announces the deprecation of the `export_to_countries` and `future_interest_countries` company fields. 

They are replaced by the `export_countries` field. 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
