### PR TITLE
Add incomplete fields to the search endpoint

### DIFF
--- a/changelog/investment/add-incomplete-fields-to-search.feature.md
+++ b/changelog/investment/add-incomplete-fields-to-search.feature.md
@@ -1,0 +1,1 @@
+Incomplete fields were added to the investment search endpoint (`POST /v3/search/investment_project`)

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -7,6 +7,7 @@ from itertools import chain
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
+from django.utils.functional import cached_property
 from mptt.fields import TreeForeignKey
 from reversion.models import Revision
 
@@ -21,6 +22,7 @@ from datahub.core.models import (
 )
 from datahub.core.utils import force_uuid, get_front_end_url, StrEnum
 from datahub.investment.project import constants
+from datahub.investment.project.validate import validate
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -542,6 +544,11 @@ class InvestmentProject(
             # For activity stream
             models.Index(fields=('created_on', 'id')),
         ]
+
+    @cached_property
+    def incomplete_fields(self):
+        """Fields that need to be completed to move to the next stage."""
+        return tuple(validate(instance=self, next_stage=True))
 
     def get_associated_advisers(self):
         """Get the advisers associated with the project."""

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -305,7 +305,6 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         ),
     }
 
-    incomplete_fields = serializers.SerializerMethodField()
     project_code = serializers.CharField(read_only=True)
     investment_type = NestedRelatedField(meta_models.InvestmentType)
     stage = NestedRelatedField(meta_models.InvestmentProjectStage, required=False)
@@ -490,12 +489,6 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         if errors:
             raise serializers.ValidationError(errors)
 
-    def get_incomplete_fields(self, instance):
-        """Returns the names of the fields that still need to be completed in order to
-        move to the next stage.
-        """
-        return tuple(validate(instance=instance, next_stage=True))
-
     def get_value_complete(self, instance):
         """Whether the value fields required to move to the next stage are complete."""
         return not validate(
@@ -529,8 +522,9 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
             'archived_reason',
             'archived_documents_url_path',
             'comments',
-            'project_manager_requested_on',
             'gross_value_added',
+            'incomplete_fields',
+            'project_manager_requested_on',
         )
 
 

--- a/datahub/investment/project/validate.py
+++ b/datahub/investment/project/validate.py
@@ -11,7 +11,7 @@ from datahub.core.constants import (
     ReferralSourceActivity as Activity,
 )
 from datahub.core.validate_utils import DataCombiner
-from datahub.investment.project.models import InvestmentProject
+from datahub.investment.project import models
 from datahub.investment.validate import field_incomplete
 
 REQUIRED_MESSAGE = 'This field is required.'
@@ -120,7 +120,7 @@ def validate(instance=None, update_data=None, fields=None, next_stage=False):
     :param next_stage:  Perform validation for the next stage (rather than the current stage)
     :return:            dict containing errors for incomplete fields
     """
-    combiner = DataCombiner(instance, update_data, model=InvestmentProject)
+    combiner = DataCombiner(instance, update_data, model=models.InvestmentProject)
     desired_stage = combiner.get_value('stage') or Stage.prospect.value
     desired_stage_order = _get_desired_stage_order(desired_stage, next_stage)
 

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -65,6 +65,7 @@ class InvestmentProject(BaseESModel):
     fdi_value = fields.id_name_field()
     foreign_equity_investment = Double()
     government_assistance = Boolean()
+    incomplete_fields = Text()
     intermediate_company = fields.id_name_field()
     investor_company = fields.id_name_partial_field()
     investor_company_country = fields.id_name_field()

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -297,6 +297,7 @@ def test_mapping(es):
             'government_assistance': {'type': 'boolean'},
             'gross_value_added': {'type': 'double'},
             'id': {'type': 'keyword'},
+            'incomplete_fields': {'type': 'text'},
             'intermediate_company': {
                 'properties': {
                     'id': {'type': 'keyword'},

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -94,6 +94,7 @@ def test_investment_project_to_dict(es):
         'approved_high_value',
         'approved_landed',
         'approved_non_fdi',
+        'incomplete_fields',
         'intermediate_company',
         'referral_source_activity_website',
         'referral_source_activity_marketing',

--- a/datahub/search/signals.py
+++ b/datahub/search/signals.py
@@ -21,12 +21,13 @@ class SignalReceiver:
     are automatically connected and disconnected as needed.
     """
 
-    def __init__(self, signal, sender, receiver_func):
+    def __init__(self, signal, sender, receiver_func, forward_kwargs=False):
         """Initialises the instance."""
         self.is_connected = False
         self.search_app = None
         self.signal = signal
         self.sender = sender
+        self.forward_kwargs = forward_kwargs
         self._receiver_func = receiver_func
         self._thread_locals = local()
 
@@ -85,7 +86,10 @@ class SignalReceiver:
     def on_signal_received(self, sender, instance, **kwargs):
         """Callback function passed to the signal."""
         if self.is_enabled:
-            self._receiver_func(instance)
+            if self.forward_kwargs:
+                self._receiver_func(instance, **kwargs)
+            else:
+                self._receiver_func(instance)
 
 
 @contextmanager


### PR DESCRIPTION
### Description of change

Adds incomplete fields to the search endpoint. This shows all the fields that need to be completed to progress the project to the next stage. Signal listeners have been added for the project's m2m fields since changes to these will change the value of `incomplete_fields`. 

The `get_incomplete_fields` method has been moved out of the investment project serializer and into a model property so that it could be reused by the search app.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
