### PR TITLE
Add policy feedback interaction export.

### DIFF
--- a/changelog/interaction/policy-feedback-export.feature.md
+++ b/changelog/interaction/policy-feedback-export.feature.md
@@ -1,0 +1,2 @@
+A new `POST /v3/search/interaction/policy-feedback` endpoint has been added. It returns a CSV file with added columns to
+match Data Workspace export.

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -1,3 +1,5 @@
+from django.db.models import CharField, OuterRef, Value
+
 from datahub.core.query_utils import (
     get_bracketed_concat_expression,
     get_choices_as_case_expression,
@@ -6,6 +8,7 @@ from datahub.core.query_utils import (
     get_string_agg_subquery,
 )
 from datahub.interaction.models import Interaction as DBInteraction
+from datahub.metadata.models import Sector
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.metadata.query_utils import get_service_name_subquery
 from datahub.search.interaction import InteractionSearchApp
@@ -134,4 +137,123 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
         'policy_issue_type_names': 'Policy issue types',
         'policy_area_names': 'Policy areas',
         'policy_feedback_notes': 'Policy feedback notes',
+    }
+
+
+@register_v3_view(sub_path='policy-feedback')
+class SearchInteractionPolicyFeedbackExportAPIView(
+    SearchInteractionAPIViewMixin,
+    SearchExportAPIView,
+):
+    """Filtered interaction policy feedback search export view."""
+
+    queryset = DBInteraction.objects.annotate(
+        company_link=get_front_end_url_expression('company', 'company__pk'),
+        company_sector_name=get_sector_name_subquery('company__sector'),
+        company_sector_cluster=Sector.objects.filter(
+            parent_id__isnull=True,
+            tree_id=OuterRef('company__sector__tree_id'),
+        ).values('sector_cluster__name'),
+        contact_names=get_string_agg_subquery(
+            DBInteraction,
+            get_full_name_expression(
+                person_field_name='contacts',
+                bracketed_field_name='job_title',
+            ),
+        ),
+        created_by_name=get_full_name_expression(
+            person_field_name='created_by',
+        ),
+        adviser_names=get_string_agg_subquery(
+            DBInteraction,
+            get_bracketed_concat_expression(
+                'dit_participants__adviser__first_name',
+                'dit_participants__adviser__last_name',
+                expression_to_bracket='dit_participants__team__name',
+            ),
+        ),
+        adviser_emails=get_string_agg_subquery(
+            DBInteraction,
+            'dit_participants__adviser__email',
+        ),
+        team_names=get_string_agg_subquery(
+            DBInteraction,
+            'dit_participants__team__name',
+        ),
+        team_countries=get_string_agg_subquery(
+            DBInteraction,
+            'dit_participants__team__country__name',
+        ),
+        link=get_front_end_url_expression('interaction', 'pk'),
+        kind_name=get_choices_as_case_expression(DBInteraction, 'kind'),
+        policy_issue_type_names=get_string_agg_subquery(
+            DBInteraction,
+            'policy_issue_types__name',
+        ),
+        policy_area_names=get_string_agg_subquery(
+            DBInteraction,
+            'policy_areas__name',
+            # Some policy areas contain commas, so we use a semicolon to delimit multiple values
+            delimiter='; ',
+        ),
+        service_name=get_service_name_subquery('service'),
+        # Placeholder values
+        tags_prediction=Value('', CharField()),
+        tag_1=Value('', CharField()),
+        probability_score_tag_1=Value('', CharField()),
+        tag_2=Value('', CharField()),
+        probability_score_tag_2=Value('', CharField()),
+        tag_3=Value('', CharField()),
+        probability_score_tag_3=Value('', CharField()),
+        tag_4=Value('', CharField()),
+        probability_score_tag_4=Value('', CharField()),
+        tag_5=Value('', CharField()),
+        probability_score_tag_5=Value('', CharField()),
+    )
+
+    field_titles = {
+        'date': 'Date',
+        'created_on': 'Created date',
+        'modified_on': 'Modified date',
+        'link': 'Link',
+        'service_name': 'Service',
+        'subject': 'Subject',
+        'company__name': 'Company',
+        'company__global_headquarters__name': 'Parent',
+        'company__address_country__name': 'Company country',
+        'company__uk_region__name': 'Company UK region',
+        'company__one_list_tier__name': 'One List Tier',
+        'company_sector_name': 'Company sector',
+        'company_sector_cluster': 'Company sector cluster',
+        'company__turnover': 'turnover',
+        'company__number_of_employees': 'number_of_employees',
+        'team_names': 'team_names',
+        'team_countries': 'team_countries',
+        'kind_name': 'kind_name',
+        'communication_channel__name': 'Communication channel',
+        'was_policy_feedback_provided': 'was_policy_feedback_provided',
+        'policy_issue_type_names': 'Policy issue types',
+        'policy_area_names': 'Policy areas',
+        'policy_feedback_notes': 'Policy feedback notes',
+
+        'adviser_names': 'advisers',
+        'adviser_emails': 'adviser_emails',
+        'created_by_name': 'created_by',
+
+        'tags_prediction': 'tags_prediction',
+        'tag_1': 'tag_1',
+        'probability_score_tag_1': 'probability_score_tag_1',
+        'tag_2': 'tag_2',
+        'probability_score_tag_2': 'probability_score_tag_2',
+        'tag_3': 'tag_3',
+        'probability_score_tag_3': 'probability_score_tag_3',
+        'tag_4': 'tag_4',
+        'probability_score_tag_4': 'probability_score_tag_4',
+        'tag_5': 'tag_5',
+        'probability_score_tag_5': 'probability_score_tag_5',
+
+        'contact_names': 'Contacts',
+        'event__name': 'Event',
+        'service_delivery_status__name': 'Service delivery status',
+        'net_company_receipt': 'Net company receipt',
     }


### PR DESCRIPTION
### Description of change

A new `POST /v3/search/interaction/policy-feedback` endpoint has been added. It returns a CSV file with added columns to
match Data Workspace export.

The endpoint will be called if a user wants to export interactions and checks "includes policy feedback" filter.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
