### PR TITLE
Update default total hits limit

### DIFF
--- a/changelog/update-default-total-hits-limit.feature.md
+++ b/changelog/update-default-total-hits-limit.feature.md
@@ -1,0 +1,1 @@
+Add `track_total_hits` flag is set to `True` for all basic searches. This will ensure that the `total.hits.value` returns the accurate total value rather than the default limit set to `10000`.

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -397,6 +397,7 @@ def test_get_basic_search_query():
             '_score',
             'id',
         ],
+        'track_total_hits': True,
     }
 
 

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -349,6 +349,7 @@ def test_get_basic_search_query():
             '_score',
             'id',
         ],
+        'track_total_hits': True,
     }
 
 

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -764,6 +764,7 @@ def test_get_basic_search_query():
             '_score',
             'id',
         ],
+        'track_total_hits': True,
     }
 
 

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -68,7 +68,7 @@ def get_basic_search_query(
     ).source(
         excludes=fields_to_exclude,
     ).extra(
-        track_total_hits=True
+        track_total_hits=True,
     )
 
     search.aggs.bucket(

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -67,6 +67,8 @@ def get_basic_search_query(
         'id',
     ).source(
         excludes=fields_to_exclude,
+    ).extra(
+        track_total_hits=True
     )
 
     search.aggs.bucket(

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -661,6 +661,7 @@ def test_get_basic_search_query(mocked_get_global_search_apps_as_mapping):
             '_score',
             'id',
         ],
+        'track_total_hits': True,
         'from': 2,
         'size': 3,
     }


### PR DESCRIPTION
### Description of change

Overwriting the default hits.total.value amount of `10000` by setting the `track_total_hits` to `True`

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
