### PR TITLE
Fix investigation api endpoint

### DIFF
--- a/changelog/company/dnb-investigation-blank-values.api.md
+++ b/changelog/company/dnb-investigation-blank-values.api.md
@@ -1,0 +1,2 @@
+The `/v4/dnb/company-investigation` API endpoint was adjusted to allow blank
+values for address `line_2`, `county` and `postcode`.

--- a/changelog/company/dnb-investigation-fixes.bugfix.md
+++ b/changelog/company/dnb-investigation-fixes.bugfix.md
@@ -1,0 +1,1 @@
+The format for calls to the `dnb-service` create investigation endpoint was corrected.

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -248,10 +248,10 @@ class DNBAddressSerializer(serializers.Serializer):
     """
 
     line_1 = serializers.CharField(source='address_line_1')
-    line_2 = serializers.CharField(source='address_line_2', required=False)
+    line_2 = serializers.CharField(source='address_line_2', required=False, allow_blank=True)
     town = serializers.CharField(source='address_town')
-    county = serializers.CharField(source='address_county', required=False)
-    postcode = serializers.CharField(source='address_postcode', required=False)
+    county = serializers.CharField(source='address_county', required=False, allow_blank=True)
+    postcode = serializers.CharField(source='address_postcode', required=False, allow_blank=True)
     country = NestedRelatedField(model=CountryModel, source='address_country')
 
     def validate_country(self, country):

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1951,21 +1951,23 @@ class TestCompanyInvestigationView(APITestMixin):
         """
         company = CompanyFactory()
         dnb_formatted_company_details = {
-            'primary_name': 'Joe Bloggs LTD',
-            'domain': 'www.example.com',
-            'telephone_number': '123456789',
-            'address_line_1': '23 Code Street',
-            'address_line_2': 'Someplace',
-            'address_town': 'London',
-            'address_county': 'Greater London',
-            'address_postcode': 'W1 0TN',
-            'address_country': 'GB',
+            'company_details': {
+                'primary_name': 'Joe Bloggs LTD',
+                'domain': 'www.example.com',
+                'telephone_number': '123456789',
+                'address_line_1': '23 Code Street',
+                'address_line_2': 'Someplace',
+                'address_town': 'London',
+                'address_county': 'Greater London',
+                'address_postcode': 'W1 0TN',
+                'address_country': 'GB',
+            },
         }
         dnb_response = {
             'id': '11111111-2222-3333-4444-555555555555',
             'status': 'pending',
             'created_on': '2020-01-05T11:00:00',
-            'company_details': dnb_formatted_company_details,
+            **dnb_formatted_company_details,
         }
 
         requests_mock.post(

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -371,8 +371,8 @@ class DNBCompanyInvestigationView(APIView):
         investigation_serializer = DNBCompanyInvestigationSerializer(data=request.data)
         investigation_serializer.is_valid(raise_exception=True)
 
-        data = investigation_serializer.validated_data
-        company = data.pop('company')
+        data = {'company_details': investigation_serializer.validated_data}
+        company = data['company_details'].pop('company')
 
         try:
             response = create_investigation(data)


### PR DESCRIPTION
### Description of change

This PR does two things to fix the company investigation API endpoint:
- The format for calls to the `dnb-service` create investigation endpoint was corrected.  Previously these calls from data-hub-api to dnb-service were failing with a 400 response as they were incorrectly formatted.
- The `/v4/dnb/company-investigation` API endpoint was adjusted to allow blank values for address `line_2`, `county` and `postcode`.  This will help with frontend integration.

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
