### PR TITLE
Add stub schema to change_stage action method

### DIFF
--- a/changelog/investment/add_stub_schema_for_update_stage_endpoint.api.md
+++ b/changelog/investment/add_stub_schema_for_update_stage_endpoint.api.md
@@ -1,0 +1,1 @@
+In Swagger, the documentation for the `/v3/investment/{id}/update-stage` endpoint now shows the stub schema, instead of wrongly displaying the fields from the `IProjectSerializer`. 

--- a/datahub/investment/project/views.py
+++ b/datahub/investment/project/views.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 from datahub.core.audit import AuditViewSet
 from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.permissions import HasPermissions
+from datahub.core.schemas import StubSchema
 from datahub.core.viewsets import CoreViewSet
 from datahub.investment.project.models import (
     InvestmentProject,
@@ -140,6 +141,7 @@ class IProjectViewSet(ArchivableViewSetMixin, CoreViewSet):
             HasPermissions(f'investment.{InvestmentProjectPermission.change_to_any_stage}'),
         ],
         filter_backends=[],
+        schema=StubSchema(),
     )
     def change_stage(self, request, *args, **kwargs):
         """Change the stage of an investment project"""


### PR DESCRIPTION
### Description of change

This PR adds schema=StubSchema( ) to the newly created action method for the `/v3/investment/{id}/update-stage` endpoint. 

This avoids swagger wrongly showing the fields from the `IProjectSerializer` in the request template. 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
