### PR TITLE
Only wait for ES-APM if ES_APM_ENABLED = True

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - postgres
       - mi-postgres
       - es
-      - es-apm
       - redis
       - celery
     command: /app/start.sh

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -3,7 +3,13 @@
 # on circleCI. For more information about how this is used please see
 # https://github.com/uktrade/data-hub-frontend#continuous-integration
 
-dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://es-apm:8200 -wait tcp://redis:6379
+es_amp=""
+## If ES_APM_ENABLED is True wait for it to start
+if [ "$ES_APM_ENABLED" = 'True' ] ; then
+   es_amp="-wait tcp://es-apm:8200"
+fi
+dockerize -wait  tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200  -wait tcp://redis:6379 $es_amp
+
 python /app/manage.py migrate
 python /app/manage.py migrate --database mi
 python /app/manage.py migrate_es


### PR DESCRIPTION
### Description of change

In the front end CI test the test will download and wait for the es-apm container to start. This add a bit of time for the test to run. In this PR I've tweaked the start up script only wait for es-apm container to start if the flag is true.


![image](https://user-images.githubusercontent.com/5575331/87538753-1011f980-c69d-11ea-9319-176476078ce6.png)


### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
