### PR TITLE
Add update One List company Core Team endpoint

### DIFF
--- a/changelog/company/one-list-core-team-update-endpoint.api.md
+++ b/changelog/company/one-list-core-team-update-endpoint.api.md
@@ -1,0 +1,20 @@
+A new `PATCH /v4/company/<company-id>/update-one-list-core-team` endpoint to update the Core Team of One List company 
+has been added. Adviser with correct permissions can update Core Team of a company.
+
+Example request body:
+
+```
+{
+  "core_team_members": [
+    {
+      "adviser": <adviser_1_uuid>
+    },
+    {
+      "adviser": <adviser_2_uuid>
+    }, 
+    ...
+  ]
+}
+```
+
+Successful request should expect empty response with 204 (no content) HTTP status.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -446,6 +446,14 @@ class Company(ArchivableModel, BaseModel):
         self.one_list_tier = None
         self.save()
 
+    def add_one_list_core_team_member(self, adviser):
+        """Add Core team member to the company."""
+        OneListCoreTeamMember.objects.get_or_create(adviser=adviser, company=self)
+
+    def delete_one_list_core_team_member(self, adviser):
+        """Remove Core Team member from the company."""
+        OneListCoreTeamMember.objects.filter(adviser=adviser, company=self).delete()
+
     def add_export_country(self, country, status, record_date, adviser, track_history=False):
         """
         Add a company export_country, if it doesn't exist.

--- a/datahub/company/test/conftest.py
+++ b/datahub/company/test/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+
+from datahub.company.models import CompanyPermission
+from datahub.core.test_utils import create_test_user
+
+
+@pytest.fixture
+def one_list_editor():
+    """An adviser with permission to change one list company."""
+    permission_codenames = [
+        CompanyPermission.change_company,
+        CompanyPermission.change_one_list_tier_and_global_account_manager,
+    ]
+
+    return create_test_user(permission_codenames=permission_codenames, dit_team=None)

--- a/datahub/company/test/test_company_views_one_list.py
+++ b/datahub/company/test/test_company_views_one_list.py
@@ -7,30 +7,12 @@ from reversion.models import Version
 from datahub.company.constants import OneListTierID
 from datahub.company.models import CompanyPermission, OneListTier
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, SubsidiaryFactory
+from datahub.company.test.utils import random_non_ita_one_list_tier
 from datahub.core.test_utils import (
     APITestMixin,
     create_test_user,
     random_obj_for_model,
-    random_obj_for_queryset,
 )
-
-
-@pytest.fixture
-def one_list_editor():
-    """An adviser with permission to change one list company."""
-    permission_codenames = [
-        CompanyPermission.change_company,
-        CompanyPermission.change_one_list_tier_and_global_account_manager,
-    ]
-
-    return create_test_user(permission_codenames=permission_codenames, dit_team=None)
-
-
-def _random_non_ita_one_list_tier():
-    queryset = OneListTier.objects.exclude(
-        pk=OneListTierID.tier_d_international_trade_advisers.value,
-    )
-    return random_obj_for_queryset(queryset)
 
 
 class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
@@ -85,7 +67,7 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
             pytest.param(
                 lambda: CompanyFactory(
                     one_list_account_owner=AdviserFactory(),
-                    one_list_tier=_random_non_ita_one_list_tier(),
+                    one_list_tier=random_non_ita_one_list_tier(),
                 ),
                 id='existing-global-account-manager',
             ),
@@ -107,7 +89,7 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
         api_client = self.create_api_client(user=one_list_editor)
         url = self._get_url(company)
 
-        new_one_list_tier = _random_non_ita_one_list_tier()
+        new_one_list_tier = random_non_ita_one_list_tier()
 
         global_account_manager = AdviserFactory()
 
@@ -157,7 +139,7 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
                     global_headquarters__one_list_account_owner=AdviserFactory(),
                 ),
                 lambda: AdviserFactory().pk,
-                lambda: _random_non_ita_one_list_tier().pk,
+                lambda: random_non_ita_one_list_tier().pk,
                 {
                     api_settings.NON_FIELD_ERRORS_KEY: [
                         'A subsidiary cannot be on One List.',
@@ -171,7 +153,7 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
                     one_list_account_owner=AdviserFactory(),
                 ),
                 lambda: AdviserFactory().pk,
-                lambda: _random_non_ita_one_list_tier().pk,
+                lambda: random_non_ita_one_list_tier().pk,
                 {
                     api_settings.NON_FIELD_ERRORS_KEY: [
                         'A company on this One List tier can only be changed by ITA.',
@@ -181,7 +163,7 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
             ),
             pytest.param(
                 lambda: CompanyFactory(
-                    one_list_tier=_random_non_ita_one_list_tier(),
+                    one_list_tier=random_non_ita_one_list_tier(),
                     one_list_account_owner=AdviserFactory(),
                 ),
                 lambda: AdviserFactory().pk,
@@ -274,7 +256,7 @@ class TestRemoveCompanyFromOneList(APITestMixin):
             pytest.param(
                 lambda: CompanyFactory(
                     one_list_account_owner=AdviserFactory(),
-                    one_list_tier_id=_random_non_ita_one_list_tier().pk,
+                    one_list_tier_id=random_non_ita_one_list_tier().pk,
                 ),
                 id='existing-one-list-assignment',
             ),

--- a/datahub/company/test/utils.py
+++ b/datahub/company/test/utils.py
@@ -1,3 +1,18 @@
+from datahub.company.constants import OneListTierID
+from datahub.company.models import OneListTier
+from datahub.core.test_utils import (
+    random_obj_for_queryset,
+)
+
+
+def random_non_ita_one_list_tier():
+    """Returns random non ITA One List tier."""
+    queryset = OneListTier.objects.exclude(
+        pk=OneListTierID.tier_d_international_trade_advisers.value,
+    )
+    return random_obj_for_queryset(queryset)
+
+
 def format_expected_adviser(adviser):
     """
     Formats Adviser object into format expected to be returned by

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -48,6 +48,10 @@ one_list_group_core_team = OneListGroupCoreTeamViewSet.as_view({
     'get': 'list',
 })
 
+update_one_list_core_team = CompanyViewSet.as_action_view(
+    'update_one_list_core_team',
+)
+
 public_company_item = PublicCompanyViewSet.as_view({
     'get': 'retrieve',
 })
@@ -82,6 +86,11 @@ urls = [
         'company/<uuid:pk>/one-list-group-core-team',
         one_list_group_core_team,
         name='one-list-group-core-team',
+    ),
+    path(
+        'company/<uuid:pk>/update-one-list-core-team',
+        update_one_list_core_team,
+        name='update-one-list-core-team',
     ),
     path(
         'company/<uuid:pk>/export-detail',

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -49,6 +49,7 @@ from datahub.company.serializers import (
     RemoveCompanyFromOneListSerializer,
     SelfAssignAccountManagerSerializer,
     UpdateExportDetailsSerializer,
+    UpdateOneListCoreTeamMembersSerializer,
 )
 from datahub.company.validators import NotATransferredCompanyValidator
 from datahub.core.audit import AuditViewSet
@@ -217,6 +218,29 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         """
         instance = self.get_object()
         serializer = RemoveCompanyFromOneListSerializer(instance=instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(request.user)
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    @action(
+        methods=['patch'],
+        detail=True,
+        permission_classes=[
+            HasPermissions(
+                f'company.{CompanyPermission.change_company}',
+                f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
+            ),
+        ],
+        schema=StubSchema(),
+    )
+    def update_one_list_core_team(self, request, *args, **kwargs):
+        """Updates core team for the company."""
+        instance = self.get_object()
+        serializer = UpdateOneListCoreTeamMembersSerializer(
+            instance=instance,
+            data=request.data,
+            partial=True,
+        )
         serializer.is_valid(raise_exception=True)
         serializer.save(request.user)
         return Response(None, status=status.HTTP_204_NO_CONTENT)

--- a/datahub/core/serializers.py
+++ b/datahub/core/serializers.py
@@ -12,7 +12,6 @@ from rest_framework.fields import ReadOnlyField, UUIDField
 from datahub.core.validate_utils import DataCombiner
 from datahub.metadata.models import Country
 
-
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
 


### PR DESCRIPTION
### Description of change

A new `PATCH /v4/company/<company-id>/update-one-list-core-team` endpoint to update the Core Team of One List company has been added. Adviser with correct permissions can update Core Team of a company.

I am not sure whether to validate if company is in One List. This is because an endpoint that removes company from One List will not remove any Core Team members. 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
