### PR TITLE
Bump automatic company archive limit

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -437,7 +437,7 @@ if REDIS_BASE_URL:
             'task': 'datahub.company.tasks.automatic_company_archive',
             'schedule': crontab(minute=0, hour=20, day_of_week='SAT'),
             'kwargs': {
-                'limit': 10000,
+                'limit': 20000,
                 'simulate': False,
             }
         },


### PR DESCRIPTION
### Description of change

This bumps the limit of the automatic-company-archive to 20k.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
