### PR TITLE
Make the website field on D&B companies editable via API

### DIFF
--- a/changelog/company/dnb-company-editable-website.feature.md
+++ b/changelog/company/dnb-company-editable-website.feature.md
@@ -1,0 +1,1 @@
+The `website` field of D&B companies is now editable via the API

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -516,7 +516,6 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'trading_names',
             'company_number',
             'vat_number',
-            'website',
             'business_type',
             'employee_range',
             'turnover_range',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -999,7 +999,6 @@ class TestUpdateCompany(APITestMixin):
                 'postcode': 'new registered address postcode',
                 'country': Country.azerbaijan.value.id,
             },
-            'website': 'new website',
             'business_type': BusinessTypeConstant.community_interest_company.value.id,
             'employee_range': EmployeeRange.range_1_to_9.value.id,
             'turnover_range': TurnoverRange.range_33_5_plus.value.id,

--- a/datahub/dnb_api/constants.py
+++ b/datahub/dnb_api/constants.py
@@ -10,7 +10,7 @@ ALL_DNB_UPDATED_SERIALIZER_FIELDS = (
     'is_number_of_employees_estimated',
     'turnover',
     'is_turnover_estimated',
-    # TODO: Uncomment when D&B fix their data
+    # TODO: Uncomment when D&B fix their data and add to CompanySerializer.dnb_read_only_fields
     # 'website',
     'global_ultimate_duns_number',
     'company_number',
@@ -36,7 +36,7 @@ ALL_DNB_UPDATED_MODEL_FIELDS = (
     'is_number_of_employees_estimated',
     'turnover',
     'is_turnover_estimated',
-    # TODO: Uncomment when D&B fix their data
+    # TODO: Uncomment when D&B fix their data and add to CompanySerializer.dnb_read_only_fields
     # 'website',
     'global_ultimate_duns_number',
     'company_number',


### PR DESCRIPTION
### Description of change

Make the `website` field on D&B companies editable again so users can change it via frontend as we no longer accept updates from D&B against that field.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
