### PR TITLE
Add multiple contacts field to pipeline api

### DIFF
--- a/changelog/adviser/pipeline-contacts.api.md
+++ b/changelog/adviser/pipeline-contacts.api.md
@@ -1,0 +1,3 @@
+`contacts` field was added to `GET /v4/pipeline-item/` and `PATCH /v4/pipeline-item/<UUID>` as an array field to replace the existing `contact` field.
+
+The `contact` and `contacts` field will mirror each other (except that `contact` will only return a single contact).

--- a/datahub/user/company_list/queryset.py
+++ b/datahub/user/company_list/queryset.py
@@ -70,9 +70,11 @@ def get_pipeline_item_queryset():
     """
     Returns a query set used by PipelineItemViewSet.
     """
-    return PipelineItem.objects.select_related('company').only(
-        # Only select the fields we need to reduce data transfer time for large lists
-        # (in particular, companies have a lot of fields which are not needed here)
+    return PipelineItem.objects.select_related(
+        'company',
+    ).prefetch_related(
+        'contacts',
+    ).only(
         'id',
         'company__id',
         'company__name',

--- a/datahub/user/company_list/test/test_pipeline_serializers.py
+++ b/datahub/user/company_list/test/test_pipeline_serializers.py
@@ -1,0 +1,49 @@
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+
+from datahub.core.test_utils import MockQuerySet
+from datahub.user.company_list.serializers import _ManyRelatedAsSingleItemField
+
+
+class TestManyRelatedAsSingleItemField:
+    """Tests for _ManyRelatedAsSingleItemField."""
+
+    MOCK_ITEM_1 = Mock(pk=uuid4(), name='item 1')
+    MOCK_ITEM_2 = Mock(pk=uuid4(), name='item 2')
+
+    @pytest.mark.parametrize(
+        'value,expected',
+        (
+            (None, []),
+            ({'id': str(MOCK_ITEM_1.pk)}, [MOCK_ITEM_1]),
+        ),
+    )
+    def test_run_validation(self, value, expected):
+        """Test that run_validation() returns a list."""
+        model = Mock(objects=MockQuerySet([self.MOCK_ITEM_1]))
+        field = _ManyRelatedAsSingleItemField(model, allow_null=True)
+        assert field.run_validation(value) == expected
+
+    @pytest.mark.parametrize(
+        'value,expected',
+        (
+            (
+                MockQuerySet([]),
+                None,
+            ),
+            (
+                MockQuerySet([MOCK_ITEM_1]),
+                {'id': str(MOCK_ITEM_1.pk), 'name': MOCK_ITEM_1.name},
+            ),
+            (
+                MockQuerySet([MOCK_ITEM_1, MOCK_ITEM_2]),
+                {'id': str(MOCK_ITEM_1.pk), 'name': MOCK_ITEM_1.name},
+            ),
+        ),
+    )
+    def test_to_representation(self, value, expected):
+        """Test that to_representation() returns a single item as a dict."""
+        field = _ManyRelatedAsSingleItemField(Mock())
+        assert field.to_representation(value) == expected


### PR DESCRIPTION
### Description of change

This is part of moving pipeline item from single FK contact to many-to-many contacts.

It adds the multiple `contacts` field to the pipeline item endpoints API, and changes the `contact` field to use `contacts` as the data source.

Do not merge this until https://github.com/uktrade/data-hub-api/pull/2962 is released.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
