### PR TITLE
Feature/pipelineitem delete

### DIFF
--- a/changelog/pipelineitem-delete.api.md
+++ b/changelog/pipelineitem-delete.api.md
@@ -1,0 +1,1 @@
+For `/v4/pipeline-item/<uuid:pk>>` url, added support to the `DELETE` method. Logic has been added to ensure that only archived pipeline items can be deleted. If a pipeline item is not archived and a delete is attempted, the api will return bad request http status 400.

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -1683,7 +1683,7 @@ class TestDeletePipelineItemView(APITestMixin):
 
     def test_can_delete_a_pipeline_item_when_archived(self):
         """Test that an item can be deleted.."""
-        item = ArchivedPipelineItemFactory(adviser=self.user, )
+        item = ArchivedPipelineItemFactory(adviser=self.user)
         url = _pipeline_item_detail_url(item.pk)
 
         response = self.api_client.delete(url)

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -1681,6 +1681,14 @@ class TestDeletePipelineItemView(APITestMixin):
         response = self.api_client.delete(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
+    def test_only_owner_of_item_can_delete_pipeline_item(self):
+        """Test that a 404 is returned if the user is not the items owner."""
+        item = ArchivedPipelineItemFactory()
+        url = _pipeline_item_detail_url(item.pk)
+
+        response = self.api_client.delete(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     def test_can_delete_a_pipeline_item_when_archived(self):
         """Test that an item can be deleted.."""
         item = ArchivedPipelineItemFactory(adviser=self.user)

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -59,6 +59,7 @@ urlpatterns = [
             {
                 'patch': 'partial_update',
                 'get': 'retrieve',
+                'delete': 'destroy',
             },
         ),
         name='pipelineitem-detail',

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -37,8 +37,9 @@ CANT_ADD_ARCHIVED_COMPANY_MESSAGE = gettext_lazy(
 )
 
 CANT_DELETE_NON_ARCHIVED_PIPELINE_ITEM_MESSAGE = gettext_lazy(
-    "Only archived pipeline item can be deleted.",
+    'Only archived pipeline item can be deleted.',
 )
+
 
 class CompanyListViewSet(CoreViewSet, DestroyModelMixin):
     """
@@ -201,6 +202,7 @@ class CompanyListItemAPIView(APIView):
 
 class PipelineItemViewSet(ArchivableViewSetMixin, CoreViewSet, DestroyModelMixin):
     """A view set for returning the contents of a pipeline item and to add a new one."""
+
     serializer_class = PipelineItemSerializer
     filter_backends = (
         DjangoFilterBackend,
@@ -216,9 +218,11 @@ class PipelineItemViewSet(ArchivableViewSetMixin, CoreViewSet, DestroyModelMixin
         return super().get_queryset().filter(adviser=self.request.user)
 
     def perform_destroy(self, instance):
-        if instance.archived == False:
+        """Perform destroy validation ensuring that the instance is archived before deleting"""
+        if not instance.archived:
             errors = {
-               api_settings.NON_FIELD_ERRORS_KEY: CANT_DELETE_NON_ARCHIVED_PIPELINE_ITEM_MESSAGE,
+                api_settings.NON_FIELD_ERRORS_KEY: CANT_DELETE_NON_ARCHIVED_PIPELINE_ITEM_MESSAGE,
             }
+
             raise serializers.ValidationError(errors)
         return instance.delete()


### PR DESCRIPTION
### Description of change

The intent of this PR is add the DELETE method to `/v4/pipeline-item/<pk:uuid>` url. This method will have validation to ensure only archived pipeline items can be deleted. If the item is not archived the API will return a 400.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
