### PR TITLE
Add defaults for opportunity create endpoint.

### DIFF
--- a/changelog/investment/large-capital-opportunity-defaults.feature.md
+++ b/changelog/investment/large-capital-opportunity-defaults.feature.md
@@ -1,0 +1,2 @@
+The `POST /v4/large-capital-opportunity` endpoint has been updated, so that it only requires a `name` parameter 
+to create a new opportunity.

--- a/datahub/investment/opportunity/constants.py
+++ b/datahub/investment/opportunity/constants.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+from datahub.core.constants import Constant
+
+
+class OpportunityType(Enum):
+    """Opportunity type constants."""
+
+    large_capital = Constant('Large capital', 'c064e66a-a6bc-4ad6-9a88-0bdd69519f55')
+
+
+class OpportunityStatus(Enum):
+    """Opportunity status constants."""
+
+    seeking_investments = Constant('Seeking investments', '1386d4f4-732d-44b9-af8e-dffe7dd07d7b')

--- a/datahub/investment/opportunity/serializers.py
+++ b/datahub/investment/opportunity/serializers.py
@@ -12,6 +12,10 @@ from datahub.investment.investor_profile.models import (
 )
 from datahub.investment.investor_profile.serializers import RequiredChecksConductedSerializer
 from datahub.investment.investor_profile.validate import get_incomplete_fields
+from datahub.investment.opportunity.constants import (
+    OpportunityStatus as OpportunityStatusConstant,
+    OpportunityType as OpportunityTypeConstant,
+)
 from datahub.investment.opportunity.models import (
     AbandonmentReason,
     LargeCapitalOpportunity,
@@ -78,16 +82,26 @@ ALL_LARGE_CAPITAL_OPPORTUNITY_FIELDS = [
 ]
 
 
+def _get_default_opportunity_type():
+    return OpportunityType.objects.get(id=OpportunityTypeConstant.large_capital.value.id)
+
+
+def _get_default_opportunity_status():
+    return OpportunityStatus.objects.get(id=OpportunityStatusConstant.seeking_investments.value.id)
+
+
 class LargeCapitalOpportunitySerializer(RequiredChecksConductedSerializer):
     """Large capital opportunity serializer."""
 
     type = NestedRelatedField(
         OpportunityType,
         allow_null=False,
+        default=_get_default_opportunity_type,
     )
     status = NestedRelatedField(
         OpportunityStatus,
         allow_null=False,
+        default=_get_default_opportunity_status,
     )
 
     created_on = serializers.DateTimeField(
@@ -198,4 +212,13 @@ class LargeCapitalOpportunitySerializer(RequiredChecksConductedSerializer):
 
     class Meta(RequiredChecksConductedSerializer.Meta):
         model = LargeCapitalOpportunity
+        extra_kwargs = {
+            'dit_support_provided': {
+                'default': False,
+            },
+            'description': {
+                'allow_blank': True,
+                'required': False,
+            },
+        }
         fields = ALL_LARGE_CAPITAL_OPPORTUNITY_FIELDS

--- a/datahub/investment/opportunity/test/test_views.py
+++ b/datahub/investment/opportunity/test/test_views.py
@@ -24,10 +24,6 @@ from datahub.investment.investor_profile.test.constants import (
     ReturnRate as ReturnRateConstant,
     TimeHorizon as TimeHorizonConstant,
 )
-from datahub.investment.opportunity.test.constants import (
-    OpportunityStatus as OpportunityStatusConstant,
-    OpportunityType as OpportunityTypeConstant,
-)
 from datahub.investment.opportunity.test.factories import LargeCapitalOpportunityFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 
@@ -61,27 +57,18 @@ class TestCreateLargeCapitalOpportunityView(APITestMixin):
         response_data = response.json()
         assert response_data == {
             'name': ['This field is required.'],
-            'description': ['This field is required.'],
-            'status': ['This field is required.'],
-            'type': ['This field is required.'],
-            'dit_support_provided': ['This field is required.'],
         }
 
     def test_create_large_capital_opportunity_with_minimum_required_values(self):
         """Test creating a large capital opportunity with minimum required fields."""
         url = reverse('api-v4:large-capital-opportunity:collection')
 
-        request_data = {
-            'name': 'test',
-            'description': 'Lorem ipsum',
-            'type': OpportunityTypeConstant.large_capital.value.id,
-            'status': OpportunityStatusConstant.seeking_investment.value.id,
-            'dit_support_provided': False,
-        }
+        request_data = {'name': 'test'}
         with freeze_time(datetime(2017, 4, 28, 17, 35, tzinfo=utc)):
             response = self.api_client.post(url, data=request_data)
 
         expected_incomplete_details_fields = [
+            'description',
             'uk_region_locations',
             'promoters',
             'required_checks_conducted',


### PR DESCRIPTION
### Description of change

The `POST /v4/large-capital-opportunity` endpoint has been updated, so that it only requires a `name` parameter 
to create a new opportunity.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
