### PR TITLE
Add archived field to filterset_fields for Pipelines

### DIFF
--- a/changelog/user/pipeline.api.md
+++ b/changelog/user/pipeline.api.md
@@ -1,0 +1,2 @@
+
+ It's now possible to filter pipeline results by archived as well as status and company_id on `/v4/pipeline-item`

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -204,7 +204,7 @@ class PipelineItemViewSet(ArchivableViewSetMixin, CoreViewSet):
         DjangoFilterBackend,
         OrderingFilter,
     )
-    filterset_fields = ('status', 'company_id')
+    filterset_fields = ('status', 'company_id', 'archived')
     ordering = ('-created_on')
     ordering_fields = ('created_on', 'modified_on', 'name')
     queryset = get_pipeline_item_queryset()


### PR DESCRIPTION
### Description of change

The PR add the ability to filter by archived. It is using the standard DjangoFilterBackend

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
