### PR TITLE
Remove SSO token introspection email fallback

### DIFF
--- a/changelog/adviser/intro-remove-email.feature.md
+++ b/changelog/adviser/intro-remove-email.feature.md
@@ -1,0 +1,1 @@
+The SSO authentication logic no longer falls back to using the primary email address of a user when there is no match using the SSO email user ID. This is because all genuinely active advisers in Data Hub should now have an SSO email user ID set.

--- a/datahub/oauth/auth.py
+++ b/datahub/oauth/auth.py
@@ -113,28 +113,14 @@ def _look_up_adviser(cached_token_data):
     """
     Look up the adviser using data about an access token.
 
-    This first tries to look up the adviser using the SSO email user ID, and falls
-    back to using the email field if no match is found using the SSO email user ID.
+    The adviser is looked up using its SSO email user ID.
     """
-    email = cached_token_data['email']
     sso_email_user_id = cached_token_data['sso_email_user_id']
 
     try:
         return _get_adviser(sso_email_user_id=sso_email_user_id)
     except Advisor.DoesNotExist:
-        pass
-
-    # No match on sso_email_user_id – fall back to looking up using the email field
-    # TODO: Remove the below logic once active users have sso_email_user_id set
-    try:
-        # Note: The email field uses CICharField so this lookup is case-insensitive
-        adviser = _get_adviser(email=email, sso_email_user_id__isnull=True)
-    except Advisor.DoesNotExist:
         return None
-
-    adviser.sso_email_user_id = sso_email_user_id
-    adviser.save(update_fields=('sso_email_user_id',))
-    return adviser
 
 
 def _calculate_expiry(timestamp):

--- a/datahub/oauth/test/test_auth.py
+++ b/datahub/oauth/test/test_auth.py
@@ -198,29 +198,6 @@ class TestSSOIntrospectionAuthentication:
         with freeze_time(post_expiry_time):
             assert not cache.get('access_token:token')
 
-    def test_falls_back_to_email_field(self, api_request_factory, requests_mock):
-        """
-        Test that advisers are looked up using the email field when a match using
-        sso_email_user_id is not found, and the adviser's sso_email_user_id is updated.
-        """
-        adviser = AdviserFactory(email='email@email.test', sso_email_user_id=None)
-
-        requests_mock.post(
-            STAFF_SSO_INTROSPECT_URL,
-            json=_make_introspection_data(username='email@email.test'),
-        )
-
-        request = api_request_factory.get('/test-path', HTTP_AUTHORIZATION='Bearer token')
-        response = view(request)
-
-        assert request.user == adviser
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data == {'content': 'introspection-test-view'}
-
-        # Check that the sso_email_user_id was set on the user
-        adviser.refresh_from_db()
-        assert adviser.sso_email_user_id == 'user_id@example.test'
-
     def test_authentication_fails_if_user_is_inactive(self, api_request_factory, requests_mock):
         """Test that authentication fails when there is a matching but inactive user."""
         AdviserFactory(sso_email_user_id=EXAMPLE_SSO_EMAIL_USER_ID, is_active=False)


### PR DESCRIPTION
### Description of change

This removes the fallback to the `email` field in the SSO token introspection logic. This is being removed as all genuinely active advisers in Data Hub should now have an SSO email user ID set.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
