### PR TITLE
add create_investment_sector command

### DIFF
--- a/changelog/investment/create_and_delete_investment_sector_command.md
+++ b/changelog/investment/create_and_delete_investment_sector_command.md
@@ -1,3 +1,3 @@
-An management command was added for creating/deleteing investment sectors defined in datahub/investment/project/models.py.
+A management command was added for creating/deleteing investment sectors defined in datahub/investment/project/models.py.
 
 This will be initially used to update investment sectors that are changing due to the sector migration project.

--- a/changelog/investment/create_and_delete_investment_sector_command.md
+++ b/changelog/investment/create_and_delete_investment_sector_command.md
@@ -1,0 +1,3 @@
+An management command was added for creating/deleteing investment sectors defined in datahub/investment/project/models.py.
+
+This will be initially used to update investment sectors that are changing due to the sector migration project.

--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -22,7 +22,10 @@ from datahub.interaction.test.factories import (
 )
 from datahub.investment.investor_profile.test.factories import LargeCapitalInvestorProfileFactory
 from datahub.investment.project.test.factories import (
-    InvestmentActivityFactory, InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
+    InvestmentActivityFactory,
+    InvestmentProjectFactory,
+    InvestmentProjectTeamMemberFactory,
+    InvestmentSectorFactory,
 )
 from datahub.metadata.test.factories import SectorFactory
 from datahub.omis.order.test.factories import OrderFactory
@@ -41,6 +44,7 @@ MAPPINGS = {
     'investment.InvestmentProject': InvestmentProjectFactory,
     'investment.InvestmentProjectTeamMember': InvestmentProjectTeamMemberFactory,
     'investment.InvestmentActivity': InvestmentActivityFactory,
+    'investment.InvestmentSector': InvestmentSectorFactory,
     'investor_profile.LargeCapitalInvestorProfile': LargeCapitalInvestorProfileFactory,
     'metadata.Sector': SectorFactory,
     'order.Order': OrderFactory,

--- a/datahub/dbmaintenance/management/commands/create_investment_sector.py
+++ b/datahub/dbmaintenance/management/commands/create_investment_sector.py
@@ -1,0 +1,42 @@
+from logging import getLogger
+
+import reversion
+
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.investment.project.models import (
+    FDISICGrouping,
+    InvestmentSector,
+)
+from datahub.metadata.models import Sector
+
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """Command to create a new InvestmentSector object."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        sector_id = parse_uuid(row['sector_id'])
+        fdi_sic_grouping_id = parse_uuid(row['fdi_sic_grouping_id'])
+        matches = InvestmentSector.objects.filter(sector_id=sector_id)
+        if len(matches) > 0:
+            raise Exception(
+                f'InvestmentSector for sector_id: {sector_id} already exists',
+            )
+
+        sector = Sector.objects.get(pk=sector_id)
+        fdi_sic_grouping = FDISICGrouping.objects.get(pk=fdi_sic_grouping_id)
+        investment_sector = InvestmentSector(
+            sector=sector,
+            fdi_sic_grouping=fdi_sic_grouping,
+        )
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            investment_sector.save()
+            reversion.set_comment('InvestmentSector creation.')

--- a/datahub/dbmaintenance/management/commands/delete_investment_sector.py
+++ b/datahub/dbmaintenance/management/commands/delete_investment_sector.py
@@ -1,0 +1,37 @@
+from logging import getLogger
+
+import reversion
+
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.investment.project.models import InvestmentSector
+
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """Command to delete a new InvestmentSector object."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        sector_id = parse_uuid(row['sector_id'])
+        fdi_sic_grouping_id = parse_uuid(row['fdi_sic_grouping_id'])
+        matches = InvestmentSector.objects.filter(
+            sector_id=sector_id,
+            fdi_sic_grouping_id=fdi_sic_grouping_id,
+        )
+        if len(matches) == 0:
+            error_msg = (
+                'InvestmentSector does not exist\n'
+                'sector_id: {0}'
+                'fdi_sic_grouping_id: {1}'
+            ).format(sector_id, fdi_sic_grouping_id)
+            raise Exception(error_msg)
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            matches.delete()
+            reversion.set_comment('InvestmentSector creation.')

--- a/datahub/dbmaintenance/management/commands/delete_investment_sector.py
+++ b/datahub/dbmaintenance/management/commands/delete_investment_sector.py
@@ -11,7 +11,7 @@ logger = getLogger(__name__)
 
 
 class Command(CSVBaseCommand):
-    """Command to delete a new InvestmentSector object."""
+    """Command to delete an InvestmentSector object."""
 
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
@@ -34,4 +34,4 @@ class Command(CSVBaseCommand):
 
         with reversion.create_revision():
             matches.delete()
-            reversion.set_comment('InvestmentSector creation.')
+            reversion.set_comment('InvestmentSector deletion.')

--- a/datahub/dbmaintenance/test/commands/test_create_investment_sector.py
+++ b/datahub/dbmaintenance/test/commands/test_create_investment_sector.py
@@ -1,0 +1,349 @@
+from io import BytesIO
+
+import factory
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.investment.project.models import FDISICGrouping, InvestmentSector
+from datahub.investment.project.test.factories import FDISICGroupingFactory
+from datahub.metadata.models import Sector
+from datahub.metadata.test.factories import SectorFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_happy_path(s3_stubber):
+    """Test that command creates specified investment sectors"""
+    sectors = SectorFactory.create_batch(
+        3,
+        segment=factory.Iterator(['sector1', 'sector2', 'sector3']),
+    )
+    fdi_sic_groupings = FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'sector',
+        'fdi_sic_grouping_id',
+        'fdi_sic_grouping_name',
+    ]
+    data = [
+        (sectors[0].pk, 'path1', fdi_sic_groupings[0].pk, 'name1'),
+        (sectors[1].pk, 'path2', fdi_sic_groupings[0].pk, 'name1'),
+        (sectors[2].pk, 'path3', fdi_sic_groupings[1].pk, 'name2'),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    n_investment_sectors_before = len(InvestmentSector.objects.all())
+
+    call_command('create_investment_sector', bucket, object_key)
+
+    investment_sectors = InvestmentSector.objects.all()
+
+    assert len(investment_sectors) == n_investment_sectors_before + 3
+
+    for d in data:
+        matches = InvestmentSector.objects.filter(sector_id=d[0])
+        assert len(matches) == 1
+        investment_sector = matches[0]
+        assert investment_sector.fdi_sic_grouping_id == d[2]
+
+
+def test_non_existent_sector(s3_stubber, caplog):
+    """Test that the command logs an error when the sector PK does not exist."""
+    caplog.set_level('ERROR')
+
+    SectorFactory.create_batch(
+        3,
+        segment=factory.Iterator(['sector1', 'sector2', 'sector3']),
+    )
+    fdi_sic_groupings = FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'sector',
+        'fdi_sic_grouping_id',
+        'fdi_sic_grouping_name',
+    ]
+    data = [
+        (
+            Sector(segment='does not exist').id,
+            'path1',
+            fdi_sic_groupings[0].pk,
+            'name1',
+        ),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    n_investment_sectors_before = len(InvestmentSector.objects.all())
+
+    call_command('create_investment_sector', bucket, object_key)
+
+    investment_sectors = InvestmentSector.objects.all()
+
+    assert len(investment_sectors) == n_investment_sectors_before
+
+    assert len(caplog.records) == 1
+    assert 'Sector matching query does not exist' in caplog.text
+
+
+def test_non_existent_fdi_sic_grouping(s3_stubber, caplog):
+    """
+    Test that the command logs an error when the FDISICGrouping
+    PK does not exist.
+    """
+    caplog.set_level('ERROR')
+
+    sectors = SectorFactory.create_batch(
+        3,
+        segment=factory.Iterator(['sector1', 'sector2', 'sector3']),
+    )
+    FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'sector',
+        'fdi_sic_grouping_id',
+        'fdi_sic_grouping_name',
+    ]
+    data = [
+        (
+            sectors[0].pk,
+            'path1',
+            FDISICGrouping(name='does not exist').pk,
+            'name1',
+        ),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    n_investment_sectors_before = len(InvestmentSector.objects.all())
+
+    call_command('create_investment_sector', bucket, object_key)
+
+    investment_sectors = InvestmentSector.objects.all()
+
+    assert len(investment_sectors) == n_investment_sectors_before
+
+    assert len(caplog.records) == 1
+    assert 'FDISICGrouping matching query does not exist' in caplog.text
+
+
+def test_entry_already_exists_for_sector(s3_stubber, caplog):
+    """
+    Test that the command ignores records for with sector_ids that already
+    exist in the InvestmentSector table
+    """
+    caplog.set_level('ERROR')
+
+    sectors = SectorFactory.create_batch(
+        3,
+        segment=factory.Iterator(['sector1', 'sector2', 'sector3']),
+    )
+    fdi_sic_groupings = FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+    investment_sector = InvestmentSector(
+        sector=sectors[0],
+        fdi_sic_grouping=fdi_sic_groupings[0],
+    )
+    investment_sector.save()
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'sector',
+        'fdi_sic_grouping_id',
+        'fdi_sic_grouping_name',
+    ]
+    data = [
+        (sectors[0].pk, 'path1', fdi_sic_groupings[1].pk, 'name1'),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    n_investment_sectors_before = len(InvestmentSector.objects.all())
+
+    call_command('create_investment_sector', bucket, object_key)
+
+    investment_sectors = InvestmentSector.objects.all()
+
+    assert len(investment_sectors) == n_investment_sectors_before
+
+    assert len(caplog.records) == 1
+    assert f'InvestmentSector for sector_id: {sectors[0].pk} already exists' in caplog.text
+
+
+def test_simulate(s3_stubber):
+    """Test that the command simulates updates if --simulate is passed in."""
+    sectors = SectorFactory.create_batch(
+        3,
+        segment=factory.Iterator(['sector1', 'sector2', 'sector3']),
+    )
+    fdi_sic_groupings = FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'sector',
+        'fdi_sic_grouping_id',
+        'fdi_sic_grouping_name',
+    ]
+
+    data = [
+        (sectors[0].pk, 'path1', fdi_sic_groupings[0].pk, 'name1'),
+        (sectors[1].pk, 'path2', fdi_sic_groupings[0].pk, 'name1'),
+        (sectors[2].pk, 'path3', fdi_sic_groupings[1].pk, 'name2'),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    n_investment_sectors_before = len(InvestmentSector.objects.all())
+
+    call_command('create_investment_sector', bucket, object_key, simulate=True)
+
+    investment_sectors = InvestmentSector.objects.all()
+
+    assert len(investment_sectors) == n_investment_sectors_before
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    sectors = SectorFactory.create_batch(
+        3,
+        segment=factory.Iterator(['sector1', 'sector2', 'sector3']),
+    )
+    fdi_sic_groupings = FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'sector',
+        'fdi_sic_grouping_id',
+        'fdi_sic_grouping_name',
+    ]
+
+    data = [
+        (sectors[0].pk, 'path1', fdi_sic_groupings[0].pk, 'name1'),
+        (sectors[1].pk, 'path2', fdi_sic_groupings[0].pk, 'name1'),
+        (sectors[2].pk, 'path3', fdi_sic_groupings[1].pk, 'name2'),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('create_investment_sector', bucket, object_key)
+
+    new_investment_sectors = InvestmentSector.objects.filter(
+        sector_id__in=[d[0] for d in data],
+    )
+
+    for investment_sector in new_investment_sectors:
+        versions = Version.objects.get_for_object(investment_sector)
+        assert versions.count() == 1
+        assert versions[0].revision.get_comment() == 'InvestmentSector creation.'

--- a/datahub/dbmaintenance/test/commands/test_delete_investment_sector.py
+++ b/datahub/dbmaintenance/test/commands/test_delete_investment_sector.py
@@ -1,0 +1,222 @@
+from io import BytesIO
+
+import factory
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.investment.project.models import FDISICGrouping, InvestmentSector
+from datahub.investment.project.test.factories import (
+    FDISICGroupingFactory,
+    InvestmentSectorFactory,
+)
+from datahub.metadata.models import Sector
+from datahub.metadata.test.factories import SectorFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_happy_path(s3_stubber):
+    """Test that command deletes specified investment sectors"""
+    sectors = SectorFactory.create_batch(
+        2,
+        segment=factory.Iterator(['sector1', 'sector2']),
+    )
+    fdi_sic_groupings = FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+    investment_sectors = InvestmentSectorFactory.create_batch(
+        2,
+        sector=factory.Iterator([sectors[0], sectors[1]]),
+        fdi_sic_grouping=factory.Iterator(
+            [fdi_sic_groupings[0], fdi_sic_groupings[1]],
+        ),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'fdi_sic_grouping_id',
+    ]
+    data = [(sectors[0].pk, fdi_sic_groupings[0].pk)]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    n_investment_sectors_before = len(InvestmentSector.objects.all())
+
+    call_command('delete_investment_sector', bucket, object_key)
+
+    investment_sectors = InvestmentSector.objects.all()
+
+    assert len(investment_sectors) == n_investment_sectors_before - 1
+    investment_sectors = InvestmentSector.objects.filter(
+        sector_id=sectors[1].pk,
+    )
+    assert len(investment_sectors) == 1
+    assert investment_sectors[0].fdi_sic_grouping == fdi_sic_groupings[1]
+
+
+def test_non_existent_investment_sector(s3_stubber, caplog):
+    """Test that the command logs an error when the sector PK does not exist."""
+    caplog.set_level('ERROR')
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'fdi_sic_grouping_id',
+    ]
+    data = [
+        (
+            Sector(segment='does not exist').id,
+            FDISICGrouping(name='does not exist').id,
+        ),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    n_investment_sectors_before = len(InvestmentSector.objects.all())
+
+    call_command('delete_investment_sector', bucket, object_key)
+
+    investment_sectors = InvestmentSector.objects.all()
+
+    assert len(investment_sectors) == n_investment_sectors_before
+
+    assert len(caplog.records) == 1
+    assert 'InvestmentSector does not exist' in caplog.text
+
+
+def test_simulate(s3_stubber):
+    """Test that the command simulates updates if --simulate is passed in."""
+    sectors = SectorFactory.create_batch(
+        2,
+        segment=factory.Iterator(['sector1', 'sector2']),
+    )
+    fdi_sic_groupings = FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+    investment_sectors = InvestmentSectorFactory.create_batch(
+        2,
+        sector=factory.Iterator([sectors[0], sectors[1]]),
+        fdi_sic_grouping=factory.Iterator(
+            [fdi_sic_groupings[0], fdi_sic_groupings[1]],
+        ),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'fdi_sic_grouping_id',
+    ]
+
+    data = [
+        (sectors[0].pk, fdi_sic_groupings[0].pk),
+        (sectors[1].pk, fdi_sic_groupings[1].pk),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    n_investment_sectors_before = len(InvestmentSector.objects.all())
+
+    call_command('delete_investment_sector', bucket, object_key, simulate=True)
+
+    investment_sectors = InvestmentSector.objects.all()
+
+    assert len(investment_sectors) == n_investment_sectors_before
+    assert len(InvestmentSector.objects.filter(sector=sectors[0])) == 1
+    assert len(InvestmentSector.objects.filter(sector=sectors[1])) == 1
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    sectors = SectorFactory.create_batch(
+        2,
+        segment=factory.Iterator(['sector1', 'sector2']),
+    )
+    fdi_sic_groupings = FDISICGroupingFactory.create_batch(
+        2,
+        name=factory.Iterator(['fdi_sic_grouping1', 'fdi_sic_grouping2']),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    headers = [
+        'sector_id',
+        'fdi_sic_grouping_id',
+    ]
+
+    data = [
+        (sectors[0].pk, fdi_sic_groupings[0].pk),
+        (sectors[1].pk, fdi_sic_groupings[1].pk),
+    ]
+
+    csv_content = ','.join(headers)
+    for row in data:
+        csv_content += '\n' + ','.join([str(col) for col in row])
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('delete_investment_sector', bucket, object_key)
+
+    new_investment_sectors = InvestmentSector.objects.filter(
+        sector_id__in=[d[0] for d in data],
+    )
+
+    for investment_sector in new_investment_sectors:
+        versions = Version.objects.get_for_object(investment_sector)
+        assert versions.count() == 1
+        assert versions[0].revision.get_comment() == 'InvestmentSector deletion.'

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -658,6 +658,7 @@ class InvestmentProjectCode(models.Model):
     project = models.OneToOneField(InvestmentProject, on_delete=models.CASCADE)
 
 
+@reversion.register_base_model()
 class InvestmentSector(models.Model):
     """Investment Sector a link between a DIT Sector and an FDI SIC Grouping."""
 

--- a/datahub/investment/project/test/factories.py
+++ b/datahub/investment/project/test/factories.py
@@ -26,8 +26,19 @@ from datahub.investment.project.constants import (
     LikelihoodToLand,
     SpecificProgramme,
 )
-from datahub.investment.project.models import InvestmentDeliveryPartner, InvestmentProject
+from datahub.investment.project.models import (
+    InvestmentDeliveryPartner,
+    InvestmentProject,
+)
 from datahub.metadata.models import UKRegion
+from datahub.metadata.test.factories import SectorFactory
+
+
+class FDISICGroupingFactory(factory.django.DjangoModelFactory):
+    """FIDSICGrouping factory."""
+
+    class Meta:
+        model = 'investment.FDISICGrouping'
 
 
 class InvestmentProjectFactory(factory.django.DjangoModelFactory):
@@ -85,6 +96,16 @@ class InvestmentProjectFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'investment.InvestmentProject'
+
+
+class InvestmentSectorFactory(factory.django.DjangoModelFactory):
+    """InvestmentSector factory."""
+
+    sector = factory.SubFactory(SectorFactory)
+    fdi_sic_grouping = factory.SubFactory(FDISICGroupingFactory)
+
+    class Meta:
+        model = 'investment.InvestmentSector'
 
 
 class FDIInvestmentProjectFactory(InvestmentProjectFactory):


### PR DESCRIPTION
### Description of change

An management command was added for creating/deleteing investment sectors defined in datahub/investment/project/models.py.

This will be initially used to update investment sectors that are changing due to the sector migration project.

### Checklist

* [ x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ?] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
