### PR TITLE
Use default mapping type name in Elasticsearch indexes

### DIFF
--- a/changelog/es-use-default-mapping-type-names.internal.md
+++ b/changelog/es-use-default-mapping-type-names.internal.md
@@ -1,0 +1,1 @@
+Elasticsearch indexes now use the default mapping type name of `_doc` rather than custom names. This change has been made because custom mapping type names are deprecated.

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -4,9 +4,7 @@ from elasticsearch_dsl import Boolean, Date, Keyword, Object, Text
 
 from datahub.company.models import CompanyExportCountry
 from datahub.search import dict_utils, fields
-from datahub.search.models import BaseESModel
-
-DOC_TYPE = 'company'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 def _adviser_field_with_indexed_id():
@@ -116,7 +114,7 @@ class Company(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -17,10 +17,10 @@ def test_mapping(es):
     """Test the ES mapping for a company."""
     mapping = Mapping.from_es(
         CompanySearchApp.es_model.get_write_index(),
-        CompanySearchApp.name,
+        DEFAULT_MAPPING_TYPE,
     )
     assert mapping.to_dict() == {
-        'company': {
+        DEFAULT_MAPPING_TYPE: {
             'dynamic': 'false',
             'properties': {
                 '_document_type': {

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -3,10 +3,7 @@ from elasticsearch_dsl import Boolean, Date, Keyword, Text
 from datahub.search import dict_utils
 from datahub.search import fields
 from datahub.search.contact import dict_utils as contact_dict_utils
-from datahub.search.models import BaseESModel
-
-
-DOC_TYPE = 'contact'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 class Contact(BaseESModel):
@@ -90,7 +87,7 @@ class Contact(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -2,6 +2,7 @@ from elasticsearch_dsl import Mapping
 
 from datahub.search.contact import ContactSearchApp
 from datahub.search.contact.models import Contact as ESContact
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.query_builder import (
     get_basic_search_query,
     get_search_by_entities_query,
@@ -13,11 +14,11 @@ def test_mapping(es):
     """Test the ES mapping for a contact."""
     mapping = Mapping.from_es(
         ContactSearchApp.es_model.get_write_index(),
-        ContactSearchApp.name,
+        DEFAULT_MAPPING_TYPE,
     )
 
     assert mapping.to_dict() == {
-        'contact': {
+        DEFAULT_MAPPING_TYPE: {
             'properties': {
                 '_document_type': {
                     'type': 'keyword',

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -1,10 +1,7 @@
 from elasticsearch_dsl import Date, Keyword, Text
 
 from datahub.search import dict_utils, fields
-from datahub.search.models import BaseESModel
-
-
-DOC_TYPE = 'event'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 class Event(BaseESModel):
@@ -69,7 +66,7 @@ class Event(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/event/test/test_elasticsearch.py
+++ b/datahub/search/event/test/test_elasticsearch.py
@@ -1,17 +1,18 @@
 from elasticsearch_dsl import Mapping
 
 from datahub.search.event import EventSearchApp
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 
 
 def test_mapping(es):
     """Test the ES mapping for an event."""
     mapping = Mapping.from_es(
         EventSearchApp.es_model.get_write_index(),
-        EventSearchApp.name,
+        DEFAULT_MAPPING_TYPE,
     )
 
     assert mapping.to_dict() == {
-        'event': {
+        DEFAULT_MAPPING_TYPE: {
             'dynamic': 'false',
             'properties': {
                 '_document_type': {

--- a/datahub/search/export_country_history/models.py
+++ b/datahub/search/export_country_history/models.py
@@ -1,9 +1,7 @@
 from elasticsearch_dsl import Date, Keyword
 
 from datahub.search import dict_utils, fields
-from datahub.search.models import BaseESModel
-
-DOC_TYPE = 'export-country-history'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 class ExportCountryHistory(BaseESModel):
@@ -35,7 +33,7 @@ class ExportCountryHistory(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -5,10 +5,7 @@ from elasticsearch_dsl import Boolean, Date, Double, InnerDoc, Keyword, Object, 
 from datahub.search import dict_utils, fields
 from datahub.search.fields import TrigramText
 from datahub.search.inner_docs import IDNameTrigram, Person
-from datahub.search.models import BaseESModel
-
-
-DOC_TYPE = 'interaction'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 def _contact_field():
@@ -143,7 +140,7 @@ class Interaction(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -2,10 +2,7 @@ from elasticsearch_dsl import Boolean, Date, Double, Integer, Keyword, Long, Obj
 
 from datahub.search import dict_utils
 from datahub.search import fields
-from datahub.search.models import BaseESModel
-
-
-DOC_TYPE = 'investment_project'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 def _related_investment_project_field():
@@ -187,7 +184,7 @@ class InvestmentProject(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -1,6 +1,7 @@
 from elasticsearch_dsl import Mapping
 
 from datahub.search.investment.models import InvestmentProject as ESInvestmentProject
+from datahub.search.models import DEFAULT_MAPPING_TYPE
 from datahub.search.query_builder import (
     get_basic_search_query,
     get_search_by_entities_query,
@@ -12,11 +13,11 @@ def test_mapping(es):
     """Test the ES mapping for an investment project."""
     mapping = Mapping.from_es(
         ESInvestmentProject.get_write_index(),
-        ESInvestmentProject._doc_type.name,
+        DEFAULT_MAPPING_TYPE,
     )
 
     assert mapping.to_dict() == {
-        'investment_project': {
+        DEFAULT_MAPPING_TYPE: {
             'dynamic': 'false',
             'properties': {
                 '_document_type': {

--- a/datahub/search/large_investor_profile/models.py
+++ b/datahub/search/large_investor_profile/models.py
@@ -2,10 +2,7 @@ from elasticsearch_dsl import Date, Keyword, Long
 
 from datahub.search import dict_utils
 from datahub.search import fields
-from datahub.search.models import BaseESModel
-
-
-DOC_TYPE = 'large-investor-profile'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 def _get_adviser_list(col):
@@ -87,7 +84,7 @@ class LargeInvestorProfile(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/large_investor_profile/test/test_elasticsearch.py
+++ b/datahub/search/large_investor_profile/test/test_elasticsearch.py
@@ -18,10 +18,10 @@ def test_mapping(es):
     """Test the ES mapping for a large capital investor profile."""
     mapping = Mapping.from_es(
         LargeInvestorProfileSearchApp.es_model.get_write_index(),
-        LargeInvestorProfileSearchApp.name,
+        DEFAULT_MAPPING_TYPE,
     )
     assert mapping.to_dict() == {
-        'large-investor-profile': {
+        DEFAULT_MAPPING_TYPE: {
             'properties': {
                 '_document_type': {
                     'type': 'keyword',

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -2,10 +2,7 @@ from elasticsearch_dsl import Boolean, Date, Integer, Keyword, Text
 
 from datahub.search import dict_utils
 from datahub.search import fields
-from datahub.search.models import BaseESModel
-
-
-DOC_TYPE = 'order'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 class Order(BaseESModel):
@@ -110,7 +107,7 @@ class Order(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -18,10 +18,10 @@ pytestmark = pytest.mark.django_db
 
 def test_mapping(es):
     """Test the ES mapping for an order."""
-    mapping = Mapping.from_es(OrderSearchApp.es_model.get_write_index(), OrderSearchApp.name)
+    mapping = Mapping.from_es(OrderSearchApp.es_model.get_write_index(), DEFAULT_MAPPING_TYPE)
 
     assert mapping.to_dict() == {
-        'order': {
+        DEFAULT_MAPPING_TYPE: {
             'dynamic': 'false',
             'properties': {
                 '_document_type': {

--- a/datahub/search/test/search_support/relatedmodel/models.py
+++ b/datahub/search/test/search_support/relatedmodel/models.py
@@ -2,10 +2,7 @@ from elasticsearch_dsl import Keyword
 
 from datahub.search import dict_utils
 from datahub.search import fields
-from datahub.search.models import BaseESModel
-
-
-DOC_TYPE = 'relatedmodel'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 class ESRelatedModel(BaseESModel):
@@ -20,10 +17,10 @@ class ESRelatedModel(BaseESModel):
 
     SEARCH_FIELDS = ('simpleton.name',)
 
-    class Meta:
-        """Model configuration."""
-
-        doc_type = DOC_TYPE
-
     class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE
+
+    class Meta:
+        """Default document meta data."""
+
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/test/search_support/simplemodel/models.py
+++ b/datahub/search/test/search_support/simplemodel/models.py
@@ -1,10 +1,7 @@
 from elasticsearch_dsl import Date, Keyword, Text
 
 from datahub.search import fields
-from datahub.search.models import BaseESModel
-
-
-DOC_TYPE = 'simplemodel'
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 
 
 class ESSimpleModel(BaseESModel):
@@ -24,10 +21,10 @@ class ESSimpleModel(BaseESModel):
         'name.trigram',
     )
 
+    class Index:
+        doc_type = DEFAULT_MAPPING_TYPE
+
     class Meta:
         """Default document meta data."""
 
-        doc_type = DOC_TYPE
-
-    class Index:
-        doc_type = DOC_TYPE
+        doc_type = DEFAULT_MAPPING_TYPE

--- a/datahub/search/test/test_migrate.py
+++ b/datahub/search/test/test_migrate.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from datahub.core.exceptions import DataHubException
 from datahub.search.apps import _load_search_apps, get_search_apps, SearchApp
 from datahub.search.migrate import migrate_app, migrate_apps
-from datahub.search.models import BaseESModel
+from datahub.search.models import BaseESModel, DEFAULT_MAPPING_TYPE
 from datahub.search.test.utils import create_mock_search_app
 
 SAMPLE_APP_NAME = 'sample'
@@ -16,10 +16,10 @@ class SampleModel(BaseESModel):
     """Sample (dummy) search model."""
 
     class Meta:
-        doc_type = SAMPLE_APP_NAME
+        doc_type = DEFAULT_MAPPING_TYPE
 
     class Index:
-        doc_type = SAMPLE_APP_NAME
+        doc_type = DEFAULT_MAPPING_TYPE
 
 
 class SampleSearchApp(SearchApp):
@@ -65,7 +65,7 @@ def test_migrate_app_with_uninitialised_app(monkeypatch, mock_es_client, sample_
     migrate_app(sample_search_app)
 
     expected_index_name = (
-        f'{settings.ES_INDEX_PREFIX}-{SAMPLE_APP_NAME}-7c4194a0f6eaa2cee1dda9df1dfc2856'
+        f'{settings.ES_INDEX_PREFIX}-{SAMPLE_APP_NAME}-091a1c3a42f7e9fb3ff69b49a7b45881'
     )
     assert mock_client.indices.create.call_args_list == [
         call(index=expected_index_name, body=ANY),


### PR DESCRIPTION
### Description of change

This follows on from https://github.com/uktrade/data-hub-api/pull/2766. and updates all Elasticsearch indexes to use the default mapping type name of `_doc`.

This change has been made because custom mapping type names are deprecated. The change will help facilitate the upgrade to Elasticsearch 7.

(The change of mapping type names will cause the migration logic to kick in on deployment, and create new indexes using the new mapping type names. This is because the change of mapping type name causes the calculated mapping hash to change.)

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
