### PR TITLE
Add automatic creation of access token in Docker start-up script

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ Dependencies:
     ```shell
     ./manage.py createsuperuser
     ```
+    
+    (You can enter any valid email address as the username and SSO email user ID.)
 
 14. Start the server:
 

--- a/changelog/adviser/create-super-user-sso-user-id.feature.md
+++ b/changelog/adviser/create-super-user-sso-user-id.feature.md
@@ -1,0 +1,1 @@
+The `createsuperuser` management command now prompts for an SSO email user ID. It can be left blank when not needed.

--- a/datahub/company/models/adviser.py
+++ b/datahub/company/models/adviser.py
@@ -99,7 +99,9 @@ class Advisor(AbstractBaseUser, PermissionsMixin):
     objects = AdviserManager()
 
     USERNAME_FIELD = 'email'
-    REQUIRED_FIELDS = []
+    # This allows the DJANGO_SUPERUSER_SSO_EMAIL_USER_ID environment variable to be used
+    # with the createsuperuser management command.
+    REQUIRED_FIELDS = ['sso_email_user_id']
 
     @cached_property
     def name(self):

--- a/sample.env
+++ b/sample.env
@@ -41,9 +41,18 @@ DATA_HUB_FRONTEND_SECRET_ACCESS_KEY=frontend-key
 COMPOSE_PROJECT_NAME=data-hub
 # Some extra ENV variables to make superuser creation easier on docker copies
 # If you're working with data-hub-frontend and mock-sso, DJANGO_SUPERUSER_EMAIL should
-# be the same as MOCK_SSO_USERNAME in the frontend's .env file
+# be the same as MOCK_SSO_USERNAME in mock-sso's .env file, and
+# DJANGO_SUPERUSER_SSO_EMAIL_USER_ID the same as MOCK_SSO_EMAIL_USER_ID
 #DJANGO_SUPERUSER_EMAIL=some.person@digital.trade.gov.uk
 #DJANGO_SUPERUSER_PASSWORD=foobarbaz
+#DJANGO_SUPERUSER_SSO_EMAIL_USER_ID=some.person@id.trade.local
+
+# If these lines are uncommented and SUPERUSER_ACCESS_TOKEN is given a value,
+# an access token for the superuser with that value will be created when the
+# container comes up. The superuser should have an SSO email user ID set
+# for this to work.
+#STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True
+#SUPERUSER_ACCESS_TOKEN=
 
 # OAuth2 settings for Django Admin access
 ADMIN_OAUTH2_ENABLED=False

--- a/start.sh
+++ b/start.sh
@@ -12,8 +12,12 @@ python /app/manage.py createinitialrevisions
 python /app/manage.py collectstatic --noinput
 # Create superuser - ignore errors as we may have already loaded it in to
 # this DB.
-if [[ -n "${DJANGO_SUPERUSER_EMAIL}" && -n "${DJANGO_SUPERUSER_PASSWORD}" ]]; then
+if [[ -n "${DJANGO_SUPERUSER_EMAIL}" && -n "${DJANGO_SUPERUSER_PASSWORD}" && -n "${DJANGO_SUPERUSER_SSO_EMAIL_USER_ID}" ]]; then
     python manage.py createsuperuser --noinput || true
+fi
+# Add an access token for the superuser
+if [[ -n "${DJANGO_SUPERUSER_SSO_EMAIL_USER_ID}" && -n "${SUPERUSER_ACCESS_TOKEN}" ]]; then
+    python manage.py add_access_token --skip-checks --token "${SUPERUSER_ACCESS_TOKEN}" --hours 999 "${DJANGO_SUPERUSER_SSO_EMAIL_USER_ID}"
 fi
 
 # Run runserver in a while loop as the whole docker container will otherwise die


### PR DESCRIPTION
### Description of change

This adds the ability to automatically create an access token when using Docker locally.

It also adds `sso_email_user_id` to the fields that `createsuperuser` prompts for.

Existing Docker users should add `DJANGO_SUPERUSER_SSO_EMAIL_USER_ID` to their `.env` file.

`setup-uat.sh` will also need an update – this will be done separately.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
