### PR TITLE
Add modified_by to Large Capital Investor Profile Activity Stream endpoint

### DIFF
--- a/changelog/investment/update-large-capital-profile-as-endpoint.api.md
+++ b/changelog/investment/update-large-capital-profile-as-endpoint.api.md
@@ -1,0 +1,2 @@
+It is now possible to view the `modified_by` of a Large Capital Investment Profile in the activity-stream using 
+the following URL `/v3/activity-stream/investment/large-capital-investor-profiles`.

--- a/datahub/activity_stream/company_referral/serializers.py
+++ b/datahub/activity_stream/company_referral/serializers.py
@@ -8,11 +8,6 @@ class CompanyReferralActivitySerializer(ActivitySerializer):
     class Meta:
         model = CompanyReferral
 
-    def _get_adviser_with_team_and_role(self, adviser, role):
-        adviser = self._get_adviser_with_team(adviser, adviser.dit_team)
-        adviser['dit:DataHubCompanyReferral:role'] = role
-        return adviser
-
     def to_representation(self, instance):
         """
         Serialize the interaction as per Activity Stream spec:
@@ -32,8 +27,16 @@ class CompanyReferralActivitySerializer(ActivitySerializer):
                 'dit:status': str(instance.status),
                 'attributedTo': [
                     self._get_company(instance.company),
-                    self._get_adviser_with_team_and_role(instance.created_by, 'sender'),
-                    self._get_adviser_with_team_and_role(instance.recipient, 'recipient'),
+                    self._get_adviser_with_team_and_role(
+                        instance.created_by,
+                        'sender',
+                        'DataHubCompanyReferral',
+                    ),
+                    self._get_adviser_with_team_and_role(
+                        instance.recipient,
+                        'recipient',
+                        'DataHubCompanyReferral',
+                    ),
                 ],
                 'url': instance.get_absolute_url(),
             },
@@ -42,7 +45,11 @@ class CompanyReferralActivitySerializer(ActivitySerializer):
         if instance.completed_by:
             company_referral['object']['dit:completedOn'] = instance.completed_on
             company_referral['object']['attributedTo'].append(
-                self._get_adviser_with_team_and_role(instance.completed_by, 'completer'),
+                self._get_adviser_with_team_and_role(
+                    instance.completed_by,
+                    'completer',
+                    'DataHubCompanyReferral',
+                ),
             )
 
         if instance.contact:

--- a/datahub/activity_stream/investor_profile/serializers.py
+++ b/datahub/activity_stream/investor_profile/serializers.py
@@ -8,6 +8,31 @@ class LargeCapitalInvestorProfileActivitySerializer(ActivitySerializer):
     class Meta:
         model = LargeCapitalInvestorProfile
 
+    def _get_attributed_to(self, instance):
+        attributed_to = [
+            self._get_company(instance.investor_company),
+        ]
+
+        if instance.created_by:
+            attributed_to.append(
+                self._get_adviser_with_team_and_role(
+                    instance.created_by,
+                    'creator',
+                    'DataHubLargeCapitalInvestorProfile',
+                ),
+            )
+
+        if instance.modified_by:
+            attributed_to.append(
+                self._get_adviser_with_team_and_role(
+                    instance.modified_by,
+                    'modifier',
+                    'DataHubLargeCapitalInvestorProfile',
+                ),
+            )
+
+        return attributed_to
+
     def to_representation(self, instance):
         """
         Serialize the interaction as per Activity Stream spec:
@@ -23,17 +48,10 @@ class LargeCapitalInvestorProfileActivitySerializer(ActivitySerializer):
                 'id': investor_profile_id,
                 'type': ['dit:LargeCapitalInvestorProfile'],
                 'startTime': instance.created_on,
-                'attributedTo': [
-                    self._get_company(instance.investor_company),
-                ],
+                'attributedTo': self._get_attributed_to(instance),
                 'url': instance.get_absolute_url(),
             },
         }
-
-        if instance.created_by:
-            investor_profile['object']['attributedTo'].append(
-                self._get_adviser_with_team(instance.created_by, instance.created_by.dit_team),
-            )
 
         if instance.required_checks_conducted_by:
             investor_profile['object']['dit:requiredChecksConductedBy'] = (

--- a/datahub/activity_stream/investor_profile/test/test_views.py
+++ b/datahub/activity_stream/investor_profile/test/test_views.py
@@ -116,6 +116,22 @@ def test_complete_large_capital_investor_profile_activity(api_client):
                                 'type': ['Group', 'dit:Team'],
                                 'name': investor_profile.created_by.dit_team.name,
                             },
+                            'dit:DataHubLargeCapitalInvestorProfile:role': 'creator',
+                        },
+                        {
+                            'id': f'dit:DataHubAdviser:{investor_profile.modified_by.pk}',
+                            'type': ['Person', 'dit:Adviser'],
+                            'dit:emailAddress':
+                                investor_profile.modified_by.contact_email
+                                or investor_profile.modified_by.email,
+                            'name': investor_profile.modified_by.name,
+                            'dit:team': {
+                                'id':
+                                    f'dit:DataHubTeam:{investor_profile.modified_by.dit_team.pk}',
+                                'type': ['Group', 'dit:Team'],
+                                'name': investor_profile.modified_by.dit_team.name,
+                            },
+                            'dit:DataHubLargeCapitalInvestorProfile:role': 'modifier',
                         },
                     ],
                     'url': investor_profile.get_absolute_url(),

--- a/datahub/activity_stream/serializers.py
+++ b/datahub/activity_stream/serializers.py
@@ -60,6 +60,11 @@ class ActivitySerializer(serializers.Serializer):
             adviser_with_team['dit:team'] = self._get_team(team)
         return adviser_with_team
 
+    def _get_adviser_with_team_and_role(self, adviser, role, type):
+        adviser = self._get_adviser_with_team(adviser, adviser.dit_team)
+        adviser[f'dit:{type}:role'] = role
+        return adviser
+
     def _get_team(self, team):
         return {} if team is None else {
             'id': f'dit:DataHubTeam:{team.pk}',

--- a/datahub/investment/investor_profile/test/factories.py
+++ b/datahub/investment/investor_profile/test/factories.py
@@ -93,6 +93,7 @@ class CompleteLargeCapitalInvestorProfileFactory(LargeCapitalInvestorProfileFact
     minimum_equity_percentage_id = EquityPercentageConstant.zero_percent.value.id
     notes_on_locations = factory.Faker('text')
     created_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SubFactory(AdviserFactory)
 
     @to_many_field
     def construction_risks(self):

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -1825,6 +1825,7 @@
     investor_type: 113d864c-1657-4e01-b215-2fe8797cdf12
     minimum_equity_percentage: f7b72f8b-399e-43b2-b7ef-f42a154ef916
     minimum_return_rate: 6fec56ba-0be9-4931-bd76-16e11924ec55
+    modified_by: a80ff5fd-8904-4940-bf96-fe8047e34be5
     modified_on: '2021-01-14T11:25:04.805742+00:00'
     notes_on_locations: ''
     other_countries_being_considered: []
@@ -1854,6 +1855,7 @@
     investor_type: 1be9c7d0-3cc1-435d-ace5-8c7e3686e022
     minimum_equity_percentage: null
     minimum_return_rate: null
+    modified_by: 7bad8082-4978-4fe8-a018-740257f01637
     modified_on: '2021-01-10T11:26:03.680015+00:00'
     notes_on_locations: ''
     other_countries_being_considered: []
@@ -1888,6 +1890,7 @@
     investor_type: ac294431-94ba-4318-9b27-75f0ada99c0d
     minimum_equity_percentage: ec061f70-b287-41cf-aaf4-620aec79616b
     minimum_return_rate: 65c9bc7a-af68-4549-a9c9-70cd73109617
+    modified_by: 7bad8082-4978-4fe8-a018-740257f01637
     modified_on: '2021-01-01T11:27:48.064811+00:00'
     notes_on_locations: Here are some notes
     other_countries_being_considered:


### PR DESCRIPTION
### Description of change
Adds `modified_by` to the `attributedTo` field of the Large Capital Investor Profile endpoint for the Activity Stream.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
