### PR TITLE
Make sso_email_user_id editable

### DIFF
--- a/changelog/adviser/enable-sso-email-user-id-editing.feature.md
+++ b/changelog/adviser/enable-sso-email-user-id-editing.feature.md
@@ -1,0 +1,1 @@
+The `sso_email_user_id` used to be read-only in Django admin. It is now editable to support making the new email user ID-based introspection logic live.

--- a/datahub/company/admin/adviser.py
+++ b/datahub/company/admin/adviser.py
@@ -67,7 +67,6 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
             },
         ),
     )
-    readonly_fields = ('sso_email_user_id',)
     list_display = ('email', 'first_name', 'last_name', 'dit_team', 'is_active', 'is_staff')
     search_fields = (
         '=pk',


### PR DESCRIPTION
### Description of change

`sso_email_user_id` was previously read-only in Django admin. It has now been made editable to enable making the new email user ID-based introspection logic live.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
