### PR TITLE
Chore/remove get consent feature flag

### DIFF
--- a/changelog/contact/get-consent-feature-flag-removed.internal.md
+++ b/changelog/contact/get-consent-feature-flag-removed.internal.md
@@ -1,0 +1,1 @@
+The `GET_CONSENT_FROM_CONSENT_SERVICE` feature flag has now been removed. This flag was used to activate or deactivate consent lookup from the consent service on `v3/contact/<uuid> `(ContactViewSet). This feature will remain active and no longer configurable with a feature flag.

--- a/datahub/company/constants.py
+++ b/datahub/company/constants.py
@@ -8,7 +8,6 @@ NOTIFY_DNB_INVESTIGATION_FEATURE_FLAG = 'notify-dnb-investigations'
 AUTOMATIC_COMPANY_ARCHIVE_FEATURE_FLAG = 'automatic-company-archive'
 EXPORT_COUNTRIES_FEATURE_FLAG = 'export-countries-switch'
 UPDATE_CONSENT_SERVICE_FEATURE_FLAG = 'update-consent-service'
-GET_CONSENT_FROM_CONSENT_SERVICE = 'get-consent-from-consent-service'
 
 CONSENT_SERVICE_EMAIL_CONSENT_TYPE = 'email_marketing'
 

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -12,7 +12,6 @@ from rest_framework import serializers
 from datahub.company import consent
 from datahub.company.constants import (
     BusinessTypeConstant,
-    GET_CONSENT_FROM_CONSENT_SERVICE,
     OneListTierID,
 )
 from datahub.company.models import (
@@ -51,7 +50,6 @@ from datahub.core.validators import (
     RulesBasedValidator,
     ValidationRule,
 )
-from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.metadata import models as meta_models
 from datahub.metadata.serializers import TeamWithGeographyField
 
@@ -229,12 +227,11 @@ class ContactDetailSerializer(ContactSerializer):
         is enabled.
         """
         representation = super().to_representation(instance)
-        if is_feature_flag_active(GET_CONSENT_FROM_CONSENT_SERVICE):
-            try:
-                representation['accepts_dit_email_marketing'] = \
-                    consent.get_one(representation['email'])
-            except consent.ConsentAPIException:
-                representation['accepts_dit_email_marketing'] = False
+        try:
+            representation['accepts_dit_email_marketing'] = \
+                consent.get_one(representation['email'])
+        except consent.ConsentAPIException:
+            representation['accepts_dit_email_marketing'] = False
         return representation
 
     def _notify_consent_service(self, validated_data):

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -79,6 +79,14 @@ class SearchContactAPIView(SearchContactAPIViewMixin, SearchAPIView):
 class SearchContactExportAPIView(SearchContactAPIViewMixin, SearchExportAPIView):
     """Company search export view."""
 
+    def _is_valid_email(self, value):
+        """Validate if emails are valid and return a boolean flag."""
+        try:
+            validate_email(value)
+            return True
+        except ValidationError:
+            return False
+
     consent_page_size = 100
 
     db_sort_by_remappings = {
@@ -151,7 +159,7 @@ class SearchContactExportAPIView(SearchContactAPIViewMixin, SearchExportAPIView)
             rows = list(chunk)
             # Peform constent lookup on emails POST request
             consent_lookups = consent.get_many(
-                [row['email'] for row in rows],
+                [row['email'] for row in rows if self._is_valid_email(row['email'])],
             )
             for row in rows:
                 # Assign contact consent boolean to accepts_dit_email_marketing

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -1,8 +1,9 @@
+from django.core.exceptions import ValidationError
+from django.core.validators import validate_email
 from django.db.models import Case, Max, Value, When
 from django.db.models.functions import NullIf
 
 from datahub.company import consent
-from datahub.company.constants import GET_CONSENT_FROM_CONSENT_SERVICE
 from datahub.company.models import Contact as DBContact
 from datahub.core.query_utils import (
     ConcatWS,
@@ -13,7 +14,6 @@ from datahub.core.query_utils import (
     get_top_related_expression_subquery,
 )
 from datahub.core.utils import slice_iterable_into_chunks
-from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.interaction.models import Interaction as DBInteraction
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.search.contact import ContactSearchApp
@@ -170,6 +170,4 @@ class SearchContactExportAPIView(SearchContactAPIViewMixin, SearchExportAPIView)
     def _get_rows(self, ids, search_ordering):
         """Get row queryset for constent service if the feature flag is enabled."""
         rows = super()._get_rows(ids, search_ordering)
-        if is_feature_flag_active(GET_CONSENT_FROM_CONSENT_SERVICE):
-            return self._add_consent_response(rows)
-        return rows
+        return self._add_consent_response(rows)


### PR DESCRIPTION
### Description of change


The `GET_CONSENT_FROM_CONSENT_SERVICE` feature flag has now been removed. This flag was used to activate or deactivate consent lookup from the consent service on `v3/contact/<uuid> `(ContactViewSet). This feature will remain active and no longer configurable with a feature flag.

This PR is dependant on #3053
### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
