### PR TITLE
Remove total company updates log

### DIFF
--- a/changelog/company/remove-total-update-count-log.internal.md
+++ b/changelog/company/remove-total-update-count-log.internal.md
@@ -1,0 +1,1 @@
+The logging of total available company updates in `dnb-service` has been removed from Data Hub API because this feature is going to be deprecated from the `dnb-service`.

--- a/datahub/dnb_api/tasks/update.py
+++ b/datahub/dnb_api/tasks/update.py
@@ -103,9 +103,6 @@ def _get_company_updates(task, last_updated_after, fields_to_update):
         if next_page is None:
             break
 
-    update_count = response.get('count', 0)
-    logger.info(f'get_company_updates total update count: {update_count}')
-
     # Wait for all update tasks to finish...
     ResultSet(results=update_results).join(
         propagate=False,

--- a/datahub/dnb_api/test/test_tasks.py
+++ b/datahub/dnb_api/test/test_tasks.py
@@ -341,12 +341,11 @@ class TestGetCompanyUpdates:
         ),
     )
     @freeze_time('2019-01-02T2:00:00')
-    def test_updates(self, monkeypatch, caplog, data, fields_to_update):
+    def test_updates(self, monkeypatch, data, fields_to_update):
         """
         Test if the update_company task is called with the right parameters for all the records
         spread across pages.
         """
-        caplog.set_level('INFO')
         mock_get_company_update_page = mock.Mock(
             side_effect=lambda _, next_page: data[next_page],
         )
@@ -388,8 +387,6 @@ class TestGetCompanyUpdates:
             args=({'baz': 3},),
             kwargs=expected_kwargs,
         )
-
-        assert 'get_company_updates total update count: 3' in caplog.text
 
     @pytest.mark.parametrize(
         'lock_acquired, call_count',
@@ -500,7 +497,6 @@ class TestGetCompanyUpdates:
         self,
         mocked_log_to_sentry,
         mocked_send_realtime_message,
-        caplog,
         monkeypatch,
         dnb_company_updates_response_uk,
     ):
@@ -508,7 +504,6 @@ class TestGetCompanyUpdates:
         Test full integration for the `get_company_updates` task with the
         `update_company_from_dnb_data` task when all fields are updated.
         """
-        caplog.set_level('INFO')
         company = CompanyFactory(duns_number='123456789')
         mock_get_company_update_page = mock.Mock(
             return_value=dnb_company_updates_response_uk,
@@ -540,7 +535,6 @@ class TestGetCompanyUpdates:
             'updated: 1; failed to update: 0'
         )
         mocked_send_realtime_message.assert_called_once_with(expected_message)
-        assert 'get_company_updates total update count: 1' in caplog.text
 
     @mock.patch('datahub.dnb_api.tasks.update.send_realtime_message')
     @mock.patch('datahub.dnb_api.tasks.update.log_to_sentry')


### PR DESCRIPTION
### Description of change

The logging of total available company updates in `dnb-service` has been removed from Data Hub API because this feature is going to be deprecated from the `dnb-service`.
### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
