### PR TITLE
Consent service: Transform emails to lowercase

### DIFF
--- a/changelog/contact/consent_lookup_normise. bugfix.md
+++ b/changelog/contact/consent_lookup_normise. bugfix.md
@@ -1,0 +1,1 @@
+A bug was resolved that resulted in emails stored in mixed casing was not found by the consent service. This is because the consent service will transform saved data into lowercase. With this fix datahub will transform the emails to lowercase when performing a lookup.


### PR DESCRIPTION
### Description of change

A bug was resolved that resulted in emails stored in mixed casing was not found by the consent service. This is because the consent service will transform saved data into lowercase. With this fix datahub will transform the emails to lowercase when performing a lookup.


### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
