### PR TITLE
Add latest interaction to investment projects search endpoint

### DIFF
--- a/changelog/investment/last-interaction-details.feature.md
+++ b/changelog/investment/last-interaction-details.feature.md
@@ -1,0 +1,1 @@
+The latest interaction (with date and subject) was added to the investment projects search endpoint.

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -263,6 +263,11 @@ class IProjectAbstract(models.Model):
 
         return self.Involvement.INVOLVED
 
+    @property
+    def latest_interaction(self):
+        """Return the most recent interaction."""
+        return self.interactions.order_by('-date').first()
+
 
 class IProjectValueAbstract(models.Model):
     """The value part of an investment project."""

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -199,6 +199,18 @@ def sector_dict(obj):
     }
 
 
+def interaction_dict(obj):
+    """Creates a dictionary for an interaction."""
+    if obj is None:
+        return None
+
+    return {
+        'id': str(obj.id),
+        'date': obj.date,
+        'subject': obj.subject,
+    }
+
+
 def _list_of_dicts(dict_factory, manager):
     """Creates a list of dicts with ID and name keys from a manager."""
     return [dict_factory(obj) for obj in manager.all()]

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -1,6 +1,6 @@
 from functools import partial
 
-from elasticsearch_dsl import Keyword, Object, Text
+from elasticsearch_dsl import Date, Keyword, Object, Text
 
 from datahub.search.elasticsearch import (
     lowercase_asciifolding_normalizer,
@@ -155,5 +155,16 @@ def sector_field():
             'id': Keyword(),
             'name': NormalizedKeyword(),
             'ancestors': ancestors,
+        },
+    )
+
+
+def interaction_field():
+    """Interaction field with id, subject and date."""
+    return Object(
+        properties={
+            'id': Keyword(),
+            'subject': Text(index=False),
+            'date': Date(),
         },
     )

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -55,6 +55,7 @@ class InvestmentSearchApp(SearchApp):
         'actual_uk_regions',
         'delivery_partners',
         'uk_region_locations',
+        'interactions',
         Prefetch(
             'team_members',
             queryset=InvestmentProjectTeamMember.objects.select_related('adviser__dit_team'),

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -123,6 +123,7 @@ class InvestmentProject(BaseESModel):
     uk_region_locations = fields.id_name_field()
     will_new_jobs_last_two_years = Boolean()
     level_of_involvement_simplified = Keyword()
+    latest_interaction = fields.interaction_field()
 
     gross_value_added = Double()
 
@@ -149,6 +150,7 @@ class InvestmentProject(BaseESModel):
         'investor_company': dict_utils.id_name_dict,
         'investor_company_country': dict_utils.id_name_dict,
         'investor_type': dict_utils.id_name_dict,
+        'latest_interaction': dict_utils.interaction_dict,
         'level_of_involvement': dict_utils.id_name_dict,
         'likelihood_to_land': dict_utils.id_name_dict,
         'project_assurance_adviser': dict_utils.adviser_dict_with_team,

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -360,8 +360,12 @@ def test_mapping(es):
                 'properties': {
                     'id': {'type': 'keyword'},
                     'date': {'type': 'date'},
-                    'subject': {'type': 'text'},
-                }
+                    'subject': {
+                        'index': False,
+                        'type': 'text',
+                    },
+                },
+                'type': 'object',
             },
             'level_of_involvement': {
                 'properties': {

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -356,6 +356,13 @@ def test_mapping(es):
                 },
                 'type': 'object',
             },
+            'latest_interaction': {
+                'properties': {
+                    'id': {'type': 'keyword'},
+                    'date': {'type': 'date'},
+                    'subject': {'type': 'text'},
+                }
+            },
             'level_of_involvement': {
                 'properties': {
                     'id': {'type': 'keyword'},

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -145,6 +145,7 @@ def test_investment_project_to_dict(es):
         'country_lost_to',
         'country_investment_originates_from',
         'level_of_involvement_simplified',
+        'latest_interaction',
     }
 
     assert set(result.keys()) == keys

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -19,6 +19,27 @@ def test_id_name_dict():
     }
 
 
+def test_interaction_dict():
+    """Interaction dict should serialize id, date and subject"""
+    obj = construct_mock(
+        id=1234,
+        date='2018-01-01',
+        subject='mock interaction',
+    )
+    res = dict_utils.interaction_dict(obj)
+    assert res == {
+        'id': str(obj.id),
+        'date': obj.date,
+        'subject': obj.subject,
+    }
+
+
+def test_interaction_dict_none():
+    """Interaction dict should return none for none input"""
+    res = dict_utils.interaction_dict(None)
+    assert res is None
+
+
 def test_id_name_list_of_dicts():
     """Test that id_name_list_of_dicts returns a list of dicts with ID and name keys."""
     data = [


### PR DESCRIPTION
### Description of change

Add latest interaction to investment projects search endpoint. The Elastic Search model needed to be updated to include the latest interaction and then the signals also needed updating to listen to changes to the Interaction model.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
