### PR TITLE
Add large capital opportunity to interaction API

### DIFF
--- a/changelog/interaction/large-capital-opportunity-add.api.md
+++ b/changelog/interaction/large-capital-opportunity-add.api.md
@@ -1,0 +1,10 @@
+`POST /v3/interaction`: It is now possible to create a large capital opportunity interactions, by adding:
+
+  ```json
+  {
+    ...
+    "large_capital_opportunity": {"id": <large_capital_opportunity_id>},
+    "theme": "large_capital_opportunity",
+    ...
+  }
+  ```

--- a/changelog/interaction/large-capital-opportunity-get.api.md
+++ b/changelog/interaction/large-capital-opportunity-get.api.md
@@ -1,0 +1,15 @@
+`GET /v3/interaction`, `GET /v3/interaction/<id>`: A `large_capital_opportunity` field was added to responses. 
+If large capital opportunity interaction has been created, the field will have following structure:
+
+  ```json
+  {
+    ...
+    "large_capital_opportunity": {
+      "id": <large_capital_opportunity_id>,
+      "name": "Name of the opportunity",
+    }
+  }
+  ```
+
+  Otherwise, the value will be `null`.
+

--- a/changelog/interaction/large-capital-opportunity-list.api.md
+++ b/changelog/interaction/large-capital-opportunity-list.api.md
@@ -1,0 +1,2 @@
+`GET /v3/interaction`: It is now possible to filter interactions by large capital opportunity, 
+by adding `large_capital_opportunity_id` to the request.

--- a/datahub/company_referral/test/test_complete_view.py
+++ b/datahub/company_referral/test/test_complete_view.py
@@ -333,6 +333,7 @@ class TestCompleteCompanyReferral(APITestMixin):
                 'created_on': format_date_or_datetime(referral.created_on),
                 'recipient': format_expected_adviser(referral.recipient),
             },
+            'large_capital_opportunity': None,
         }
 
         assert referral.status == CompanyReferral.Status.COMPLETE

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -40,6 +40,7 @@ from datahub.interaction.validators import (
     ServiceAnswersValidator,
     StatusChangeValidator,
 )
+from datahub.investment.opportunity.models import LargeCapitalOpportunity
 from datahub.investment.project.serializers import NestedInvestmentProjectField
 from datahub.metadata.models import Country, Service, Team
 from datahub.metadata.serializers import SERVICE_LEAF_NODE_NOT_SELECTED_MESSAGE
@@ -165,6 +166,11 @@ class InteractionSerializer(serializers.ModelSerializer):
     is_event = serializers.BooleanField(required=False, allow_null=True)
     event = NestedRelatedField(Event, required=False, allow_null=True)
     investment_project = NestedInvestmentProjectField(required=False, allow_null=True)
+    large_capital_opportunity = NestedRelatedField(
+        LargeCapitalOpportunity,
+        required=False,
+        allow_null=True,
+    )
     modified_by = NestedAdviserField(read_only=True)
     service = NestedRelatedField(Service, required=False, allow_null=True)
     service_answers = serializers.JSONField(required=False)
@@ -388,6 +394,7 @@ class InteractionSerializer(serializers.ModelSerializer):
             'communication_channel',
             'grant_amount_offered',
             'investment_project',
+            'large_capital_opportunity',
             'net_company_receipt',
             'service',
             'service_answers',

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -14,6 +14,7 @@ from datahub.interaction.models import (
     PolicyIssueType,
     ServiceDeliveryStatus,
 )
+from datahub.investment.opportunity.test.factories import LargeCapitalOpportunityFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 from datahub.metadata.models import Country
 from datahub.metadata.test.factories import ServiceFactory
@@ -151,6 +152,14 @@ class InvestmentProjectInteractionFactory(InteractionFactoryBase):
     communication_channel = factory.LazyFunction(
         lambda: random_obj_for_model(CommunicationChannel),
     )
+
+
+class LargeCapitalOpportunityInteractionFactory(InteractionFactoryBase):
+    """Factory for creating an interaction relating to a large capital opportunity."""
+
+    kind = Interaction.Kind.INTERACTION
+    theme = Interaction.Theme.LARGE_CAPITAL_OPPORTUNITY
+    large_capital_opportunity = factory.SubFactory(LargeCapitalOpportunityFactory)
 
 
 class ServiceDeliveryFactory(InteractionFactoryBase):

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -39,6 +39,7 @@ from datahub.interaction.test.factories import (
     CompanyReferralInteractionFactory,
     ExportCountriesInteractionFactory,
     InvestmentProjectInteractionFactory,
+    LargeCapitalOpportunityInteractionFactory,
 )
 from datahub.interaction.test.permissions import (
     NON_RESTRICTED_ADD_PERMISSIONS,
@@ -46,6 +47,7 @@ from datahub.interaction.test.permissions import (
     NON_RESTRICTED_VIEW_PERMISSIONS,
 )
 from datahub.interaction.test.views.utils import resolve_data
+from datahub.investment.opportunity.test.factories import LargeCapitalOpportunityFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 from datahub.metadata import models as meta_models
 from datahub.metadata.test.factories import TeamFactory
@@ -82,6 +84,10 @@ class TestAddInteraction(APITestMixin):
             {
                 'investment_project': InvestmentProjectFactory,
                 'notes': 'hello',
+            },
+            {
+                'theme': Interaction.Theme.LARGE_CAPITAL_OPPORTUNITY,
+                'large_capital_opportunity': LargeCapitalOpportunityFactory,
             },
             # company interaction with policy feedback
             {
@@ -199,6 +205,7 @@ class TestAddInteraction(APITestMixin):
             'archived_on': None,
             'archived_reason': None,
             'company_referral': None,
+            'large_capital_opportunity': request_data.get('large_capital_opportunity'),
         }
 
     @freeze_time('2017-04-18 13:25:30.986208')
@@ -355,6 +362,7 @@ class TestAddInteraction(APITestMixin):
             'archived_on': None,
             'archived_reason': None,
             'company_referral': None,
+            'large_capital_opportunity': None,
         }
 
     @freeze_time('2017-04-18 13:25:30.986208')
@@ -651,7 +659,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                     'were_countries_discussed': None,
@@ -675,7 +682,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                 },
@@ -698,7 +704,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                     'were_countries_discussed': None,
@@ -734,7 +739,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
 
@@ -761,7 +765,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                     'were_countries_discussed': True,
@@ -802,7 +805,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                     'were_countries_discussed': True,
@@ -832,7 +834,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                     'were_countries_discussed': True,
@@ -864,7 +865,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                     'were_countries_discussed': True,
@@ -897,7 +897,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                     'were_countries_discussed': True,
@@ -931,7 +930,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                     'were_countries_discussed': True,
@@ -972,7 +970,6 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
 
@@ -1495,6 +1492,7 @@ class TestGetInteraction(APITestMixin):
                 'created_on': '2017-04-18T13:25:30.986208Z',
                 'recipient': format_expected_adviser(company_referral.recipient),
             } if company_referral else None,
+            'large_capital_opportunity': None,
         }
 
     @freeze_time('2017-04-18 13:25:30.986208')
@@ -1608,6 +1606,7 @@ class TestGetInteraction(APITestMixin):
             'archived_on': None,
             'archived_reason': None,
             'company_referral': None,
+            'large_capital_opportunity': None,
         }
 
     def test_restricted_user_cannot_get_non_associated_investment_project_interaction(self):
@@ -2102,3 +2101,32 @@ class TestListInteractions(APITestMixin):
         actual_ids = {i['id'] for i in response_data['results']}
         expected_ids = {str(i.id) for i in associated_project_interactions}
         assert actual_ids == expected_ids
+
+    @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
+    def test_user_can_filter_by_large_capital_opportunities(self, permissions):
+        """Test that a user can filter interactions by large capital opportunity."""
+        requester = create_test_user(permission_codenames=permissions)
+        api_client = self.create_api_client(user=requester)
+
+        opportunity = LargeCapitalOpportunityFactory()
+        CompanyInteractionFactory.create_batch(3)
+        opportunity_interactions = LargeCapitalOpportunityInteractionFactory.create_batch(
+            3,
+            large_capital_opportunity=opportunity,
+        )
+        url = reverse('api-v3:interaction:collection')
+        response = api_client.get(url, {
+            'large_capital_opportunity_id': opportunity.pk,
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == 3
+        actual_ids = {i['id'] for i in response_data['results']}
+        expected_ids = {str(i.id) for i in opportunity_interactions}
+        assert actual_ids == expected_ids
+        for result in response_data['results']:
+            assert result['large_capital_opportunity'] == {
+                'id': str(opportunity.pk),
+                'name': opportunity.name,
+            }

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -175,6 +175,7 @@ class TestAddServiceDelivery(APITestMixin):
             'archived_on': None,
             'archived_reason': None,
             'company_referral': None,
+            'large_capital_opportunity': None,
         }
 
     @pytest.mark.parametrize(

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -31,6 +31,7 @@ class InteractionViewSet(ArchivableViewSetMixin, CoreViewSet):
         'contacts__id',
         'event_id',
         'investment_project_id',
+        'large_capital_opportunity_id',
     ]
     ordering_fields = (
         'company__name',


### PR DESCRIPTION
### Description of change

`POST /v3/interaction`: It is now possible to create a large capital opportunity interactions, by adding:

  ```json
  {
    ...
    "large_capital_opportunity": {"id": <large_capital_opportunity_id>},
    "theme": "large_capital_opportunity",
    ...
  }
  ```

`GET /v3/interaction`, `GET /v3/interaction/<id>`: A `large_capital_opportunity` field was added to responses. 
If large capital opportunity interaction has been created, the field will have following structure:

  ```json
  {
    ...
    "large_capital_opportunity": {
      "id": <large_capital_opportunity_id>,
      "name": "Name of the opportunity",
    }
  }
  ```

  Otherwise, the value will be `null`.

`GET /v3/interaction`: It is now possible to filter interactions by large capital opportunity, 
by adding `large_capital_opportunity_id` to the request.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
