### PR TITLE
Add error handling to the functions that retrieve consent status from the Legal Basis API

### DIFF
--- a/changelog/company/bugfix/add-error-handling-to-consent-service-get-calls.bugfix.md
+++ b/changelog/company/bugfix/add-error-handling-to-consent-service-get-calls.bugfix.md
@@ -1,0 +1,4 @@
+Error handling has now been added to the `datahub/company/consent.py` file's `get_many()` function. 
+This change will be active when the Legal Basis API intergration is completed.
+If the API returns a 500 error when retrieving contact marketing preferences, 
+the contact's marketing preferences will be defaulted to False.

--- a/datahub/company/consent.py
+++ b/datahub/company/consent.py
@@ -7,6 +7,7 @@ import logging
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from requests.exceptions import HTTPError
 
 from datahub.company.constants import CONSENT_SERVICE_EMAIL_CONSENT_TYPE
 from datahub.core.api_client import APIClient, HawkAuth
@@ -22,7 +23,6 @@ CONSENT_SERVICE_READ_TIMEOUT = 30.0
 def _get_client():
     """
     Get configured API client for the consent service,
-
     _api_client could've just been set as a top level attribute
     of this module but that makes testing harder as the settings are
     loaded at `import` time rather than at run time. Which breaks test
@@ -81,20 +81,31 @@ def update_consent(email_address, accepts_dit_email_marketing, modified_at=None)
 def get_many(emails):
     """
     Bulk lookup consent for a list of emails
-
     :param emails: List of email addresses
     :return: dict of email address to consent status
     """
     body = {
         'emails': emails,
     }
+    api_client = _get_client()
 
-    response = _get_client().request(
-        'POST',
-        CONSENT_SERVICE_PERSON_PATH_LOOKUP,
-        json=body,
-        params={'limit': len(emails)},
-    )
+    try:
+        response = api_client.request(
+            'POST',
+            CONSENT_SERVICE_PERSON_PATH_LOOKUP,
+            json=body,
+            params={'limit': len(emails)},
+        )
+    except HTTPError as exc:
+        status = exc.response.status_code
+        if status >= 500:
+            return {
+                email: False
+                for email in emails
+            }
+        else:
+            raise
+
     return {
         result['email']: CONSENT_SERVICE_EMAIL_CONSENT_TYPE in result['consents']
         for result in response.json()['results']


### PR DESCRIPTION
### Description of change
 This PR is one of many involved with integrating the Consent Service. The overall aim of the project is to source the `accepts_dit_email_marketing` field from the Legal Basis API rather than the Datahub API. If you would like to read more about the roll out process, please see [here](https://docs.google.com/document/d/1csAPy3fPaDGSS0BManpozZmiZBXm6HN0U7a28Nryfrc/edit#). 

This PR adds error handling for the `get_many()` function. This function is involved with retrieving whether a contact accepts DIT email marketing. After some previous discussions [on this PR](https://github.com/uktrade/data-hub-api/pull/2722/files), It's been decided that if the LB API goes down these functions should hide the error and simply return that none of the contacts accept email marketing. 


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.

