### PR TITLE
show export wins of merged companies

### DIFF
--- a/changelog/company/export-wins.bugfix.md
+++ b/changelog/company/export-wins.bugfix.md
@@ -1,0 +1,3 @@
+`GET /v4/company/<uuid:pk>/export-win` API endpoint is now updated to to allow export wins of merged companies to be surfaced on export tab for the target company.
+
+`match_id` of the target company as well as all `transferred_from` companies are extracted from company matching service before supplying them to export wins service. Export wins service will in turn expose all wins matching those match ids.

--- a/datahub/company/company_matching_api.py
+++ b/datahub/company/company_matching_api.py
@@ -72,32 +72,39 @@ def request_match_companies(json_body):
     return response
 
 
-def _format_company_for_post(company):
+def _format_company_for_post(companies):
     """Format the Company model to json for the POST body."""
-    description = {
-        'id': str(company.id),
-        'company_name': company.name,
-        'companies_house_id': company.company_number,
-        'duns_number': company.duns_number,
-        'postcode': company.address_postcode,
-        'cdms_ref': company.reference_code,
-    }
+    descriptions = [
+        {
+            'id': str(company.id),
+            'company_name': company.name,
+            'companies_house_id': company.company_number,
+            'duns_number': company.duns_number,
+            'postcode': company.address_postcode,
+            'cdms_ref': company.reference_code,
+        }
+        for company in companies
+    ]
 
     return {
         'descriptions': [
-            {key: value for key, value in description.items() if value},
+            {
+                key: value
+                for key, value in description.items() if value
+            }
+            for description in descriptions
         ],
     }
 
 
-def match_company(company):
+def match_company(companies):
     """
-    Get a company match from a Company object return a response from the company
+    Get match id for all Company objects and return response from the company
     matching service.
     Raises exception an requests.exceptions.HTTPError for status, timeout and a connection error.
     """
     try:
-        response = request_match_companies(_format_company_for_post(company))
+        response = request_match_companies(_format_company_for_post(companies))
     except ConnectionError as exc:
         error_message = 'Encountered an error connecting to Company matching service'
         raise CompanyMatchingServiceConnectionError(error_message) from exc

--- a/datahub/company/export_wins_api.py
+++ b/datahub/company/export_wins_api.py
@@ -35,9 +35,11 @@ class ExportWinsAPIConnectionError(ExportWinsAPIException):
     """
 
 
-def fetch_export_wins(match_id):
+def fetch_export_wins(match_ids):
     """
-    Queries the Export Wins API with the given match id.
+    Queries the Export Wins API with the given list of match ids.
+    Export Wins API takes either a single match id or comma separated
+    list of match ids.
     """
     if not all([
         settings.EXPORT_WINS_SERVICE_BASE_URL,
@@ -46,22 +48,24 @@ def fetch_export_wins(match_id):
     ]):
         raise ImproperlyConfigured('The all EXPORT_WINS_SERVICE* setting must be set')
 
+    match_ids_str = ','.join(list(map(str, match_ids)))
     response = api_client.request(
         'GET',
-        f'wins/match/{match_id}/',
+        f'wins/match?match_id={match_ids_str}',
         timeout=3.0,
     )
     return response
 
 
-def get_export_wins(match_id):
+def get_export_wins(match_ids):
     """
-    Get all export wins for a given the company match_id.
+    Get all export wins for all given company match_ids.
 
+    `match_ids` is a list of match ids from Company matchin service.
     Raises exception an requests.exceptions.HTTPError for status, timeout and a connection error.
     """
     try:
-        response = fetch_export_wins(match_id)
+        response = fetch_export_wins(match_ids)
     except ConnectionError as exc:
         error_message = 'Encountered an error connecting to Export Wins API'
         raise ExportWinsAPIConnectionError(error_message) from exc

--- a/datahub/company/test/test_company_matching_api.py
+++ b/datahub/company/test/test_company_matching_api.py
@@ -85,7 +85,7 @@ class TestCompanyMatchingApi(APITestMixin):
             status_code=status.HTTP_200_OK,
             text=dynamic_response,
         )
-        match_company(company)
+        match_company([company])
 
         assert matcher.called_once
         assert matcher.last_request.json() == {
@@ -99,7 +99,7 @@ class TestCompanyMatchingApi(APITestMixin):
         """
         company = CompanyFactory()
         with pytest.raises(ImproperlyConfigured):
-            match_company(company)
+            match_company([company])
 
     @pytest.mark.parametrize(
         'request_exception,expected_exception',
@@ -138,7 +138,7 @@ class TestCompanyMatchingApi(APITestMixin):
         )
         company = CompanyFactory()
         with pytest.raises(expected_exception):
-            match_company(company)
+            match_company([company])
 
     @pytest.mark.parametrize(
         'response_status',
@@ -166,4 +166,4 @@ class TestCompanyMatchingApi(APITestMixin):
             CompanyMatchingServiceHTTPError,
             match=f'The Company matching service returned an error status: {response_status}',
         ):
-            match_company(company)
+            match_company([company])


### PR DESCRIPTION
### Description of change
`GET /v4/company/<uuid:pk>/export-win` API endpoint is now updated to to allow export wins of merged companies to be surfaced on export tab for target company.

`match_id` of the target company as well as all `transferred_from` companies are extracted from company matching service before supplying them to export wins service. Export wins service will in turn expose all wins matching those match ids.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
