### PR TITLE
Add consent News Fragment

### DIFF
--- a/changelog/contact/filter_invalid_emails_from_consent_payload.bugfix.md
+++ b/changelog/contact/filter_invalid_emails_from_consent_payload.bugfix.md
@@ -1,0 +1,2 @@
+The following endpoint `GET /v4/dataset/contacts-dataset` returns an error 500 when the `GET_CONSENT_FROM_CONSENT_SERVICE` is active. This is due to emails not be valid in the database.
+This bugfix will strip out invalid emails before sending emails as payload.


### PR DESCRIPTION
### Description of change

Forgot to add a news fragment again for a https://github.com/uktrade/data-hub-api/pull/3037
### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
