### PR TITLE
Add support for additional pipelineitem fields

### DIFF
--- a/changelog/pipeline-item-post-method-change-iter-2.api.md
+++ b/changelog/pipeline-item-post-method-change-iter-2.api.md
@@ -1,0 +1,7 @@
+For existing endpoint `/v4/pipeline-item`, add additional 5 fields that can be seen below. All of these fields are optional and nullable at this stage so no additional validation required. The api should be able to create a pipeline item with or without any of these fields.
+
+- `"contact_id" uuid NULL`
+- `"sector_id" uuid NULL`
+- `"potential_value" biginteger NULL`
+- `"likelihood_to_win" int NULL`
+- `"expected_win_date" timestamp with time zone NULL`

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -115,6 +115,11 @@ class PipelineItemSerializer(serializers.ModelSerializer):
             'status',
             'adviser',
             'created_on',
+            'contact',
+            'sector',
+            'potential_value',
+            'likelihood_to_win',
+            'expected_win_date',
         )
         read_only_fields = (
             'id',

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -5,8 +5,9 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.company.test.factories import ArchivedCompanyFactory, CompanyFactory
+from datahub.company.test.factories import ArchivedCompanyFactory, CompanyFactory, ContactFactory
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
+from datahub.metadata.test.factories import SectorFactory
 from datahub.user.company_list.models import PipelineItem
 from datahub.user.company_list.test.factories import PipelineItemFactory
 
@@ -286,6 +287,11 @@ class TestGetPipelineItemsView(APITestMixin):
             'name': item.name,
             'status': item.status,
             'created_on': format_date_or_datetime(item.created_on),
+            'contact': str(item.contact.pk),
+            'sector': str(item.sector.pk),
+            'potential_value': str(item.potential_value),
+            'likelihood_to_win': item.likelihood_to_win,
+            'expected_win_date': format_date_or_datetime(item.expected_win_date),
         }
 
 
@@ -390,6 +396,9 @@ class TestAddPipelineItemView(APITestMixin):
     def test_successfully_create_a_pipeline_item(self):
         """Test that a pipeline item can be created."""
         company = CompanyFactory()
+        sector = SectorFactory()
+        contact = ContactFactory()
+
         pipeline_status = PipelineItem.Status.LEADS
         response = self.api_client.post(
             pipeline_collection_url,
@@ -397,9 +406,13 @@ class TestAddPipelineItemView(APITestMixin):
                 'company': str(company.pk),
                 'name': 'project name',
                 'status': pipeline_status,
+                'contact': str(contact.pk),
+                'sector': str(sector.pk),
+                'likelihood_to_win': PipelineItem.LikelihoodToWin.LOW,
+                'expected_win_date': '2019-04-19',
+                'potential_value': 1000,
             },
         )
-
         assert response.status_code == status.HTTP_201_CREATED
 
         response_data = response.json()
@@ -414,6 +427,11 @@ class TestAddPipelineItemView(APITestMixin):
             },
             'status': pipeline_status,
             'created_on': '2017-04-19T15:25:30.986208Z',
+            'contact': str(contact.pk),
+            'sector': str(sector.pk),
+            'potential_value': str(1000),
+            'likelihood_to_win': PipelineItem.LikelihoodToWin.LOW,
+            'expected_win_date': '2019-04-19',
         }
 
         pipeline_item = PipelineItem.objects.get(pk=response_data['id'])
@@ -450,6 +468,11 @@ class TestAddPipelineItemView(APITestMixin):
             },
             'status': pipeline_status,
             'created_on': '2017-04-19T15:25:30.986208Z',
+            'contact': None,
+            'sector': None,
+            'potential_value': None,
+            'likelihood_to_win': None,
+            'expected_win_date': None,
         }
 
         pipeline_item = PipelineItem.objects.get(pk=response_data['id'])
@@ -486,6 +509,11 @@ class TestAddPipelineItemView(APITestMixin):
             },
             'status': 'in_progress',
             'created_on': '2017-04-19T15:25:30.986208Z',
+            'contact': None,
+            'sector': None,
+            'potential_value': None,
+            'likelihood_to_win': None,
+            'expected_win_date': None,
         }
 
     @freeze_time('2017-04-19 15:25:30.986208')
@@ -519,6 +547,11 @@ class TestAddPipelineItemView(APITestMixin):
             },
             'status': 'in_progress',
             'created_on': '2017-04-19T15:25:30.986208Z',
+            'contact': None,
+            'sector': None,
+            'potential_value': None,
+            'likelihood_to_win': None,
+            'expected_win_date': None,
         }
 
     def test_with_archived_company(self):
@@ -687,6 +720,11 @@ class TestPatchPipelineItemView(APITestMixin):
             'name': new_name,
             'status': new_status,
             'created_on': format_date_or_datetime(item.created_on),
+            'contact': str(item.contact.pk),
+            'sector': str(item.sector.pk),
+            'potential_value': str(item.potential_value),
+            'likelihood_to_win': item.likelihood_to_win,
+            'expected_win_date': format_date_or_datetime(item.expected_win_date),
         }
 
     def test_can_patch_an_individual_field(self):
@@ -719,6 +757,11 @@ class TestPatchPipelineItemView(APITestMixin):
             'name': item.name,
             'status': new_status,
             'created_on': format_date_or_datetime(item.created_on),
+            'contact': str(item.contact.pk),
+            'sector': str(item.sector.pk),
+            'potential_value': str(item.potential_value),
+            'likelihood_to_win': item.likelihood_to_win,
+            'expected_win_date': format_date_or_datetime(item.expected_win_date),
         }
 
     def test_cannot_patch_other_users_item(self):
@@ -800,6 +843,11 @@ class TestGetPipelineItemView(APITestMixin):
             'name': item.name,
             'status': item.status,
             'created_on': format_date_or_datetime(item.created_on),
+            'contact': str(item.contact.pk),
+            'sector': str(item.sector.pk),
+            'potential_value': str(item.potential_value),
+            'likelihood_to_win': item.likelihood_to_win,
+            'expected_win_date': format_date_or_datetime(item.expected_win_date),
         }
 
     def test_cannot_get_another_users_list(self):


### PR DESCRIPTION
### Description of change

Added support for additional fields for pipeline items. These fields are all optional so no validation required for them, meaning the API should still be successful if any of these fields are included or missing on a `POST` and they should be returned with the default value of `None` in `GET` if no value is attributed to them.

Fields:
- `"contact_id" uuid NULL`
- `"sector_id" uuid NULL`
- `"potential_value" biginteger NULL`
- `"likelihood_to_win" int NULL`
- `"expected_win_date" timestamp with time zone NULL`


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
