### PR TITLE
Fix update-core-team-member endpoint permission

### DIFF
--- a/changelog/company/update-core-team-permission.bugfix.md
+++ b/changelog/company/update-core-team-permission.bugfix.md
@@ -1,0 +1,3 @@
+The following endpoint `PATCH /v4/company/<company-id>/update-one-list-core-team` expected user to have incorrect
+permission. It has been corrected so that a user needs `change_company` and `change_one_list_core_team_member`
+permissions to access it.

--- a/datahub/company/test/conftest.py
+++ b/datahub/company/test/conftest.py
@@ -10,6 +10,7 @@ def one_list_editor():
     permission_codenames = [
         CompanyPermission.change_company,
         CompanyPermission.change_one_list_tier_and_global_account_manager,
+        CompanyPermission.change_one_list_core_team_member,
     ]
 
     return create_test_user(permission_codenames=permission_codenames, dit_team=None)

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -264,7 +264,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         permission_classes=[
             HasPermissions(
                 f'company.{CompanyPermission.change_company}',
-                f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
+                f'company.{CompanyPermission.change_one_list_core_team_member}',
             ),
         ],
         schema=StubSchema(),


### PR DESCRIPTION
### Description of change

The following endpoint `PATCH /v4/company/<company-id>/update-one-list-core-team` expected user to have incorrect permission. 
 It has been corrected so that a user needs `change_company` and `change_one_list_core_team_member` permissions to access it.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
