### PR TITLE
Add the delete_orphaned_teams command

### DIFF
--- a/datahub/cleanup/management/commands/_base_command.py
+++ b/datahub/cleanup/management/commands/_base_command.py
@@ -21,6 +21,7 @@ class BaseCleanupCommand(BaseCommand):
 
     CONFIGS = None
     requires_migrations_checks = True
+    model_name = None
 
     def __repr__(self):
         """Python representation (used for parametrised tests)."""
@@ -29,11 +30,12 @@ class BaseCleanupCommand(BaseCommand):
 
     def add_arguments(self, parser):
         """Define extra arguments."""
-        parser.add_argument(
-            'model_label',
-            choices=self.CONFIGS,
-            help='Model to clean up.',
-        )
+        if not self.model_name:
+            parser.add_argument(
+                'model_label',
+                choices=self.CONFIGS,
+                help='Model to clean up.',
+            )
         simulation_group = parser.add_mutually_exclusive_group()
         simulation_group.add_argument(
             '--simulate',
@@ -51,7 +53,7 @@ class BaseCleanupCommand(BaseCommand):
         """Main logic for the actual command."""
         is_simulation = options['simulate']
         only_print_queries = options['only_print_queries']
-        model_name = options['model_label']
+        model_name = self.model_name or options['model_label']
 
         model = apps.get_model(model_name)
         qs = self._get_query(model)

--- a/datahub/cleanup/management/commands/delete_orphaned_teams.py
+++ b/datahub/cleanup/management/commands/delete_orphaned_teams.py
@@ -1,0 +1,50 @@
+from django.db.models import Q
+
+from datahub.cleanup.cleanup_config import ModelCleanupConfig
+from datahub.cleanup.management.commands._base_command import BaseCleanupCommand
+from datahub.metadata.models import Team
+
+
+class DummyFilter(object):
+    """
+    Just a dummy filter to satisfy the
+    :class:`datahub.cleanup.cleanup_config.ModelCleanupConfig` constructor,
+    which is expecting a list where the first item is an instance of
+    :class:`datahub.cleanup.cleanup_config.DatetimeLessThanCleanupFilter`,
+    which doesn't make sense with
+    :class:`datahub.metadata.models.Team`.
+
+    This class just implements the minimal required interface.
+    """
+
+    date_field = 'disabled_on'
+
+    @staticmethod
+    def as_q():
+        """Returns an empty query"""
+        return Q()
+
+
+class Command(BaseCleanupCommand):
+    """Deletes all orphaned :class:`datahub.metadata.models.Team` records"""
+
+    model_name = 'metadata.Team'
+    CONFIGS = {'metadata.Team': ModelCleanupConfig([DummyFilter()])}
+
+    def add_arguments(self, parser):
+        """Override to add the ``list-only`` argument"""
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '-l',
+            '--list-only',
+            action='store_true',
+            help='List team IDs which will be deleted by the command',
+        )
+
+    def handle(self, *args, list_only, **options):
+        """Override to add the ``list-only`` argument"""
+        if list_only:
+            for item in self._get_query(Team):
+                self.stdout.write(str(item.id))
+        else:
+            super(Command, self).handle(*args, **options)

--- a/datahub/cleanup/test/commands/test_delete_orphaned_teams.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_teams.py
@@ -1,0 +1,144 @@
+from itertools import chain, product, repeat
+from uuid import uuid4
+
+import pytest
+from django.core.management import call_command
+from django.db import transaction
+
+from datahub.cleanup.management.commands.delete_orphaned_teams import Command
+from datahub.company.models import Company
+from datahub.company.models.adviser import Advisor
+from datahub.company.models.contact import Contact
+from datahub.event.models import Event, EventType
+from datahub.metadata.models import Country, Team
+from datahub.omis.order.models import Order, OrderAssignee
+
+
+def power_set(s):
+    """Returns a *power set* for the set ``s``"""
+    return set(map(frozenset, product(*repeat(s, len(s))))) | {frozenset()}
+
+
+@pytest.fixture
+@pytest.mark.django_db
+def with_empty_teams():
+    """
+    A fixture which ensures that the test runs with an empty
+    :class:`datahub.metadata.models.Team` model.
+
+    The state of the model will be restored after each test.
+    """
+    with transaction.atomic():
+        original_items = set(Team.objects.all())
+        savepoint = transaction.savepoint()
+        Team.objects.all().delete()
+        assert Team.objects.count() == 0
+
+        yield
+
+        transaction.savepoint_rollback(savepoint)
+        assert set(Team.objects.all()) == original_items
+
+
+# We are not using the existing model factories, because they pollute the
+# metadata.Team model with lot of records, complicating assertions about them.
+def order_assignee_factory(team):
+    """
+    Creates a :class:`datahub.omis.order.models.OrderAssignee` instance related to ``team``
+    """
+    adviser = Advisor.objects.create(
+        first_name='John',
+        last_name='Doe',
+        email=f'{uuid4()}@example.com',
+    )
+    order_assignee = OrderAssignee.objects.create(
+        order=Order.objects.create(
+            company=Company.objects.create(),
+            contact=Contact.objects.create(primary=True),
+            primary_market=Country.objects.create(),
+        ),
+        adviser=adviser,
+        created_by=adviser)
+    order_assignee.team = team
+    order_assignee.save()
+    return order_assignee
+
+
+def event_with_lead_team_factory(team):
+    """
+    Creates a :class:`datahub.event.models.Event` instance with ``team`` assigned
+    to ``Event.lead_team``.
+    """
+    return Event.objects.create(
+        event_type=EventType.objects.create(),
+        address_country=Country.objects.create(),
+        lead_team=team,
+    )
+
+
+def event_with_teams_factory(team):
+    """
+    Creates a :class:`datahub.event.models.Event` instance with ``team`` assigned
+    to ``Event.teams``.
+    """
+    event = Event.objects.create(
+        event_type=EventType.objects.create(),
+        address_country=Country.objects.create(),
+    )
+    event.teams.add(team)
+    return event
+
+
+def adviser_factory(team):
+    """
+    Creates a :class:`datahub.company.models.adviser.Advisor` related to ``team``.
+    """
+    return Advisor.objects.create(email=f'{uuid4()}@example.com', dit_team=team)
+
+
+# Team can be related to Event in two ways, the Event.lead_team relation is
+# represented by the Event model and the Event.teams by this constant.
+EVENT_TEAMS = 'EVENT_TEAMS'
+
+
+# Maps Team relationships (as models) to related model instance factories
+RELATIONSHIP_FACTORY_MAP = {
+    Advisor: adviser_factory,
+    OrderAssignee: order_assignee_factory,
+    Event: event_with_lead_team_factory,
+    EVENT_TEAMS: event_with_teams_factory,
+}
+
+
+RELATIONS_POWER_SET = power_set({OrderAssignee, Event, Advisor, EVENT_TEAMS})
+
+
+@pytest.mark.parametrize('teams', [
+    # All possible relation combinations
+    RELATIONS_POWER_SET,
+    # Only non-related teams
+    repeat((), 7),
+    # Plenty of related and non-related teams
+    chain(repeat((), 5), chain(*repeat(RELATIONS_POWER_SET, 3))),
+])
+@pytest.mark.django_db
+def test_command(teams, with_empty_teams):
+    """
+    Tests the :class:`datahub.cleanup.management.commands.delete_orphaned_teams.Command`
+    """
+    should_be_deleted = set()
+    should_stay = set()
+    for related_models in teams:
+        team = Team.objects.create(tags=[])
+        relations = [RELATIONSHIP_FACTORY_MAP[model](team) for model in related_models]
+        (should_stay if relations else should_be_deleted).add(team)
+
+    assert should_be_deleted & should_stay == set(),\
+        'The sets of related and non-related teams should have no overlap'
+    assert set(Team.objects.all()) == should_stay | should_be_deleted,\
+        'The model should have both related and non-related teams'
+
+    call_command(Command())
+
+    assert set(Team.objects.all()) == should_stay, \
+        'The model should only have related teams'


### PR DESCRIPTION
### Description of change

Adds the `delete_orphaned_teams` command.

A new command was created instead of adding an `metadata.Team` item to the config of the existing `delete_orphans` command, because the tests of that command assume there is a _search app_ defined for each model, but there's none defined for the `metadata.Team` model.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
