### PR TITLE
Fix a flaky test for investment exports

### DIFF
--- a/changelog/investment/investment-export-test-fixup.internal.md
+++ b/changelog/investment/investment-export-test-fixup.internal.md
@@ -1,0 +1,2 @@
+A flaky test was fixed which would infrequently fail when the value for
+'Other team members' was not following the expected ordering.

--- a/changelog/investment/investment-export-test-fixup.internal.md
+++ b/changelog/investment/investment-export-test-fixup.internal.md
@@ -1,2 +1,3 @@
-A flaky test was fixed which would infrequently fail when the value for
-'Other team members' was not following the expected ordering.
+The ordering was made consistent for the value of 'Other team members' in the
+investment project export view.  This was resulting in a seemingly flaky test
+case.

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -62,7 +62,7 @@ class JSONBBuildObject(Func):
         super().__init__(*args)
 
 
-def get_string_agg_subquery(model, expression, delimiter=', ', distinct=False):
+def get_string_agg_subquery(model, expression, delimiter=', ', distinct=False, ordering=None):
     """
     Gets a subquery that uses string_agg to concatenate values in a to-many field.
 
@@ -80,7 +80,7 @@ def get_string_agg_subquery(model, expression, delimiter=', ', distinct=False):
         StringAgg(
             expression,
             delimiter,
-            ordering=(expression,),
+            ordering=ordering or (expression,),
             distinct=distinct,
         ),
     )

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -104,6 +104,7 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectAPIViewMixin, SearchE
         team_member_names=get_string_agg_subquery(
             DBInvestmentProject,
             get_full_name_expression('team_members__adviser'),
+            ordering=('team_members__adviser__first_name', 'team_members__adviser__last_name'),
         ),
         delivery_partner_names=get_string_agg_subquery(
             DBInvestmentProject,


### PR DESCRIPTION
### Description of change

This PR ensures that the ordering for 'Other team members' in the investment project export view is consistent.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
