### PR TITLE
Revert "Bump pip-tools from 4.5.1 to 5.0.0"

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -57,7 +57,7 @@ freezegun==0.3.15
 requests-mock==1.7.0
 django-debug-toolbar==2.2
 werkzeug==1.0.1  # Required by runserver_plus - useful for local dev
-pip-tools==5.0.0
+pip-tools==4.5.1
 piprot==0.9.11
 semantic_version==2.8.4
 towncrier==19.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -82,7 +82,7 @@ pathtools==0.1.2          # via watchdog
 pep8-naming==0.10.0       # via -r requirements.in
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==5.0.0          # via -r requirements.in
+pip-tools==4.5.1          # via -r requirements.in
 piprot==0.9.11            # via -r requirements.in
 pluggy==0.13.1            # via pytest
 prompt-toolkit==3.0.4     # via ipython
@@ -132,5 +132,4 @@ whitenoise==5.0.1         # via -r requirements.in
 yarl==1.4.2               # via aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-# pip
 # setuptools


### PR DESCRIPTION
Reverts uktrade/data-hub-api#2785

Unfortunately we are installing pip-tools on deployment and the new version forces a pip update which breaks the Cloud Foundry Python buildpack. Hence, this reverts the update for now.