### PR TITLE
Reinstate company create endpoint

### DIFF
--- a/changelog/company/reinstate-create-company.api.md
+++ b/changelog/company/reinstate-create-company.api.md
@@ -1,0 +1,23 @@
+The create company endpoint `POST /v4/company` was re-instated. This allows clients to create
+stub Company records - i.e. Company records that are not matched with D&B records.
+Companies created with this endpoint are created with `pending_dnb_investigation=True`.
+
+The endpoint should be called with a POST body of the following format:
+```
+{
+    'business_type': <uuid>,
+    'name': 'Test Company',
+    'address': {
+        'line_1': 'Foo',
+        'line_2': 'Bar',
+        'town': 'Baz',
+        'county': 'Qux',
+        'country': {
+            'id': <uuid>,
+        },
+        'postcode': 'AB5 XY2',
+    },
+    'sector': <uuid>,
+    'uk_region': <uuid>,
+}
+```

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -441,6 +441,16 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         field = NestedAdviserWithEmailAndTeamGeographyField()
         return field.to_representation(global_account_manager)
 
+    def create(self, validated_data):
+        """
+        Override create method to ensure that all Company objects created through this serializer
+        have pending_dnb_investigation=True. This ensures that we always mark Company records based
+        on untrusted data in a consistent way.
+        """
+        if not validated_data.get('duns_number'):
+            validated_data['pending_dnb_investigation'] = True
+        return Company.objects.create(**validated_data)
+
     class Meta:
         model = Company
         fields = (

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -1,16 +1,8 @@
 import pytest
 from django.db.utils import IntegrityError
-from rest_framework import status
-from rest_framework.reverse import reverse
 
-from datahub.company.constants import BusinessTypeConstant
 from datahub.company.models import Company
 from datahub.company.test.factories import CompanyFactory
-from datahub.core.constants import (
-    Country,
-    Sector,
-    UKRegion,
-)
 from datahub.core.test_utils import APITestMixin
 
 
@@ -40,46 +32,6 @@ class TestPendingDNBInvestigation(APITestMixin):
         """
         with pytest.raises(IntegrityError):
             CompanyFactory(pending_dnb_investigation=None)
-
-    @pytest.mark.parametrize(
-        'company_data',
-        (
-            {
-                'name': 'Acme',
-                'business_type': {
-                    'id': BusinessTypeConstant.company.value.id,
-                },
-                'address': {
-                    'line_1': '75 Stramford Road',
-                    'town': 'London',
-                    'country': {
-                        'id': Country.united_kingdom.value.id,
-                    },
-                },
-                'sector': Sector.renewable_energy_wind.value.id,
-                'uk_region': {
-                    'id': UKRegion.england.value.id,
-                },
-            },
-        ),
-    )
-    @pytest.mark.django_db
-    def test_company_post(self, company_data):
-        """
-        Test if a company created via create-company endpoint has
-        `pending_dnb_investigation` set to False.
-        """
-        url = reverse('api-v4:company:collection')
-        response = self.api_client.post(
-            url,
-            company_data,
-        )
-        assert response.status_code == status.HTTP_201_CREATED
-
-        company = Company.objects.get(
-            id=response.json()['id'],
-        )
-        assert not company.pending_dnb_investigation
 
 
 class TestDNBInvestigationData:

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -1,8 +1,16 @@
 import pytest
 from django.db.utils import IntegrityError
+from rest_framework import status
+from rest_framework.reverse import reverse
 
+from datahub.company.constants import BusinessTypeConstant
 from datahub.company.models import Company
 from datahub.company.test.factories import CompanyFactory
+from datahub.core.constants import (
+    Country,
+    Sector,
+    UKRegion,
+)
 from datahub.core.test_utils import APITestMixin
 
 
@@ -32,6 +40,46 @@ class TestPendingDNBInvestigation(APITestMixin):
         """
         with pytest.raises(IntegrityError):
             CompanyFactory(pending_dnb_investigation=None)
+
+    @pytest.mark.parametrize(
+        'company_data',
+        (
+            {
+                'name': 'Acme',
+                'business_type': {
+                    'id': BusinessTypeConstant.company.value.id,
+                },
+                'address': {
+                    'line_1': '75 Stramford Road',
+                    'town': 'London',
+                    'country': {
+                        'id': Country.united_kingdom.value.id,
+                    },
+                },
+                'sector': Sector.renewable_energy_wind.value.id,
+                'uk_region': {
+                    'id': UKRegion.england.value.id,
+                },
+            },
+        ),
+    )
+    @pytest.mark.django_db
+    def test_company_post(self, company_data):
+        """
+        Test if a company created via create-company endpoint has
+        `pending_dnb_investigation` set to False.
+        """
+        url = reverse('api-v4:company:collection')
+        response = self.api_client.post(
+            url,
+            company_data,
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        company = Company.objects.get(
+            id=response.json()['id'],
+        )
+        assert not company.pending_dnb_investigation
 
 
 class TestDNBInvestigationData:

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -26,14 +26,16 @@ from datahub.company.test.factories import (
     CompanyExportCountryHistoryFactory,
     CompanyFactory,
 )
-from datahub.core.constants import Country, EmployeeRange, HeadquarterType, TurnoverRange
+from datahub.core.constants import Country, EmployeeRange, HeadquarterType, TurnoverRange, UKRegion
 from datahub.core.test_utils import (
     APITestMixin,
     create_test_user,
     format_date_or_datetime,
     HawkMockJSONResponse,
+    random_obj_for_model,
 )
 from datahub.metadata.models import Country as CountryModel
+from datahub.metadata.models import Sector
 from datahub.metadata.test.factories import TeamFactory
 
 
@@ -807,73 +809,6 @@ class TestUpdateCompany(APITestMixin):
                     'registered_address': None,
                 },
             ),
-
-            # Add a company number
-            (
-                {'company_number': None},
-                {
-                    'company_number': '1234567890',
-                    'business_type': BusinessTypeConstant.company.value.id,
-                },
-                {
-                    'company_number': '1234567890',
-                    'business_type': {
-                        'id': BusinessTypeConstant.company.value.id,
-                        'name': BusinessTypeConstant.company.value.name,
-                    },
-                },
-            ),
-
-            # Add a company number for UK establishment with correct company_number format
-            (
-                {'company_number': None},
-                {
-                    'company_number': 'BR000006',
-                    'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
-                },
-                {
-                    'company_number': 'BR000006',
-                    'business_type': {
-                        'id': BusinessTypeConstant.uk_establishment.value.id,
-                        'name': BusinessTypeConstant.uk_establishment.value.name,
-                    },
-                },
-            ),
-
-            # http:// is prepended to the website if a scheme is not present
-            (
-                {},
-                {'website': 'www.google.com'},
-                {'website': 'http://www.google.com'},
-            ),
-
-            # website is not converted if it includes an http scheme
-            (
-                {},
-                {'website': 'http://www.google.com'},
-                {'website': 'http://www.google.com'},
-            ),
-
-            # website is not converted if it includes an https scheme
-            (
-                {},
-                {'website': 'https://www.google.com'},
-                {'website': 'https://www.google.com'},
-            ),
-
-            # website is not converted if it's empty
-            (
-                {},
-                {'website': ''},
-                {'website': ''},
-            ),
-
-            # website is not converted if it's None
-            (
-                {},
-                {'website': None},
-                {'website': None},
-            ),
         ),
     )
     def test_update_company(self, initial_model_values, data, expected_response):
@@ -1122,46 +1057,6 @@ class TestUpdateCompany(APITestMixin):
                 {
                     'address_country':
                         ['A UK establishment (branch of non-UK company) must be in the UK.'],
-                },
-            ),
-
-            # company_number should start with BR if business type == uk establishment
-            (
-                {
-                    'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
-                    'company_number': '123',
-                    'address': {
-                        'line_1': '75 Stramford Road',
-                        'town': 'London',
-                        'country': {
-                            'id': Country.united_kingdom.value.id,
-                        },
-                    },
-                },
-                {
-                    'company_number':
-                        ['This must be a valid UK establishment number, beginning with BR.'],
-                },
-            ),
-            # company_number shouldn't have invalid characters
-            (
-                {
-                    'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
-                    'company_number': 'BR000444é',
-                    'address': {
-                        'line_1': '75 Stramford Road',
-                        'town': 'London',
-                        'country': {
-                            'id': Country.united_kingdom.value.id,
-                        },
-                    },
-                },
-                {
-                    'company_number':
-                        [
-                            'This field can only contain the letters A to Z and numbers '
-                            '(no symbols, punctuation or spaces).',
-                        ],
                 },
             ),
         ),
@@ -2372,3 +2267,366 @@ class TestGetCompanyExportWins(APITestMixin):
         response = api_client.get(url)
         assert response.status_code == 200
         assert response.json() == export_wins_response
+
+
+class TestAddCompany(APITestMixin):
+    """Tests for adding a company."""
+
+    @pytest.mark.parametrize(
+        'data,expected_response',
+        (
+            # uk company
+            (
+                {
+                    'name': 'Acme',
+                    'trading_names': ['Trading name'],
+                    'business_type': {'id': BusinessTypeConstant.company.value.id},
+                    'address': {
+                        'line_1': '75 Stramford Road',
+                        'town': 'London',
+                        'country': {
+                            'id': Country.united_kingdom.value.id,
+                        },
+                    },
+                    'uk_region': {'id': UKRegion.england.value.id},
+                    'headquarter_type': {'id': HeadquarterType.ghq.value.id},
+                },
+                {
+                    'name': 'Acme',
+                    'trading_names': ['Trading name'],
+                    'business_type': {
+                        'id': BusinessTypeConstant.company.value.id,
+                        'name': BusinessTypeConstant.company.value.name,
+                    },
+                    'address': {
+                        'line_1': '75 Stramford Road',
+                        'line_2': '',
+                        'town': 'London',
+                        'county': '',
+                        'postcode': '',
+                        'country': {
+                            'id': Country.united_kingdom.value.id,
+                            'name': Country.united_kingdom.value.name,
+                        },
+                    },
+                    'registered_address': None,
+                    'uk_region': {
+                        'id': UKRegion.england.value.id,
+                        'name': UKRegion.england.value.name,
+                    },
+                    'headquarter_type': {
+                        'id': HeadquarterType.ghq.value.id,
+                        'name': HeadquarterType.ghq.value.name,
+                    },
+                },
+            ),
+            # non-UK
+            (
+                {
+                    'address': {
+                        'line_1': '75 Stramford Road',
+                        'town': 'Cordova',
+                        'country': {
+                            'id': Country.united_states.value.id,
+                        },
+                    },
+                },
+                {
+                    'address': {
+                        'line_1': '75 Stramford Road',
+                        'line_2': '',
+                        'town': 'Cordova',
+                        'county': '',
+                        'postcode': '',
+                        'country': {
+                            'id': Country.united_states.value.id,
+                            'name': Country.united_states.value.name,
+                        },
+                    },
+                    'registered_address': None,
+                },
+            ),
+            # promote a CH company
+            (
+                {
+                    'company_number': '1234567890',
+                    'business_type': BusinessTypeConstant.company.value.id,
+                },
+                {'company_number': '1234567890'},
+            ),
+            # no special validation on company_number is done for non UK establishment companies
+            (
+                {
+                    'business_type': BusinessTypeConstant.company.value.id,
+                    'company_number': 'sc000444é',
+                },
+                {'company_number': 'sc000444é'},
+            ),
+            # UK establishment with correct company_number format
+            (
+                {
+                    'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                    'company_number': 'BR000006',
+                },
+                {'company_number': 'BR000006'},
+            ),
+            # http:// is prepended to the website if a scheme is not present
+            (
+                {'website': 'www.google.com'},
+                {'website': 'http://www.google.com'},
+            ),
+            # website is not converted if it includes an http scheme
+            (
+                {'website': 'http://www.google.com'},
+                {'website': 'http://www.google.com'},
+            ),
+            # website is not converted if it includes an http scheme
+            (
+                {'website': 'https://www.google.com'},
+                {'website': 'https://www.google.com'},
+            ),
+            # website is not converted if it's empty
+            (
+                {'website': ''},
+                {'website': ''},
+            ),
+            # website is not converted if it's None
+            (
+                {'website': None},
+                {'website': None},
+            ),
+            # registered address is saved
+            (
+                {
+                    'registered_address': {
+                        'line_1': '1 Hello st.',
+                        'town': 'Dublin',
+                        'country': {
+                            'id': Country.ireland.value.id,
+                        },
+                    },
+                },
+                {
+                    'registered_address': {
+                        'line_1': '1 Hello st.',
+                        'line_2': '',
+                        'town': 'Dublin',
+                        'county': '',
+                        'postcode': '',
+                        'country': {
+                            'id': Country.ireland.value.id,
+                            'name': Country.ireland.value.name,
+                        },
+                    },
+                },
+            ),
+        ),
+    )
+    def test_success_cases(self, data, expected_response):
+        """Test success scenarios."""
+        post_data = {
+            'name': 'Acme',
+            'business_type': BusinessTypeConstant.company.value.id,
+            'sector': random_obj_for_model(Sector).id,
+            'address': {
+                'line_1': '75 Stramford Road',
+                'town': 'London',
+                'country': Country.united_kingdom.value.id,
+            },
+            'uk_region': UKRegion.england.value.id,
+
+            **data,
+        }
+
+        url = reverse('api-v4:company:collection')
+        response = self.api_client.post(
+            url,
+            data=post_data,
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+        actual_response = {
+            field_name: response_data[field_name]
+            for field_name in expected_response
+        }
+        assert actual_response == expected_response
+
+    def test_required_fields(self):
+        """Test required fields."""
+        url = reverse('api-v4:company:collection')
+        response = self.api_client.post(
+            url,
+            data={},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'name': ['This field is required.'],
+            'address': ['This field is required.'],
+        }
+
+    @pytest.mark.parametrize(
+        'data,expected_error',
+        (
+            # uk_region is required
+            (
+                {'uk_region': None},
+                {'uk_region': ['This field is required.']},
+            ),
+            # partial registered address, other fields are required
+            (
+                {
+                    'registered_address': {
+                        'line_1': 'test',
+                    },
+                },
+                {
+                    'registered_address': {
+                        'town': ['This field is required.'],
+                        'country': ['This field is required.'],
+                    },
+                },
+            ),
+            # address cannot be null
+            (
+                {
+                    'address': None,
+                },
+                {
+                    'address': ['This field may not be null.'],
+                },
+            ),
+            # address cannot be null
+            (
+                {
+                    'address': {
+                        'line_1': None,
+                        'town': None,
+                        'country': Country.united_kingdom.value.id,
+                    },
+                },
+                {
+                    'address': {
+                        'line_1': ['This field may not be null.'],
+                        'town': ['This field may not be null.'],
+                    },
+                },
+            ),
+            # address cannot be empty
+            (
+                {
+                    'address': {
+                        'line_1': '',
+                        'town': '',
+                        'country': None,
+                    },
+                },
+                {
+                    'address': {
+                        'line_1': ['This field is required.'],
+                        'town': ['This field is required.'],
+                        'country': ['This field is required.'],
+                    },
+                },
+            ),
+            # company_number required if business type == uk establishment
+            (
+                {
+                    'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                    'company_number': '',
+                    'address': {
+                        'line_1': '75 Stramford Road',
+                        'town': 'London',
+                        'country': {
+                            'id': Country.united_kingdom.value.id,
+                        },
+                    },
+                },
+                {
+                    'company_number': ['This field is required.'],
+                },
+            ),
+            # country should be UK if business type == uk establishment
+            (
+                {
+                    'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                    'company_number': 'BR1234',
+                    'address': {
+                        'line_1': '75 Stramford Road',
+                        'town': 'Cordova',
+                        'country': {
+                            'id': Country.united_states.value.id,
+                        },
+                    },
+                },
+                {
+                    'address_country':
+                        ['A UK establishment (branch of non-UK company) must be in the UK.'],
+                },
+            ),
+            # company_number should start with BR if business type == uk establishment
+            (
+                {
+                    'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                    'company_number': '123',
+                    'address': {
+                        'line_1': '75 Stramford Road',
+                        'town': 'London',
+                        'country': {
+                            'id': Country.united_kingdom.value.id,
+                        },
+                    },
+                },
+                {
+                    'company_number':
+                        ['This must be a valid UK establishment number, beginning with BR.'],
+                },
+            ),
+            # company_number shouldn't have invalid characters
+            (
+                {
+                    'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                    'company_number': 'BR000444é',
+                    'address': {
+                        'line_1': '75 Stramford Road',
+                        'town': 'London',
+                        'country': {
+                            'id': Country.united_kingdom.value.id,
+                        },
+                    },
+                },
+                {
+                    'company_number':
+                        [
+                            'This field can only contain the letters A to Z and numbers '
+                            '(no symbols, punctuation or spaces).',
+                        ],
+                },
+            ),
+        ),
+    )
+    def test_validation_error(self, data, expected_error):
+        """Test validation scenarios."""
+        post_data = {
+            'name': 'Acme',
+            'business_type': BusinessTypeConstant.company.value.id,
+            'sector': random_obj_for_model(Sector).id,
+            'address': {
+                'line_1': '75 Stramford Road',
+                'town': 'London',
+                'country': Country.united_kingdom.value.id,
+            },
+            'uk_region': UKRegion.england.value.id,
+
+            **data,
+        }
+
+        url = reverse('api-v4:company:collection')
+        response = self.api_client.post(
+            url,
+            data=post_data,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_error

--- a/datahub/company/test/test_company_views_versioning.py
+++ b/datahub/company/test/test_company_views_versioning.py
@@ -4,18 +4,104 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from reversion.models import Version
 
-from datahub.company.test.factories import CompanyFactory
+from datahub.company.constants import BusinessTypeConstant
+from datahub.company.models import Company
+from datahub.company.test.factories import CompaniesHouseCompanyFactory, CompanyFactory
+from datahub.core.constants import Country, UKRegion
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
 from datahub.core.test_utils import (
     APITestMixin,
     format_date_or_datetime,
+    random_obj_for_model,
 )
+from datahub.metadata.models import Sector
 
 
 class TestCompanyVersioning(APITestMixin):
     """
     Tests for versions created when interacting with the company endpoints.
     """
+
+    def test_add_creates_a_new_version(self):
+        """Test that creating a company creates a new version."""
+        assert Version.objects.count() == 0
+
+        response = self.api_client.post(
+            reverse('api-v4:company:collection'),
+            data={
+                'name': 'Acme',
+                'trading_names': ['Trading name'],
+                'business_type': {'id': BusinessTypeConstant.company.value.id},
+                'sector': {'id': random_obj_for_model(Sector).id},
+                'address': {
+                    'line_1': '75 Stramford Road',
+                    'town': 'London',
+                    'country': {
+                        'id': Country.united_kingdom.value.id,
+                    },
+                },
+                'uk_region': {'id': UKRegion.england.value.id},
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+        assert response_data['name'] == 'Acme'
+        assert response_data['trading_names'] == ['Trading name']
+
+        company = Company.objects.get(pk=response_data['id'])
+
+        # check version created
+        assert Version.objects.get_for_object(company).count() == 1
+        version = Version.objects.get_for_object(company).first()
+        assert version.revision.user == self.user
+        assert version.field_dict['name'] == 'Acme'
+        assert version.field_dict['trading_names'] == ['Trading name']
+        assert not any(set(version.field_dict) & set(EXCLUDED_BASE_MODEL_FIELDS))
+
+    def test_promoting_a_ch_company_creates_a_new_version(self):
+        """Test that promoting a CH company to full company creates a new version."""
+        assert Version.objects.count() == 0
+        CompaniesHouseCompanyFactory(company_number=1234567890)
+
+        response = self.api_client.post(
+            reverse('api-v4:company:collection'),
+            data={
+                'name': 'Acme',
+                'company_number': 1234567890,
+                'business_type': BusinessTypeConstant.company.value.id,
+                'sector': random_obj_for_model(Sector).id,
+                'address': {
+                    'line_1': '75 Stramford Road',
+                    'town': 'London',
+                    'country': {
+                        'id': Country.united_kingdom.value.id,
+                    },
+                },
+                'uk_region': UKRegion.england.value.id,
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        company = Company.objects.get(pk=response.json()['id'])
+
+        # check version created
+        assert Version.objects.get_for_object(company).count() == 1
+        version = Version.objects.get_for_object(company).first()
+        assert version.field_dict['company_number'] == '1234567890'
+
+    def test_add_400_doesnt_create_a_new_version(self):
+        """Test that if the endpoint returns 400, no version is created."""
+        assert Version.objects.count() == 0
+
+        response = self.api_client.post(
+            reverse('api-v4:company:collection'),
+            data={'name': 'Acme'},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert Version.objects.count() == 0
 
     def test_update_creates_a_new_version(self):
         """Test that updating a company creates a new version."""

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -11,6 +11,7 @@ from datahub.company.views import (
 
 company_collection = CompanyViewSet.as_view({
     'get': 'list',
+    'post': 'create',
 })
 
 company_item = CompanyViewSet.as_view({


### PR DESCRIPTION
### Description of change
The create company endpoint `POST /v4/company` was re-instated. This allows clients to create
stub Company records - i.e. Company records that are not matched with D&B records.
Companies created with this endpoint which do not have a `duns_number` are created with `pending_dnb_investigation=True`.

The endpoint should be called with a POST body of the following format:
```
{
    'business_type': <uuid>,
    'name': 'Test Company',
    'address': {
        'line_1': 'Foo',
        'line_2': 'Bar',
        'town': 'Baz',
        'county': 'Qux',
        'country': {
            'id': <uuid>,
        },
        'postcode': 'AB5 XY2',
    },
    'sector': <uuid>,
    'uk_region': <uuid>,
}
```

This will allow us to deprecate/remove the `POST /v4/dnb/create-company-investigation` API endpoint as we are only using that to create stub companies now.  The FE will need to be updated to use this new company create API instead.

### Checklist

* [X] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
