### PR TITLE
Add management command to set `create_on` for Companies

### DIFF
--- a/changelog/company/company-created-on-management-command.md
+++ b/changelog/company/company-created-on-management-command.md
@@ -1,0 +1,1 @@
+A new management command, `update_company_created_on`, was added to allow the correction of legacy Company records which exist in Data Hub without a `created_on` value.

--- a/datahub/dbmaintenance/management/commands/update_company_created_on.py
+++ b/datahub/dbmaintenance/management/commands/update_company_created_on.py
@@ -1,0 +1,49 @@
+from logging import getLogger
+
+import reversion
+from dateutil.parser import parse, parserinfo
+
+from datahub.company.models import Company
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """
+    Command to set Company.created_on where missing.
+
+    Some Company records have missing created_on values which
+    besides being inconsistent with the parent BaseModel
+    class is also causing these Companies to be omitted
+    from Data Workspace.
+    """
+
+    _uk_date_format_parserinfo = parserinfo(dayfirst=True)
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process a single row."""
+        # .parse() creates a datetime object even in the absence of hours, minutes
+        supplied_datetime = parse(
+            row['Suggested Created Date'],
+            parserinfo=self._uk_date_format_parserinfo,
+        )
+
+        pk = parse_uuid(row['UUID'])
+        company = Company.objects.get(pk=pk)
+
+        if company.created_on is not None:
+            logger.warning(
+                f'Company {pk} already has a `created_on`; skipping',
+            )
+            return
+
+        if simulate:
+            return
+
+        company.created_on = supplied_datetime
+        with reversion.create_revision():
+            company.save(update_fields=('created_on',))
+            reversion.set_comment('Created datetime updated.')

--- a/datahub/dbmaintenance/test/commands/test_update_company_created_on.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_created_on.py
@@ -1,0 +1,131 @@
+"""Tests for the update_company_uk_region management command."""
+from datetime import datetime
+from io import BytesIO
+
+import pytest
+from django.core.management import call_command
+from django.utils.timezone import utc
+from freezegun import freeze_time
+from reversion.models import Version
+
+from datahub.company.models import Company
+from datahub.company.test.factories import CompanyFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    'simulate',
+    (
+        True,
+        False,
+    ),
+)
+def test_run(s3_stubber, caplog, simulate):
+    """
+    Test that the command:
+
+    - updates records only if simulate=False is passed
+    - does not update records if simulate=True is passed
+    - does not update created_on if it exists already
+    - ignores rows with unmatched Company UUIDs
+    """
+    caplog.set_level('WARNING')
+
+    original_created_on = datetime(2017, 1, 1, tzinfo=utc)
+
+    with freeze_time(original_created_on):
+        companies = CompanyFactory.create_batch(2)
+
+    company_with_created_on = companies[0]
+    company_without_created_on = companies[1]
+    company_without_created_on.created_on = None
+    company_without_created_on.save()
+
+    apr_13_2018_str = '13/04/2018'
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""UUID,Suggested Created Date
+00000000-0000-0000-0000-000000000000,17/02/2018
+{company_with_created_on.pk},19/02/2018
+{company_without_created_on.pk},{apr_13_2018_str}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command(
+        'update_company_created_on',
+        bucket,
+        object_key,
+        simulate=simulate,
+    )
+
+    for company in companies:
+        company.refresh_from_db()
+
+    log_records = caplog.get_records(when='call')
+    assert log_records[0].exc_info[0] == Company.DoesNotExist
+    assert log_records[1].msg == (
+        f'Company {company_with_created_on.pk} already has a `created_on`; skipping'
+    )
+
+    assert company_with_created_on.created_on == original_created_on
+
+    if simulate:
+        assert company_without_created_on.created_on is None
+    else:
+        new_created_on = company_without_created_on.created_on
+        d, m, y = new_created_on.day, new_created_on.month, new_created_on.year
+        assert (d, m, y) == tuple([int(s) for s in apr_13_2018_str.split('/')])
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created when created_on is set."""
+    companies = CompanyFactory.create_batch(2)
+
+    company_with_created_on = companies[0]
+    company_without_created_on = companies[1]
+    company_without_created_on.created_on = None
+    company_without_created_on.save()
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""UUID,Suggested Created Date
+{company_without_created_on.pk},19/02/2018
+{company_with_created_on.pk},13/04/2018
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command(
+        'update_company_created_on',
+        bucket,
+        object_key,
+        simulate=False,
+    )
+
+    versions = Version.objects.get_for_object(company_with_created_on)
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(company_without_created_on)
+    assert versions.count() == 1
+    assert versions[0].revision.get_comment() == 'Created datetime updated.'


### PR DESCRIPTION
### Description of change

This addresses a problem whereby some old Company records
exist without a `created_on` value. This is causing these
Companies to be omitted from Data Workspace.

The command processes a CSV file from the default S3 bucket.
It does not overwrite a `created_on` value for a Company
which already has one.

### Checklist

* [ Y ] If this is a releasable change, has a news fragment been added?
  
* [ Y ] Has this branch been rebased on top of the current `develop` branch?

* [ Y ] Is the CircleCI build passing?
