### PR TITLE
Update list of reviewers

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,8 +4,6 @@ update_configs:
     directory: "/"
     update_schedule: "weekly"
     default_reviewers:
-    - "alixedi"
-    - "currycoder"
     - "elcct"
     - "sekharpanja"
     - "adamledwards"


### PR DESCRIPTION
### Description of change

This updates the dependabot reviewers to remove people who have left the department. The update is required in order for Depandabot to run correctly.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
