### PR TITLE
Update fixture to include adviser in a International Trade Team

### DIFF
--- a/changelog/update_test_data_fixture.internal.md
+++ b/changelog/update_test_data_fixture.internal.md
@@ -1,1 +1,1 @@
-New adviser being added to the test fixtures now allows us to run a full end to end test around managing a lead ITA.
+A new adviser has been added to the test fixtures. This adviser will be used in frontend end-to-end tests for managing a lead ITA.

--- a/changelog/update_test_data_fixture.internal.md
+++ b/changelog/update_test_data_fixture.internal.md
@@ -1,0 +1,1 @@
+New adviser being added to the test fixtures now allows us to run a full end to end test around managing a lead ITA.

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -1,4 +1,12 @@
 - model: company.advisor
+  pk: 453a608e-84a4-11e6-ea22-56b6b6499622
+  fields:
+    email: Harold.Jones@example.com
+    first_name: Harold
+    last_name: Jones
+    dit_team: 162a3959-9798-e211-a939-e4115bead28a  # International Trade Team
+
+- model: company.advisor
   pk: e83a608e-84a4-11e6-ae22-56b6b6499611
   fields:
     email: Puck.Head@example.com


### PR DESCRIPTION
### Description of change
In the context of "Assigning a Lead Adviser" Trello - https://trello.com/c/7L3fqtyY/1290-update-the-manage-lead-ita-page I need an adviser that is in the International Trade Team so I can complete an E2E test - https://github.com/uktrade/data-hub-frontend/pull/2755

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
