### PR TITLE
Change request field status not required anymore

### DIFF
--- a/changelog/change-request-serializer.api.md
+++ b/changelog/change-request-serializer.api.md
@@ -1,0 +1,1 @@
+It's now possible to query change requests without passing `status` parameter.

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -314,7 +314,11 @@ class DNBGetCompanyChangeRequestSerializer(serializers.Serializer):
         min_length=9,
         validators=(integer_validator,),
     )
-    status = serializers.ChoiceField(choices=['pending', 'submitted'])
+    status = serializers.ChoiceField(
+        choices=['pending', 'submitted'],
+        required=False,
+        allow_null=True,
+    )
 
     def validate_duns_number(self, duns_number):
         """


### PR DESCRIPTION
### Description of change

In order to display _change request banner_ on frontend for more than a day, we have to be able to query for change requests regardless of status. Currently status `pending` was used to query but change requests are in status `pending` for at most one day and are updated to status `submitted` when submitted to DnB service by celery task once a day.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
