### PR TITLE
Fix investment summary schema dates

### DIFF
--- a/changelog/investment/investment-summary-schema.bugfix.md
+++ b/changelog/investment/investment-summary-schema.bugfix.md
@@ -1,0 +1,1 @@
+The investment project summary schema now shows specifies the start and end dates with the proper data schema.

--- a/datahub/investment/summary/schemas.py
+++ b/datahub/investment/summary/schemas.py
@@ -31,8 +31,16 @@ class IProjectSummarySchema(AutoSchema):
                             'type': 'object',
                             'properties': {
                                 'label': {'type': 'string', 'example': '2020-21'},
-                                'start': {'type': 'date', 'example': '2020-04-01'},
-                                'end': {'type': 'date', 'example': '2021-03-31'},
+                                'start': {
+                                    'type': 'string',
+                                    'format': 'date',
+                                    'example': '2020-04-01',
+                                },
+                                'end': {
+                                    'type': 'string',
+                                    'format': 'date',
+                                    'example': '2021-03-31',
+                                },
                             },
                         },
                         'totals': {

--- a/datahub/investment/summary/test/test_schemas.py
+++ b/datahub/investment/summary/test/test_schemas.py
@@ -21,8 +21,8 @@ def test_annual_summaries_schema():
                     'type': 'object',
                     'properties': {
                         'label': {'type': 'string', 'example': '2020-21'},
-                        'start': {'type': 'date', 'example': '2020-04-01'},
-                        'end': {'type': 'date', 'example': '2021-03-31'},
+                        'start': {'type': 'string', 'format': 'date', 'example': '2020-04-01'},
+                        'end': {'type': 'string', 'format': 'date', 'example': '2021-03-31'},
                     },
                 },
                 'totals': {


### PR DESCRIPTION
### Description of change

Fixes the investment summary schema for swagger.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
