### PR TITLE
The endpoint `company/<uuid:pk>/export-win` now responds with a 200 empty list instead of throwing a 404

### DIFF
--- a/changelog/company/export_win_endpoint_modification.internal.md
+++ b/changelog/company/export_win_endpoint_modification.internal.md
@@ -1,0 +1,1 @@
+The company endpoint `company/<uuid:pk>/export-win` now returns an empty list HTTP 200, instead of throwing a HTTP 404 when it can't match a company via the Company Matching Service.

--- a/datahub/company/test/test_company_exportwins_views.py
+++ b/datahub/company/test/test_company_exportwins_views.py
@@ -80,7 +80,7 @@ class TestGetCompanyExportWins(APITestMixin):
         requests_mock,
         match_response,
     ):
-        """Test that any issues with company matching service results in a 404."""
+        """Test that any issues with company matching service results in a 200 empty list."""
         company_dynamic_response = HawkMockJSONResponse(
             api_id=settings.COMPANY_MATCHING_HAWK_ID,
             api_key=settings.COMPANY_MATCHING_HAWK_KEY,
@@ -101,8 +101,13 @@ class TestGetCompanyExportWins(APITestMixin):
         company = CompanyFactory()
         url = reverse('api-v4:company:export-win', kwargs={'pk': company.id})
         response = api_client.get(url)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-        assert response.json() == {'detail': 'Not found.'}
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'count': 0,
+            'next': None,
+            'previous': None,
+            'results': [],
+        }
 
     @pytest.mark.parametrize(
         'response_status',


### PR DESCRIPTION
### Description of change
Previously the endpoint was throwing a `HTTP 404` when a match couldn't be found with the Company Matching Service, now the endpoint responds with a `HTTP 200` empty list. This prevents error messages being displayed on the frontend due to a non-match, now we show `0 Export wins` instead (hence, the empty array).

To be clear, the happy path is this:

**Happy path**
DH API -> Matching Company Service (responds with a list of matching IDs providing the company [criteria](https://github.com/uktrade/company-matching-service#matching-algorithm) is met)
DH API -> Export wins API (accepts the matching IDs and responds with a list of Export wins)

**Unhappy path**
API -> Matching Company Service (no match, previously throws a 404, now returns an empty list 200) and doesn't bother to call the Export wins API as we can't find a match.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
