### PR TITLE
Add endpoint for assigning ITAs as an account manager

### DIFF
--- a/changelog/company/add-assign-account-manager-endpoint.feature.md
+++ b/changelog/company/add-assign-account-manager-endpoint.feature.md
@@ -1,0 +1,10 @@
+A new endpoint `POST /v4/company/<company-id>/assign-regional-account-manager` has been added to allow users with `company.change_company and company.change_regional_account_manager` permissions to change the account manager of companies in the `Tier D - International Trade Advisers` One List Tier.
+
+Example request body:
+```
+{ 
+    "regional_account_manager": <adviser_uuid>
+}
+```
+
+A successful request should expect an empty response with 204 (no content) HTTP status.

--- a/datahub/company/test/test_company_views_account_manager.py
+++ b/datahub/company/test/test_company_views_account_manager.py
@@ -32,6 +32,150 @@ def _random_non_ita_one_list_tier():
     return random_obj_for_queryset(queryset)
 
 
+class TestAssignRegionalCompanyAccountManagerView(APITestMixin):
+    """
+    Tests for the self-assign company account manager view.
+
+    (Implemented in CompanyViewSet.assign_regional_account_manager().)
+    """
+
+    @staticmethod
+    def _get_url(company):
+        return reverse('api-v4:company:assign-regional-account-manager', kwargs={'pk': company.pk})
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if no credentials are provided."""
+        company = CompanyFactory()
+        url = self._get_url(company)
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames',
+        (
+            (),
+            (CompanyPermission.change_company,),
+            (CompanyPermission.change_regional_account_manager,),
+        ),
+    )
+    def test_returns_403_if_without_permission(self, permission_codenames):
+        """
+        Test that a 403 is returned if the user does not have all of the required
+        permissions.
+        """
+        company = CompanyFactory()
+        user = create_test_user(permission_codenames=permission_codenames, dit_team=None)
+        api_client = self.create_api_client(user=user)
+        url = self._get_url(company)
+
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json() == {'detail': 'You do not have permission to perform this action.'}
+
+    @pytest.mark.parametrize(
+        'company_factory',
+        (
+            pytest.param(
+                lambda: CompanyFactory(one_list_account_owner=None, one_list_tier=None),
+                id='no-existing-account-manager',
+            ),
+            pytest.param(
+                lambda: CompanyFactory(
+                    one_list_account_owner=AdviserFactory(),
+                    one_list_tier_id=OneListTierID.tier_d_international_trade_advisers.value,
+                ),
+                id='existing-international-trade-adviser-account-manager',
+            ),
+        ),
+    )
+    def test_assigns_account_manager(self, company_factory, international_trade_adviser):
+        """
+        Test that an account manager can be assigned to:
+
+        - a company not on the One List
+        - a company on the One List tier 'Tier D - International Trade Adviser Accounts'
+        """
+        company = company_factory()
+        api_client = self.create_api_client(user=international_trade_adviser)
+        url = self._get_url(company)
+
+        regional_account_manager = AdviserFactory()
+
+        response = api_client.post(url, {'regional_account_manager': regional_account_manager.id})
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        company.refresh_from_db()
+        assert company.one_list_account_owner == regional_account_manager
+        assert company.one_list_tier_id == OneListTierID.tier_d_international_trade_advisers.value
+        assert company.modified_by == international_trade_adviser
+
+    @pytest.mark.parametrize(
+        'company_factory,expected_errors,regional_account_manager_fn',
+        (
+            pytest.param(
+                lambda: SubsidiaryFactory(
+                    global_headquarters__one_list_tier=random_obj_for_model(OneListTier),
+                    global_headquarters__one_list_account_owner=AdviserFactory(),
+                ),
+                {
+                    api_settings.NON_FIELD_ERRORS_KEY: [
+                        "A lead adviser can't be set on a subsidiary of a One List company.",
+                    ],
+                },
+                lambda: AdviserFactory().pk,
+                id='subsidiary-of-one-list-company',
+            ),
+            pytest.param(
+                lambda: CompanyFactory(
+                    one_list_tier=_random_non_ita_one_list_tier(),
+                    one_list_account_owner=AdviserFactory(),
+                ),
+                {
+                    api_settings.NON_FIELD_ERRORS_KEY: [
+                        "A lead adviser can't be set for companies on this One List tier.",
+                    ],
+                },
+                lambda: AdviserFactory().pk,
+                id='already-on-another-one-list-tier',
+            ),
+            pytest.param(
+                lambda: CompanyFactory(),
+                {
+                    'regional_account_manager': [
+                        'This field may not be null.',
+                    ],
+                },
+                lambda: None,
+            ),
+        ),
+    )
+    def test_validation(
+        self,
+        company_factory,
+        expected_errors,
+        regional_account_manager_fn,
+        international_trade_adviser,
+    ):
+        """
+        Test that an account manager can't be assigned:
+
+        - to a company on a One List tier other than
+        'Tier D - International Trade Adviser Accounts'
+        - to a company on that is a subsidiary of any One List company
+        - without providing a new account manager
+        """
+        company = company_factory()
+        api_client = self.create_api_client(user=international_trade_adviser)
+        url = self._get_url(company)
+
+        response = api_client.post(
+            url,
+            {'regional_account_manager': regional_account_manager_fn()},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_errors
+
+
 class TestSelfAssignCompanyAccountManagerView(APITestMixin):
     """
     Tests for the self-assign company account manager view.

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -27,6 +27,10 @@ company_archive = CompanyViewSet.as_action_view('archive')
 
 company_unarchive = CompanyViewSet.as_action_view('unarchive')
 
+company_assign_regional_account_manager = CompanyViewSet.as_action_view(
+    'assign_regional_account_manager',
+)
+
 company_self_assign_account_manager = CompanyViewSet.as_action_view(
     'self_assign_account_manager',
 )
@@ -63,6 +67,11 @@ urls = [
     path('company/<uuid:pk>/archive', company_archive, name='archive'),
     path('company/<uuid:pk>/unarchive', company_unarchive, name='unarchive'),
     path('company/<uuid:pk>/audit', company_audit, name='audit-item'),
+    path(
+        'company/<uuid:pk>/assign-regional-account-manager',
+        company_assign_regional_account_manager,
+        name='assign-regional-account-manager',
+    ),
     path(
         'company/<uuid:pk>/self-assign-account-manager',
         company_self_assign_account_manager,

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -41,6 +41,7 @@ from datahub.company.queryset import (
 from datahub.company.serializers import (
     AdviserSerializer,
     AssignOneListTierAndGlobalAccountManagerSerializer,
+    AssignRegionalAccountManagerSerializer,
     CompanySerializer,
     ContactSerializer,
     OneListCoreTeamMemberSerializer,
@@ -107,6 +108,41 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         'sector',
         Prefetch('export_countries', queryset=get_export_country_queryset()),
     )
+
+    @action(
+        methods=['post'],
+        detail=True,
+        permission_classes=[
+            HasPermissions(
+                f'company.{CompanyPermission.change_company}',
+                f'company.{CompanyPermission.change_regional_account_manager}',
+            ),
+        ],
+        schema=StubSchema(),
+    )
+    def assign_regional_account_manager(self, request, *args, **kwargs):
+        """
+        Sets the company to be an international trade adviser-managed One List company, and
+        assigns the requested user as the account manager.
+
+        This means:
+
+        - setting the One List tier to 'Tier D - Interaction Trade Adviser Accounts' (using the
+        tier ID, not the name)
+        - setting the requested user as the One List account manager (overwriting the
+        existing value)
+
+        The operation is not allowed if:
+
+        - the company is a subsidiary of a One List company
+        - the company is already a One List company on a different tier (i.e. not 'Tier D -
+        Interaction Trade Adviser Accounts')
+        """
+        instance = self.get_object()
+        serializer = AssignRegionalAccountManagerSerializer(instance=instance, data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(request.user)
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     @action(
         methods=['post'],


### PR DESCRIPTION
### Description of change

Adds a new endpoint `POST /v4/company/<company-id>/assign-regional-account-manager` has been added to allow users with `company.change_company and company.change_regional_account_manager` permissions to change the account manager of companies in the `Tier D - International Trade Advisers` One List tier.

This is an update to the current system whereby permitted users can only assign themselves to be an account manager for this One List tier.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
