### PR TITLE
Remove feature flag for adviser admin

### DIFF
--- a/changelog/adviser/remove-add-adviser-from-sso-feature-flag.feature.md
+++ b/changelog/adviser/remove-add-adviser-from-sso-feature-flag.feature.md
@@ -1,0 +1,1 @@
+`Add adviser from SSO` is now visible in Django admin for Advisers, without needing a feature flag.

--- a/datahub/company/admin/adviser.py
+++ b/datahub/company/admin/adviser.py
@@ -4,9 +4,7 @@ from django.urls import path
 from reversion.admin import VersionAdmin
 
 from datahub.company.admin.adviser_forms import AddAdviserFromSSOForm
-from datahub.company.admin.constants import ADMIN_ADD_ADVISER_FROM_SSO_FEATURE_FLAG
 from datahub.company.models import Advisor
-from datahub.feature_flag.utils import is_feature_flag_active
 
 
 @admin.register(Advisor)
@@ -78,21 +76,6 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
         'dit_team__name',
     )
     ordering = ('email',)
-
-    def changelist_view(self, request, extra_context=None):
-        """
-        The changelist view.
-
-        Overridden to add the add adviser from SSO feature flag to the template context.
-
-        TODO: Remove this once the feature flag has been removed.
-        """
-        combined_extra_context = {
-            'show_add_from_sso':
-                is_feature_flag_active(ADMIN_ADD_ADVISER_FROM_SSO_FEATURE_FLAG),
-            **(extra_context or {}),
-        }
-        return super().changelist_view(request, combined_extra_context)
 
     def get_urls(self):
         """

--- a/datahub/company/admin/constants.py
+++ b/datahub/company/admin/constants.py
@@ -1,1 +1,0 @@
-ADMIN_ADD_ADVISER_FROM_SSO_FEATURE_FLAG = 'admin-add-adviser-from-sso'

--- a/datahub/company/templates/admin/company/advisor/change_list_object_tools.html
+++ b/datahub/company/templates/admin/company/advisor/change_list_object_tools.html
@@ -2,7 +2,7 @@
 {% load i18n admin_urls %}
 
 {% block object-tools-items %}
-  {% if has_add_permission and show_add_from_sso %}
+  {% if has_add_permission %}
     <li>
       {% url cl.opts|admin_urlname:'add-from-sso' as add_from_sso_url %}
       <a href="{% add_preserved_filters add_from_sso_url is_popup to_field %}" class="addlink">

--- a/datahub/company/test/admin/test_adviser.py
+++ b/datahub/company/test/admin/test_adviser.py
@@ -4,11 +4,9 @@ from django.urls import reverse
 from rest_framework import status
 
 from datahub.company.admin.adviser_forms import AddAdviserFromSSOForm, DUPLICATE_USER_MESSAGE
-from datahub.company.admin.constants import ADMIN_ADD_ADVISER_FROM_SSO_FEATURE_FLAG
 from datahub.company.models import Advisor
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import AdminTestMixin, create_test_user
-from datahub.feature_flag.test.factories import FeatureFlagFactory
 
 changelist_url = reverse('admin:company_advisor_changelist')
 add_from_sso_url = reverse('admin:company_advisor_add-from-sso')
@@ -32,26 +30,20 @@ class TestAdviserChangeListLinks(AdminTestMixin):
     """Tests for customisations for the adviser admin change list links."""
 
     @pytest.mark.parametrize(
-        'permission_codenames,enable_feature_flag,should_link_exist',
+        'permission_codenames,should_link_exist',
         (
-            (['view_advisor'], True, False),
-            (['view_advisor', 'add_advisor'], True, True),
-            (['view_advisor', 'add_advisor'], False, False),
+            (['view_advisor'], False),
+            (['view_advisor', 'add_advisor'], True),
         ),
     )
     def test_add_adviser_link_existence(
         self,
         permission_codenames,
-        enable_feature_flag,
         should_link_exist,
     ):
+        """Test that there is a link to add an adviser from SSO if the user has the correct
+        permissions.
         """
-        Test that there is a link to add an adviser from SSO if the user has the correct
-        permissions and the feature flag is enabled.
-        """
-        if enable_feature_flag:
-            FeatureFlagFactory(code=ADMIN_ADD_ADVISER_FROM_SSO_FEATURE_FLAG)
-
         user = create_test_user(
             permission_codenames=permission_codenames,
             password=self.PASSWORD,


### PR DESCRIPTION
### Description of change

Removes now unnecessary feature flag from Django admin for the advisers. This adds a button in the list advisers admin view (for users with 'add' rights) to allow adding users using their `sso_email_user_id`.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
