### PR TITLE
Add a bug fix to assign one list tier endpoint.

### DIFF
--- a/changelog/company/assign-one-list-tier-and-global-account-manager-version.bugfix.md
+++ b/changelog/company/assign-one-list-tier-and-global-account-manager-version.bugfix.md
@@ -1,0 +1,2 @@
+A bug in `POST /v4/company/<company-id>/assign-one-list-tier-and-global-account-manager` endpoint that 
+resulted in incorrect version being saved has been fixed.

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -731,7 +731,7 @@ class AssignOneListTierAndGlobalAccountManagerSerializer(serializers.Serializer)
         """Update company One List account manager and tier."""
         self.instance.assign_one_list_account_manager_and_tier(
             self.validated_data['global_account_manager'],
-            self.validated_data['one_list_tier'],
+            self.validated_data['one_list_tier'].id,
             adviser,
         )
         return self.instance

--- a/datahub/company/test/test_company_views_one_list.py
+++ b/datahub/company/test/test_company_views_one_list.py
@@ -2,6 +2,7 @@ import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
+from reversion.models import Version
 
 from datahub.company.constants import OneListTierID
 from datahub.company.models import CompanyPermission, OneListTier
@@ -123,6 +124,12 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
         assert company.one_list_account_owner == global_account_manager
         assert company.one_list_tier_id == new_one_list_tier.pk
         assert company.modified_by == one_list_editor
+
+        # Check that object version is stored correctly
+        versions = Version.objects.get_for_object(company)
+        assert versions.count() == 1
+        assert versions[0].field_dict['one_list_tier_id'] == new_one_list_tier.id
+        assert versions[0].field_dict['one_list_account_owner_id'] == global_account_manager.id
 
     @pytest.mark.parametrize(
         'company_factory,adviser_id_fn,new_one_list_tier_id_fn,expected_errors',


### PR DESCRIPTION
### Description of change

A bug in `POST /v4/company/<company-id>/assign-one-list-tier-and-global-account-manager` endpoint that 
resulted in incorrect version being saved has been fixed.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
