### PR TITLE
Add get and patch endpoints for large capital opportunities.

### DIFF
--- a/changelog/investment/large-capital-opportunity-get.api.md
+++ b/changelog/investment/large-capital-opportunity-get.api.md
@@ -1,0 +1,1 @@
+A new endpoint `GET /v4/large-capital-opportunity/<uuid>` has been added. It retrieves a given large capital opportunity. Refer to the API documentation for the schema.

--- a/changelog/investment/large-capital-opportunity-patch.api.md
+++ b/changelog/investment/large-capital-opportunity-patch.api.md
@@ -1,0 +1,1 @@
+A new endpoint `PATCH /v4/large-capital-opportunity/<uuid>` has been added. It updates a given large capital opportunity. Refer to the API documentation for the schema.

--- a/datahub/investment/opportunity/urls.py
+++ b/datahub/investment/opportunity/urls.py
@@ -7,10 +7,17 @@ GET_AND_POST_COLLECTION = {
     'post': 'create',
 }
 
+GET_AND_PATCH_ITEM = {
+    'get': 'retrieve',
+    'patch': 'partial_update',
+}
+
 
 collection = LargeCapitalOpportunityViewSet.as_view(actions=GET_AND_POST_COLLECTION)
 
+item = LargeCapitalOpportunityViewSet.as_view(actions=GET_AND_PATCH_ITEM)
 
 urlpatterns = [
     path('large-capital-opportunity', collection, name='collection'),
+    path('large-capital-opportunity/<uuid:pk>', item, name='item'),
 ]


### PR DESCRIPTION
### Description of change

A new endpoint `GET /v4/large-capital-opportunity/<uuid>` has been added. It retrieves a given large capital opportunity. 

A new endpoint `PATCH /v4/large-capital-opportunity/<uuid>` has been added. It updates a given large capital opportunity.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
