### PR TITLE
Add SSO email user id to adviser search

### DIFF
--- a/changelog/adviser/update-adviser-search-fields.feature.md
+++ b/changelog/adviser/update-adviser-search-fields.feature.md
@@ -1,0 +1,1 @@
+The adviser search fields in the Django admin are updated to include `sso_email_user_id`. 

--- a/datahub/company/admin/adviser.py
+++ b/datahub/company/admin/adviser.py
@@ -73,6 +73,7 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
         'first_name',
         'last_name',
         'email',
+        'sso_email_user_id',
         '=dit_team__pk',
         'dit_team__name',
     )


### PR DESCRIPTION
### Description of change
This adds `sso_email_user_id` to the potential search fields in the adviser search on Admin, as part of wider changes adding this field as a user identifier.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
