### PR TITLE
Updated fixtures because of removed field

### DIFF
--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -429,7 +429,6 @@
     address_town: Willington
     address_postcode: NE28 5JB
     address_country: 80756b9a-5d95-e211-a939-e4115bead28a
-    accepts_dit_email_marketing: false
     notes: This is a dummy contact for testing
     created_on: '2017-02-28T15:00:00Z'
     modified_on: '2017-06-05T00:00:00Z'
@@ -446,7 +445,6 @@
     telephone_number: 67890123432
     email: jenny@cakeman.com
     address_same_as_company: true
-    accepts_dit_email_marketing: true
     notes: This is a dummy contact for testing
     created_on: '2017-02-28T15:00:00Z'
     modified_on: '2017-06-05T00:00:00Z'
@@ -462,7 +460,6 @@
     telephone_number: 6 39 15 95 29
     email: dean@cox.com
     address_same_as_company: true
-    accepts_dit_email_marketing: true
     notes: This is a dummy contact for testing
     created_on: '2017-02-28T15:00:00Z'
     modified_on: '2017-06-08T00:00:00Z'
@@ -481,7 +478,6 @@
     address_town: Lefevre
     address_postcode: 15404
     address_country: 82756b9a-5d95-e211-a939-e4115bead28a
-    accepts_dit_email_marketing: false
     notes: This is a dummy contact for testing
     created_on: '2017-02-28T15:00:00Z'
     modified_on: '2017-04-05T00:00:00Z'
@@ -500,7 +496,6 @@
     address_town: washington
     address_postcode: ne38 0px
     address_country: 81756b9a-5d95-e211-a939-e4115bead28a
-    accepts_dit_email_marketing: false
     notes: This is a dummy contact for testing
     created_on: '2017-04-28T15:00:00Z'
     modified_on: '2016-04-05T00:00:00Z'
@@ -519,7 +514,6 @@
     address_town: california
     address_postcode: 90001
     address_country: 81756b9a-5d95-e211-a939-e4115bead28a
-    accepts_dit_email_marketing: false
     notes: This is a dummy contact for testing
     created_on: '2017-04-28T15:00:00Z'
     modified_on: '2017-06-05T00:00:00Z'
@@ -538,7 +532,6 @@
     address_town: Ampton
     address_postcode: IP31 2RH
     address_country: 80756b9a-5d95-e211-a939-e4115bead28a
-    accepts_dit_email_marketing: false
     notes: This is a dummy contact for testing
     created_on: '2018-02-28T15:00:00Z'
     modified_on: '2018-06-05T00:00:00Z'
@@ -558,7 +551,6 @@
     address_town: Fake Town
     address_postcode: BN2 9QB
     address_country: 80756b9a-5d95-e211-a939-e4115bead28a
-    accepts_dit_email_marketing: false
     notes: This is a dummy contact for testing
     created_on: '2018-02-28T15:00:00Z'
     modified_on: '2018-06-05T00:00:00Z'


### PR DESCRIPTION
### Description of change
Field `accepts_dit_email_marketing` was removed from `Contact` model and fixtures data was failing to load.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
