### PR TITLE
Add archive fields to pipeline get

### DIFF
--- a/changelog/adviser/pipelineitem_archive.api.md
+++ b/changelog/adviser/pipelineitem_archive.api.md
@@ -1,0 +1,1 @@
+New fields `archived, `archived_on` and `archived_reason` are now exposed in the result of `GET /v4/pipeline-item`.

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -172,6 +172,9 @@ class PipelineItemSerializer(serializers.ModelSerializer):
             'potential_value',
             'likelihood_to_win',
             'expected_win_date',
+            'archived',
+            'archived_on',
+            'archived_reason',
         )
         read_only_fields = (
             'id',

--- a/datahub/user/company_list/test/factories.py
+++ b/datahub/user/company_list/test/factories.py
@@ -1,4 +1,5 @@
 import factory
+from django.utils.timezone import utc
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.metadata.test.factories import SectorFactory
@@ -32,7 +33,9 @@ class PipelineItemFactory(factory.django.DjangoModelFactory):
     company = factory.SubFactory(CompanyFactory)
     adviser = factory.SubFactory(AdviserFactory)
     status = PipelineItem.Status.LEADS
-    contact = factory.SubFactory(ContactFactory, company=factory.SelfAttribute('..company'))
+    contact = factory.SubFactory(
+        ContactFactory, company=factory.SelfAttribute('..company'),
+    )
     sector = factory.SubFactory(SectorFactory)
     potential_value = 1000000
     likelihood_to_win = PipelineItem.LikelihoodToWin.MEDIUM
@@ -40,3 +43,11 @@ class PipelineItemFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'company_list.PipelineItem'
+
+
+class ArchivedPipelineItemFactory(PipelineItemFactory):
+    """Factory for an archived pipeline item"""
+
+    archived = True
+    archived_on = factory.Faker('past_datetime', tzinfo=utc)
+    archived_reason = factory.Faker('sentence')


### PR DESCRIPTION
### Description of change

This PR exposes the fields 'archive', 'archived_on' and 'archived_reason' in the result of `GET /v4/pipeline-item`.

These fields were added in #2897 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
