### PR TITLE
Remove list of reviewers

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,13 +3,3 @@ update_configs:
   - package_manager: "python"
     directory: "/"
     update_schedule: "weekly"
-    default_reviewers:
-    - "elcct"
-    - "sekharpanja"
-    - "adamledwards"
-    - "mcbhenwood"
-    - "debitan"
-    - "rachaelcodes"
-    - "mforner13"
-    - "cgsunkel"
-    - "pipporaimondi"


### PR DESCRIPTION
### Description of change

Dependabot PRs are now being reviewed by the green team on a rota basis, so it has been agreed within the team that the list of reviewers is no longer required.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
