### PR TITLE
Remove stray company referral news fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -455,6 +455,7 @@
 - **Advisers** The new authentication class with SSO email user ID support now records user events whenever an introspection occurs. This new authentication class continues to be currently disabled by default.
 - **Advisers** It‘s now possible to search for user events in the admin site by API URL path prefix and adviser ID. The user event API URL path field filter was also removed due to the large number of entries in this filter.
 - **Companies** Two scheduled tasks - "automatic company archive" and "get company updates" - will now send summary messages to a Slack channel upon completion.
+- **Companies** Help text was added to the admin site for the 'Interaction', 'Completed on' and 'Completed by' company referral fields.
 
 ## Internal changes
 

--- a/datahub/company/admin-referral-help-text.feature.md
+++ b/datahub/company/admin-referral-help-text.feature.md
@@ -1,1 +1,0 @@
-Help text was added to the admin site for the 'Interaction', 'Completed on' and 'Completed by' company referral fields.


### PR DESCRIPTION
### Description of change

This removes a stray company referral news fragment and puts it in the correct place in the changelog.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
