### PR TITLE
Add a setting for loading additional Django apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `EXPORT_WINS_SERVICE_BASE_URL` | No | The base url of the Export Wins API (default=None). |
 | `EXPORT_WINS_HAWK_ID` | No | The hawk id to use when making a request to the Export Wins API (default=None). |
 | `EXPORT_WINS_HAWK_KEY` | No | The hawk key to use when making a request to the Export Wins API (default=None). |
+| `EXTRA_DJANGO_APPS`  | Yes | Additional Django apps to load (comma-separated). Can be used to reverse the migrations of a removed third-party app (see comment in config/settings/common.py for more detail). |
 | `GUNICORN_ACCESSLOG`  | No | File to direct Gunicorn logs to (default=stdout). |
 | `GUNICORN_ACCESS_LOG_FORMAT`  | No |  |
 | `GUNICORN_ENABLE_ASYNC_PSYCOPG2` | No | Whether to enable asynchronous psycopg2 when the worker class is 'gevent' (default=True). |

--- a/changelog/extra-apps.internal.md
+++ b/changelog/extra-apps.internal.md
@@ -1,0 +1,1 @@
+A setting was added to conditionally load Django apps so that there's a reliable way to reverse the migrations of a third-party Django app.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -115,7 +115,23 @@ MI_APPS = [
     'datahub.mi_dashboard',
 ]
 
+# Can be used as a way to load a third-party app that has been removed from the
+# default INSTALLED_APPS list so its migrations can be reversed without them
+# being automatically reapplied.
+#
+# E.g.:
+# EXTRA_DJANGO_APPS=oauth2_provider ./manage.py migrate oauth2_provider zero
+#
+# Check the plan first if doing this using e.g.:
+# EXTRA_DJANGO_APPS=oauth2_provider ./manage.py migrate --plan oauth2_provider zero
+EXTRA_DJANGO_APPS = env.list('EXTRA_DJANGO_APPS', default=[])
+
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS + MI_APPS
+
+if set(EXTRA_DJANGO_APPS) & set(INSTALLED_APPS):
+    raise ImproperlyConfigured('EXTRA_DJANGO_APPS should not overlap with the default app list')
+
+INSTALLED_APPS += EXTRA_DJANGO_APPS
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
### Description of change

This adds a setting, `EXTRA_DJANGO_APPS`, for specifying additional Django apps to load.

This is part of the work to remove the dependency on Django OAuth Toolkit.

The setting gives us a way of removing the `oauth2_provider` app and undoing its migrations without those migrations being automatically reapplied (when `./manage.py migrate` runs).

(Before we actually do this, we will need to untangle `oauth2_provider` from the `oauth` app migrations e.g. by squashing the migrations.)

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
