### PR TITLE
Investigation website should be optional

### DIFF
--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -381,7 +381,7 @@ class DNBCompanyInvestigationSerializer(serializers.Serializer):
         data = super().validate(data)
 
         if (
-            data.get('website') in (None, '')
+            data.get('domain') in (None, '')
             and data.get('telephone_number') in (None, '')
         ):
             raise serializers.ValidationError(


### PR DESCRIPTION
### Description of change

@paulgain reported that DataHub API was incorrectly returning a 400 when an investigation was submitted without a `website` but with a `telephone_number`.

This was not the intended behaviour as either a `website` or a `telephone_number` should suffice here. 

This PR adds a test to expose the bug and fixes it.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
