### PR TITLE
Update pipeline item serializer

### DIFF
--- a/changelog/update-pipeline-item-serializer.api.md
+++ b/changelog/update-pipeline-item-serializer.api.md
@@ -1,0 +1,23 @@
+For existing endpoint `/v4/pipeline-item`, ensure that contact and sector segment are set to nestedRelatedFields so that we get the contact name and sector segment alongside with their ids. These fields are optional so no extra logic is present in this change.
+
+previous response:
+```
+...
+"contact": "uuid",
+"sector": "uuid",
+...
+```
+
+current response:
+```
+...
+"contact": {
+  "id": "uuid",
+  "name": "name"
+},
+"sector": {
+  "id": "uuid",
+  "segment": "segment"
+},
+...
+```

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from datahub.company.models import Company, Contact
 from datahub.core.serializers import NestedRelatedField
+from datahub.metadata import models as metadata_models
 from datahub.user.company_list.models import CompanyList, CompanyListItem, PipelineItem
 
 
@@ -78,6 +79,16 @@ class PipelineItemSerializer(serializers.ModelSerializer):
         extra_fields=('name', 'turnover', 'export_potential'),
     )
     adviser = serializers.HiddenField(default=serializers.CurrentUserDefault())
+    sector = NestedRelatedField(
+        metadata_models.Sector,
+        extra_fields=('id', 'segment'),
+        required=False,
+    )
+    contact = NestedRelatedField(
+        Contact,
+        extra_fields=('id', 'name'),
+        required=False,
+    )
 
     def validate_company(self, company):
         """Make sure company is not archived"""

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -290,8 +290,14 @@ class TestGetPipelineItemsView(APITestMixin):
             'name': item.name,
             'status': item.status,
             'created_on': format_date_or_datetime(item.created_on),
-            'contact': str(item.contact.pk),
-            'sector': str(item.sector.pk),
+            'contact': {
+                'id': str(item.contact.pk),
+                'name': item.contact.name,
+            },
+            'sector': {
+                'id': str(item.sector.pk),
+                'segment': item.sector.segment,
+            },
             'potential_value': str(item.potential_value),
             'likelihood_to_win': item.likelihood_to_win,
             'expected_win_date': format_date_or_datetime(item.expected_win_date),
@@ -560,8 +566,14 @@ class TestAddPipelineItemView(APITestMixin):
             },
             'status': pipeline_status,
             'created_on': '2017-04-19T15:25:30.986208Z',
-            'contact': str(contact.pk),
-            'sector': str(sector.pk),
+            'contact': {
+                'id': str(contact.pk),
+                'name': contact.name,
+            },
+            'sector': {
+                'id': str(sector.pk),
+                'segment': sector.segment,
+            },
             'potential_value': str(1000),
             'likelihood_to_win': PipelineItem.LikelihoodToWin.LOW,
             'expected_win_date': '2019-04-19',
@@ -848,8 +860,14 @@ class TestPatchPipelineItemView(APITestMixin):
             'name': new_name,
             'status': new_status,
             'created_on': format_date_or_datetime(item.created_on),
-            'contact': str(item.contact.pk),
-            'sector': str(item.sector.pk),
+            'contact': {
+                'id': str(item.contact.pk),
+                'name': item.contact.name,
+            },
+            'sector': {
+                'id': str(item.sector.pk),
+                'segment': item.sector.segment,
+            },
             'potential_value': str(item.potential_value),
             'likelihood_to_win': item.likelihood_to_win,
             'expected_win_date': format_date_or_datetime(item.expected_win_date),
@@ -939,7 +957,7 @@ class TestPatchPipelineItemView(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
 
         response_data = response.json()
-        assert response_data['sector'] == str(sector.id)
+        assert response_data['sector']['id'] == str(sector.id)
 
     def test_can_patch_contact_field(self):
         """Test that contact can be patched."""
@@ -958,7 +976,7 @@ class TestPatchPipelineItemView(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
 
         response_data = response.json()
-        assert response_data['contact'] == str(contact.id)
+        assert response_data['contact']['id'] == str(contact.id)
 
     def test_cannot_patch_non_existent_contact(self):
         """Test that non existent contact can't be patched."""
@@ -1075,8 +1093,14 @@ class TestGetPipelineItemView(APITestMixin):
             'name': item.name,
             'status': item.status,
             'created_on': format_date_or_datetime(item.created_on),
-            'contact': str(item.contact.pk),
-            'sector': str(item.sector.pk),
+            'contact': {
+                'id': str(item.contact.pk),
+                'name': item.contact.name,
+            },
+            'sector': {
+                'id': str(item.sector.pk),
+                'segment': item.sector.segment,
+            },
             'potential_value': str(item.potential_value),
             'likelihood_to_win': item.likelihood_to_win,
             'expected_win_date': format_date_or_datetime(item.expected_win_date),


### PR DESCRIPTION
### Description of change

ensure that contact and segment are set to nestedRelatedFields so that we get the contact name and sector segment alongside with their ids. These fields are optional so no extra logic is present in this change.

previous response:
```
...
"contact": "uuid",
"sector": "uuid",
...
```

current response:
```
...
"contact": {
  "id": "uuid",
  "name": "name"
},
"sector": {
  "id": "uuid",
  "segment": "segment"
},
...
```

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
