### PR TITLE
Fix/project schema

### DIFF
--- a/changelog/investment/project-schema.bugfix.md
+++ b/changelog/investment/project-schema.bugfix.md
@@ -1,0 +1,1 @@
+The investment project schema now shows "incomplete_fields" correctly as an array of strings (instead of a plain string).

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -370,6 +370,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         meta_models.InvestmentStrategicDriver, many=True, required=False,
     )
     uk_company = NestedRelatedField(Company, required=False, allow_null=True)
+    incomplete_fields = serializers.ListField(child=serializers.CharField(), read_only=True)
     requirements_complete = serializers.SerializerMethodField()
 
     # Team fields
@@ -523,7 +524,6 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
             'archived_documents_url_path',
             'comments',
             'gross_value_added',
-            'incomplete_fields',
             'project_manager_requested_on',
         )
 


### PR DESCRIPTION
### Description of change

Updates the schema for investment projects to show that `incomplete_fields` are a list of strings and not just a string.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
