### PR TITLE
Chore: add inactive user to advisor fixture data

### DIFF
--- a/changelog/adviser/add-expired-trade-advisor.chore.md
+++ b/changelog/adviser/add-expired-trade-advisor.chore.md
@@ -1,0 +1,1 @@
+An example trade advisor with `is_active` set to `false` has been added to the test fixture data to support `data-hub-frontend` e2e testing.

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -15,6 +15,15 @@
     dit_team: 162a3959-9798-e211-a939-e4115bead28a  # International Trade Team
 
 - model: company.advisor
+  pk: 95a99736-5402-11eb-ae93-0242ac130002
+  fields:
+    email: Ava.Walsh@example.com
+    first_name: Ava
+    last_name: Walsh
+    is_active: false
+    dit_team: 162a3959-9798-e211-a939-e4115bead28a  # International Trade Team
+
+- model: company.advisor
   pk: e83a608e-84a4-11e6-ae22-56b6b6499611
   fields:
     email: Puck.Head@example.com


### PR DESCRIPTION
### Description of change

Adds an inactive user to the advisor fixtures. This is to allow e2e testing of a frontend fix to prevent inactive advisors being suggested to users as a Lead ITA.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
