### PR TITLE
Ignore existing fixtures when rerunning the setup-uat script

### DIFF
--- a/changelog/fix-uat-fixtures.internal.md
+++ b/changelog/fix-uat-fixtures.internal.md
@@ -1,0 +1,3 @@
+Ignore existing fixtures when rerunning the setup-uat script
+
+It will allow developers to rerun setup-uat.sh script without the need to clear the entire DB.

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -7,7 +7,7 @@ dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:
 python /app/manage.py migrate
 python /app/manage.py migrate --database mi
 python /app/manage.py migrate_es
-python /app/manage.py loadinitialmetadata
+python /app/manage.py loadinitialmetadata --force
 
 # TODO abstract this into a method in ./manage.py
 echo "import datetime
@@ -50,7 +50,7 @@ lep_staff_user = Advisor.objects.create_user(
 python /app/manage.py add_access_token --skip-checks --hours 24 --token ditStaffToken dit_staff@id.test
 python /app/manage.py add_access_token --skip-checks --hours 24 --token daStaffToken da_staff@id.test
 python /app/manage.py add_access_token --skip-checks --hours 24 --token lepStaffToken lep_staff@id.test
-python /app/manage.py loaddata /app/fixtures/test_data.yaml
+python /app/manage.py loaddata --ignorenonexistent /app/fixtures/test_data.yaml
 python /app/manage.py createinitialrevisions
 python /app/manage.py collectstatic --noinput
 DEBUG=False gunicorn config.wsgi --config config/gunicorn.py -b 0.0.0.0


### PR DESCRIPTION
### Description of change

Allow developers to rerun `setup-uat.sh` script without the need to clear the entire DB.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
