### PR TITLE
Add patch and get by uuid method to pipeline item endpoint

### DIFF
--- a/changelog/add-patch-for-pipeline-item.api.md
+++ b/changelog/add-patch-for-pipeline-item.api.md
@@ -1,0 +1,16 @@
+A new endpoint `/v4/pipeline-item/uuid`, was added to allow the frontend to `GET` or `PATCH` a pipeline item by uuid. Logic has been added to ensure that only the status can be patched. A 400 will be thrown if any field other than status is sent in the `PATCH` request. The below is the response returned from the `GET`. 
+
+
+ ```json
+ ...
+    {
+        "company": {
+            "id": 123,
+            "name": "Name",
+            "turnover": 123,
+            "export_potential": "Low",
+        },
+        "status": "win",
+        "created_on": date,
+    }
+  ```

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -566,3 +566,135 @@ class TestAddPipelineItemView(APITestMixin):
             },
         )
         assert response.status_code == status.HTTP_201_CREATED
+
+
+class TestPatchPipelineItemView(APITestMixin):
+    """Tests for patching a pipeline item."""
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if the user is unauthenticated."""
+        url = self._pipeline_item_detail_url(uuid4())
+        response = api_client.patch(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames,expected_status',
+        (
+            ([], status.HTTP_403_FORBIDDEN),
+            (['view_pipelineitem'], status.HTTP_403_FORBIDDEN),
+            (['change_pipelineitem'], status.HTTP_200_OK),
+        ),
+    )
+    def test_permission_checking(self, permission_codenames, expected_status, api_client):
+        """Test that the expected status is returned for various user permissions."""
+        user = create_test_user(permission_codenames=permission_codenames, dit_team=None)
+        item = PipelineItemFactory(adviser=user)
+        url = self._pipeline_item_detail_url(item.pk)
+
+        api_client = self.create_api_client(user=user)
+        response = api_client.patch(
+            url,
+            data={
+                'status': 'leads',
+            },
+        )
+        assert response.status_code == expected_status
+
+    @pytest.mark.parametrize(
+        'request_data,expected_errors',
+        (
+            pytest.param(
+                {
+                    'status': None,
+                },
+                {
+                    'status': ['This field may not be null.'],
+                },
+                id='status is null',
+            ),
+            pytest.param(
+                {
+                    'status': '',
+                },
+                {
+                    'status': ['"" is not a valid choice.'],
+                },
+                id='status is not a valid choice',
+            ),
+            pytest.param(
+                {
+                    'status': 'invalid',
+                },
+                {
+                    'status': ['"invalid" is not a valid choice.'],
+                },
+                id='status is not a valid choice',
+            ),
+        ),
+    )
+    def test_validation(self, request_data, expected_errors):
+        """Test validation."""
+        item = PipelineItemFactory(adviser=self.user)
+        url = self._pipeline_item_detail_url(item.pk)
+        response = self.api_client.patch(url, data=request_data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_errors
+
+    def test_patch_a_pipeline_item(self):
+        """Test that status of a pipeline item can be patched."""
+        company = CompanyFactory()
+        item = PipelineItemFactory(
+            adviser=self.user,
+            company=company,
+            status=PipelineItem.Status.WIN,
+        )
+        url = self._pipeline_item_detail_url(item.pk)
+        new_status = PipelineItem.Status.LEADS
+        response = self.api_client.patch(
+            url,
+            data={
+                'status': new_status,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data == {
+            'company': {
+                'id': str(company.pk),
+                'name': company.name,
+                'turnover': company.turnover,
+                'export_potential': company.export_potential,
+            },
+            'id': str(item.id),
+            'name': item.name,
+            'status': new_status,
+            'created_on': format_date_or_datetime(item.created_on),
+        }
+
+    def test_cannot_patch_other_users_item(self):
+        """Test that cannot patch other users item."""
+        item = PipelineItemFactory()
+        url = self._pipeline_item_detail_url(item.pk)
+        response = self.api_client.patch(
+            url,
+            data={
+                'status': PipelineItem.Status.LEADS,
+            },
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_no_item_to_patch(self):
+        """Test that 404 is returned when no item."""
+        url = self._pipeline_item_detail_url(uuid4())
+        response = self.api_client.patch(
+            url,
+            data={
+                'status': PipelineItem.Status.WIN,
+            },
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def _pipeline_item_detail_url(self, item_pk):
+        return reverse('api-v4:company-list:pipelineitem-detail', kwargs={'pk': item_pk})

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -638,7 +638,9 @@ class TestPatchPipelineItemView(APITestMixin):
                 {
                     'name': 'Bat',
                 },
-                ['"name" is not allowed to be updated.'],
+                {
+                    'name': ['field not allowed to be update.'],
+                },
                 id='name is not allowed to be updated',
             ),
             pytest.param(
@@ -646,7 +648,9 @@ class TestPatchPipelineItemView(APITestMixin):
                     'name': 'Man',
                     'status': 'win',
                 },
-                ['"name" is not allowed to be updated.'],
+                {
+                    'name': ['field not allowed to be update.'],
+                },
                 id='name is not allowed to be updated',
             ),
         ),
@@ -744,7 +748,7 @@ class TestGetPipelineItemView(APITestMixin):
         response = api_client.get(url)
         assert response.status_code == expected_status
 
-    def test_returns_404_if_list_doesnt_exist(self):
+    def test_returns_404_if_pipeline_item_doesnt_exist(self):
         """Test that a 404 is returned if the pipeline item doesn't exist."""
         url = _pipeline_item_detail_url(uuid4())
         response = self.api_client.get(url)

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -53,4 +53,13 @@ urlpatterns = [
         ),
         name='pipelineitem-collection',
     ),
+    path(
+        'pipeline-item/<uuid:pk>',
+        PipelineItemViewSet.as_view(
+            {
+                'patch': 'partial_update',
+            },
+        ),
+        name='pipelineitem-detail',
+    ),
 ]

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -58,6 +58,7 @@ urlpatterns = [
         PipelineItemViewSet.as_view(
             {
                 'patch': 'partial_update',
+                'get': 'retrieve',
             },
         ),
         name='pipelineitem-detail',

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -210,3 +210,17 @@ class PipelineItemViewSet(CoreViewSet):
     def get_queryset(self):
         """Get a query set filtered to the authenticated user's pipeline items."""
         return super().get_queryset().filter(adviser=self.request.user)
+
+    def partial_update(self, request, *args, **kwargs):
+        """
+        Raise a validation error if anything else other than allowed fields is updated.
+        """
+        allowed_fields = ['status']
+        fields = list(request.data.keys())
+        field_delta = list(set(fields) - set(allowed_fields))
+        formated_fields = ', '.join(field_delta)
+        if field_delta:
+            raise serializers.ValidationError(
+                f'"{formated_fields}" is not allowed to be updated.',
+            )
+        return super().partial_update(request, *args, **kwargs)

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -210,17 +210,3 @@ class PipelineItemViewSet(CoreViewSet):
     def get_queryset(self):
         """Get a query set filtered to the authenticated user's pipeline items."""
         return super().get_queryset().filter(adviser=self.request.user)
-
-    def partial_update(self, request, *args, **kwargs):
-        """
-        Raise a validation error if anything else other than allowed fields is updated.
-        """
-        allowed_fields = ['status']
-        fields = list(request.data.keys())
-        field_delta = list(set(fields) - set(allowed_fields))
-        formated_fields = ', '.join(field_delta)
-        if field_delta:
-            raise serializers.ValidationError(
-                f'"{formated_fields}" is not allowed to be updated.',
-            )
-        return super().partial_update(request, *args, **kwargs)


### PR DESCRIPTION
### Description of change

**Background**
As part of improving information and process within Data Hub, yellow team is implementing a Pipeline for users to add companies they are dealing with and their current status within the pipeline (Lead, In Progress or Win). They can then maintain its status as they progress.

Idea of MVP is to show a separate Pipeline tab next to My company lists and My referrals, allowing the users maintain a dashboard of companies separated by predefined statuses. Users can add companies and also be able to move items between statuses.

**The intent of this PR** is to add an endpoint which allows the frontend to get a single pipeline item by uuid and also patch a pipeline item status. For the moment no other field other than the status will be allowed to be updated.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
