### PR TITLE
making sector and contact fields nullable while editing

### DIFF
--- a/changelog/adviser/set_fields_nullable.bugfix.md
+++ b/changelog/adviser/set_fields_nullable.bugfix.md
@@ -1,0 +1,1 @@
+`PATCH /v4/pipeline-item` is now changed to allow `Sector` and `Contact` fields can be set to back to null from any value.

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -82,12 +82,12 @@ class PipelineItemSerializer(serializers.ModelSerializer):
     sector = NestedRelatedField(
         metadata_models.Sector,
         extra_fields=('id', 'segment'),
-        required=False,
+        required=False, allow_null=True,
     )
     contact = NestedRelatedField(
         Contact,
         extra_fields=('id', 'name'),
-        required=False,
+        required=False, allow_null=True,
     )
 
     def validate_company(self, company):
@@ -108,8 +108,11 @@ class PipelineItemSerializer(serializers.ModelSerializer):
         return name
 
     def validate_contact(self, contact):
-        """Vaidate contact belongs to company"""
-        if self.instance and contact not in self.instance.company.contacts.all():
+        """
+        Vaidate contact belongs to company
+        when its provided.
+        """
+        if contact and self.instance and contact not in self.instance.company.contacts.all():
             raise serializers.ValidationError(
                 self.error_messages['contact_company_mismatch'],
             )

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -916,13 +916,28 @@ class TestPatchPipelineItemView(APITestMixin):
                 id='patch potential_value',
             ),
             pytest.param(
+                'potential_value',
+                None,
+                id='patch potential_value_null',
+            ),
+            pytest.param(
                 'likelihood_to_win',
                 PipelineItem.LikelihoodToWin.HIGH,
                 id='patch likelihood_to_win',
             ),
             pytest.param(
+                'likelihood_to_win',
+                None,
+                id='patch likelihood_to_win_null',
+            ),
+            pytest.param(
                 'expected_win_date',
                 '2021-04-19',
+                id='patch expected_win_date',
+            ),
+            pytest.param(
+                'expected_win_date',
+                None,
                 id='patch expected_win_date',
             ),
         ),
@@ -983,6 +998,24 @@ class TestPatchPipelineItemView(APITestMixin):
         response_data = response.json()
         assert response_data['sector']['id'] == str(sector.id)
 
+    def test_can_patch_sector_field_to_null(self):
+        """Test that sector can be patched to null."""
+        company = CompanyFactory()
+        item = PipelineItemFactory(
+            adviser=self.user,
+            company=company,
+            status=PipelineItem.Status.WIN,
+        )
+        url = _pipeline_item_detail_url(item.pk)
+        response = self.api_client.patch(
+            url,
+            data={'sector': None},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['sector'] is None
+
     def test_can_patch_contact_field(self):
         """Test that contact can be patched."""
         company = CompanyFactory()
@@ -1001,6 +1034,24 @@ class TestPatchPipelineItemView(APITestMixin):
 
         response_data = response.json()
         assert response_data['contact']['id'] == str(contact.id)
+
+    def test_can_patch_contact_field_null(self):
+        """Test that contact can be patched back to null."""
+        company = CompanyFactory()
+        item = PipelineItemFactory(
+            adviser=self.user,
+            company=company,
+            status=PipelineItem.Status.WIN,
+        )
+        url = _pipeline_item_detail_url(item.pk)
+        response = self.api_client.patch(
+            url,
+            data={'contact': None},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['contact'] is None
 
     def test_cannot_patch_non_existent_contact(self):
         """Test that non existent contact can't be patched."""


### PR DESCRIPTION
### Description of change

This PR is to make sure both `Sector` and `Contact` fields can be set back to null, once filled in. Both are `NestedRelatedField`s and will have to add `allow_nulls=True` to them. And add relevant tests to make sure all optional fields can be set to null.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
