### PR TITLE
Add missing field to policy feedback export

### DIFF
--- a/changelog/interaction/policy-feedback-export.bugfix.md
+++ b/changelog/interaction/policy-feedback-export.bugfix.md
@@ -1,0 +1,1 @@
+A missing "Company Link" column has been added to the policy feedback export.

--- a/changelog/interaction/policy-feedback-export.bugfix.md
+++ b/changelog/interaction/policy-feedback-export.bugfix.md
@@ -1,1 +1,1 @@
-A missing "Company Link" column has been added to the policy feedback export.
+A missing "Company link" column has been added to the policy feedback export.

--- a/datahub/search/interaction/test/test_views.py
+++ b/datahub/search/interaction/test/test_views.py
@@ -1182,6 +1182,9 @@ class TestInteractionExportView(APITestMixin):
                 'Service': get_attr_or_none(interaction, 'service.name'),
                 'Subject': interaction.subject,
                 'Company': get_attr_or_none(interaction, 'company.name'),
+                'Company link':
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
+                    f'/{interaction.company.pk}',
                 'Parent': get_attr_or_none(interaction, 'company.global_headquarters.name'),
                 'Company country': get_attr_or_none(
                     interaction,

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -219,6 +219,7 @@ class SearchInteractionPolicyFeedbackExportAPIView(
         'service_name': 'Service',
         'subject': 'Subject',
         'company__name': 'Company',
+        'company_link': 'Company link',
         'company__global_headquarters__name': 'Parent',
         'company__address_country__name': 'Company country',
         'company__uk_region__name': 'Company UK region',


### PR DESCRIPTION
### Description of change

A missing "Company link" column has been added to the policy feedback export.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
