### PR TITLE
Add new event type `Export Academy`

### DIFF
--- a/datahub/event/fixtures/add_event_type_export_academy.yaml
+++ b/datahub/event/fixtures/add_event_type_export_academy.yaml
@@ -1,0 +1,3 @@
+- model: event.eventtype
+  pk: 543e4ca4-ed74-d60f-f6bf-1a0fd64b772d
+  fields: {disabled_on: null, name: "Export Academy"}

--- a/datahub/event/fixtures/event_types.yaml
+++ b/datahub/event/fixtures/event_types.yaml
@@ -29,9 +29,6 @@
   pk: 91dbf298-84b3-4aa9-af7d-540721e5127c
   fields: {disabled_on: null, name: "UK region local service"}
 - model: event.eventtype
-  pk: 543e4ca4-ed74-d60f-f6bf-1a0fd64b772d
-  fields: {disabled_on: null, name: "Export Academy"}
-- model: event.eventtype
   pk: 48afd8d0-5d95-e211-a939-e4115bead28a
   fields: {disabled_on: '2017-11-24T00:00:00Z', name: "Awayday"}
 - model: event.eventtype

--- a/datahub/event/migrations/0017_add_event_type_export_academy.py
+++ b/datahub/event/migrations/0017_add_event_type_export_academy.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+def load_add_event(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parents[1] / 'fixtures/add_event_type_export_academy.yaml',
+    )
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('event', '0016_add_composite_index_to_event'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_add_event, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
### Description of change

Added a new event type `Export Academy`

**Note:** the event type was added in a previous PR: 
https://github.com/uktrade/data-hub-api/pull/3187/files

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
