### PR TITLE
Pipelineitem update modified on

### DIFF
--- a/changelog/pipelineitem-update-modified-on.api.md
+++ b/changelog/pipelineitem-update-modified-on.api.md
@@ -1,0 +1,1 @@
+For endpoint `/v4/pipeline-item/<uuid:pk>`, field `modified_on` will now be updated with the current datetime stamp whenever a PATCH transaction occurrs.

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -173,7 +173,7 @@ class PipelineItemSerializer(serializers.ModelSerializer):
         Update modified_on field with current date time
         during PATCH transactions
         """
-        if self.partial:
+        if self.partial and self.instance:
             self.instance.modified_on = now().isoformat()
 
         return super().update(instance, validated_data)

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -1,3 +1,4 @@
+from django.utils.timezone import now
 from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 
@@ -166,6 +167,16 @@ class PipelineItemSerializer(serializers.ModelSerializer):
             data['contacts'] = [data['contact']]
 
         return data
+
+    def update(self, instance, validated_data):
+        """
+        Update modified_on field with current date time
+        during PATCH transactions
+        """
+        if self.partial:
+            self.instance.modified_on = now().isoformat()
+
+        return super().update(instance, validated_data)
 
     class Meta:
         model = PipelineItem

--- a/datahub/user/company_list/test/test_pipeline_views.py
+++ b/datahub/user/company_list/test/test_pipeline_views.py
@@ -1101,6 +1101,7 @@ class TestPatchPipelineItemView(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'company': ['field not allowed to be update.']}
 
+    @freeze_time('2017-04-19 15:25:30.986208')
     def test_patch_a_pipeline_item(self):
         """Test that status and name of a pipeline item can be patched."""
         company = CompanyFactory()
@@ -1133,7 +1134,7 @@ class TestPatchPipelineItemView(APITestMixin):
             'name': new_name,
             'status': new_status,
             'created_on': format_date_or_datetime(item.created_on),
-            'modified_on': format_date_or_datetime(item.modified_on),
+            'modified_on': '2017-04-19T15:25:30.986208Z',
             'contact': {
                 'id': str(item.contact.pk),
                 'name': item.contact.name,
@@ -1305,6 +1306,20 @@ class TestPatchPipelineItemView(APITestMixin):
 
         response_data = response.json()
         assert response_data['contact'] is None
+
+    def test_modified_on_is_updated(self):
+        """Test that modified on is updated."""
+        item = PipelineItemFactory(adviser=self.user)
+        url = _pipeline_item_detail_url(item.pk)
+        response = self.api_client.patch(
+            url,
+            data={'contact': None},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert format_date_or_datetime(response_data['modified_on']) > \
+            format_date_or_datetime(item.modified_on)
 
     def test_cannot_patch_non_existent_contact(self):
         """Test that non existent contact can't be patched."""


### PR DESCRIPTION
### Description of change

The intent of this PR is to ensure the `modified_on` field is updated during every PATCH transaction so we can reliably sort against it.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
