### PR TITLE
Add dit_team role filter to adviser search

### DIFF
--- a/changelog/adviser/add-adviser-team-filter.feature.md
+++ b/changelog/adviser/add-adviser-team-filter.feature.md
@@ -1,0 +1,5 @@
+`GET /adviser/`: A new query parameter, `dit_team__role`, was added. This filters results to 
+advisers within a particular DIT team role, using ID lookup.
+
+For example, `GET /adviser/?dit_team__role=<UUID>` returns
+advisers that are in 'International Trade Team' roles.

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -460,6 +460,7 @@ class AdviserFilter(FilterSet):
         model = Advisor
         fields = {
             'is_active': ('exact',),
+            'dit_team__role': ('exact',),
         }
 
 


### PR DESCRIPTION
### Description of change
Update to the `/adviser/` query allowing users to filter advisers by their DIT Team role.

This has been implemented to allow the Data Hub FE team to create a typeahead search component that allows users to search for advisers in International Trade Teams.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
