### PR TITLE
Enhance One List report

### DIFF
--- a/changelog/company/one-list-headquarters.feature.md
+++ b/changelog/company/one-list-headquarters.feature.md
@@ -1,0 +1,1 @@
+A `Headquarter Type` column has been added to the One List report. It is now possible to assign One List tier to any company.

--- a/datahub/company/admin_reports.py
+++ b/datahub/company/admin_reports.py
@@ -2,7 +2,6 @@ from django.db.models import BooleanField, Case, When
 
 from datahub.admin_report.report import QuerySetReport
 from datahub.company.models import Advisor, Company
-from datahub.core import constants
 from datahub.core.query_utils import get_front_end_url_expression, get_full_name_expression
 
 
@@ -45,7 +44,6 @@ class OneListReport(QuerySetReport):
     model = Company
     permissions_required = ('company.view_company',)
     queryset = Company.objects.filter(
-        headquarter_type_id=constants.HeadquarterType.ghq.value.id,
         one_list_tier_id__isnull=False,
         one_list_account_owner_id__isnull=False,
     ).annotate(
@@ -59,6 +57,7 @@ class OneListReport(QuerySetReport):
         'name': 'Account Name',
         'one_list_tier__name': 'Tier',
         'sector__segment': 'Sector',
+        'headquarter_type__name': 'Headquarter Type',
         'primary_contact_name': 'Primary Contact',
         'one_list_account_owner__telephone_number': 'Contact Number',
         'one_list_account_owner__contact_email': 'E-mail',

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -780,8 +780,6 @@ class AssignOneListTierAndGlobalAccountManagerSerializer(serializers.Serializer)
     excluded_one_list_tier_id = OneListTierID.tier_d_international_trade_advisers.value
 
     default_error_messages = {
-        'cannot_assign_subsidiary_to_one_list':
-            gettext_lazy('A subsidiary cannot be on One List.'),
         'cannot_assign_company_one_list_tier':
             gettext_lazy('A company can only have this One List tier assigned by ITA.'),
         'cannot_change_company_with_current_one_list_tier':
@@ -805,12 +803,6 @@ class AssignOneListTierAndGlobalAccountManagerSerializer(serializers.Serializer)
         Validate that given one list tier and global account manager can be assigned to a company.
         """
         attrs = super().validate(attrs)
-
-        if self.instance.global_headquarters:
-            raise serializers.ValidationError(
-                self.error_messages['cannot_assign_subsidiary_to_one_list'],
-                code='cannot_assign_subsidiary_to_one_list',
-            )
 
         old_one_list_tier = self.instance.one_list_tier
         if old_one_list_tier and old_one_list_tier.id == self.excluded_one_list_tier_id:

--- a/datahub/company/test/test_company_views_one_list.py
+++ b/datahub/company/test/test_company_views_one_list.py
@@ -6,7 +6,7 @@ from reversion.models import Version
 
 from datahub.company.constants import OneListTierID
 from datahub.company.models import CompanyPermission, OneListTier
-from datahub.company.test.factories import AdviserFactory, CompanyFactory, SubsidiaryFactory
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.company.test.utils import random_non_ita_one_list_tier
 from datahub.core.test_utils import (
     APITestMixin,
@@ -132,20 +132,6 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
                     ],
                 },
                 id='required',
-            ),
-            pytest.param(
-                lambda: SubsidiaryFactory(
-                    global_headquarters__one_list_tier=random_obj_for_model(OneListTier),
-                    global_headquarters__one_list_account_owner=AdviserFactory(),
-                ),
-                lambda: AdviserFactory().pk,
-                lambda: random_non_ita_one_list_tier().pk,
-                {
-                    api_settings.NON_FIELD_ERRORS_KEY: [
-                        'A subsidiary cannot be on One List.',
-                    ],
-                },
-                id='subsidiary-of-one-list-company',
             ),
             pytest.param(
                 lambda: CompanyFactory(


### PR DESCRIPTION
### Description of change

A `Headquarter Type` column has been added to the One List report. It is now possible to assign One List tier to any company.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
