### PR TITLE
Enable name field on PATCH pipeline item

### DIFF
--- a/changelog/add-update-pipeline-name.api.md
+++ b/changelog/add-update-pipeline-name.api.md
@@ -1,0 +1,1 @@
+For existing endpoint `/v4/pipeline-item/uuid`, extend the logic to allow field `name` to be updated on the `PATCH` method. After this change, both `name` and `status` will be allowed to be updated. If we attempt to update any other field other than the allowed fields, the endpoint should still throw a `400`.

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -95,7 +95,7 @@ class PipelineItemSerializer(serializers.ModelSerializer):
         Raise a validation error if anything else other than allowed fields is updated.
         """
         if self.partial and self.instance:
-            allowed_fields = {'status'}
+            allowed_fields = {'status', 'name'}
             fields = data.keys()
             extra_fields = fields - allowed_fields
             if extra_fields:

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -12,6 +12,7 @@ from datahub.user.company_list.test.factories import PipelineItemFactory
 
 pipeline_collection_url = reverse('api-v4:company-list:pipelineitem-collection')
 
+
 def _pipeline_item_detail_url(item_pk):
     return reverse('api-v4:company-list:pipelineitem-detail', kwargs={'pk': item_pk})
 
@@ -645,7 +646,7 @@ class TestPatchPipelineItemView(APITestMixin):
         assert response.json() == expected_errors
 
     def test_validate_only_allowed_fields_can_be_updated(self):
-        """Test validation."""
+        """Test that any other field other than status or name throws a 400"""
         company = CompanyFactory()
         item = PipelineItemFactory(adviser=self.user)
         url = _pipeline_item_detail_url(item.pk)
@@ -698,7 +699,6 @@ class TestPatchPipelineItemView(APITestMixin):
         )
         url = _pipeline_item_detail_url(item.pk)
         new_status = PipelineItem.Status.LEADS
-        new_name = 'BATMAN'
         response = self.api_client.patch(
             url,
             data={


### PR DESCRIPTION
### Description of change

The intent of this PR is to allow updates on the name field during the PATCH method for `/v4/pipeline-item/uuid` endpoint. This will allow the FE to update the name of a pipeline item if needed.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
