### PR TITLE
Delete orphaned teams

### DIFF
--- a/datahub/cleanup/cleanup_config.py
+++ b/datahub/cleanup/cleanup_config.py
@@ -51,7 +51,7 @@ class ModelCleanupConfig(NamedTuple):
     # The filters to apply to the model to determine the records to clean up.
     # The filters will be combined using an AND operator, so records will only be
     # cleaned up if they match all of the filters
-    filters: Sequence[DatetimeLessThanCleanupFilter]
+    filters: Sequence[DatetimeLessThanCleanupFilter] = ()
     # Fields (e.g. `Company.get_meta('interactions')`) to ignore when checking for
     # referencing objects
     excluded_relations: Sequence[Any] = ()

--- a/datahub/cleanup/management/commands/_base_command.py
+++ b/datahub/cleanup/management/commands/_base_command.py
@@ -99,15 +99,18 @@ class BaseCleanupCommand(BaseCommand):
             for field, filters in relation_filter_mapping.items()
         }
 
-        return get_unreferenced_objects_query(
+        query = get_unreferenced_objects_query(
             model,
             excluded_relations=config.excluded_relations,
             relation_exclusion_filter_mapping=relation_filter_kwargs,
         ).filter(
             _join_cleanup_filters(config.filters),
-        ).order_by(
-            f'-{config.filters[0].date_field}',
         )
+
+        if config.filters:
+            query = query.order_by(f'-{config.filters[0].date_field}')
+
+        return query
 
 
 def _print_query(model, qs, relation=None):

--- a/datahub/cleanup/management/commands/delete_orphans.py
+++ b/datahub/cleanup/management/commands/delete_orphans.py
@@ -43,4 +43,5 @@ class Command(BaseCleanupCommand):
                 DatetimeLessThanCleanupFilter('end_date', relativedelta(months=18)),
             ),
         ),
+        'metadata.Team': ModelCleanupConfig(),
     }


### PR DESCRIPTION
### Description of change

Added `metadata.Team` configuration to the `delete_orphans` command.

Also relaxed the rule of only a single filter for the `datahub.cleanup.cleanup_config.ModelCleanupConfig` constructor. The only allowed and required filter `DatetimeLessThanCleanupFilter` didn't make sense for deletion of orphaned `metadata.Team`. In general, an argumet asking for a sequence of exactly one particular item never makes sense.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
