### PR TITLE
Remove flake8-blind-except

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -69,7 +69,6 @@ pre-commit==2.9.3
 
 # Code static analysis
 flake8==3.8.4
-flake8-blind-except==0.1.1
 flake8-bugbear==20.11.1
 flake8-commas==2.0.0
 flake8-debugger==4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,25 +4,26 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-aiohttp==3.6.2            # via slackclient
-amqp==2.6.0               # via kombu
+aiohttp==3.7.3            # via slackclient
+amqp==2.6.1               # via kombu
 apipkg==1.5               # via execnet
 appdirs==1.4.4            # via virtualenv
+appnope==0.1.2            # via ipython
 argh==0.26.2              # via watchdog
-asgiref==3.2.10           # via django
+asgiref==3.3.1            # via django
 async-timeout==3.0.1      # via aiohttp
-attrs==19.3.0             # via aiohttp, flake8-bugbear, pytest
+attrs==20.3.0             # via aiohttp, flake8-bugbear, pytest
 backcall==0.2.0           # via ipython
 billiard==3.6.3.0         # via -r requirements.in, celery
 boto3==1.16.47            # via -r requirements.in
-botocore==1.19.47         # via boto3, s3transfer
+botocore==1.19.51         # via boto3, s3transfer
 celery[redis]==4.4.7      # via -r requirements.in
-certifi==2020.6.20        # via elastic-apm, elasticsearch, requests, sentry-sdk
-cfgv==3.1.0               # via pre-commit
+certifi==2020.12.5        # via elastic-apm, elasticsearch, requests, sentry-sdk
+cfgv==3.2.0               # via pre-commit
 chardet==3.0.4            # via -r requirements.in, aiohttp, requests
 click==7.1.2              # via pip-tools, towncrier
-coverage==5.1             # via pytest-cov
-decorator==4.4.2          # via ipython, traitlets
+coverage==5.3.1           # via pytest-cov
+decorator==4.4.2          # via ipython
 distlib==0.3.1            # via virtualenv
 django-debug-toolbar==3.2  # via -r requirements.in
 django-environ==0.4.5     # via -r requirements.in
@@ -41,9 +42,8 @@ elasticsearch-dsl==7.3.0  # via -r requirements.in
 elasticsearch==7.10.1     # via -r requirements.in, elasticsearch-dsl
 execnet==1.7.1            # via pytest-xdist
 factory-boy==3.2.0        # via -r requirements.in
-faker==4.1.1              # via factory-boy
+faker==5.4.0              # via factory-boy
 filelock==3.0.12          # via virtualenv
-flake8-blind-except==0.1.1  # via -r requirements.in
 flake8-bugbear==20.11.1   # via -r requirements.in
 flake8-commas==2.0.0      # via -r requirements.in
 flake8-debugger==4.0.0    # via -r requirements.in
@@ -60,13 +60,13 @@ gevent==20.12.1           # via -r requirements.in
 greenlet==0.4.17          # via gevent
 gunicorn==20.0.4          # via -r requirements.in
 icalendar==4.0.7          # via -r requirements.in
-identify==1.4.21          # via pre-commit
+identify==1.5.12          # via pre-commit
 idna==2.10                # via requests, yarl
 incremental==17.5.0       # via towncrier
-iniconfig==1.0.1          # via pytest
+iniconfig==1.1.1          # via pytest
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.19.0           # via -r requirements.in
-jedi==0.17.1              # via ipython
+jedi==0.18.0              # via ipython
 jinja2==2.11.2            # via towncrier
 jmespath==0.10.0          # via boto3, botocore
 kombu==4.6.11             # via -r requirements.in, celery
@@ -75,11 +75,11 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 mohawk==1.1.0             # via -r requirements.in
 monotonic==1.5            # via notifications-python-client
-multidict==4.7.6          # via aiohttp, yarl
-nodeenv==1.4.0            # via pre-commit
+multidict==5.1.0          # via aiohttp, yarl
+nodeenv==1.5.0            # via pre-commit
 notifications-python-client==5.7.1  # via -r requirements.in
-packaging==20.4           # via pytest
-parso==0.7.0              # via jedi
+packaging==20.8           # via pytest
+parso==0.8.1              # via jedi
 pep8-naming==0.11.1       # via -r requirements.in
 pexpect==4.8.0            # via ipython
 pickleshare==0.7.5        # via ipython
@@ -87,24 +87,24 @@ pip-tools==4.5.1          # via -r requirements.in
 piprot==0.9.11            # via -r requirements.in
 pluggy==0.13.1            # via pytest
 pre-commit==2.9.3         # via -r requirements.in
-prompt-toolkit==3.0.5     # via ipython
+prompt-toolkit==3.0.10    # via ipython
 psycogreen==1.0.2         # via -r requirements.in
 psycopg2==2.8.6           # via -r requirements.in
-ptyprocess==0.6.0         # via pexpect
-py==1.9.0                 # via pytest
+ptyprocess==0.7.0         # via pexpect
+py==1.10.0                # via pytest, pytest-forked
 pycodestyle==2.6.0        # via flake8, flake8-debugger, flake8-import-order, flake8-print
 pydocstyle==5.1.1         # via -r requirements.in, flake8-docstrings
 pyflakes==2.2.0           # via flake8
-pygments==2.6.1           # via ipython
-pyjwt==1.7.1              # via notifications-python-client
+pygments==2.7.3           # via ipython
+pyjwt==2.0.0              # via notifications-python-client
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements.in
 pytest-django==4.1.0      # via -r requirements.in
-pytest-forked==1.2.0      # via pytest-xdist
+pytest-forked==1.3.0      # via pytest-xdist
 pytest-xdist==2.2.0       # via -r requirements.in
 pytest==6.2.1             # via -r requirements.in, pytest-cov, pytest-django, pytest-forked, pytest-xdist
 python-dateutil==2.8.1    # via -r requirements.in, botocore, elasticsearch-dsl, faker, freezegun, icalendar
-pytz==2020.1              # via celery, django, icalendar
+pytz==2020.5              # via celery, django, icalendar
 pyyaml==5.3.1             # via -r requirements.in, pre-commit, watchdog
 redis==3.5.3              # via -r requirements.in, celery, django-redis
 requests-futures==1.0.0   # via piprot
@@ -114,27 +114,28 @@ requests_toolbelt==0.9.1  # via -r requirements.in
 s3transfer==0.3.3         # via boto3
 semantic_version==2.8.5   # via -r requirements.in
 sentry_sdk==0.19.5        # via -r requirements.in
-simplejson==3.17.0        # via mail-parser
-six==1.14.0               # via django-pglocks, elasticsearch-dsl, flake8-debugger, flake8-print, mail-parser, mohawk, packaging, pip-tools, piprot, python-dateutil, requests-mock, traitlets, virtualenv
+simplejson==3.17.2        # via mail-parser
+six==1.15.0               # via django-pglocks, elasticsearch-dsl, flake8-debugger, flake8-print, mail-parser, mohawk, pip-tools, piprot, python-dateutil, requests-mock, virtualenv
 slackclient==2.9.3        # via -r requirements.in
 snowballstemmer==2.0.0    # via pydocstyle
-sqlparse==0.3.1           # via django, django-debug-toolbar
+sqlparse==0.4.1           # via django, django-debug-toolbar
 statsd==3.3.0             # via -r requirements.in
 text-unidecode==1.3       # via faker
-toml==0.10.1              # via pre-commit, pytest, towncrier
+toml==0.10.2              # via pre-commit, pytest, towncrier
 towncrier==19.2.0         # via -r requirements.in
-traitlets==4.3.3          # via ipython
+traitlets==5.0.5          # via ipython
+typing-extensions==3.7.4.3  # via aiohttp
 uritemplate==3.0.1        # via -r requirements.in
-urllib3==1.25.9           # via botocore, elastic-apm, elasticsearch, requests, sentry-sdk
+urllib3==1.26.2           # via botocore, elastic-apm, elasticsearch, requests, sentry-sdk
 vine==1.3.0               # via amqp, celery
-virtualenv==20.0.25       # via pre-commit
+virtualenv==20.3.0        # via pre-commit
 watchdog[watchmedo]==1.0.2  # via -r requirements.in
 wcwidth==0.2.5            # via prompt-toolkit
 werkzeug==1.0.1           # via -r requirements.in
 whitenoise==5.2.0         # via -r requirements.in
-yarl==1.4.2               # via aiohttp
-zope.event==4.4           # via gevent
-zope.interface==5.1.0     # via gevent
+yarl==1.6.3               # via aiohttp
+zope.event==4.5.0         # via gevent
+zope.interface==5.2.0     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
### Description of change

We have decided to remove this dependency as it no longer adds value to our `flake8` checks.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
