### PR TITLE
Deprecate pipelineitem contact field

### DIFF
--- a/changelog/pipelineitem-contact-depreaction.api.md
+++ b/changelog/pipelineitem-contact-depreaction.api.md
@@ -1,0 +1,2 @@
+`GET,PATCH /v4/pipeline-item/<uuid:pk>` and `GET,POST /v4/pipeline-item`:
+the field `contact` is deprecated and will be removed on or after 19 June 2020.

--- a/changelog/pipelineitem-contact-depreaction.db.md
+++ b/changelog/pipelineitem-contact-depreaction.db.md
@@ -1,0 +1,2 @@
+The column `pipelineitem.contact` is deprecated and will be removed
+on or after 19 June 2020.

--- a/changelog/pipelineitem-contact-depreaction.md
+++ b/changelog/pipelineitem-contact-depreaction.md
@@ -1,0 +1,2 @@
+The field `contact` is deprecated. Please check the API and Database schema
+categories for more details.


### PR DESCRIPTION
### Description of change

Deprecating pipelineitem `contact` field given we will now be using `contacts` field instead

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
