### PR TITLE
Refactor caching logic of new introspection authentication class

### DIFF
--- a/changelog/refactor-introspection-caching.internal.md
+++ b/changelog/refactor-introspection-caching.internal.md
@@ -1,0 +1,1 @@
+The caching logic in the new Staff SSO introspection authentication class was refactored. This new authentication class continues to be disabled by default.

--- a/datahub/oauth/cache.py
+++ b/datahub/oauth/cache.py
@@ -1,0 +1,23 @@
+from django.core.cache import cache
+
+
+def add_token_data_to_cache(token, email, sso_email_user_id, timeout):
+    """Add data about an access token to the cache."""
+    cache_key = _cache_key(token)
+    data = {
+        'email': email,
+        'sso_email_user_id': sso_email_user_id,
+    }
+
+    cache.set(cache_key, data, timeout=timeout)
+    return data
+
+
+def get_token_data_from_cache(token):
+    """Retrieve data about an access token from the cache."""
+    cache_key = _cache_key(token)
+    return cache.get(cache_key)
+
+
+def _cache_key(token):
+    return f'access_token:{token}'

--- a/datahub/oauth/test/test_cache.py
+++ b/datahub/oauth/test/test_cache.py
@@ -1,0 +1,73 @@
+from datetime import timedelta
+
+import pytest
+from django.core.cache import cache
+from django.utils.timezone import now
+from freezegun import freeze_time
+
+from datahub.oauth.cache import add_token_data_to_cache, get_token_data_from_cache
+
+
+@pytest.mark.usefixtures('local_memory_cache')
+class TestAddTokenDataToCache:
+    """Tests for test_add_token_data_to_cache()."""
+
+    def test_returns_cached_data(self):
+        """The data as stored in the cached should be returned."""
+        token = 'test-token'
+        email = 'email@datahub.test'
+        sso_email_user_id = 'id@datahub.test'
+
+        frozen_time = now()
+        with freeze_time(frozen_time):
+            returned_data = add_token_data_to_cache(token, email, sso_email_user_id, 10)
+
+        assert returned_data == {
+            'email': email,
+            'sso_email_user_id': sso_email_user_id,
+        }
+
+    def test_adds_data_to_cache(self):
+        """The data should be added to the cache."""
+        token = 'test-token'
+        email = 'email@datahub.test'
+        sso_email_user_id = 'id@datahub.test'
+
+        expected_data = {
+            'email': email,
+            'sso_email_user_id': sso_email_user_id,
+        }
+
+        frozen_time = now()
+        with freeze_time(frozen_time):
+            add_token_data_to_cache(token, email, sso_email_user_id, 10)
+
+        cache_key = 'access_token:test-token'
+        assert cache.get(cache_key) == expected_data
+
+        # The data should expire after 10 seconds
+        with freeze_time(frozen_time + timedelta(seconds=10)):
+            assert cache.get(cache_key) is None
+
+
+@pytest.mark.usefixtures('local_memory_cache')
+class TestGetTokenDataFromCache:
+    """Tests for get_token_data_from_cache()."""
+
+    def test_retrieves_cached_data(self):
+        """Cached data should be returned when present."""
+        cache_key = 'access_token:test-token'
+        token = 'test-token'
+
+        data = {
+            'email': 'email@datahub.test',
+            'sso_email_user_id': 'id@datahub.test',
+        }
+        cache.set(cache_key, data)
+
+        assert get_token_data_from_cache(token) == data
+
+    def test_returns_none_when_not_cached(self):
+        """None should be returned when there is no cached data for the token."""
+        token = 'test-token'
+        assert get_token_data_from_cache(token) is None


### PR DESCRIPTION
### Description of change

This breaks out the caching logic of the new introspection authentication class into a separate module.

This is to allow tokens to be added to the cache for development purposes.

The data that is actually stored in the cache was also reduced to what is actually required to make inserting entries for development purposes easier.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
