### PR TITLE
Add the COP26 service and its child services

### DIFF
--- a/changelog/add-new-service-COP26.feature.md
+++ b/changelog/add-new-service-COP26.feature.md
@@ -1,0 +1,9 @@
+Add the COP26 service and its child services:
+
+* Adaptation and Resilience
+* Clean Transport, including EV100
+* Energy Transitions, including RE100 and EP100
+* Finance, including TCFD
+* Participation at Glasgow/getting involved with COP26
+* Nature, including supply chains
+* Race to Zero, including Science Based Targets

--- a/datahub/metadata/migrations/0011_update_services.py
+++ b/datahub/metadata/migrations/0011_update_services.py
@@ -1,0 +1,33 @@
+from pathlib import PurePath
+
+import mptt
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0011_update_services.yaml'
+    )
+
+def rebuild_tree(apps, schema_editor):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0010_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0011_update_services.yaml
+++ b/datahub/metadata/migrations/0011_update_services.yaml
@@ -1,0 +1,96 @@
+- model: metadata.service
+  pk: af33a094-e8e9-4cc2-9af5-4daaea62b78a
+  fields:
+    disabled_on:
+    order: 17003.0
+    segment: COP26
+    parent:
+    contexts: []
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0
+- model: metadata.service
+  pk: d3a25003-7f32-4087-8dd0-ae9eacf8a281
+  fields:
+    disabled_on:
+    order: 17004.0
+    segment: Adaptation and Resilience
+    parent: af33a094-e8e9-4cc2-9af5-4daaea62b78a
+    contexts: ["other_interaction", other_service_delivery]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0
+- model: metadata.service
+  pk: 2f97f7f8-e9a8-41d7-ac5d-819846e6f363
+  fields:
+    disabled_on:
+    order: 17005.0
+    segment: Clean Transport, including EV100
+    parent: af33a094-e8e9-4cc2-9af5-4daaea62b78a
+    contexts: ["other_interaction", other_service_delivery]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0
+- model: metadata.service
+  pk: e3a488c6-59ab-4343-aab7-68875f0afb39
+  fields:
+    disabled_on:
+    order: 17006.0
+    segment: Energy Transitions, including RE100 and EP100
+    parent: af33a094-e8e9-4cc2-9af5-4daaea62b78a
+    contexts: ["other_interaction", other_service_delivery]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0
+- model: metadata.service
+  pk: 5c13807a-5639-4b1b-8fb6-2531645b49bc
+  fields:
+    disabled_on:
+    order: 17007.0
+    segment: Finance, including TCFD
+    parent: af33a094-e8e9-4cc2-9af5-4daaea62b78a
+    contexts: ["other_interaction", other_service_delivery]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0
+- model: metadata.service
+  pk: 361b3e67-55c1-4ea2-846c-0515a3f1ae34
+  fields:
+    disabled_on:
+    order: 17008.0
+    segment: Participation at Glasgow/getting involved with COP26
+    parent: af33a094-e8e9-4cc2-9af5-4daaea62b78a
+    contexts: ["other_interaction", other_service_delivery]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0
+- model: metadata.service
+  pk: 5c13807a-5639-4b1b-8fb6-2531645b49bc
+  fields:
+    disabled_on:
+    order: 17009.0
+    segment: Nature, including supply chains
+    parent: af33a094-e8e9-4cc2-9af5-4daaea62b78a
+    contexts: ["other_interaction", other_service_delivery]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0
+- model: metadata.service
+  pk: dc5255e5-44d8-461f-a699-0353728bc8eb
+  fields:
+    disabled_on:
+    order: 17010.0
+    segment: Race to Zero, including Science Based Targets
+    parent: af33a094-e8e9-4cc2-9af5-4daaea62b78a
+    contexts: ["other_interaction", other_service_delivery]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0


### PR DESCRIPTION
### Description of change

Add the COP26 service and its child services:

* Adaptation and Resilience
* Clean Transport, including EV100
* Energy Transitions, including RE100 and EP100
* Finance, including TCFD
* Participation at Glasgow/getting involved with COP26
* Nature, including supply chains
* Race to Zero, including Science Based Targets

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
