### PR TITLE
fixed zipkin_headers passed in kwargs to requests

### DIFF
--- a/datahub/company/consent.py
+++ b/datahub/company/consent.py
@@ -113,11 +113,16 @@ def update_consent(email_address, accepts_dit_email_marketing, modified_at=None,
     if modified_at:
         body['modified_at'] = modified_at
 
+    headers = {
+        **kwargs.get('headers', {}),
+        **kwargs.get('zipkin_headers', {}),
+    }
+
     _get_client().request(
         'post',
         CONSENT_SERVICE_PERSON_PATH,
         json=body,
-        **kwargs,
+        headers=headers,
     )
 
 


### PR DESCRIPTION
### Description of change
`zipkin_headers` parameter was being propagated through celery task into `requests.request` method which is really sensitive for unknown parameters. 

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
