### PR TITLE
Search company in admin by investigation id

### DIFF
--- a/changelog/search-company-in-admin-by-investigation-id.feature.md
+++ b/changelog/search-company-in-admin-by-investigation-id.feature.md
@@ -1,0 +1,1 @@
+It's now possible to search for the `Company` via `investigation ID` in the Django admin for matching companies and duns number

--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -116,6 +116,7 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                     'is_turnover_estimated',
                     'one_list_tier',
                     'one_list_account_owner',
+                    'dnb_investigation_id',
                 ),
             },
         ),
@@ -195,6 +196,7 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
         'id',
         'company_number',
         'duns_number',
+        'dnb_investigation_id',
     )
     raw_id_fields = (
         'global_headquarters',

--- a/datahub/company/templates/admin/company/company/dnb_link/step_1_select_ids.html
+++ b/datahub/company/templates/admin/company/company/dnb_link/step_1_select_ids.html
@@ -27,9 +27,9 @@
     {% csrf_token %}
 
     {% for field in form %}
-      <div class="fieldWrapper">
+      <div class="fieldWrapper form-row">
         {{ field.errors }}
-        {{ field.label_tag }} {{ field }}
+        <label class="aligned">{{ field.label_tag }}</label> {{ field }}
         {% if field.help_text %}
         <p class="help">{{ field.help_text|safe }}</p>
         {% endif %}


### PR DESCRIPTION
### Description of change

Live services were not comfortable with search using just `Company` name due to possibility of duplicates when matching companies and duns number. Search by `investigation ID` value would solve this problem. Initial work in other services was implemented and `investigation ID` is already being saved in database.

This change adds support to search in Django admin for the `Company` via `investigation ID`.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
