### PR TITLE
Deprecate contact.accepts_dit_email_marketing field

### DIFF
--- a/changelog/contact/deprecate-contacts-accepts-dit-email-marketing.deprecation.md
+++ b/changelog/contact/deprecate-contacts-accepts-dit-email-marketing.deprecation.md
@@ -1,0 +1,12 @@
+The `accepts_dit_email_marketing` field is deprecated and will be removed from the following contact endpoints:
+- GET /v3/contact
+- GET /v4/company
+- GET /v4/company/{id}
+- PATCH /v4/company/{id}
+- POST /v3/contact/{id}/archive
+- POST /v3/contact/{id}/unarchive
+
+These end points will keep the `accepts_dit_email_marketing` field as the FE relies on it.
+- POST /v3/contact 
+- GET /v3/contact/{id}
+- PATCH /v3/contact/{id} 


### PR DESCRIPTION
### Description of change

The `accepts_dit_email_marketing` field will no longer be sourced from the Data Hub API, but from the Legal Basis API instead. This means that we will be deprecating the field from all of the contact end points except for those which the front end rely on. 

**The end points keeping this field are:** 
- POST /v3/contact
- GET /v3/contact/{id}
- PATCH /v3/contact/{id}

**The end points losing this field are:** 
- GET /v3/contact
- GET /v4/company
- GET /v4/company/{id}
- PATCH /v4/company/{id}
- POST /v3/contact/{id}/archive
- POST /v3/contact/{id}/unarchive

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
