### PR TITLE
Add new un-nested proposition endpoint

### DIFF
--- a/changelog/investment/un-nested-propositions-endpoint.feature.md
+++ b/changelog/investment/un-nested-propositions-endpoint.feature.md
@@ -1,0 +1,1 @@
+A new propositions endpoint was added under `/v4/proposition` - this is a more flexible version of the existing `/v3/investment/<uuid>/proposition` endpoint, but does not require an investment project id.

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -16,6 +16,7 @@ from datahub.feature_flag import urls as feature_flag_urls
 from datahub.interaction import urls as interaction_urls
 from datahub.investment.investor_profile import urls as investor_profile_urls
 from datahub.investment.project import urls as investment_urls
+from datahub.investment.project.proposition import urls as proposition_urls
 from datahub.investment.summary import urls as investment_summary_urls
 from datahub.metadata import urls as metadata_urls
 from datahub.omis import urls as omis_urls
@@ -76,6 +77,10 @@ v4_urls = [
     path(
         '',
         include((investment_summary_urls, 'investment-summary'), namespace='investment-summary'),
+    ),
+    path(
+        '',
+        include((proposition_urls.urls_v4, 'proposition'), namespace='proposition'),
     ),
     path('dataset/', include((dataset_urls, 'dataset'), namespace='dataset')),
     path('metadata/', include((metadata_urls, 'metadata'), namespace='metadata')),

--- a/datahub/investment/project/proposition/urls.py
+++ b/datahub/investment/project/proposition/urls.py
@@ -3,44 +3,47 @@
 from django.urls import path
 
 from datahub.investment.project.proposition.views import (
-    PropositionDocumentViewSet,
+    ProjectPropositionDocumentViewSet,
+    ProjectPropositionViewSet,
     PropositionViewSet,
 )
 
-proposition_collection = PropositionViewSet.as_view({
+proposition_collection = ProjectPropositionViewSet.as_view({
     'get': 'list',
     'post': 'create',
 })
 
-proposition_item = PropositionViewSet.as_view({
+proposition_item = ProjectPropositionViewSet.as_view({
     'get': 'retrieve',
 })
 
-proposition_complete = PropositionViewSet.as_view({
+proposition_complete = ProjectPropositionViewSet.as_view({
     'post': 'complete',
 })
 
-proposition_abandon = PropositionViewSet.as_view({
+proposition_abandon = ProjectPropositionViewSet.as_view({
     'post': 'abandon',
 })
 
-proposition_document_collection = PropositionDocumentViewSet.as_view({
+proposition_document_collection = ProjectPropositionDocumentViewSet.as_view({
     'get': 'list',
     'post': 'create',
 })
 
-proposition_document_item = PropositionDocumentViewSet.as_view({
+proposition_document_item = ProjectPropositionDocumentViewSet.as_view({
     'get': 'retrieve',
     'delete': 'destroy',
 })
 
-proposition_document_callback = PropositionDocumentViewSet.as_action_view(
+proposition_document_callback = ProjectPropositionDocumentViewSet.as_action_view(
     'upload_complete_callback',
 )
 
-proposition_document_download = PropositionDocumentViewSet.as_action_view('download')
+proposition_document_download = ProjectPropositionDocumentViewSet.as_action_view('download')
 
-urlpatterns = [
+
+# API V3
+urls_v3 = [
     path('proposition', proposition_collection, name='collection'),
     path('proposition/<uuid:proposition_pk>', proposition_item, name='item'),
     path('proposition/<uuid:proposition_pk>/complete', proposition_complete, name='complete'),
@@ -65,4 +68,13 @@ urlpatterns = [
         proposition_document_download,
         name='document-item-download',
     ),
+]
+
+# API V4
+proposition_collection_v4 = PropositionViewSet.as_view({
+    'get': 'list',
+})
+
+urls_v4 = [
+    path('proposition', proposition_collection_v4, name='collection'),
 ]

--- a/datahub/investment/project/proposition/views.py
+++ b/datahub/investment/project/proposition/views.py
@@ -29,8 +29,8 @@ from datahub.user_event_log.utils import record_user_event
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
 
-class PropositionViewSet(CoreViewSet):
-    """ViewSet for public facing proposition endpoint."""
+class ProjectPropositionViewSet(CoreViewSet):
+    """ViewSet for public facing proposition endpoint (nested under investment project)."""
 
     non_existent_project_error_message = 'Specified investment project does not exist'
 
@@ -130,8 +130,8 @@ class PropositionViewSet(CoreViewSet):
         return data
 
 
-class PropositionDocumentViewSet(BaseEntityDocumentModelViewSet):
-    """Proposition Document ViewSet."""
+class ProjectPropositionDocumentViewSet(BaseEntityDocumentModelViewSet):
+    """Proposition Document ViewSet (nested under investment project)."""
 
     non_existent_proposition_error_message = 'Specified proposition does not exist'
 
@@ -183,3 +183,28 @@ class PropositionDocumentViewSet(BaseEntityDocumentModelViewSet):
         data['proposition_id'] = entity_document.proposition_id
         record_user_event(request, UserEventType.PROPOSITION_DOCUMENT_DELETE, data=data)
         return super().destroy(request, *args, **kwargs)
+
+
+class PropositionViewSet(CoreViewSet):
+    """ViewSet for public facing proposition endpoint (with no nesting)."""
+
+    permission_classes = (
+        PropositionModelPermissions,
+    )
+    serializer_class = PropositionSerializer
+    queryset = Proposition.objects.select_related(
+        'investment_project',
+        'adviser',
+        'created_by',
+        'modified_by',
+    )
+    filter_backends = (
+        DjangoFilterBackend,
+        OrderingFilter,
+    )
+    filterset_fields = ('adviser_id', 'status', 'investment_project_id')
+
+    lookup_url_kwarg = 'proposition_pk'
+
+    ordering_fields = ('deadline', 'created_on')
+    ordering = ('-deadline', '-created_on')

--- a/datahub/investment/project/urls.py
+++ b/datahub/investment/project/urls.py
@@ -3,7 +3,7 @@
 from django.urls import include, path
 
 from datahub.investment.project.evidence.urls import urlpatterns as evidence_urlpatterns
-from datahub.investment.project.proposition.urls import urlpatterns as proposition_urlpatterns
+from datahub.investment.project.proposition.urls import urls_v3 as proposition_urlpatterns
 from datahub.investment.project.views import (
     IProjectAuditViewSet,
     IProjectTeamMembersViewSet,


### PR DESCRIPTION
### Description of change

This adds a new endpoint to list investment project propositions `/v4/proposition`. 

An existing endpoint can currently be found under `/v3/investment/<uuid>/proposition`, but this is not able to give us a list of all outstanding propositions for an adviser because it is nested under an investment project. By removing this nesting the endpoint is now more flexible and will allow us to get outstanding propositions for an adviser with a request like this: `/v4/proposition?status=ongoing&adviser_id=<uuid>&sortby=-deadline&limit=5`

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
