### PR TITLE
User account lockout mechanism

### DIFF
--- a/changelog/admin-login-lock-out.internal.md
+++ b/changelog/admin-login-lock-out.internal.md
@@ -1,0 +1,1 @@
+User account lockout mechanism has been implemented for admin pages. A user account should be locked out (prevented from making further login attempts) after a certain number of consecutive unsuccessful logon attempts.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -51,6 +51,16 @@ else:
     _ADMIN_DJANGO_APP = ['django.contrib.admin']
     _ADMIN_OAUTH2_APP = []
 
+# axes settings (admin login lock-out: https://django-axes.readthedocs.io/)
+AXES_ENABLED = env.bool('AXES_ENABLED', True)
+AXES_VERBOSE = env.bool('AXES_VERBOSE', True)
+AXES_ONLY_ADMIN_SITE = env.bool('AXES_ONLY_ADMIN_SITE', True)
+AXES_COOLOFF_TIME = timedelta(seconds=60 * 30)
+AXES_FAILURE_LIMIT = env.int('AXES_FAILURE_LIMIT', 3)
+AXES_META_PRECEDENCE_ORDER = env.list(
+    'AXES_META_PRECEDENCE_ORDER', default=['HTTP_X_FORWARDED_FOR', 'REMOTE_ADDR']
+)
+
 ES_APM_ENABLED = env.bool('ES_APM_ENABLED')
 
 _ES_APM_APP = []
@@ -76,6 +86,7 @@ THIRD_PARTY_APPS = [
     'reversion',
     'django_filters',
     'mptt',
+    'axes',
 ]
 
 LOCAL_APPS = [
@@ -271,6 +282,9 @@ if ADMIN_OAUTH2_ENABLED:
         authentication_middleware_index + 1,
         'datahub.oauth.admin_sso.middleware.OAuthSessionMiddleware',
     )
+else:
+    MIDDLEWARE.extend(['axes.middleware.AxesMiddleware'])
+    AUTHENTICATION_BACKENDS.extend(['axes.backends.AxesBackend'])
 
 # Staff SSO integration settings
 
@@ -751,6 +765,5 @@ if ES_APM_ENABLED:
         'ENVIRONMENT': env('ES_APM_ENVIRONMENT'),
         'SERVER_TIMEOUT': env('ES_APM_SERVER_TIMEOUT', default='20s'),
     }
-
 
 ALLOW_TEST_FIXTURE_SETUP = env('ALLOW_TEST_FIXTURE_SETUP', default=False)

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,6 +1,5 @@
 import environ
 
-
 environ.Env.read_env()  # reads the .env file
 env = environ.Env()
 
@@ -78,11 +77,11 @@ DISABLE_PAAS_IP_CHECK = False
 HAWK_RECEIVER_CREDENTIALS = {
     'some-id': {
         'key': 'some-secret',
-        'scopes': (HawkScope.activity_stream, ),
+        'scopes': (HawkScope.activity_stream,),
     },
     'test-id-with-scope': {
         'key': 'test-key-with-scope',
-        'scopes': (next(iter(HawkScope.__members__.values())), ),
+        'scopes': (next(iter(HawkScope.__members__.values())),),
     },
     'test-id-without-scope': {
         'key': 'test-key-without-scope',
@@ -94,15 +93,15 @@ HAWK_RECEIVER_CREDENTIALS = {
     },
     'test-id-with-metadata-scope': {
         'key': 'test-key-with-metadata-scope',
-        'scopes': (HawkScope.metadata, ),
+        'scopes': (HawkScope.metadata,),
     },
     'public-company-id': {
         'key': 'public-company-key',
-        'scopes': (HawkScope.public_company, ),
+        'scopes': (HawkScope.public_company,),
     },
     'data-flow-api-id': {
         'key': 'data-flow-api-key',
-        'scopes': (HawkScope.data_flow_api, ),
+        'scopes': (HawkScope.data_flow_api,),
     },
     'omis-public-id': {
         'key': 'omis-public-key',
@@ -178,3 +177,9 @@ EXPORT_WINS_HAWK_ID = 'some-id'
 EXPORT_WINS_HAWK_KEY = 'some-secret'
 
 ALLOW_TEST_FIXTURE_SETUP = True
+
+if ADMIN_OAUTH2_ENABLED:
+    if 'axes.middleware.AxesMiddleware' in MIDDLEWARE:
+        MIDDLEWARE.remove('axes.middleware.AxesMiddleware')
+    if 'axes.backends.AxesBackend' in AUTHENTICATION_BACKENDS:
+        AUTHENTICATION_BACKENDS.remove('axes.backends.AxesBackend')

--- a/requirements.in
+++ b/requirements.in
@@ -1,12 +1,13 @@
 # Django and django related
 django==3.1.6
 djangorestframework==3.12.2
+django-axes==5.12.0
 django-environ==0.4.5
 django-extensions==3.1.1
 django-filter==2.4.0
-django-reversion==3.0.9
-django-pglocks==1.0.4
 django-mptt==0.11.0
+django-pglocks==1.0.4
+django-reversion==3.0.9
 uritemplate==3.0.1  # required for DRF schema features
 whitenoise==5.2.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,8 @@ decorator==4.4.2
     # via ipython
 distlib==0.3.1
     # via virtualenv
+django-axes==5.12.0
+    # via -r requirements.in
 django-debug-toolbar==3.2
     # via -r requirements.in
 django-environ==0.4.5
@@ -68,6 +70,8 @@ django-extensions==3.1.1
     # via -r requirements.in
 django-filter==2.4.0
     # via -r requirements.in
+django-ipware==3.0.2
+    # via django-axes
 django-js-asset==1.2.2
     # via django-mptt
 django-mptt==0.11.0
@@ -81,6 +85,7 @@ django-reversion==3.0.9
 django==3.1.6
     # via
     #   -r requirements.in
+    #   django-axes
     #   django-debug-toolbar
     #   django-filter
     #   django-mptt


### PR DESCRIPTION
### Description of change

User account lockout mechanism has been implemented for admin pages. A user account should be locked out (prevented from making further login attempts) after a certain number of consecutive unsuccessful logon attempts. This was requested based on pen-test report.

This PR is tech debt. Changes will only exist until we enable Admin SSO which is about to happen in next few weeks.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
