### PR TITLE
Update contacts dataset, remove email marketing field

### DIFF
--- a/changelog/contact/contacts-dataset.api.md
+++ b/changelog/contact/contacts-dataset.api.md
@@ -1,0 +1,1 @@
+`GET /v4/dataset/contacts-dataset`: The field `accepts_dit_email_marketing` was removed from the contacts dataset endpoint. It is no longer required by Data Workflow.

--- a/datahub/dataset/contact/test/test_views.py
+++ b/datahub/dataset/contact/test/test_views.py
@@ -1,12 +1,10 @@
 from unittest.mock import Mock
 
-import factory.fuzzy
 import pytest
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.company.constants import GET_CONSENT_FROM_CONSENT_SERVICE
 from datahub.company.test.factories import (
     ArchivedContactFactory,
     ContactFactory,
@@ -17,13 +15,11 @@ from datahub.core.test_utils import (
     get_attr_or_none,
 )
 from datahub.dataset.core.test import BaseDatasetViewTest
-from datahub.feature_flag.test.factories import FeatureFlagFactory
 
 
 def get_expected_data_from_contact(contact):
     """Returns expected dictionary based on given contact"""
     return {
-        'accepts_dit_email_marketing': contact.accepts_dit_email_marketing,
         'address_1': contact.address_1,
         'address_2': contact.address_2,
         'address_country__name': get_attr_or_none(contact, 'address_country.name'),
@@ -101,70 +97,3 @@ class TestContactsDatasetViewSet(BaseDatasetViewTest):
                                        key=lambda item: item.pk) + [contact_1, contact_2]
         for index, contact in enumerate(expected_contact_list):
             assert contact.email == response_results[index]['email']
-
-    def test_makes_api_call_to_consent_service(
-            self,
-            data_flow_api_client,
-            consent_get_many_mock,
-    ):
-        """
-        Test that if consent feature flag is enabled then call is made to
-        the consent service and values from that are in the response.
-        """
-        FeatureFlagFactory(code=GET_CONSENT_FROM_CONSENT_SERVICE, is_active=True)
-        contact1 = ContactFactory(email=factory.Faker('email'))
-        contact2 = ContactFactory(email=factory.Faker('email'))
-        contact3 = ContactFactory(email=factory.Faker('email'))
-        consent_get_many_mock.return_value = {
-            contact1.email: True,
-            contact2.email: False,
-        }
-        response = data_flow_api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_200_OK
-        consent_get_many_mock.assert_called_once_with(
-            [contact1.email, contact2.email, contact3.email],
-        )
-        response_results = response.json()['results']
-        assert response_results[0]['accepts_dit_email_marketing']
-        assert not response_results[1]['accepts_dit_email_marketing']
-        assert not response_results[2]['accepts_dit_email_marketing']
-
-    def test_removes_invalid_emails_before_calling_consent_service(
-            self,
-            data_flow_api_client,
-            consent_get_many_mock,
-    ):
-        """
-        Test that empty email strings are removed before making a call to the Consent Service.
-        Before 2016, emails for contacts were not mandatory, so there are around 40,000
-        records with no emails. Filtering has been added to make sure that the
-        Consent Service is not called with these empty emails.
-        """
-        FeatureFlagFactory(code=GET_CONSENT_FROM_CONSENT_SERVICE, is_active=True)
-        contact1 = ContactFactory(email=factory.Faker('email'))
-        contact2 = ContactFactory(email='')
-        contact3 = ContactFactory(email=factory.Faker('email'))
-        contact4 = ContactFactory(email='cc@c-c')
-        consent_get_many_mock.return_value = {
-            contact1.email: True,
-            contact3.email: True,
-        }
-        response = data_flow_api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_200_OK
-        consent_get_many_mock.assert_called_once_with(
-            [contact1.email, contact3.email],
-        )
-        response_results = response.json()['results']
-        assert len(response_results) == 4
-
-        assert response_results[0]['accepts_dit_email_marketing']
-        assert response_results[0]['email'] == contact1.email
-
-        assert not response_results[1]['accepts_dit_email_marketing']
-        assert response_results[1]['email'] == contact2.email
-
-        assert response_results[2]['accepts_dit_email_marketing']
-        assert response_results[2]['email'] == contact3.email
-
-        assert not response_results[3]['accepts_dit_email_marketing']
-        assert response_results[3]['email'] == contact4.email

--- a/datahub/dataset/contact/views.py
+++ b/datahub/dataset/contact/views.py
@@ -1,12 +1,6 @@
-from django.core.exceptions import ValidationError
-from django.core.validators import validate_email
-
-from datahub.company import consent
-from datahub.company.constants import GET_CONSENT_FROM_CONSENT_SERVICE
 from datahub.company.models.contact import Contact
 from datahub.core.query_utils import get_full_name_expression
 from datahub.dataset.core.views import BaseDatasetView
-from datahub.feature_flag.utils import is_feature_flag_active
 
 
 class ContactsDatasetView(BaseDatasetView):
@@ -18,20 +12,11 @@ class ContactsDatasetView(BaseDatasetView):
     table to get more meaningful insight.
     """
 
-    def _is_valid_email(self, value):
-        """Validate if emails are valid and return a boolean flag."""
-        try:
-            validate_email(value)
-            return True
-        except ValidationError:
-            return False
-
     def get_dataset(self):
         """Returns list of Contacts Dataset records"""
         return Contact.objects.annotate(
             name=get_full_name_expression(),
         ).values(
-            'accepts_dit_email_marketing',
             'address_1',
             'address_2',
             'address_country__name',
@@ -55,17 +40,3 @@ class ContactsDatasetView(BaseDatasetView):
             'telephone_alternative',
             'telephone_number',
         )
-
-    def _enrich_data(self, data):
-        """
-        Get the marketing consent from the consent service.
-
-        Strip invalid emails from the data, old data may be
-        empty or invalid due to validation implemented at a later date.
-        """
-        if is_feature_flag_active(GET_CONSENT_FROM_CONSENT_SERVICE):
-            emails = [item['email'] for item in data if self._is_valid_email(item['email'])]
-            consent_lookups = consent.get_many(emails)
-            for item in data:
-                item['accepts_dit_email_marketing'] = consent_lookups.get(item['email'], False)
-        return data


### PR DESCRIPTION
### Description of change

This PR removes unused field `accepts_dit_email_marketing` from contacts dataset api `GET /v4/dataset/contacts-dataset`. This field is no longer needed and it also saves api calls to Consent service during nightly contacts update for Data Workspace.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
