### PR TITLE
Update interactions dataset

### DIFF
--- a/changelog/update-interactions-dataset.api.md
+++ b/changelog/update-interactions-dataset.api.md
@@ -1,0 +1,1 @@
+For existing endpoint `interactions-dataset`, add `were_countries_discussed` field to the dataset which will be used to filter for interactions when creating data cuts.

--- a/datahub/dataset/interaction/test/test_views.py
+++ b/datahub/dataset/interaction/test/test_views.py
@@ -72,6 +72,7 @@ def get_expected_data_from_interaction(interaction):
         'service_delivery': get_attr_or_none(interaction, 'service.name'),
         'subject': interaction.subject,
         'theme': interaction.theme,
+        'were_countries_discussed': interaction.were_countries_discussed,
     }
 
 

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -68,4 +68,5 @@ class InteractionsDatasetView(BaseDatasetView):
             'service_delivery',
             'subject',
             'theme',
+            'were_countries_discussed',
         )


### PR DESCRIPTION
### Description of change

The intent of this PR is to add `were_countries_discussed` field to the interactions dataset which will be used to filter for interactions when creating data cuts.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
