### PR TITLE
Reduce the strictness of telephone country code validation so e2e tests pass

### DIFF
--- a/changelog/contact/telephone-validation-strictness.bugfix.md
+++ b/changelog/contact/telephone-validation-strictness.bugfix.md
@@ -1,0 +1,1 @@
+Reduces the strictness of country code validation for contacts - now allows with or without a preceding +

--- a/datahub/company/test/admin/test_contact.py
+++ b/datahub/company/test/admin/test_contact.py
@@ -127,9 +127,8 @@ class TestContacts(AdminTestMixin):
     @pytest.mark.parametrize(
         'country_code',
         (
-            # Should be prefixed with +
-            '44',
             # Too long
+            '12345',
             '+12345',
             # A string
             '+UK',
@@ -153,16 +152,19 @@ class TestContacts(AdminTestMixin):
         form_errors = response.context_data['adminform'].errors
         assert 'telephone_countrycode' in form_errors
         assert form_errors['telephone_countrycode'] == [
-            'Country code should be preceded with a + sign and consist of one to four numbers',
+            'Country code should consist of one to four numbers',
         ]
 
     @pytest.mark.parametrize(
         'country_code',
         (
+            '44',
             '+44',
+            '1',
             '+1',
             '+998',
             '+1242',
+            '1567',
         ),
     )
     def test_valid_telephone_country_code(self, country_code):

--- a/datahub/core/validators/telephone.py
+++ b/datahub/core/validators/telephone.py
@@ -33,5 +33,5 @@ class TelephoneCountryCodeValidator(RegexValidator):
     Validator for telephone number country code.
     """
 
-    regex = r'^\+\d{1,4}$'
-    message = 'Country code should be preceded with a + sign and consist of one to four numbers'
+    regex = r'^\+?\d{1,4}$'
+    message = 'Country code should consist of one to four numbers'


### PR DESCRIPTION
### Description of change

Allows telephone country codes to begin with or without a plus sign, so that the e2e tests on the frontend pass.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
