### PR TITLE
Update interaction business intelligence report columns

### DIFF
--- a/changelog/interaction/update-interaction-bi-report-columns.bugfix.md
+++ b/changelog/interaction/update-interaction-bi-report-columns.bugfix.md
@@ -1,0 +1,1 @@
+The columns of interaction business intelligence report have been updated to match Data Workspace report.

--- a/datahub/search/interaction/test/test_views.py
+++ b/datahub/search/interaction/test/test_views.py
@@ -1182,10 +1182,10 @@ class TestInteractionExportView(APITestMixin):
                 'Service': get_attr_or_none(interaction, 'service.name'),
                 'Subject': interaction.subject,
                 'Company': get_attr_or_none(interaction, 'company.name'),
-                'Company link':
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
-                    f'/{interaction.company.pk}',
-                'Parent': get_attr_or_none(interaction, 'company.global_headquarters.name'),
+                'Parent company': get_attr_or_none(
+                    interaction,
+                    'company.global_headquarters.name',
+                ),
                 'Company country': get_attr_or_none(
                     interaction,
                     'company.address_country.name',
@@ -1218,8 +1218,6 @@ class TestInteractionExportView(APITestMixin):
                 'Policy feedback notes': interaction.policy_feedback_notes,
                 'advisers': _format_expected_advisers(interaction),
                 'adviser_emails': _format_expected_adviser_emails(interaction),
-                'created_by': interaction.created_by.name,
-                'tags_prediction': '',
                 'tag_1': '',
                 'probability_score_tag_1': '',
                 'tag_2': '',

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -219,8 +219,7 @@ class SearchInteractionPolicyFeedbackExportAPIView(
         'service_name': 'Service',
         'subject': 'Subject',
         'company__name': 'Company',
-        'company_link': 'Company link',
-        'company__global_headquarters__name': 'Parent',
+        'company__global_headquarters__name': 'Parent company',
         'company__address_country__name': 'Company country',
         'company__uk_region__name': 'Company UK region',
         'company__one_list_tier__name': 'One List Tier',
@@ -236,12 +235,8 @@ class SearchInteractionPolicyFeedbackExportAPIView(
         'policy_issue_type_names': 'Policy issue types',
         'policy_area_names': 'Policy areas',
         'policy_feedback_notes': 'Policy feedback notes',
-
         'adviser_names': 'advisers',
         'adviser_emails': 'adviser_emails',
-        'created_by_name': 'created_by',
-
-        'tags_prediction': 'tags_prediction',
         'tag_1': 'tag_1',
         'probability_score_tag_1': 'probability_score_tag_1',
         'tag_2': 'tag_2',
@@ -252,7 +247,6 @@ class SearchInteractionPolicyFeedbackExportAPIView(
         'probability_score_tag_4': 'probability_score_tag_4',
         'tag_5': 'tag_5',
         'probability_score_tag_5': 'probability_score_tag_5',
-
         'contact_names': 'Contacts',
         'event__name': 'Event',
         'service_delivery_status__name': 'Service delivery status',


### PR DESCRIPTION
### Description of change

This updates the columns in interaction business intelligence report.

- Parent header changed to Parent company
- Company link, created_by and tags_prediction removed


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
