### PR TITLE
Update country_investment_originates_from update logic

### DIFF
--- a/changelog/investment/country-of-origin-update.feature.md
+++ b/changelog/investment/country-of-origin-update.feature.md
@@ -1,0 +1,1 @@
+The `country_investment_originates_from` field is now being updated until the investment project is won.

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -416,8 +416,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
             # Required for validation as DRF does not allow defaults for read-only fields
             data['allow_blank_possible_uk_regions'] = False
 
-            self._store_investor_company_details(data)
-
+        self._store_investor_company_details_if_not_yet_won(data)
         self._check_if_investment_project_can_be_moved_to_verify_win(data)
         self._check_if_investment_project_can_be_moved_to_won(data)
         self._validate_for_stage(data)
@@ -442,12 +441,17 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         ):
             data['project_manager_requested_on'] = now()
 
-    def _store_investor_company_details(self, data):
+    def _store_investor_company_details_if_not_yet_won(self, data):
         # Store investor company details used for reporting
         # Investor company details may change over time, that's why we need to keep the details
-        # at the time of investment project creation
-        investor_company = data['investor_company']
-        data['country_investment_originates_from'] = investor_company.address_country
+        # at the time of investment project creation and update until the project is won
+        project_isnt_won = (
+            self.instance
+            and str(self.instance.stage_id) != InvestmentProjectStage.won.value.id
+        )
+        if (not self.instance or project_isnt_won) and 'investor_company' in data:
+            investor_company = data['investor_company']
+            data['country_investment_originates_from'] = investor_company.address_country
 
     def _check_if_investment_project_can_be_moved_to_verify_win(self, data):
         # only project manager or project assurance adviser can move a project to verify win


### PR DESCRIPTION
### Description of change

This ensures that `country_investment_originates_from` is being updated when investor company changes until the investment project is won.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
