### PR TITLE
Remove dependency on Django OAuth Toolkit

### DIFF
--- a/changelog/django-oauth-toolkit.internal.md
+++ b/changelog/django-oauth-toolkit.internal.md
@@ -1,0 +1,1 @@
+The dependency Django OAuth Toolkit was removed as it’s no longer required.

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,6 @@ django-filter==2.2.0
 django-reversion==3.0.7
 django-pglocks==1.0.4
 django-mptt==0.11.0
-django-oauth-toolkit==1.3.2
 uritemplate==3.0.1  # required for DRF schema features
 whitenoise==5.1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,11 +27,10 @@ django-extensions==2.2.9  # via -r requirements.in
 django-filter==2.2.0      # via -r requirements.in
 django-js-asset==1.2.2    # via django-mptt
 django-mptt==0.11.0       # via -r requirements.in
-django-oauth-toolkit==1.3.2  # via -r requirements.in
 django-pglocks==1.0.4     # via -r requirements.in
 django-redis==4.11.0      # via -r requirements.in
 django-reversion==3.0.7   # via -r requirements.in
-django==3.0.6             # via -r requirements.in, django-debug-toolbar, django-filter, django-mptt, django-oauth-toolkit, django-redis, django-reversion, djangorestframework
+django==3.0.6             # via -r requirements.in, django-debug-toolbar, django-filter, django-mptt, django-redis, django-reversion, djangorestframework
 djangorestframework==3.11.0  # via -r requirements.in
 docopt==0.6.2             # via notifications-python-client
 docutils==0.15.2          # via botocore
@@ -74,7 +73,6 @@ monotonic==1.5            # via notifications-python-client
 more-itertools==8.2.0     # via pytest
 multidict==4.7.5          # via aiohttp, yarl
 notifications-python-client==5.6.0  # via -r requirements.in
-oauthlib==3.1.0           # via django-oauth-toolkit
 packaging==20.3           # via pytest
 parso==0.6.2              # via jedi
 pathtools==0.1.2          # via watchdog
@@ -106,7 +104,7 @@ pyyaml==5.3.1             # via -r requirements.in, watchdog
 redis==3.5.2              # via -r requirements.in, celery, django-redis
 requests-futures==1.0.0   # via piprot
 requests-mock==1.8.0      # via -r requirements.in
-requests==2.23.0          # via -r requirements.in, django-oauth-toolkit, notifications-python-client, piprot, requests-futures, requests-mock, requests-toolbelt
+requests==2.23.0          # via -r requirements.in, notifications-python-client, piprot, requests-futures, requests-mock, requests-toolbelt
 requests_toolbelt==0.9.1  # via -r requirements.in
 s3transfer==0.3.3         # via boto3
 semantic_version==2.8.5   # via -r requirements.in


### PR DESCRIPTION
### Description of change

This follows on from #2867 and removes Django OAuth Toolkit now it's no longer required and its migrations have been reversed.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
