### PR TITLE
Add local feature flag for CI investor profile changes

### DIFF
--- a/changelog/investment/add-local-ci-investment-flag.internal.md
+++ b/changelog/investment/add-local-ci-investment-flag.internal.md
@@ -1,0 +1,2 @@
+It is now possible to use the `capital-investments-filters` feature flag
+automatically during local development without manual setup.

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -1799,6 +1799,15 @@
     created_by: 7bad8082-4978-4fe8-a018-740257f01637
     created_on: '2018-01-23T00:00:00Z'
 
+- model: feature_flag.featureflag
+  pk: e14f907e-6488-4e43-8f9b-9089a02112a4
+  fields:
+    code: capital-investments-filters
+    description: This is a flag to show filters on CI profiles 
+    is_active: true
+    created_by: 7bad8082-4978-4fe8-a018-740257f01637
+    created_on: '2018-01-23T00:00:00Z'
+
 - model: investor_profile.largecapitalinvestorprofile
   pk: 04d9215f-f9f9-4183-af85-326e7cf5482b
   fields:


### PR DESCRIPTION
### Description of change
Adds a feature flag in the test data for `capital-investments-filters` that will allow FE developers to use this for their current work on filters without repeatedly regenerating the feature flag.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
