### PR TITLE
Remove deprecated /token/ view

### DIFF
--- a/changelog/oauth2-provider-references.internal.md
+++ b/changelog/oauth2-provider-references.internal.md
@@ -1,0 +1,2 @@
+Some unneeded references to the `oauth2_provider` package (from Django OAuth Toolkit) were removed
+in preparation for the removal of Django OAuth Toolkit.

--- a/changelog/token-view.removal.md
+++ b/changelog/token-view.removal.md
@@ -1,0 +1,1 @@
+The deprecated `/token/` endpoint was removed.

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path
-from oauth2_provider.views import TokenView
 
 from config import api_urls
 from config.api_docs_urls import api_docs_urls
@@ -14,7 +13,6 @@ unversioned_urls = [
     path('', include('datahub.investment.project.report.urls')),
     path('', include('datahub.oauth.admin.urls')),
     path('ping.xml', ping, name='ping'),
-    path('token/', TokenView.as_view(), name='token'),
     path('whoami/', who_am_i, name='who_am_i'),
 ]
 

--- a/datahub/documents/test/my_entity_document/views.py
+++ b/datahub/documents/test/my_entity_document/views.py
@@ -1,5 +1,5 @@
 """Document test views."""
-from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated
 
 from datahub.documents.test.my_entity_document.models import MyEntityDocument
 from datahub.documents.test.my_entity_document.serializers import MyEntityDocumentSerializer

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -13,7 +13,6 @@ python /app/manage.py loadinitialmetadata
 echo "import datetime
 from django.contrib.auth.models import Group
 from django.utils.timezone import now
-from oauth2_provider.models import AccessToken
 from datahub.company.models import Advisor
 
 dit_east_midlands_id = '9010dd28-9798-e211-a939-e4115bead28a'


### PR DESCRIPTION
### Description of change

This removes the `/token/` view that was deprecated in #2845.

It also removes a couple of unneeded references to the `oauth2_provider` package (from Django OAuth Toolkit). This is in preparation for the removal of Django OAuth Toolkit.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
