### PR TITLE
Add ability to archive and unarchive pipeline items

### DIFF
--- a/changelog/adviser/pipelineitem_archive_unarchive_post.api.md
+++ b/changelog/adviser/pipelineitem_archive_unarchive_post.api.md
@@ -1,0 +1,1 @@
+Pipeline items can now be archived (with a reason) and unarchived through the `POST /v4/pipeline-item/<uuid:pk>/archive` and `POST /v4/pipeline-item/<uuid:pk>/unarchive` endpoints.

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -149,6 +149,9 @@ class PipelineItemSerializer(serializers.ModelSerializer):
                 'potential_value',
                 'likelihood_to_win',
                 'expected_win_date',
+                'archived',
+                'archived_on',
+                'archived_reason',
             }
             fields = data.keys()
             extra_fields = fields - allowed_fields

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -63,4 +63,18 @@ urlpatterns = [
         ),
         name='pipelineitem-detail',
     ),
+    path(
+        'pipeline-item/<uuid:pk>/archive',
+        PipelineItemViewSet.as_action_view(
+            'archive',
+        ),
+        name='pipelineitem-archive',
+    ),
+    path(
+        'pipeline-item/<uuid:pk>/unarchive',
+        PipelineItemViewSet.as_action_view(
+            'unarchive',
+        ),
+        name='pipelineitem-unarchive',
+    ),
 ]

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -14,6 +14,7 @@ from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from datahub.company.models import Company, CompanyPermission
+from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.query_utils import get_aggregate_subquery
 from datahub.core.viewsets import CoreViewSet
 from datahub.user.company_list.models import (
@@ -195,7 +196,7 @@ class CompanyListItemAPIView(APIView):
         return obj
 
 
-class PipelineItemViewSet(CoreViewSet):
+class PipelineItemViewSet(ArchivableViewSetMixin, CoreViewSet):
     """A view set for returning the contents of a pipeline item and to add a new one."""
 
     serializer_class = PipelineItemSerializer


### PR DESCRIPTION
### Description of change

This PR adds the `POST /v4/pipeline-item/<uuid:pk>/archive` and `POST /v4/pipeline-item/<uuid:pk>/unarchive` endpoints, which allows the user to archive and unarchive their pipeline items. 

The archive fields were added in #2897
They were added to the result of the GET endpoint in #2908 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
