### PR TITLE
Passing query params to DnB service in api call

### DIFF
--- a/changelog/dnb-api-change-request-params.bugfix.md
+++ b/changelog/dnb-api-change-request-params.bugfix.md
@@ -1,0 +1,1 @@
+Parameters are now passed in query string for `GET` request when calling `change-request` endpoint in DnB service.

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -423,7 +423,7 @@ def request_changes(duns_number, changes):
     return dnb_response.json()
 
 
-def _get_change_request(payload):
+def _get_change_request(params):
     """
     Get change request from dnb-service.
     """
@@ -432,7 +432,7 @@ def _get_change_request(payload):
     response = api_client.request(
         'GET',
         'change-request/',
-        json=payload,
+        params=params,
         timeout=3.0,
     )
     return response


### PR DESCRIPTION
### Description of change

Parameters are now passed in query string for `GET` when calling `change-request` endpoint in DnB service.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
