### PR TITLE
Automatic contact archive task

### DIFF
--- a/changelog/contact/automatic-contact-archive.feature.md 
+++ b/changelog/contact/automatic-contact-archive.feature.md 
@@ -1,0 +1,6 @@
+A new Celery task called `automatic_contact_archive` was added to Data Hub API.
+
+This task would run every Saturday at 9pm in *simulation mode* with an upper limit of a *20000 contacts*. In simulation mode, this task would log the IDs of the contacts that would have been automatically archived using the following criteria:
+
+- Are not yet archived
+- Are attached to archived companies

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -10,14 +10,13 @@ https://docs.djangoproject.com/en/dev/ref/settings/
 import base64
 import os
 import stat
-from datetime import timedelta
-from datetime import datetime
-from pytz import utc  # Note: importing django.utils.timezone.utc would cause a circular import
+from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
 import environ
 from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
+from pytz import utc  # Note: importing django.utils.timezone.utc would cause a circular import
 
 from config.settings.types import HawkScope
 from datahub.core.constants import InvestmentProjectStage
@@ -452,6 +451,14 @@ if REDIS_BASE_URL:
         'simulate_automatic_company_archive': {
             'task': 'datahub.company.tasks.automatic_company_archive',
             'schedule': crontab(minute=0, hour=19),
+            'kwargs': {
+                'limit': 20000,
+                'simulate': True,
+            }
+        },
+        'simulate_automatic_contact_archive': {
+            'task': 'datahub.company.tasks.automatic_contact_archive',
+            'schedule': crontab(minute=0, hour=21, day_of_week='SAT'),
             'kwargs': {
                 'limit': 20000,
                 'simulate': True,

--- a/datahub/company/tasks/__init__.py
+++ b/datahub/company/tasks/__init__.py
@@ -1,4 +1,8 @@
 from datahub.company.tasks.company import automatic_company_archive
-from datahub.company.tasks.contact import update_contact_consent
+from datahub.company.tasks.contact import automatic_contact_archive, update_contact_consent
 
-__all__ = ('automatic_company_archive', 'update_contact_consent')
+__all__ = (
+    'automatic_company_archive',
+    'automatic_contact_archive',
+    'update_contact_consent',
+)

--- a/datahub/company/tasks/contact.py
+++ b/datahub/company/tasks/contact.py
@@ -1,7 +1,39 @@
 import requests
 from celery import shared_task
+from celery.utils.log import get_task_logger
+from django.utils import timezone
+from django_pglocks import advisory_lock
 
 from datahub.company import consent
+from datahub.company.models import Contact
+from datahub.core.realtime_messaging import send_realtime_message
+
+logger = get_task_logger(__name__)
+
+
+def _automatic_contact_archive(limit=1000, simulate=False):
+    contacts_to_be_archived = Contact.objects.filter(
+        archived=False, company__archived=True,
+    )[:limit]
+
+    for contact in contacts_to_be_archived:
+        message = f'Automatically archived contact: {contact.id}'
+        if simulate:
+            logger.info(f'[SIMULATION] {message}')
+            continue
+        contact.archived = True
+        contact.archived_reason = 'Record was automatically archived due to inactivity'
+        contact.archived_on = timezone.now()
+        contact.save(
+            update_fields=[
+                'archived',
+                'archived_reason',
+                'archived_on',
+            ],
+        )
+        logger.info(message)
+
+    return contacts_to_be_archived.count()
 
 
 @shared_task(
@@ -18,3 +50,27 @@ def update_contact_consent(email_address, accepts_dit_email_marketing, modified_
         accepts_dit_email_marketing,
         modified_at=modified_at,
     )
+
+
+@shared_task(
+    bind=True,
+    acks_late=True,
+    priority=9,
+    max_retries=3,
+    queue='long-running',
+    # name set explicitly to maintain backwards compatibility
+    name='datahub.company.tasks.automatic_contact_archive',
+)
+def automatic_contact_archive(self, limit=1000, simulate=False):
+    """
+    Archive inactive contacts.
+    """
+    with advisory_lock('automatic_contact_archive', wait=False) as acquired:
+
+        if not acquired:
+            logger.info('Another instance of this task is already running.')
+            return
+
+        archive_count = _automatic_contact_archive(limit=limit, simulate=simulate)
+        realtime_message = f'{self.name} archived: {archive_count}'
+        send_realtime_message(realtime_message)

--- a/datahub/company/tasks/contact.py
+++ b/datahub/company/tasks/contact.py
@@ -14,7 +14,7 @@ logger = get_task_logger(__name__)
 def _automatic_contact_archive(limit=1000, simulate=False):
     contacts_to_be_archived = Contact.objects.filter(
         archived=False, company__archived=True,
-    )[:limit]
+    ).prefetch_related('company')[:limit]
 
     for contact in contacts_to_be_archived:
         message = f'Automatically archived contact: {contact.id}'
@@ -22,7 +22,8 @@ def _automatic_contact_archive(limit=1000, simulate=False):
             logger.info(f'[SIMULATION] {message}')
             continue
         contact.archived = True
-        contact.archived_reason = 'Record was automatically archived due to inactivity'
+        contact.archived_reason = f'Record was automatically archived due to the company ' \
+                                  f'"{contact.company.name}" being archived'
         contact.archived_on = timezone.now()
         contact.save(
             update_fields=[

--- a/datahub/company/test/tasks/test_contact_task.py
+++ b/datahub/company/test/tasks/test_contact_task.py
@@ -1,14 +1,20 @@
+import logging
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
 from celery.exceptions import Retry
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test import override_settings
+from django.utils import timezone
+from freezegun import freeze_time
 from requests import ConnectTimeout
 from rest_framework import status
 
-from datahub.company.tasks import update_contact_consent
+from datahub.company.tasks import automatic_contact_archive, update_contact_consent
+from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core.test_utils import HawkMockJSONResponse
 
 
@@ -135,3 +141,197 @@ class TestConsentServiceTask:
             update_contact_consent('example@example.com', True)
         assert mock_post.called
         assert not mock_retry.called
+
+
+@pytest.mark.django_db
+class TestContactArchiveTask:
+    """
+    Tests for the task that archives contacts
+    """
+
+    @pytest.mark.parametrize(
+        'lock_acquired, call_count',
+        (
+            (False, 0),
+            (True, 1),
+        ),
+    )
+    def test_lock(
+        self,
+        monkeypatch,
+        lock_acquired,
+        call_count,
+    ):
+        """
+        Test that the task doesn't run if it cannot acquire the advisory_lock
+        """
+        mock_advisory_lock = mock.MagicMock()
+        mock_advisory_lock.return_value.__enter__.return_value = lock_acquired
+        monkeypatch.setattr(
+            'datahub.company.tasks.contact.advisory_lock',
+            mock_advisory_lock,
+        )
+        mock_automatic_contact_archive = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.company.tasks.contact._automatic_contact_archive',
+            mock_automatic_contact_archive,
+        )
+        automatic_contact_archive()
+        assert mock_automatic_contact_archive.call_count == call_count
+
+    def test_limit(self):
+        """
+        Test contact archiving query limit
+        """
+        limit = 2
+        contacts = [ContactFactory(company=CompanyFactory(archived=True)) for _ in range(3)]
+        task_result = automatic_contact_archive.apply_async(kwargs={'limit': limit})
+        assert task_result.successful()
+
+        count = 0
+        for contact in contacts:
+            contact.refresh_from_db()
+            if contact.archived:
+                count += 1
+        assert count == limit
+
+    @pytest.mark.parametrize('simulate', (True, False))
+    def test_simulate(self, caplog, simulate):
+        """
+        Test contact archiving simulate flag
+        """
+        caplog.set_level(logging.INFO, logger='datahub.company.tasks.contact')
+        date = timezone.now() - relativedelta(days=10)
+        with freeze_time(date):
+            company1 = CompanyFactory()
+            company2 = CompanyFactory(archived=True)
+            contact1 = ContactFactory(company=company1)
+            contact2 = ContactFactory(company=company2)
+        task_result = automatic_contact_archive.apply_async(kwargs={'simulate': simulate})
+        contact1.refresh_from_db()
+        contact2.refresh_from_db()
+        if simulate:
+            assert caplog.messages == [
+                f'[SIMULATION] Automatically archived contact: {contact2.id}',
+            ]
+        else:
+            assert task_result.successful()
+            assert contact1.archived is False
+            assert contact2.archived is True
+            assert caplog.messages == [f'Automatically archived contact: {contact2.id}']
+
+    @pytest.mark.parametrize(
+        'contacts, message',
+        (
+            (
+                (False, False, False),
+                'datahub.company.tasks.automatic_contact_archive archived: 0',
+            ),
+            (
+                (False, False, True),
+                'datahub.company.tasks.automatic_contact_archive archived: 1',
+            ),
+            (
+                (True, True, True),
+                'datahub.company.tasks.automatic_contact_archive archived: 3',
+            ),
+        ),
+    )
+    def test_realtime_messages_sent(
+        self,
+        monkeypatch,
+        contacts,
+        message,
+    ):
+        """
+        Test that appropriate realtime messaging is sent which reflects the archiving actions
+        """
+        for is_archived in contacts:
+            company = CompanyFactory(archived=is_archived)
+            ContactFactory(company=company)
+
+        mock_send_realtime_message = mock.Mock()
+        monkeypatch.setattr(
+            'datahub.company.tasks.contact.send_realtime_message',
+            mock_send_realtime_message,
+        )
+        automatic_contact_archive.apply_async()
+        mock_send_realtime_message.assert_called_once_with(message)
+
+    def test_archive_no_updates(self):
+        """
+        Test contact archiving with no updates on contacts
+        """
+        date = timezone.now() - relativedelta(days=10)
+        with freeze_time(date):
+            company1 = CompanyFactory()
+            company2 = CompanyFactory()
+            contact1 = ContactFactory(company=company1)
+            contact2 = ContactFactory(company=company2)
+            contact3 = ContactFactory(company=company2)
+            for c in [contact1, contact2, contact3]:
+                assert c.archived is False
+                assert c.archived_reason is None
+                assert c.archived_on is None
+
+            # run task twice expecting same result
+            for _ in range(2):
+                task_result = automatic_contact_archive.apply_async(kwargs={'limit': 200})
+                assert task_result.successful()
+
+                for c in [contact1, contact2, contact3]:
+                    c.refresh_from_db()
+                    assert c.archived is False
+                    assert c.archived_reason is None
+                    assert c.archived_on is None
+
+    def test_archive_with_updates(self):
+        """
+        Test contact archiving with updates on correct contacts
+        """
+        date = timezone.now() - relativedelta(days=10)
+        with freeze_time(date):
+            company1 = CompanyFactory()
+            company2 = CompanyFactory(archived=True)
+            contact1 = ContactFactory(company=company1)
+            contact2 = ContactFactory(company=company2)
+            contact3 = ContactFactory(company=company2)
+            for c in [contact1, contact2, contact3]:
+                assert c.archived is False
+                assert c.archived_reason is None
+                assert c.archived_on is None
+
+            # run task twice expecting same result
+            for _ in range(2):
+                task_result = automatic_contact_archive.apply_async(kwargs={'limit': 200})
+                assert task_result.successful()
+
+                contact1.refresh_from_db()
+                contact2.refresh_from_db()
+                contact3.refresh_from_db()
+                assert contact1.archived is False
+                assert contact2.archived is True
+                assert contact3.archived is True
+                assert contact1.archived_reason is None
+                assert contact2.archived_reason is not None
+                assert contact3.archived_reason is not None
+                assert contact1.archived_on is None
+                assert contact2.archived_on == date
+                assert contact3.archived_on == date
+
+        # run again at later time expecting no changes
+        task_result = automatic_contact_archive.apply_async(kwargs={'limit': 200})
+        assert task_result.successful()
+
+        contact1.refresh_from_db()
+        contact2.refresh_from_db()
+        contact3.refresh_from_db()
+        assert contact1.archived is False
+        assert contact2.archived is True
+        assert contact3.archived is True
+        assert contact1.archived_reason is None
+        assert contact2.archived_reason is not None
+        assert contact3.archived_reason is not None
+        assert contact1.archived_on is None
+        assert contact2.archived_on == date
+        assert contact3.archived_on == date


### PR DESCRIPTION
### Description of change

A new Celery task called `automatic_contact_archive` was added to Data Hub API.

This task would run every Saturday at 9pm in *simulation mode* with an upper limit of a *20000 contacts*. In simulation mode, this task would log the IDs of the contacts that would have been automatically archived using the following criteria:

- Are not yet archived
- Are attached to archived companies

Once we have clearer requirements regarding contacts archiving we might start in non-simulate mode.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
