### PR TITLE
Remove update consent feature flag

### DIFF
--- a/changelog/contact/update-consent-feature-flag-removed.internal.md
+++ b/changelog/contact/update-consent-feature-flag-removed.internal.md
@@ -1,0 +1,1 @@
+The `UPDATE_CONSENT_SERVICE_FEATURE_FLAG` feature flag has now been removed. This flag was used to activate or deactivate `create`, `retrieve`, `partial_update` actions on `v3/contact/<uuid> `(ContactViewSet) to trigger the update_contact_consent celery task. This feature will remain active and no longer configurable with a feature flag.

--- a/datahub/company/tasks/contact.py
+++ b/datahub/company/tasks/contact.py
@@ -1,14 +1,7 @@
 import requests
 from celery import shared_task
-from celery.utils.log import get_task_logger
 
 from datahub.company import consent
-from datahub.company.constants import (
-    UPDATE_CONSENT_SERVICE_FEATURE_FLAG,
-)
-from datahub.feature_flag.utils import is_feature_flag_active
-
-logger = get_task_logger(__name__)
 
 
 @shared_task(
@@ -18,13 +11,8 @@ logger = get_task_logger(__name__)
 )
 def update_contact_consent(email_address, accepts_dit_email_marketing, modified_at=None):
     """
-    Archive inactive companies.
+    Update consent preferences.
     """
-    if not is_feature_flag_active(UPDATE_CONSENT_SERVICE_FEATURE_FLAG):
-        logger.info(
-            f'Feature flag "{UPDATE_CONSENT_SERVICE_FEATURE_FLAG}" is not active, exiting.',
-        )
-        return
     consent.update_consent(
         email_address,
         accepts_dit_email_marketing,


### PR DESCRIPTION
### Description of change

The `UPDATE_CONSENT_SERVICE_FEATURE_FLAG` feature flag has now been removed. This flag was used to activate or deactivate `create`, `retrieve`, `partial_update` actions on `v3/contact/<uuid> `(ContactViewSet) to trigger the update_contact_consent celery task. This feature will remain active and no longer configurable with a feature flag.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
