### PR TITLE
Add deprecation notice for legacy investigation

### DIFF
--- a/changelog/company/legacy-investigation.api.md
+++ b/changelog/company/legacy-investigation.api.md
@@ -1,0 +1,3 @@
+The endpoint `POST /v4/dnb/company-create-investigation` is deprecated and will be removed on or after 15 June.
+
+It is replaced by `POST /v4/company/` which creates a stub Company record with `pending_dnb_investigation=True` and `POST /v4/dnb/company_investigation/` which creates a new investigation in `dnb-service`.

--- a/changelog/company/legacy-investigation.db.md
+++ b/changelog/company/legacy-investigation.db.md
@@ -1,0 +1,3 @@
+The column `company_company.dnb_investigation_data` is deprecated and will be removed from the database on or after 15 June.
+
+All pending investigations data have been ported to `dnb-service`.


### PR DESCRIPTION
### Description of change

Deprecation notices for `POST /v4/dnb/create-company-investigation` endpoint and `dnb_investigation_data` field.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
