### PR TITLE
Add submit_legacy_dnb_investigations management command

### DIFF
--- a/changelog/company/submit-legacy-dnb-investigations.feature.md
+++ b/changelog/company/submit-legacy-dnb-investigations.feature.md
@@ -1,0 +1,9 @@
+A django management command `submit_legacy_dnb_investigations` was added to submit
+remaining unsubmitted legacy investigations to D&B.  Companies are eligible
+for submission through this command if they were created using the legacy
+investigations API endpoint, have a telephone number recorded in `dnb_investigation_data`
+and do not have a `website` set. Companies created through the legacy investigation endpoint
+that do have a `website` have already been sent through to D&B outside of Data Hub.
+
+This work enables us to deprecate and remove the `dnb_investigation_data` field
+on Company.

--- a/datahub/dnb_api/management/commands/submit_legacy_dnb_investigations.py
+++ b/datahub/dnb_api/management/commands/submit_legacy_dnb_investigations.py
@@ -1,0 +1,87 @@
+from logging import getLogger
+
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from datahub.company.models import Company
+from datahub.dnb_api.utils import (
+    create_investigation,
+    DNBServiceConnectionError,
+    DNBServiceError,
+    DNBServiceTimeoutError,
+)
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command to submit legacy dnb investigations to dnb-service.
+    """
+
+    help = (
+        'Submit legacy dnb investigations to dnb-service. Investigations are '
+        'submitted for companies where pending_dnb_investigation=True, '
+        'investigation_id=False and website=None. This allows us to submit investigations '
+        'for companies which only have a phone number for investigation evidence.'
+    )
+
+    def add_arguments(self, parser):
+        """
+        Parse arguments/options for this command.
+        """
+        parser.add_argument(
+            '--simulate',
+            help='Simulate investigation submissions.',
+            action='store_true',
+        )
+
+    def handle(self, *args, **options):
+        """
+        Run the celery task.
+        """
+        companies = Company.objects.filter(
+            Q(website='') | Q(website=None),
+            pending_dnb_investigation=True,
+            dnb_investigation_id=None,
+        )
+        for company in companies:
+            if not (
+                company.dnb_investigation_data
+                and company.dnb_investigation_data.get('telephone_number')
+            ):
+                continue
+
+            investigation_data = {
+                'company_details': {
+                    'primary_name': company.name,
+                    'website': '',
+                    'telephone_number': company.dnb_investigation_data['telephone_number'],
+                    'address_line_1': company.address_1,
+                    'address_line_2': company.address_2,
+                    'address_town': company.address_town,
+                    'address_county': company.address_county,
+                    'address_postcode': company.address_postcode,
+                    'address_country': company.address_country.iso_alpha2_code,
+                },
+            }
+            message = f'Submitting investigation for company ID "{company.id}" to dnb-service.'
+            if options['simulate']:
+                logger.info(f'[SIMULATE] {message}')
+                continue
+            logger.info(message)
+
+            # NOTE: there is some duplication here with
+            # dnb_api/views.py::DNBCompanyInvestigationView however this command is temporary and
+            # will be removed after use
+            try:
+                response = create_investigation(investigation_data)
+            except (
+                DNBServiceConnectionError,
+                DNBServiceTimeoutError,
+                DNBServiceError,
+            ) as exc:
+                logger.error(str(exc))
+
+            company.dnb_investigation_id = response['id']
+            company.save()

--- a/datahub/dnb_api/management/commands/submit_legacy_dnb_investigations.py
+++ b/datahub/dnb_api/management/commands/submit_legacy_dnb_investigations.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             pending_dnb_investigation=True,
             dnb_investigation_id=None,
         ).order_by('created_on')
-        for company in companies:
+        for company in companies.iterator():
             if not (
                 company.dnb_investigation_data
                 and company.dnb_investigation_data.get('telephone_number')
@@ -86,4 +86,4 @@ class Command(BaseCommand):
                 continue
 
             company.dnb_investigation_id = response['id']
-            company.save()
+            company.save(update_fields=['dnb_investigation_id'])

--- a/datahub/dnb_api/test/commands/test_submit_legacy_dnb_investigations.py
+++ b/datahub/dnb_api/test/commands/test_submit_legacy_dnb_investigations.py
@@ -117,6 +117,10 @@ def test_legacy_investigations_submitted(mock_create_investigation):
         website='',
         dnb_investigation_id='11111111-2222-3333-4444-555555555555',
     )
+    CompanyFactory(
+        pending_dnb_investigation=True,
+        dnb_investigation_data={},
+    )
     call_command('submit_legacy_dnb_investigations')
     assert mock_create_investigation.call_count == len(legacy_investigation_companies)
 

--- a/datahub/dnb_api/test/commands/test_submit_legacy_dnb_investigations.py
+++ b/datahub/dnb_api/test/commands/test_submit_legacy_dnb_investigations.py
@@ -1,0 +1,110 @@
+from unittest import mock
+
+import pytest
+from django.core.management import call_command
+
+from datahub.company.test.factories import CompanyFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mock_create_investigation(monkeypatch):
+    """
+    Test fixture to mock create_investigation utility.
+    """
+    mocked_create_investigation = mock.Mock()
+    monkeypatch.setattr(
+        'datahub.dnb_api.management.commands.submit_legacy_dnb_investigations.'
+        'create_investigation',
+        mocked_create_investigation,
+    )
+    return mocked_create_investigation
+
+
+def test_no_companies_no_investigations_created(mock_create_investigation):
+    """
+    Test that calling the management command when there are no companies results
+    in no `create_investigation` calls.
+    """
+    call_command('submit_legacy_dnb_investigations')
+    assert mock_create_investigation.call_count == 0
+
+
+def test_legacy_investigations_submitted(mock_create_investigation):
+    """
+    Test that investigations are submitted as expected when we have a variety
+    of company data in the database.
+    """
+    mocked_investigation_ids = [
+        '22222222-2222-3333-4444-555555555555', '33333333-2222-3333-4444-555555555555',
+    ]
+    mock_create_investigation.side_effect = [
+        {'id': mocked_id}
+        for mocked_id in mocked_investigation_ids
+    ]
+    legacy_investigation_companies = [
+        CompanyFactory(
+            pending_dnb_investigation=True,
+            website='',
+            dnb_investigation_data={'telephone_number': '1234'},
+        ),
+        CompanyFactory(
+            pending_dnb_investigation=True,
+            website=None,
+            dnb_investigation_data={'telephone_number': '5678'},
+        ),
+    ]
+    # Companies that should be ignored by the management command
+    CompanyFactory(
+        pending_dnb_investigation=False,
+    )
+    CompanyFactory(
+        pending_dnb_investigation=True,
+        website='http://www.example.com/',
+    )
+    CompanyFactory(
+        pending_dnb_investigation=True,
+        website='',
+        dnb_investigation_id='11111111-2222-3333-4444-555555555555',
+    )
+    call_command('submit_legacy_dnb_investigations')
+    assert mock_create_investigation.call_count == len(legacy_investigation_companies)
+
+    for company in legacy_investigation_companies:
+        mock_create_investigation.assert_any_call(
+            {
+                'company_details': {
+                    'primary_name': company.name,
+                    'website': '',
+                    'telephone_number': company.dnb_investigation_data['telephone_number'],
+                    'address_line_1': company.address_1,
+                    'address_line_2': company.address_2,
+                    'address_town': company.address_town,
+                    'address_county': company.address_county,
+                    'address_postcode': company.address_postcode,
+                    'address_country': company.address_country.iso_alpha2_code,
+                },
+            },
+        )
+        company.refresh_from_db()
+        assert str(company.dnb_investigation_id) in mocked_investigation_ids
+
+
+def test_simulate(caplog, mock_create_investigation):
+    """
+    Test that the simulate flag logs messages as expected.
+    """
+    caplog.set_level('INFO')
+    company = CompanyFactory(
+        pending_dnb_investigation=True,
+        website='',
+        dnb_investigation_data={'telephone_number': '1234'},
+    )
+    call_command('submit_legacy_dnb_investigations', simulate=True)
+    assert mock_create_investigation.call_count == 0
+    expected_message = (
+        f'[SIMULATE] Submitting investigation for company ID "{company.id}" to dnb-service.'
+    )
+    assert expected_message in caplog.text


### PR DESCRIPTION
### Description of change

A django management command `submit_legacy_dnb_investigations` was added to submit remaining unsubmitted legacy investigations to D&B.  Companies are eligible for submission through this command if they were created using the legacy investigations API endpoint, have a telephone number recorded in `dnb_investigation_data` and do not have a `website` set. Companies created through the legacy investigation endpoint that do have a `website` have already been sent through to D&B outside of Data Hub.

This work enables us to deprecate and remove the `dnb_investigation_data` field on Company.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
