### PR TITLE
Add daily job to track auto-archive backlog

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -441,6 +441,16 @@ if REDIS_BASE_URL:
                 'simulate': False,
             }
         },
+        # The purpose of the following is to keep us posted on the backlog of
+        # companies that are eligible for automatic archiving
+        'simulate_automatic_company_archive': {
+            'task': 'datahub.company.tasks.automatic_company_archive',
+            'schedule': crontab(minute=0, hour=19),
+            'kwargs': {
+                'limit': 20000,
+                'simulate': True,
+            }
+        },
     }
 
     if env.bool('ENABLE_DAILY_HIERARCHY_ROLLOUT', False):

--- a/datahub/company/tasks/company.py
+++ b/datahub/company/tasks/company.py
@@ -89,4 +89,7 @@ def automatic_company_archive(self, limit=1000, simulate=True):
             return
 
         archive_count = _automatic_company_archive(limit, simulate)
-        send_realtime_message(f'{self.name} archived: {archive_count}')
+        realtime_message = f'{self.name} archived: {archive_count}'
+        if simulate:
+            realtime_message = f'[SIMULATE] {realtime_message}'
+        send_realtime_message(realtime_message)


### PR DESCRIPTION
### Description of change

We have been running the `automatic_company_archive` job for a while. Lately, we have noticed that the number of companies archived automatically have exceeded our original estimates.

The estimates in this case were only valid for a point-in-time because the criteria includes clauses that mean the set of companies eligible for automatic archiving is a rolling one.

We would like to track the number of companies that are eligible for archiving. It would be interesting to take note of how this set grows etc.

This introduces a cron entry that runs the `automatic_company_archive` job in simulation mode every night. This should provide us with the visibility we need.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
