### PR TITLE
Tweak investment summary endpoint to include stage ids

### DIFF
--- a/changelog/investment/add-ids-to-investment-summary.feature.md
+++ b/changelog/investment/add-ids-to-investment-summary.feature.md
@@ -1,0 +1,1 @@
+The investment summary endpoint now includes the UUIDs of each stage with the project total counts.

--- a/datahub/investment/summary/schemas.py
+++ b/datahub/investment/summary/schemas.py
@@ -1,6 +1,16 @@
 from rest_framework.schemas.openapi import AutoSchema
 
 
+PROJECT_COUNT_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'label': {'type': 'string'},
+        'id': {'type': 'string'},
+        'value': {'type': 'integer'}
+    }
+}
+
+
 class IProjectSummarySchema(AutoSchema):
     """
     Schema for Investment Project Summaries
@@ -28,11 +38,11 @@ class IProjectSummarySchema(AutoSchema):
                         'totals': {
                             'type': 'object',
                             'properties': {
-                                'prospect': {'type': 'integer'},
-                                'assign_pm': {'type': 'integer'},
-                                'active': {'type': 'integer'},
-                                'verify_win': {'type': 'integer'},
-                                'won': {'type': 'integer'},
+                                'prospect': PROJECT_COUNT_SCHEMA,
+                                'assign_pm': PROJECT_COUNT_SCHEMA,
+                                'active': PROJECT_COUNT_SCHEMA,
+                                'verify_win': PROJECT_COUNT_SCHEMA,
+                                'won': PROJECT_COUNT_SCHEMA,
                             },
                         },
                     },

--- a/datahub/investment/summary/schemas.py
+++ b/datahub/investment/summary/schemas.py
@@ -6,8 +6,8 @@ PROJECT_COUNT_SCHEMA = {
     'properties': {
         'label': {'type': 'string'},
         'id': {'type': 'string'},
-        'value': {'type': 'integer'}
-    }
+        'value': {'type': 'integer'},
+    },
 }
 
 

--- a/datahub/investment/summary/serializers.py
+++ b/datahub/investment/summary/serializers.py
@@ -60,7 +60,7 @@ class AdvisorIProjectSummarySerializer(serializers.Serializer):
         )
 
         results = {}
-        for financial_year in range(start_year, end_year):
+        for financial_year in reversed(range(start_year, end_year)):
             results[financial_year] = {
                 'financial_year': {
                     'label': f'{financial_year}-{str(financial_year + 1)[-2:]}',
@@ -68,18 +68,38 @@ class AdvisorIProjectSummarySerializer(serializers.Serializer):
                     'end': date(year=financial_year + 1, month=3, day=31),
                 },
                 'totals': {
-                    'prospect': prospect_count,
-                    'assign_pm': 0,
-                    'active': 0,
-                    'verify_win': 0,
-                    'won': 0,
+                    InvestmentProjectStage.prospect.name: {
+                        'label': 'Prospect',
+                        'id': InvestmentProjectStage.prospect.value.id,
+                        'value': prospect_count,
+                    },
+                    InvestmentProjectStage.assign_pm.name: {
+                        'label': 'Assigned',
+                        'id': InvestmentProjectStage.assign_pm.value.id,
+                        'value': 0,
+                    },
+                    InvestmentProjectStage.active.name: {
+                        'label': 'Active',
+                        'id': InvestmentProjectStage.active.value.id,
+                        'value': 0,
+                    },
+                    InvestmentProjectStage.verify_win.name: {
+                        'label': 'Verify Win',
+                        'id': InvestmentProjectStage.verify_win.value.id,
+                        'value': 0,
+                    },
+                    InvestmentProjectStage.won.name: {
+                        'label': 'Won',
+                        'id': InvestmentProjectStage.won.value.id,
+                        'value': 0,
+                    },
                 },
             }
 
         for project_summary in project_summaries:
             year = project_summary['financial_year']
             stage = InvestmentProjectStage.get_by_id(project_summary['stage'])
-            stage_name = None if stage is None else stage.name
-            results[year]['totals'][stage_name] = project_summary['count']
+            if stage is not None and stage.name in results[year]['totals']:
+                results[year]['totals'][stage.name]['value'] = project_summary['count']
 
         return list(results.values())

--- a/datahub/investment/summary/test/test_schemas.py
+++ b/datahub/investment/summary/test/test_schemas.py
@@ -33,40 +33,40 @@ def test_annual_summaries_schema():
                             'properties': {
                                 'label': {'type': 'string'},
                                 'id': {'type': 'string'},
-                                'value': {'type': 'integer'}
-                            }
+                                'value': {'type': 'integer'},
+                            },
                         },
                         'assign_pm': {
                             'type': 'object',
                             'properties': {
                                 'label': {'type': 'string'},
                                 'id': {'type': 'string'},
-                                'value': {'type': 'integer'}
-                            }
+                                'value': {'type': 'integer'},
+                            },
                         },
                         'active': {
                             'type': 'object',
                             'properties': {
                                 'label': {'type': 'string'},
                                 'id': {'type': 'string'},
-                                'value': {'type': 'integer'}
-                            }
+                                'value': {'type': 'integer'},
+                            },
                         },
                         'verify_win': {
                             'type': 'object',
                             'properties': {
                                 'label': {'type': 'string'},
                                 'id': {'type': 'string'},
-                                'value': {'type': 'integer'}
-                            }
+                                'value': {'type': 'integer'},
+                            },
                         },
                         'won': {
                             'type': 'object',
                             'properties': {
                                 'label': {'type': 'string'},
                                 'id': {'type': 'string'},
-                                'value': {'type': 'integer'}
-                            }
+                                'value': {'type': 'integer'},
+                            },
                         },
                     },
                 },

--- a/datahub/investment/summary/test/test_schemas.py
+++ b/datahub/investment/summary/test/test_schemas.py
@@ -28,11 +28,46 @@ def test_annual_summaries_schema():
                 'totals': {
                     'type': 'object',
                     'properties': {
-                        'prospect': {'type': 'integer'},
-                        'assign_pm': {'type': 'integer'},
-                        'active': {'type': 'integer'},
-                        'verify_win': {'type': 'integer'},
-                        'won': {'type': 'integer'},
+                        'prospect': {
+                            'type': 'object',
+                            'properties': {
+                                'label': {'type': 'string'},
+                                'id': {'type': 'string'},
+                                'value': {'type': 'integer'}
+                            }
+                        },
+                        'assign_pm': {
+                            'type': 'object',
+                            'properties': {
+                                'label': {'type': 'string'},
+                                'id': {'type': 'string'},
+                                'value': {'type': 'integer'}
+                            }
+                        },
+                        'active': {
+                            'type': 'object',
+                            'properties': {
+                                'label': {'type': 'string'},
+                                'id': {'type': 'string'},
+                                'value': {'type': 'integer'}
+                            }
+                        },
+                        'verify_win': {
+                            'type': 'object',
+                            'properties': {
+                                'label': {'type': 'string'},
+                                'id': {'type': 'string'},
+                                'value': {'type': 'integer'}
+                            }
+                        },
+                        'won': {
+                            'type': 'object',
+                            'properties': {
+                                'label': {'type': 'string'},
+                                'id': {'type': 'string'},
+                                'value': {'type': 'integer'}
+                            }
+                        },
                     },
                 },
             },

--- a/datahub/investment/summary/test/test_serializers.py
+++ b/datahub/investment/summary/test/test_serializers.py
@@ -70,30 +70,70 @@ def projects(adviser):
 EXPECTED_ANNUAL_SUMMARIES = [
     {
         'financial_year': {
-            'label': '2014-15',
-            'start': date(2014, 4, 1),
-            'end': date(2015, 3, 31),
-        },
-        'totals': {
-            'prospect': 4,
-            'assign_pm': 0,
-            'active': 0,
-            'verify_win': 1,
-            'won': 2,
-        },
-    },
-    {
-        'financial_year': {
             'label': '2015-16',
             'start': date(2015, 4, 1),
             'end': date(2016, 3, 31),
         },
         'totals': {
-            'prospect': 4,
-            'assign_pm': 3,
-            'active': 2,
-            'verify_win': 0,
-            'won': 0,
+            'prospect': {
+                'label': 'Prospect',
+                'id': InvestmentProjectStage.prospect.value.id,
+                'value': 4,
+            },
+            'assign_pm': {
+                'label': 'Assigned',
+                'id': InvestmentProjectStage.assign_pm.value.id,
+                'value': 3,
+            },
+            'active': {
+                'label': 'Active',
+                'id': InvestmentProjectStage.active.value.id,
+                'value': 2,
+            },
+            'verify_win': {
+                'label': 'Verify Win',
+                'id': InvestmentProjectStage.verify_win.value.id,
+                'value': 0,
+            },
+            'won': {
+                'label': 'Won',
+                'id': InvestmentProjectStage.won.value.id,
+                'value': 0,
+            },
+        },
+    },
+    {
+        'financial_year': {
+            'label': '2014-15',
+            'start': date(2014, 4, 1),
+            'end': date(2015, 3, 31),
+        },
+        'totals': {
+            'prospect': {
+                'label': 'Prospect',
+                'id': InvestmentProjectStage.prospect.value.id,
+                'value': 4,
+            },
+            'assign_pm': {
+                'label': 'Assigned',
+                'id': InvestmentProjectStage.assign_pm.value.id,
+                'value': 0,
+            },
+            'active': {
+                'label': 'Active',
+                'id': InvestmentProjectStage.active.value.id,
+                'value': 0,
+            },
+            'verify_win': {
+                'label': 'Verify Win',
+                'id': InvestmentProjectStage.verify_win.value.id,
+                'value': 1,
+            },
+            'won': {
+                'label': 'Won',
+                'id': InvestmentProjectStage.won.value.id,
+                'value': 2,
+            },
         },
     },
 ]
@@ -153,11 +193,11 @@ class TestAdvisorIProjectSummarySerializer:
 
         assert 'annual_summaries' in serializer.data
         assert len(serializer.data['annual_summaries']) == 2
-        previous_summary, current_summary = serializer.data['annual_summaries']
+        current_summary, previous_summary = serializer.data['annual_summaries']
         assert previous_summary['financial_year']['label'] == '2014-15'
-        assert previous_summary['totals']['won'] == 0
+        assert previous_summary['totals']['won']['value'] == 0
         assert current_summary['financial_year']['label'] == '2015-16'
-        assert current_summary['totals']['won'] == 2
+        assert current_summary['totals']['won']['value'] == 2
 
     def test_financial_year_edges(self, adviser):
         """
@@ -184,30 +224,70 @@ class TestAdvisorIProjectSummarySerializer:
         assert serializer.data['annual_summaries'] == [
             {
                 'financial_year': {
-                    'label': '2014-15',
-                    'start': date(2014, 4, 1),
-                    'end': date(2015, 3, 31),
-                },
-                'totals': {
-                    'prospect': 0,
-                    'assign_pm': 0,
-                    'active': 0,
-                    'verify_win': 0,
-                    'won': 3,
-                },
-            },
-            {
-                'financial_year': {
                     'label': '2015-16',
                     'start': date(2015, 4, 1),
                     'end': date(2016, 3, 31),
                 },
                 'totals': {
-                    'prospect': 0,
-                    'assign_pm': 0,
-                    'active': 2,
-                    'verify_win': 0,
-                    'won': 0,
+                    'prospect': {
+                        'label': 'Prospect',
+                        'id': InvestmentProjectStage.prospect.value.id,
+                        'value': 0,
+                    },
+                    'assign_pm': {
+                        'label': 'Assigned',
+                        'id': InvestmentProjectStage.assign_pm.value.id,
+                        'value': 0,
+                    },
+                    'active': {
+                        'label': 'Active',
+                        'id': InvestmentProjectStage.active.value.id,
+                        'value': 2,
+                    },
+                    'verify_win': {
+                        'label': 'Verify Win',
+                        'id': InvestmentProjectStage.verify_win.value.id,
+                        'value': 0,
+                    },
+                    'won': {
+                        'label': 'Won',
+                        'id': InvestmentProjectStage.won.value.id,
+                        'value': 0,
+                    },
+                },
+            },
+            {
+                'financial_year': {
+                    'label': '2014-15',
+                    'start': date(2014, 4, 1),
+                    'end': date(2015, 3, 31),
+                },
+                'totals': {
+                    'prospect': {
+                        'label': 'Prospect',
+                        'id': InvestmentProjectStage.prospect.value.id,
+                        'value': 0,
+                    },
+                    'assign_pm': {
+                        'label': 'Assigned',
+                        'id': InvestmentProjectStage.assign_pm.value.id,
+                        'value': 0,
+                    },
+                    'active': {
+                        'label': 'Active',
+                        'id': InvestmentProjectStage.active.value.id,
+                        'value': 0,
+                    },
+                    'verify_win': {
+                        'label': 'Verify Win',
+                        'id': InvestmentProjectStage.verify_win.value.id,
+                        'value': 0,
+                    },
+                    'won': {
+                        'label': 'Won',
+                        'id': InvestmentProjectStage.won.value.id,
+                        'value': 3,
+                    },
                 },
             },
         ]

--- a/datahub/investment/summary/test/test_serializers.py
+++ b/datahub/investment/summary/test/test_serializers.py
@@ -10,6 +10,7 @@ from datahub.investment.project.test.factories import (
     InvestmentProjectTeamMemberFactory,
 )
 from datahub.investment.summary.serializers import AdvisorIProjectSummarySerializer
+from datahub.metadata.models import InvestmentProjectStage as InvestmentProjectStageModel
 
 
 @pytest.fixture
@@ -166,6 +167,25 @@ class TestAdvisorIProjectSummarySerializer:
             InvestmentProjectFactory(
                 stage_id=InvestmentProjectStage.won.value.id,
                 client_relationship_manager=another_adviser,
+                actual_land_date=date(2015, 1, 1),
+            )
+
+        serializer = AdvisorIProjectSummarySerializer(adviser)
+        assert 'annual_summaries' in serializer.data
+        assert serializer.data == {
+            'adviser_id': str(adviser.id),
+            'annual_summaries': EXPECTED_ANNUAL_SUMMARIES,
+        }
+
+    def test_unexpected_stage_is_not_included(self, adviser, projects):
+        """
+        Annual Summaries should ignore unexpected stages.
+        """
+        bad_stage = InvestmentProjectStageModel.objects.create(name='Bad Stage')
+        for _index in range(2):
+            InvestmentProjectFactory(
+                stage_id=bad_stage.id,
+                client_relationship_manager=adviser,
                 actual_land_date=date(2015, 1, 1),
             )
 

--- a/datahub/investment/summary/test/test_views.py
+++ b/datahub/investment/summary/test/test_views.py
@@ -3,6 +3,7 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.core.constants import InvestmentProjectStage
 from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 
@@ -34,24 +35,10 @@ class TestIProjectSummaryView(APITestMixin):
             kwargs={'adviser_pk': str(self.user.id)},
         )
         response = self.api_client.get(url)
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {
+
+        expected_data = {
             'adviser_id': str(self.user.id),
             'annual_summaries': [
-                {
-                    'financial_year': {
-                        'label': '2014-15',
-                        'start': '2014-04-01',
-                        'end': '2015-03-31',
-                    },
-                    'totals': {
-                        'prospect': 0,
-                        'assign_pm': 0,
-                        'active': 0,
-                        'verify_win': 0,
-                        'won': 0,
-                    },
-                },
                 {
                     'financial_year': {
                         'label': '2015-16',
@@ -59,12 +46,69 @@ class TestIProjectSummaryView(APITestMixin):
                         'end': '2016-03-31',
                     },
                     'totals': {
-                        'prospect': 0,
-                        'assign_pm': 0,
-                        'active': 0,
-                        'verify_win': 0,
-                        'won': 0,
+                        'prospect': {
+                            'label': 'Prospect',
+                            'id': InvestmentProjectStage.prospect.value.id,
+                            'value': 0,
+                        },
+                        'assign_pm': {
+                            'label': 'Assigned',
+                            'id': InvestmentProjectStage.assign_pm.value.id,
+                            'value': 0,
+                        },
+                        'active': {
+                            'label': 'Active',
+                            'id': InvestmentProjectStage.active.value.id,
+                            'value': 0,
+                        },
+                        'verify_win': {
+                            'label': 'Verify Win',
+                            'id': InvestmentProjectStage.verify_win.value.id,
+                            'value': 0,
+                        },
+                        'won': {
+                            'label': 'Won',
+                            'id': InvestmentProjectStage.won.value.id,
+                            'value': 0,
+                        },
+                    },
+                },
+                {
+                    'financial_year': {
+                        'label': '2014-15',
+                        'start': '2014-04-01',
+                        'end': '2015-03-31',
+                    },
+                    'totals': {
+                        'prospect': {
+                            'label': 'Prospect',
+                            'id': InvestmentProjectStage.prospect.value.id,
+                            'value': 0,
+                        },
+                        'assign_pm': {
+                            'label': 'Assigned',
+                            'id': InvestmentProjectStage.assign_pm.value.id,
+                            'value': 0,
+                        },
+                        'active': {
+                            'label': 'Active',
+                            'id': InvestmentProjectStage.active.value.id,
+                            'value': 0,
+                        },
+                        'verify_win': {
+                            'label': 'Verify Win',
+                            'id': InvestmentProjectStage.verify_win.value.id,
+                            'value': 0,
+                        },
+                        'won': {
+                            'label': 'Won',
+                            'id': InvestmentProjectStage.won.value.id,
+                            'value': 0,
+                        },
                     },
                 },
             ],
         }
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == expected_data


### PR DESCRIPTION
### Description of change

This tweaks the new investments summary api endpoint to send the project stage id (it just sent the name previously) - this is needed to provide the full functionality to the new dashboard project summary chart.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
