### PR TITLE
Enable new SSO token introspection logic by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This project uses Docker compose to setup and run all the necessary components. 
     cp sample.env .env
     ```
 
-    If you're working with data-hub-frontend and mock-sso, `DJANGO_SUPERUSER_EMAIL`
-    should be the same as MOCK_SSO_USERNAME in the frontend's .env file.
+    If you're working with data-hub-frontend and mock-sso, `DJANGO_SUPERUSER_SSO_EMAIL_USER_ID`
+    should be the same as MOCK_SSO_EMAIL_USER_ID in mock-sso’s .env file.
 
 3.  Build and run the necessary containers for the required environment:
 
@@ -215,10 +215,8 @@ flake8
 The [internal front end](https://github.com/uktrade/data-hub-frontend) uses single sign-on. You should configure the API as follows to use with the front end:
 
 * `SSO_ENABLED`: `True`
-* `RESOURCE_SERVER_INTROSPECTION_URL`: URL of the [RFC 7662](https://tools.ietf.org/html/rfc7662) introspection endpoint (should be the same server the front end is using). This is provided by a [Staff SSO](https://github.com/uktrade/staff-sso) instance.
-* `RESOURCE_SERVER_AUTH_TOKEN`: Access token for the introspection server.
-
-The token should have the `data-hub:internal-front-end` scope. django-oauth-toolkit will create a user corresponding to the token if one does not already exist.
+* `STAFF_SSO_BASE_URL`: URL of a [Staff SSO](https://github.com/uktrade/staff-sso) or [Mock SSO](https://github.com/uktrade/mock-sso) instance. This should be the same server the front end is configured to use.
+* `STAFF_SSO_AUTH_TOKEN`: Access token for Staff SSO.
 
 ## Granting access to machine-to-machine clients
 
@@ -345,7 +343,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `STAFF_SSO_AUTH_TOKEN` | If SSO enabled | Access token for the Staff SSO API. (Used only when STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True). |
 | `STAFF_SSO_BASE_URL` | If SSO enabled | The base URL for the Staff SSO API. (Used only when STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True). |
 | `STAFF_SSO_REQUEST_TIMEOUT` | No | Staff SSO API request timeout in seconds (default=5). (Used only when STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True). |
-| `STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC` | No | Whether to enable the new Staff SSO token introspection logic with email user ID support (default=False). |
+| `STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC` | No | Whether to enable the new Staff SSO token introspection logic with email user ID support (default=True). |
 | `STATSD_HOST` | No | StatsD host url. |
 | `STATSD_PORT` | No | StatsD port number. |
 | `STATSD_PREFIX` | No | Prefix for metrics being pushed to StatsD. |

--- a/changelog/adviser/introspection-on-default.feature.md
+++ b/changelog/adviser/introspection-on-default.feature.md
@@ -1,0 +1,5 @@
+The new SSO authentication logic is now enabled by default.
+
+This means that, when logging into Data Hub, users are now identified using their unique SSO email user ID instead of their primary email address.
+
+'OAuth token introspection' events are now logged on the User events page in the admin site whenever Data Hub API checks in with Staff SSO to get details about a user’s access token.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -270,7 +270,7 @@ else:
 
 STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC = env.bool(
     'STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC',
-    default=False,
+    default=True,
 )
 STAFF_SSO_REQUEST_TIMEOUT = env.int('STAFF_SSO_REQUEST_TIMEOUT', default=5)  # seconds
 STAFF_SSO_USER_TOKEN_CACHING_PERIOD = env.int(

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -153,10 +153,11 @@ DATAHUB_SUPPORT_EMAIL_ADDRESS = 'support@datahub.com'
 
 STAFF_SSO_BASE_URL = 'http://sso.test/'
 STAFF_SSO_AUTH_TOKEN = 'test-sso-token'
+STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC = True
 # TODO: Remove this once SSOIntrospectionAuthentication is the default, django-oauth-toolkit
 # is removed and APITestMixin has been updated
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = [
-    'oauth2_provider.contrib.rest_framework.OAuth2Authentication',
+    'datahub.oauth.auth.SSOIntrospectionAuthentication',
 ]
 
 ADMIN_OAUTH2_ENABLED = True

--- a/datahub/core/test/test_advisor_permissions.py
+++ b/datahub/core/test/test_advisor_permissions.py
@@ -29,7 +29,7 @@ class TestPermissions(APITestMixin):
             '/',
             data={},
             content_type='application/json',
-            Authorization=f'Bearer {token}',
+            HTTP_AUTHORIZATION=f'Bearer {token}',
         )
         my_view = PermissionModelViewset.as_view(
             actions={'get': 'list'},
@@ -49,7 +49,7 @@ class TestPermissions(APITestMixin):
             '/',
             data={},
             content_type='application/json',
-            Authorization=f'Bearer {token}',
+            HTTP_AUTHORIZATION=f'Bearer {token}',
         )
         my_view = PermissionModelViewset.as_view(
             actions={'get': 'list'},
@@ -70,7 +70,7 @@ class TestPermissions(APITestMixin):
             '/',
             data={},
             content_type='application/json',
-            Authorization=f'Bearer {token}',
+            HTTP_AUTHORIZATION=f'Bearer {token}',
         )
         my_view = PermissionModelViewset.as_view(
             actions={'get': 'list'},

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -1,6 +1,6 @@
 import json
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import datetime
 from decimal import Decimal
 from operator import attrgetter
 from secrets import token_hex
@@ -17,12 +17,12 @@ from django.test.client import Client
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.utils.timezone import now
-from oauth2_provider.models import AccessToken
 from rest_framework.fields import DateField, DateTimeField
 from rest_framework.test import APIClient
 
 from datahub.core.utils import join_truthy_strings
 from datahub.metadata.models import Team
+from datahub.oauth.cache import add_token_data_to_cache
 
 
 class HawkAPITestClient:
@@ -127,6 +127,7 @@ def create_test_user(permission_codenames=(), password=None, **user_attrs):
         'first_name': factory.Faker('first_name').generate({}),
         'last_name': factory.Faker('last_name').generate({}),
         'email': factory.Faker('email').generate({}),
+        'sso_email_user_id': factory.Faker('email').generate({'domain': 'id.test'}),
         'date_joined': now(),
     }
     user_defaults.update(user_attrs)
@@ -192,7 +193,10 @@ class AdminTestMixin:
 class APITestMixin:
     """All the tests using the DB and accessing end points behind auth should use this class."""
 
-    pytestmark = pytest.mark.django_db  # use db
+    pytestmark = [
+        pytest.mark.django_db,
+        pytest.mark.usefixtures('local_memory_cache'),
+    ]
 
     @property
     def user(self):
@@ -209,13 +213,13 @@ class APITestMixin:
         if user is None:
             user = self.user
 
-        token_cache_key = user.email
+        token_cache_key = user.sso_email_user_id
+
         if token_cache_key not in self._tokens:
-            self._tokens[token_cache_key] = AccessToken.objects.create(
-                user=user,
-                token=token_hex(16),
-                expires=now() + timedelta(hours=1),
-            )
+            token = token_hex(16)
+            add_token_data_to_cache(token, user.email, user.sso_email_user_id, None)
+            self._tokens[token_cache_key] = token
+
         return self._tokens[token_cache_key]
 
     @property
@@ -229,7 +233,7 @@ class APITestMixin:
         """Creates an API client associated with an OAuth token with the specified scope."""
         token = self.get_token(user=user)
         client = APIClient()
-        client.credentials(Authorization=f'Bearer {token}')
+        client.credentials(HTTP_AUTHORIZATION=f'Bearer {token}')
         return client
 
 

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -65,7 +65,7 @@ class TestDNBAPICommon(APITestMixin):
         requests_mock.post(DNB_SEARCH_URL)
 
         unauthorised_api_client = self.create_api_client()
-        unauthorised_api_client.credentials(Authorization='foo')
+        unauthorised_api_client.credentials(HTTP_AUTHORIZATION='foo')
 
         response = unauthorised_api_client.post(
             url,
@@ -1783,7 +1783,7 @@ class TestCompanyInvestigationView(APITestMixin):
         Ensure that a non-authenticated request gets a 401.
         """
         unauthorised_api_client = self.create_api_client()
-        unauthorised_api_client.credentials(Authorization='foo')
+        unauthorised_api_client.credentials(HTTP_AUTHORIZATION='foo')
 
         response = unauthorised_api_client.post(
             reverse('api-v4:dnb-api:company-investigation'),

--- a/datahub/oauth/test/test_backend.py
+++ b/datahub/oauth/test/test_backend.py
@@ -1,13 +1,17 @@
+from datetime import timedelta
 from unittest.mock import patch
 from urllib.parse import urlencode
 
 import pytest
 from django.conf import settings
+from django.utils.timezone import now
+from oauth2_provider.admin import AccessToken
+from oauth2_provider.contrib.rest_framework import OAuth2Authentication
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
-from datahub.core.test_utils import APITestMixin
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.core.viewsets import CoreViewSet
 
 
@@ -24,6 +28,7 @@ def oauth2_backend_class(monkeypatch):
 class RestrictedAccessViewSet(CoreViewSet):
     """DRF ViewSet to test authentication."""
 
+    authentication_classes = (OAuth2Authentication,)
     permission_classes = (IsAuthenticated,)
 
 
@@ -55,7 +60,7 @@ class TestContentTypeAwareOAuthLibCore(APITestMixin):
             # sending invalid JSON
             data=b'{"what": "cat}',
             content_type='application/json',
-            Authorization=token,
+            HTTP_AUTHORIZATION=token,
         )
         my_view = RestrictedAccessViewSet.as_view(
             actions={'post': 'create'},
@@ -85,8 +90,15 @@ class TestContentTypeAwareOAuthLibCore(APITestMixin):
         """Tests that the request is being parsed if the auth token is in the form."""
         if expected_authorized:
             create.return_value = Response(data={'result': True})
+
+        user = create_test_user()
+        access_token = AccessToken.objects.create(
+            token='test-token',
+            expires=now() + timedelta(days=365),
+            user=user,
+        )
         data = {
-            'access_token': self.get_token(),
+            'access_token': access_token.token,
         }
         request = api_request_factory.post(
             '/',

--- a/sample.env
+++ b/sample.env
@@ -47,11 +47,9 @@ COMPOSE_PROJECT_NAME=data-hub
 #DJANGO_SUPERUSER_PASSWORD=foobarbaz
 #DJANGO_SUPERUSER_SSO_EMAIL_USER_ID=some.person@id.trade.local
 
-# If these lines are uncommented and SUPERUSER_ACCESS_TOKEN is given a value,
-# an access token for the superuser with that value will be created when the
-# container comes up. The superuser should have an SSO email user ID set
-# for this to work.
-#STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC=True
+# If SUPERUSER_ACCESS_TOKEN is given a value, an access token for the
+# superuser with that value will be created when the container comes up.
+# The superuser should have an SSO email user ID set for this to work.
 #SUPERUSER_ACCESS_TOKEN=
 
 # OAuth2 settings for Django Admin access

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -20,51 +20,37 @@ dit_east_midlands_id = '9010dd28-9798-e211-a939-e4115bead28a'
 
 dit_staff_user = Advisor.objects.create_user(
     email='dit_staff@datahub.com',
+    sso_email_user_id='dit_staff@id.test',
     first_name='DIT',
     last_name='Staff',
     dit_team_id=dit_east_midlands_id,
-)
-
-AccessToken.objects.create(
-    user=dit_staff_user,
-    token='ditStaffToken',
-    expires=now() + datetime.timedelta(days=1),
-    scope='data-hub:internal-front-end',
 )
 
 welsh_government_id = 'bc85aa17-fabd-e511-88b6-e4115bead28a'
 
 da_staff_user = Advisor.objects.create_user(
     email='da_staff@datahub.com',
+    sso_email_user_id='da_staff@id.test',
     first_name='DA',
     last_name='Staff',
     dit_team_id=welsh_government_id,
-)
-
-AccessToken.objects.create(
-    user=da_staff_user,
-    token='daStaffToken',
-    expires=now() + datetime.timedelta(days=1),
-    scope='data-hub:internal-front-end',
 )
 
 heart_of_the_south_west_lep_id = '08d987f8-6525-e511-b6bc-e4115bead28a'
 
 lep_staff_user = Advisor.objects.create_user(
     email='lep_staff@datahub.com',
+    sso_email_user_id='lep_staff@id.test',
     first_name='LEP',
     last_name='Staff',
     dit_team_id=heart_of_the_south_west_lep_id,
 )
 
-AccessToken.objects.create(
-    user=lep_staff_user,
-    token='lepStaffToken',
-    expires=now() + datetime.timedelta(days=1),
-    scope='data-hub:internal-front-end',
-)
 " | /app/manage.py shell
 
+python /app/manage.py add_access_token --skip-checks --hours 24 --token ditStaffToken dit_staff@id.test
+python /app/manage.py add_access_token --skip-checks --hours 24 --token daStaffToken da_staff@id.test
+python /app/manage.py add_access_token --skip-checks --hours 24 --token lepStaffToken lep_staff@id.test
 python /app/manage.py loaddata /app/fixtures/test_data.yaml
 python /app/manage.py createinitialrevisions
 python /app/manage.py collectstatic --noinput


### PR DESCRIPTION
### Description of change

This turns on `STAFF_SSO_USE_NEW_INTROSPECTION_LOGIC` by default so the the new SSO token introspection logic is used.

This includes updating tests and `setup-uat.sh` to be compatible with the new logic.

Some tests were passing `Authorization` to the Django Rest Framework test client instead of `HTTP_AUTHORIZATION`. While the former worked with Django OAuth Toolkit, the latter seems to be the correct argument, and so this has been updated.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
