### PR TITLE
Upgraded python and buildpacks version

### DIFF
--- a/changelog/python-version-upgrade.internal.md
+++ b/changelog/python-version-upgrade.internal.md
@@ -1,0 +1,1 @@
+Upgraded python version to 3.8.8.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
 - buildpacks:
-  - https://github.com/cloudfoundry/python-buildpack.git#v1.7.12
+  - https://github.com/cloudfoundry/python-buildpack.git#v1.7.34
   stack: cflinuxfs3
   timeout: 180

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.2
+python-3.8.8


### PR DESCRIPTION
### Description of change

Upgrading python and cloudfoundry python buildpack version forces latest pip version being used in CI pipeline which further solves issues with pip-tools installing pip which was causing issues with collecting static files for admin pages.

Change was tested on dev environment and it seems to be working.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
