### PR TITLE
Investment project country of origin

### DIFF
--- a/changelog/investment/country_of_origin.bugfix.md
+++ b/changelog/investment/country_of_origin.bugfix.md
@@ -1,0 +1,2 @@
+The `country_investment_originates_from` search filter has been updated, so now it only filters Investment Projects
+by a field of its own name.

--- a/changelog/investment/country_of_origin.feature.md
+++ b/changelog/investment/country_of_origin.feature.md
@@ -1,0 +1,2 @@
+When a new Investment Project is created, the `country_investment_originates_from` is now populated from the
+corresponding Investor Company `address_country` field.

--- a/changelog/investment/update_country_of_origin_command.feature.md
+++ b/changelog/investment/update_country_of_origin_command.feature.md
@@ -1,0 +1,2 @@
+A new command `update_country_of_origin` has been added to update all Investment Projects'
+`country_investment_originates_from` column with corresponding Investor Company address country.

--- a/datahub/investment/project/management/commands/update_country_of_origin.py
+++ b/datahub/investment/project/management/commands/update_country_of_origin.py
@@ -1,0 +1,27 @@
+from django.core.management.base import BaseCommand
+
+from datahub.investment.project.models import InvestmentProject
+from datahub.investment.project.tasks import (
+    update_country_of_origin_for_investment_projects,
+)
+from datahub.search.signals import disable_search_signal_receivers
+
+
+class Command(BaseCommand):
+    """
+    Command to update the country of origin values for investment projects.
+
+    Search signal receivers for InvestmentProject are being disabled to avoid queueing huge
+    amount of Celery tasks to refresh the object in Elasticsearch.
+
+    Elasticsearch should be manually synchronised after running the command.
+    """
+
+    help = 'Updates all investment projects that do not have country of origin set.'
+
+    @disable_search_signal_receivers(InvestmentProject)
+    def handle(self, *args, **options):
+        """
+        Main method to loop over all investment projects that do not have country of origin set.
+        """
+        update_country_of_origin_for_investment_projects()

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -238,6 +238,8 @@ class IProjectAbstract(models.Model):
     @property
     def investor_company_country(self):
         """The country of the investor company."""
+        # TODO: this property should be removed once country investment originates from is
+        # fully populated
         if self.investor_company:
             return self.investor_company.address_country
         return None

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -416,6 +416,8 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
             # Required for validation as DRF does not allow defaults for read-only fields
             data['allow_blank_possible_uk_regions'] = False
 
+            self._store_investor_company_details(data)
+
         self._check_if_investment_project_can_be_moved_to_verify_win(data)
         self._check_if_investment_project_can_be_moved_to_won(data)
         self._validate_for_stage(data)
@@ -439,6 +441,13 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
             and (self.instance is None or self.instance.project_manager_requested_on is None)
         ):
             data['project_manager_requested_on'] = now()
+
+    def _store_investor_company_details(self, data):
+        # Store investor company details used for reporting
+        # Investor company details may change over time, that's why we need to keep the details
+        # at the time of investment project creation
+        investor_company = data['investor_company']
+        data['country_investment_originates_from'] = investor_company.address_country
 
     def _check_if_investment_project_can_be_moved_to_verify_win(self, data):
         # only project manager or project assurance adviser can move a project to verify win

--- a/datahub/investment/project/test/factories.py
+++ b/datahub/investment/project/test/factories.py
@@ -58,6 +58,11 @@ class InvestmentProjectFactory(factory.django.DjangoModelFactory):
     stage_id = InvestmentProjectStage.prospect.value.id
     sector_id = Sector.aerospace_assembly_aircraft.value.id
     investor_company = factory.SubFactory(CompanyFactory)
+    country_investment_originates_from = factory.Maybe(
+        factory.SelfAttribute('investor_company'),
+        factory.SelfAttribute('investor_company.address_country'),
+        None,
+    )
     client_relationship_manager = factory.SubFactory(AdviserFactory)
     referral_source_adviser = factory.SubFactory(AdviserFactory)
     likelihood_to_land_id = LikelihoodToLand.high.value.id

--- a/datahub/investment/project/test/management/commands/test_update_country_of_origin.py
+++ b/datahub/investment/project/test/management/commands/test_update_country_of_origin.py
@@ -1,0 +1,59 @@
+import pytest
+from reversion.models import Version
+
+from datahub.investment.project.management.commands import update_country_of_origin
+from datahub.investment.project.test.factories import InvestmentProjectFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestUpdateCountryOfOriginCommand:
+    """Test update country of origin command."""
+
+    def test_update_country_of_origin(self):
+        """Test populating country of origin."""
+        projects = InvestmentProjectFactory.create_batch(
+            2,
+            country_investment_originates_from=None,
+        )
+        control_projects = [
+            # investment project with country of origin already set
+            InvestmentProjectFactory(),
+            # investment project without investor company (edge case)
+            InvestmentProjectFactory(
+                investor_company=None,
+                country_investment_originates_from=None,
+            ),
+        ]
+
+        for project in projects:
+            assert project.country_investment_originates_from is None
+            assert project.investor_company.address_country
+
+        assert (
+            control_projects[0].country_investment_originates_from
+            == control_projects[0].investor_company.address_country
+        )
+        assert control_projects[1].investor_company is None
+
+        self._run_command()
+
+        for project in projects:
+            project.refresh_from_db()
+            assert (
+                project.country_investment_originates_from
+                == project.investor_company.address_country
+            )
+            versions = Version.objects.get_for_object(project)
+            assert versions.count() == 1
+            assert versions[0].revision.get_comment() == 'Automated country of origin update.'
+
+        # check that no updates have been made to control investment project that already has
+        # country of origin set or does not have investor company set
+        for control_project in control_projects:
+            versions = Version.objects.get_for_object(control_project)
+            assert versions.count() == 0
+
+    def _run_command(self):
+        cmd = update_country_of_origin.Command()
+        cmd.handle()

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -472,6 +472,11 @@ class TestCreateView(APITestMixin):
         # GVA Multiplier for Retail & wholesale trade - 2019 - 0.0581 * 1000
         assert response_data['gross_value_added'] == '58'
 
+        assert (
+            response_data['country_investment_originates_from']['id']
+            == str(investor_company.address_country.id)
+        )
+
     def test_create_project_fail(self):
         """Test creating a project with missing required values."""
         url = reverse('api-v3:investment:investment-collection')

--- a/datahub/investment/project/views.py
+++ b/datahub/investment/project/views.py
@@ -83,6 +83,7 @@ class IProjectViewSet(ArchivableViewSetMixin, CoreViewSet):
         'client_relationship_manager__dit_team',
         'client_relationship_manager',
         'country_lost_to',
+        'country_investment_originates_from',
         'fdi_type',
         'intermediate_company',
         'investment_type',

--- a/datahub/mi_dashboard/pipelines.py
+++ b/datahub/mi_dashboard/pipelines.py
@@ -191,6 +191,8 @@ class ETLInvestmentProjects(ETLBase):
                 'investor_company__address_country__overseas_region__name',
             ),
             country_url=get_country_url(),
+            # TODO: this should be sourcing data from `country_investment_originates_from` once
+            # that column is fully populated.
             investor_company_country=get_empty_string_if_null_expression(
                 'investor_company__address_country__name',
             ),

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -525,6 +525,22 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['name'] == 'delayed project'
 
+    def test_search_investment_project_country_investment_originates_from_filter(self, setup_data):
+        """Tests country investment originates from filter."""
+        url = reverse('api-v3:search:investment_project')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'country_investment_originates_from': constants.Country.united_states.value.id,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert len(response.data['results']) == 1
+        assert response.data['results'][0]['name'] == 'abc defg'
+
     def test_search_investment_project_investor_country_when_investment_origin_set(
         self, setup_data,
     ):

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -56,6 +56,7 @@ class SearchInvestmentProjectAPIViewMixin:
         'stage': 'stage.id',
         'likelihood_to_land': 'likelihood_to_land.id',
         'uk_region_location': 'uk_region_locations.id',
+        'country_investment_originates_from': 'country_investment_originates_from.id',
     }
 
     COMPOSITE_FILTERS = {
@@ -71,10 +72,6 @@ class SearchInvestmentProjectAPIViewMixin:
             'sector.ancestors.id',
         ],
         'investor_company_country': [
-            'investor_company_country.id',
-            'country_investment_originates_from.id',
-        ],
-        'country_investment_originates_from': [
             'investor_company_country.id',
             'country_investment_originates_from.id',
         ],
@@ -137,6 +134,8 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectAPIViewMixin, SearchE
         'name': 'Project name',
         'investor_company__name': 'Investor company',
         'investor_company__address_town': 'Investor company town or city',
+        # TODO: the source field below should be replaced with `country_investment_originates_from`
+        # once it has been populated
         'investor_company__address_country__name': 'Country of origin',
         'investment_type__name': 'Investment type',
         'status_name': 'Status',


### PR DESCRIPTION
### Description of change

Report for Investment Projects contains "Country of origin" column which is populated from the linked Investor Company `address_country`. It creates a problem when a company moves to another country, then its investment project will also change its country of origin.
This PR makes use of `country_investment_originated_from` column that supposed to be used to store the country where investment project has originated from, but has never been fully implemented.

There are following changes:
- When investment project is created, the `address_country` field of `investor_company` that is mandatory will be copied over to `country_investment_originates_from`.
- Search filter `country_investment_originates_from` now only looks up data in the field of the same name.
- A command `update_country_of_origin` has been created. It loops over Investment Projects that have empty `country_investment_originated_from` column and copies `address_country` from corresponding `investment_company` record. The command disables Elasticsearch signals for Investment Projects so that the Celery queue is not going to be flooded with thousands of tasks. Once command completed, we need to sync Elasticsearch manually.
- Added TODO comments to remove `investment_company_country` where possible, as it will no longer be useful.

There will be a follow-up PR resolving the TODO comments.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
