### PR TITLE
Fix URL for dnb-service investigation endpoint

### DIFF
--- a/changelog/company/dnb-investigation-fix.bugfix.md
+++ b/changelog/company/dnb-investigation-fix.bugfix.md
@@ -1,0 +1,1 @@
+The URL for the `dnb-service` create investigation endpoint was changed from `company-investigation/` to `investigation/`.

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -31,7 +31,7 @@ from datahub.metadata.models import Country
 
 DNB_SEARCH_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/search/')
 DNB_CHANGE_REQUEST_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'change-request/')
-DNB_INVESTIGATION_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'company-investigation/')
+DNB_INVESTIGATION_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'investigation/')
 
 REQUIRED_REGISTERED_ADDRESS_FIELDS = [
     f'registered_address_{field}' for field in AddressSerializer.REQUIRED_FIELDS

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -443,7 +443,7 @@ def _create_investigation(payload):
         raise ImproperlyConfigured('The setting DNB_SERVICE_BASE_URL has not been set')
     response = api_client.request(
         'POST',
-        'company-investigation/',
+        'investigation/',
         json=payload,
         timeout=3.0,
     )


### PR DESCRIPTION
### Description of change

This PR fixes the URL for creating investigations in `dnb-service`.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
