### PR TITLE
Change DSO service name to `UK Defense and Security Exports`

### DIFF
--- a/changelog/interaction/rename-DSO-service.feature.md
+++ b/changelog/interaction/rename-DSO-service.feature.md
@@ -1,0 +1,1 @@
+Amend the name of the DSO service type from `DSO interaction` to `UK Defence and Security Exports` for a more descriptive interaction title.

--- a/datahub/metadata/migrations/0005_update_services.py
+++ b/datahub/metadata/migrations/0005_update_services.py
@@ -1,0 +1,33 @@
+from pathlib import PurePath
+
+import mptt
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0005_update_services.yaml'
+    )
+
+def rebuild_tree(apps, schema_editor):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0004_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]
+    

--- a/datahub/metadata/migrations/0005_update_services.yaml
+++ b/datahub/metadata/migrations/0005_update_services.yaml
@@ -1,0 +1,4 @@
+- model: metadata.service
+  pk: 0796b92b-3499-e211-a939-e4115bead28a
+  fields:
+    segment: UK Defence and Security Exports


### PR DESCRIPTION
### Description of change

This is a small PR to change the name of the DSO Interaction from `DSO interaction` to ` UK Defense and Security Exports`. This was requested in order to make the label clearer and more descriptive. 



### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
