### PR TITLE
Add GET endpoint for export pipeline items

### DIFF
--- a/changelog/export-pipeline-retrieve-items.feature.md
+++ b/changelog/export-pipeline-retrieve-items.feature.md
@@ -1,0 +1,18 @@
+A new endpoint, `/v4/company-list/pipelineitem-collection`, was added to expose all export pipeline items for a given user. There is also the possibility of filtering the result by status. The following structure will be returned when a call is made to this endpoint:
+
+ ```json
+ ...
+    [
+        {
+            "company": {
+                "id": 123,
+                "name": "Name",
+                "turnover": 123,
+                "export_potential": "Low",
+            },
+            "status": "win",
+            "created_on": date,
+        },
+        ...
+    ]
+  ```

--- a/changelog/export-pipeline-retrieve-items.feature.md
+++ b/changelog/export-pipeline-retrieve-items.feature.md
@@ -1,4 +1,4 @@
-A new endpoint, `/v4/company-list/pipelineitem-collection`, was added to expose all export pipeline items for a given user. There is also the possibility of filtering the result by status. The following structure will be returned when a call is made to this endpoint:
+A new endpoint `/v4/pipeline-item`, was added to expose all pipeline items for a given user. Filterable fields are: `status` and order by fields are: `created_on` (desc). The following structure will be returned when a call is made to this endpoint:
 
  ```json
  ...

--- a/datahub/user/company_list/queryset.py
+++ b/datahub/user/company_list/queryset.py
@@ -8,7 +8,7 @@ from datahub.core.query_utils import (
     JSONBBuildObject,
 )
 from datahub.interaction.models import Interaction, InteractionDITParticipant
-from datahub.user.company_list.models import CompanyListItem
+from datahub.user.company_list.models import CompanyListItem, PipelineItem
 
 
 def get_company_list_item_queryset():
@@ -63,6 +63,21 @@ def get_company_list_item_queryset():
         'company__archived',
         'company__name',
         'company__trading_names',
+    )
+
+
+def get_export_pipeline_item_queryset():
+    """
+    Returns a query set used by ExportPipelineItemViewSet.
+    """
+    return PipelineItem.objects.select_related('company').only(
+        # Only select the fields we need to reduce data transfer time for large lists
+        # (in particular, companies have a lot of fields which are not needed here)
+        'id',
+        'company__id',
+        'company__name',
+        'company__turnover',
+        'company__export_potential',
     )
 
 

--- a/datahub/user/company_list/queryset.py
+++ b/datahub/user/company_list/queryset.py
@@ -66,9 +66,9 @@ def get_company_list_item_queryset():
     )
 
 
-def get_export_pipeline_item_queryset():
+def get_pipeline_item_queryset():
     """
-    Returns a query set used by ExportPipelineItemViewSet.
+    Returns a query set used by PipelineItemViewSet.
     """
     return PipelineItem.objects.select_related('company').only(
         # Only select the fields we need to reduce data transfer time for large lists

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from datahub.company.models import Company
 from datahub.core.serializers import NestedRelatedField
-from datahub.user.company_list.models import CompanyList, CompanyListItem
+from datahub.user.company_list.models import CompanyList, CompanyListItem, PipelineItem
 
 
 class CompanyListSerializer(serializers.ModelSerializer):
@@ -56,4 +56,23 @@ class CompanyListItemSerializer(serializers.ModelSerializer):
             'company',
             'created_on',
             'latest_interaction',
+        )
+
+
+class ExportPipelineItemSerializer(serializers.ModelSerializer):
+    """Serialiser for export pipeline list items."""
+
+    company = NestedRelatedField(
+        Company,
+        # If this list of fields is changed, update the equivalent list in the QuerySet.only()
+        # call in the queryset module
+        extra_fields=('name', 'turnover', 'export_potential'),
+    )
+
+    class Meta:
+        model = PipelineItem
+        fields = (
+            'company',
+            'created_on',
+            'status',
         )

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -59,8 +59,8 @@ class CompanyListItemSerializer(serializers.ModelSerializer):
         )
 
 
-class ExportPipelineItemSerializer(serializers.ModelSerializer):
-    """Serialiser for export pipeline list items."""
+class PipelineItemSerializer(serializers.ModelSerializer):
+    """Serialiser for pipeline list items."""
 
     company = NestedRelatedField(
         Company,

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -23,8 +23,7 @@ class TestGetPipelineItemView(APITestMixin):
         'permission_codenames,expected_status',
         (
             ([], status.HTTP_403_FORBIDDEN),
-            (['view_pipelineitem'], status.HTTP_403_FORBIDDEN),
-            (['view_company', 'view_pipelineitem'], status.HTTP_200_OK),
+            (['view_pipelineitem'], status.HTTP_200_OK),
         ),
     )
     def test_permission_checking(self, permission_codenames, expected_status, api_client):

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -51,7 +51,7 @@ class TestGetPipelineItemView(APITestMixin):
         response_data = response.json()
         assert len(response_data['results']) == 1
 
-        _assert_get_export_pipeline_items_response(
+        self._assert_get_pipeline_items_response(
             response_data['results'][0],
             company,
             item,
@@ -83,17 +83,17 @@ class TestGetPipelineItemView(APITestMixin):
         response_data = response.json()
         assert len(response_data['results']) == 3
 
-        _assert_get_export_pipeline_items_response(
+        self._assert_get_pipeline_items_response(
             response_data['results'][0],
             company_3,
             item_3,
         )
-        _assert_get_export_pipeline_items_response(
+        self._assert_get_pipeline_items_response(
             response_data['results'][1],
             company_2,
             item_2,
         )
-        _assert_get_export_pipeline_items_response(
+        self._assert_get_pipeline_items_response(
             response_data['results'][2],
             company_1,
             item_1,
@@ -170,15 +170,14 @@ class TestGetPipelineItemView(APITestMixin):
         assert len(response_data['results']) == 1
         assert response_data['results'][0]['status'] == PipelineItem.Status.WIN
 
-
-def _assert_get_export_pipeline_items_response(response_data, company, item):
-    assert response_data == {
-        'company': {
-            'id': str(company.pk),
-            'name': company.name,
-            'turnover': company.turnover,
-            'export_potential': company.export_potential,
-        },
-        'status': item.status,
-        'created_on': format_date_or_datetime(item.created_on),
-    }
+    def _assert_get_pipeline_items_response(self, response_data, company, item):
+        assert response_data == {
+            'company': {
+                'id': str(company.pk),
+                'name': company.name,
+                'turnover': company.turnover,
+                'export_potential': company.export_potential,
+            },
+            'status': item.status,
+            'created_on': format_date_or_datetime(item.created_on),
+        }

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -1,0 +1,130 @@
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.test.factories import CompanyFactory
+
+from datahub.user.company_list.models import PipelineItem
+from datahub.user.company_list.test.factories import PipelineItemFactory
+
+from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
+
+
+pipeline_collection_url = reverse('api-v4:company-list:pipelineitem-collection')
+
+
+class TestGetPipelineItemView(APITestMixin):
+    """Tests for getting pipeline items."""
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if the user is unauthenticated."""
+        response = api_client.get(pipeline_collection_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames,expected_status',
+        (
+            ([], status.HTTP_403_FORBIDDEN),
+            (['view_pipelineitem'], status.HTTP_403_FORBIDDEN),
+            (['view_company', 'view_pipelineitem'], status.HTTP_200_OK),
+        ),
+    )
+    def test_permission_checking(self, permission_codenames, expected_status, api_client):
+        """Test that the expected status is returned for various user permissions."""
+        user = create_test_user(permission_codenames=permission_codenames, dit_team=None)
+        PipelineItemFactory(adviser=user)
+
+        api_client = self.create_api_client(user=user)
+        response = api_client.get(pipeline_collection_url)
+        assert response.status_code == expected_status
+
+    def test_returns_404_if_pipeline_doesnt_exist(self):
+        """Test that a 404 is returned if the there are no pipeline items."""
+        response = self.api_client.get(pipeline_collection_url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_can_retrieve_a_single_pipeline_item(self):
+        """Test that details of a single pipeline item can be retrieved."""
+        company = CompanyFactory()
+        pipeline_item = PipelineItemFactory(adviser=self.user, company=company)
+        response = self.api_client.get(pipeline_collection_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert len(response_data['results']) == 1
+        assert response_data['results'][0] == {
+            'company': {
+                'id': str(company.pk),
+                'name': company.name,
+                'turnover': company.turnover,
+                'export_potential': company.export_potential,
+            },
+            'status': pipeline_item.status,
+            'created_on': format_date_or_datetime(pipeline_item.created_on),
+        }
+
+    def test_can_retrieve_multiple_pipeline_items(self):
+        """Test that details of multiple pipeline items can be retrieved."""
+        company_1 = CompanyFactory()
+        company_2 = CompanyFactory()
+        item_1 = PipelineItemFactory(
+            adviser=self.user,
+            company=company_1,
+            status=PipelineItem.Status.WIN,
+        )
+        item_2 = PipelineItemFactory(
+            adviser=self.user,
+            company=company_2,
+            status=PipelineItem.Status.IN_PROGRESS,
+        )
+        response = self.api_client.get(pipeline_collection_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert len(response_data['results']) == 2
+        assert response_data['results'][0] == {
+            'company': {
+                'id': str(company_1.pk),
+                'name': company_1.name,
+                'turnover': company_1.turnover,
+                'export_potential': company_1.export_potential,
+            },
+            'status': item_1.status,
+            'created_on': format_date_or_datetime(item_1.created_on),
+        }
+        assert response_data['results'][1] == {
+            'company': {
+                'id': str(company_2.pk),
+                'name': company_2.name,
+                'turnover': company_2.turnover,
+                'export_potential': company_2.export_potential,
+            },
+            'status': item_2.status,
+            'created_on': format_date_or_datetime(item_2.created_on),
+        }
+
+    def test_returns_404_when_specific_user_has_no_pipeline_items(self):
+        """Test that another user's pipeline item can't be retrieved."""
+        PipelineItemFactory()
+        response = self.api_client.get(pipeline_collection_url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_only_users_pipeline_items(self):
+        """Test that only the users pipeline items can be retrieved."""
+        company = CompanyFactory()
+        PipelineItemFactory(company=company, status=PipelineItem.Status.IN_PROGRESS)
+        PipelineItemFactory(adviser=self.user, company=company, status=PipelineItem.Status.WIN)
+        response = self.api_client.get(pipeline_collection_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert len(response_data['results']) == 1
+        assert response_data['results'][0] == {
+            'company': {
+                'id': str(company.pk),
+                'name': company.name,
+                'turnover': company.turnover,
+                'export_potential': company.export_potential,
+            },
+            'status': PipelineItem.Status.WIN,
+        }

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -4,7 +4,7 @@ from datahub.user.company_list.views import (
     CompanyListItemAPIView,
     CompanyListItemViewSet,
     CompanyListViewSet,
-    ExportPipelineItemViewSet,
+    PipelineItemViewSet,
 )
 
 urlpatterns = [
@@ -45,7 +45,7 @@ urlpatterns = [
     ),
     path(
         'pipeline-item',
-        ExportPipelineItemViewSet.as_view(
+        PipelineItemViewSet.as_view(
             {
                 'get': 'list',
             },

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -4,6 +4,7 @@ from datahub.user.company_list.views import (
     CompanyListItemAPIView,
     CompanyListItemViewSet,
     CompanyListViewSet,
+    ExportPipelineItemViewSet,
 )
 
 urlpatterns = [
@@ -41,5 +42,14 @@ urlpatterns = [
         'company-list/<uuid:company_list_pk>/item/<uuid:company_pk>',
         CompanyListItemAPIView.as_view(),
         name='item-detail',
+    ),
+    path(
+        'pipeline-item',
+        ExportPipelineItemViewSet.as_view(
+            {
+                'get': 'list',
+            },
+        ),
+        name='pipelineitem-collection',
     ),
 ]

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -217,7 +217,14 @@ class ExportPipelineItemViewSet(CoreViewSet):
         ExportPipelineItemAPIPermissions,
     )
     serializer_class = ExportPipelineItemSerializer
+    filter_backends = (
+        DjangoFilterBackend,
+        OrderingFilter,
+    )
+    filterset_fields = ('adviser_id', 'status')
+    ordering = ('-created_on')
     queryset = get_export_pipeline_item_queryset()
+
     def initial(self, request, *args, **kwargs):
         """
         Raise an Http404 if user has no pipeline items.
@@ -231,4 +238,4 @@ class ExportPipelineItemViewSet(CoreViewSet):
 
     def get_queryset(self):
         """Get a query set filtered to the authenticated user's lists."""
-        return super().get_queryset().filter(adviser=self.request.user).order_by('-created_on')
+        return super().get_queryset().filter(adviser=self.request.user)

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -20,17 +20,16 @@ from datahub.user.company_list.models import (
     CompanyList,
     CompanyListItem,
     CompanyListItemPermissionCode,
-    PipelineItem,
     PipelineItemPermissionCode,
 )
 from datahub.user.company_list.queryset import (
     get_company_list_item_queryset,
-    get_export_pipeline_item_queryset,
+    get_pipeline_item_queryset,
 )
 from datahub.user.company_list.serializers import (
     CompanyListItemSerializer,
     CompanyListSerializer,
-    ExportPipelineItemSerializer,
+    PipelineItemSerializer,
 )
 
 CANT_ADD_ARCHIVED_COMPANY_MESSAGE = gettext_lazy(
@@ -197,8 +196,8 @@ class CompanyListItemAPIView(APIView):
         return obj
 
 
-class ExportPipelineItemAPIPermissions(DjangoModelPermissions):
-    """DRF permissions class for the export pipeline list item view."""
+class PipelineItemAPIPermissions(DjangoModelPermissions):
+    """DRF permissions class for the pipeline list item view."""
 
     perms_map = {
         'GET': [
@@ -208,22 +207,18 @@ class ExportPipelineItemAPIPermissions(DjangoModelPermissions):
     }
 
 
-class ExportPipelineItemViewSet(CoreViewSet):
-    """A view set for returning the contents of a export pipeline list."""
+class PipelineItemViewSet(CoreViewSet):
+    """A view set for returning the contents of a pipeline list."""
 
-    required_scopes = (Scope.internal_front_end,)
-    permission_classes = (
-        IsAuthenticatedOrTokenHasScope,
-        ExportPipelineItemAPIPermissions,
-    )
-    serializer_class = ExportPipelineItemSerializer
+    permission_classes = (PipelineItemAPIPermissions,)
+    serializer_class = PipelineItemSerializer
     filter_backends = (
         DjangoFilterBackend,
         OrderingFilter,
     )
     filterset_fields = ('status',)
     ordering = ('-created_on')
-    queryset = get_export_pipeline_item_queryset()
+    queryset = get_pipeline_item_queryset()
 
     def initial(self, request, *args, **kwargs):
         """
@@ -231,9 +226,7 @@ class ExportPipelineItemViewSet(CoreViewSet):
         """
         super().initial(request, *args, **kwargs)
 
-        if not PipelineItem.objects.filter(
-            adviser=self.request.user,
-        ).exists():
+        if not self.get_queryset().exists():
             raise Http404()
 
     def get_queryset(self):

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -20,7 +20,6 @@ from datahub.user.company_list.models import (
     CompanyList,
     CompanyListItem,
     CompanyListItemPermissionCode,
-    PipelineItemPermissionCode,
 )
 from datahub.user.company_list.queryset import (
     get_company_list_item_queryset,
@@ -196,21 +195,9 @@ class CompanyListItemAPIView(APIView):
         return obj
 
 
-class PipelineItemAPIPermissions(DjangoModelPermissions):
-    """DRF permissions class for the pipeline list item view."""
-
-    perms_map = {
-        'GET': [
-            f'company.{CompanyPermission.view_company}',
-            f'company_list.{PipelineItemPermissionCode.view_pipeline_item}',
-        ],
-    }
-
-
 class PipelineItemViewSet(CoreViewSet):
     """A view set for returning the contents of a pipeline list."""
 
-    permission_classes = (PipelineItemAPIPermissions,)
     serializer_class = PipelineItemSerializer
     filter_backends = (
         DjangoFilterBackend,

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -218,7 +218,6 @@ class ExportPipelineItemViewSet(CoreViewSet):
     )
     serializer_class = ExportPipelineItemSerializer
     queryset = get_export_pipeline_item_queryset()
-
     def initial(self, request, *args, **kwargs):
         """
         Raise an Http404 if user has no pipeline items.
@@ -232,4 +231,4 @@ class ExportPipelineItemViewSet(CoreViewSet):
 
     def get_queryset(self):
         """Get a query set filtered to the authenticated user's lists."""
-        return super().get_queryset().filter(adviser=self.request.user)
+        return super().get_queryset().filter(adviser=self.request.user).order_by('-created_on')

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -159,6 +159,17 @@ class ExportPipelineItemViewSet(CoreViewSet):
     serializer_class = ExportPipelineItemSerializer
     queryset = get_export_pipeline_item_queryset()
 
+    def initial(self, request, *args, **kwargs):
+        """
+        Raise an Http404 if user has no pipeline items.
+        """
+        super().initial(request, *args, **kwargs)
+
+        if not PipelineItem.objects.filter(
+            adviser=self.request.user,
+        ).exists():
+            raise Http404()
+
     def get_queryset(self):
         """Get a query set filtered to the authenticated user's lists."""
         return super().get_queryset().filter(adviser=self.request.user)

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -102,17 +102,6 @@ class CompanyListItemAPIPermissions(DjangoModelPermissions):
     }
 
 
-class ExportPipelineItemAPIPermissions(DjangoModelPermissions):
-    """DRF permissions class for the export pipeline list item view."""
-
-    perms_map = {
-        'GET': [
-            f'company.{CompanyPermission.view_company}',
-            f'company_list.{PipelineItemPermissionCode.view_pipeline_item}',
-        ],
-    }
-
-
 class CompanyListItemViewSet(CoreViewSet):
     """A view set for returning the contents of a company list."""
 
@@ -146,33 +135,6 @@ class CompanyListItemViewSet(CoreViewSet):
         """Filter the query set to the items relating to the authenticated users."""
         queryset = super().filter_queryset(queryset)
         return queryset.filter(list__pk=self.kwargs['company_list_pk'])
-
-
-class ExportPipelineItemViewSet(CoreViewSet):
-    """A view set for returning the contents of a export pipeline list."""
-
-    required_scopes = (Scope.internal_front_end,)
-    permission_classes = (
-        IsAuthenticatedOrTokenHasScope,
-        ExportPipelineItemAPIPermissions,
-    )
-    serializer_class = ExportPipelineItemSerializer
-    queryset = get_export_pipeline_item_queryset()
-
-    def initial(self, request, *args, **kwargs):
-        """
-        Raise an Http404 if user has no pipeline items.
-        """
-        super().initial(request, *args, **kwargs)
-
-        if not PipelineItem.objects.filter(
-            adviser=self.request.user,
-        ).exists():
-            raise Http404()
-
-    def get_queryset(self):
-        """Get a query set filtered to the authenticated user's lists."""
-        return super().get_queryset().filter(adviser=self.request.user)
 
 
 class CompanyListItemAPIView(APIView):
@@ -233,3 +195,41 @@ class CompanyListItemAPIView(APIView):
         )
         self.check_object_permissions(request, obj)
         return obj
+
+
+class ExportPipelineItemAPIPermissions(DjangoModelPermissions):
+    """DRF permissions class for the export pipeline list item view."""
+
+    perms_map = {
+        'GET': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{PipelineItemPermissionCode.view_pipeline_item}',
+        ],
+    }
+
+
+class ExportPipelineItemViewSet(CoreViewSet):
+    """A view set for returning the contents of a export pipeline list."""
+
+    required_scopes = (Scope.internal_front_end,)
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        ExportPipelineItemAPIPermissions,
+    )
+    serializer_class = ExportPipelineItemSerializer
+    queryset = get_export_pipeline_item_queryset()
+
+    def initial(self, request, *args, **kwargs):
+        """
+        Raise an Http404 if user has no pipeline items.
+        """
+        super().initial(request, *args, **kwargs)
+
+        if not PipelineItem.objects.filter(
+            adviser=self.request.user,
+        ).exists():
+            raise Http404()
+
+    def get_queryset(self):
+        """Get a query set filtered to the authenticated user's lists."""
+        return super().get_queryset().filter(adviser=self.request.user)

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -221,7 +221,7 @@ class ExportPipelineItemViewSet(CoreViewSet):
         DjangoFilterBackend,
         OrderingFilter,
     )
-    filterset_fields = ('adviser_id', 'status')
+    filterset_fields = ('status',)
     ordering = ('-created_on')
     queryset = get_export_pipeline_item_queryset()
 


### PR DESCRIPTION
### Description of change

**Background**
As part of improving information and process within Data Hub, yellow team is implementing a Pipeline for users to add companies they are dealing with and their current status within the pipeline (Lead, In Progress or Win). They can then maintain its status as they progress.

Idea of MVP is to show a separate Pipeline tab next to My company lists and My referrals, allowing the users maintain a dashboard of companies separated by predefined statuses. Users can add companies and also be able to move items between statuses.



**The intent of this PR** is to add an endpoint which allows us to get all export pipeline items for a given user. The endpoint also has the ability to filter the results by `status`.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
