### PR TITLE
Investment origin country in investment dataset

### DIFF
--- a/changelog/investment/investment-dataset.feature.md
+++ b/changelog/investment/investment-dataset.feature.md
@@ -1,0 +1,1 @@
+A new field `country_investment_originates_from` has been added to the InvestmentProjects dataset view.

--- a/datahub/dataset/investment_project/test/test_views.py
+++ b/datahub/dataset/investment_project/test/test_views.py
@@ -113,6 +113,10 @@ def get_expected_data_from_project(project):
         'country_investment_originates_from_id': str_or_none(
             project.country_investment_originates_from_id,
         ),
+        'country_investment_originates_from__name': get_attr_or_none(
+            project,
+            'country_investment_originates_from.name',
+        ),
         'created_by_id': str_or_none(project.created_by_id),
         'created_on': format_date_or_datetime(project.created_on),
         'delivery_partner_names': (

--- a/datahub/dataset/investment_project/views.py
+++ b/datahub/dataset/investment_project/views.py
@@ -89,6 +89,7 @@ class InvestmentProjectsDatasetView(BaseDatasetView):
             'client_requirements',
             'competing_countries',
             'country_investment_originates_from_id',
+            'country_investment_originates_from__name',
             'created_by_id',
             'created_on',
             'delivery_partner_names',


### PR DESCRIPTION
### Description of change

Updating Investment dataset with newly added `country_investment_originates_from` field for consumption.

See https://github.com/uktrade/data-hub-api/blob/master/CHANGELOG.md#data-hub-api-3530-2020-08-17

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
