### PR TITLE
Add large capital opportunity audit endpoint

### DIFF
--- a/changelog/investment/large-capital-opportunity-timeline.api.md
+++ b/changelog/investment/large-capital-opportunity-timeline.api.md
@@ -1,0 +1,2 @@
+A new endpoint `GET /v4/large-capital-opportunity/<uuid:pk>/audit` has been added that lists changes to a given 
+opportunity. Refer to the API documentation for the schema.

--- a/datahub/investment/opportunity/urls.py
+++ b/datahub/investment/opportunity/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
-from datahub.investment.opportunity.views import LargeCapitalOpportunityViewSet
+from datahub.investment.opportunity.views import (
+    LargeCapitalOpportunityAuditViewSet,
+    LargeCapitalOpportunityViewSet,
+)
 
 GET_AND_POST_COLLECTION = {
     'get': 'list',
@@ -17,7 +20,13 @@ collection = LargeCapitalOpportunityViewSet.as_view(actions=GET_AND_POST_COLLECT
 
 item = LargeCapitalOpportunityViewSet.as_view(actions=GET_AND_PATCH_ITEM)
 
+item_audit = LargeCapitalOpportunityAuditViewSet.as_view({
+    'get': 'list',
+})
+
+
 urlpatterns = [
     path('large-capital-opportunity', collection, name='collection'),
     path('large-capital-opportunity/<uuid:pk>', item, name='item'),
+    path('large-capital-opportunity/<uuid:pk>/audit', item_audit, name='audit-item'),
 ]

--- a/datahub/investment/opportunity/views.py
+++ b/datahub/investment/opportunity/views.py
@@ -1,5 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 
+from datahub.core.audit import AuditViewSet
 from datahub.core.viewsets import CoreViewSet
 from datahub.investment.opportunity.models import LargeCapitalOpportunity
 from datahub.investment.opportunity.serializers import LargeCapitalOpportunitySerializer
@@ -11,4 +12,10 @@ class LargeCapitalOpportunityViewSet(CoreViewSet):
     serializer_class = LargeCapitalOpportunitySerializer
     filter_backends = (DjangoFilterBackend,)
     filterset_fields = ('investment_projects__id',)
+    queryset = LargeCapitalOpportunity.objects.all()
+
+
+class LargeCapitalOpportunityAuditViewSet(AuditViewSet):
+    """Large capital opportunity audit views."""
+
     queryset = LargeCapitalOpportunity.objects.all()


### PR DESCRIPTION
### Description of change

A new endpoint `GET /v4/large-capital-opportunity/<uuid:pk>/audit` has been added that lists changes to a given 
opportunity. Refer to the API documentation for the schema.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
