### PR TITLE
Remove total hits limit for search entity

### DIFF
--- a/changelog/remove-total-hits-limit-for-search-entity.feature.md
+++ b/changelog/remove-total-hits-limit-for-search-entity.feature.md
@@ -1,0 +1,1 @@
+Add `track_total_hits` flag is set to `True` for all entity searches. This will ensure that the `total.hits.value` returns the accurate total value rather than the default limit set to `10000`.

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -504,6 +504,7 @@ def test_limited_get_search_by_entity_query():
             '_score',
             'id',
         ],
+        'track_total_hits': True,
         'from': 5,
         'size': 5,
     }

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -452,6 +452,7 @@ def test_get_limited_search_by_entity_query():
             '_score',
             'id',
         ],
+        'track_total_hits': True,
         'from': 5,
         'size': 5,
     }

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -859,6 +859,7 @@ def test_limited_get_search_by_entity_query():
             '_score',
             'id',
         ],
+        'track_total_hits': True,
         'from': 5,
         'size': 5,
     }

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -109,6 +109,8 @@ def get_search_by_entities_query(
         ],
     ).query(
         Bool(must=query),
+    ).extra(
+        track_total_hits=True,
     )
 
     permission_query = _build_entity_permission_query(permission_filters)

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -348,6 +348,7 @@ def test_build_entity_permission_query_no_conditions(filters, expected):
                     },
                 },
                 'sort': ['_score', 'id'],
+                'track_total_hits': True,
             },
         ),
 
@@ -452,6 +453,7 @@ def test_build_entity_permission_query_no_conditions(filters, expected):
                     },
                     'id',
                 ],
+                'track_total_hits': True,
                 '_source': {
                     'includes': ['id'],
                     'excludes': ['name'],
@@ -562,6 +564,7 @@ def test_get_search_by_multiple_entities_query():
         'sort': [
             '_score', 'id',
         ],
+        'track_total_hits': True,
     }
     assert query.to_dict() == expected_query
     assert query._index == [


### PR DESCRIPTION
### Description of change

Add `track_total_hits` flag is set to `True` for all entity searches. This will ensure that the `total.hits.value` returns the accurate total value rather than the default limit set to `10000`.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
