### PR TITLE
Fix handling of expired access tokens in SSO token introspection

### DIFF
--- a/changelog/introspection-expired-token.bugfix.md
+++ b/changelog/introspection-expired-token.bugfix.md
@@ -1,0 +1,1 @@
+An unhandled exception no longer occurs when an expired access token is encountered during SSO token introspection.

--- a/datahub/oauth/test/test_auth.py
+++ b/datahub/oauth/test/test_auth.py
@@ -97,7 +97,7 @@ class TestSSOIntrospectionAuthentication:
                     'status_code': status.HTTP_401_UNAUTHORIZED,
                     'json': {'active': False},
                 },
-                id='invalid-token',
+                id='non-existent-token',
             ),
             pytest.param(
                 {
@@ -106,13 +106,12 @@ class TestSSOIntrospectionAuthentication:
                 },
                 id='inactive-response',
             ),
-            # Should not happen in reality
             pytest.param(
                 {
                     'status_code': status.HTTP_200_OK,
-                    'json': _make_introspection_data(active=False),
+                    'json': {'active': False},
                 },
-                id='inactive-token',
+                id='expired-token',
             ),
             # Should not happen in reality
             pytest.param(

--- a/datahub/oauth/test/test_sso_api_client.py
+++ b/datahub/oauth/test/test_sso_api_client.py
@@ -10,8 +10,8 @@ from datahub.oauth.sso_api_client import (
     get_user_by_email,
     get_user_by_email_user_id,
     introspect_token,
+    SSOInvalidToken,
     SSORequestError,
-    SSOTokenDoesNotExist,
     SSOUserDoesNotExist,
 )
 
@@ -51,7 +51,14 @@ class TestIntrospectToken:
                     'status_code': status.HTTP_401_UNAUTHORIZED,
                     'json': {'active': False},
                 },
-                SSOTokenDoesNotExist(),
+                SSOInvalidToken(),
+            ),
+            (
+                {
+                    'status_code': status.HTTP_200_OK,
+                    'json': {'active': False},
+                },
+                SSOInvalidToken(),
             ),
             (
                 {'exc': ConnectionError},


### PR DESCRIPTION
### Description of change

When a token has expired, the Staff SSO introspection endpoint returns a 200 but with a response of `{"active": False}`.

This wasn't handled in the authentication class. This change fixes that.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
