### PR TITLE
Strip invalid emails from consent payload

### DIFF
--- a/datahub/dataset/contact/views.py
+++ b/datahub/dataset/contact/views.py
@@ -1,3 +1,6 @@
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
+
 from datahub.company import consent
 from datahub.company.constants import GET_CONSENT_FROM_CONSENT_SERVICE
 from datahub.company.models.contact import Contact
@@ -14,6 +17,14 @@ class ContactsDatasetView(BaseDatasetView):
     various reports to the users out of flattened table and let analyst to work on denormalized
     table to get more meaningful insight.
     """
+
+    def _is_valid_email(self, value):
+        """Validate if emails are valid and return a boolean flag."""
+        try:
+            validate_email(value)
+            return True
+        except ValidationError:
+            return False
 
     def get_dataset(self):
         """Returns list of Contacts Dataset records"""
@@ -47,10 +58,13 @@ class ContactsDatasetView(BaseDatasetView):
 
     def _enrich_data(self, data):
         """
-        Get the marketing consent from the consent service
+        Get the marketing consent from the consent service.
+
+        Strip invalid emails from the data, old data may be
+        empty or invalid due to validation implemented at a later date.
         """
         if is_feature_flag_active(GET_CONSENT_FROM_CONSENT_SERVICE):
-            emails = [item['email'] for item in data if item['email']]
+            emails = [item['email'] for item in data if self._is_valid_email(item['email'])]
             consent_lookups = consent.get_many(emails)
             for item in data:
                 item['accepts_dit_email_marketing'] = consent_lookups.get(item['email'], False)


### PR DESCRIPTION
### Description of change
We have been experiencing error 400 BAD REQUEST responses from the legal-basis service since we turn the feature on this is due to invalid data that the consent service rejects. 
In datahub there are empty emails and also invalid the latest example was an email in the following format`fake.name.@example-com` (real name and domain striped) it had a hyphen between the domain name and the top level domain instead of a dot.

In the PR has introduced a `is_valid_email` method that uses Django internal email validators to strip out invalid emails.


### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
