### PR TITLE
Fix country of origin audit log

### DIFF
--- a/changelog/investment/country_of_origin.bugfix.md
+++ b/changelog/investment/country_of_origin.bugfix.md
@@ -1,0 +1,1 @@
+The audit log is no longer updated when there was no change to `country_investment_originates_from`.

--- a/datahub/investment/project/signals.py
+++ b/datahub/investment/project/signals.py
@@ -1,3 +1,4 @@
+from django.db.models import Q
 from django.db.models.signals import m2m_changed, post_save, pre_save
 from django.dispatch import receiver
 
@@ -109,8 +110,10 @@ def update_country_investment_originates_from(sender, **kwargs):
         investment_projects = InvestmentProject.objects.filter(
             investor_company_id=instance.pk,
         ).exclude(
-            stage_id=InvestmentProjectStage.won.value.id,
+            Q(stage_id=InvestmentProjectStage.won.value.id)
+            or Q(country_investment_originates_from_id=instance.address_country_id),
         )
+
         for investment_project in investment_projects:
             investment_project.country_investment_originates_from_id = instance.address_country_id
             investment_project.save(

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -19,6 +19,7 @@ from reversion.models import Version
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
+from datahub.core.audit_utils import diff_versions
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
 from datahub.core.test_utils import (
     APITestMixin,
@@ -2373,6 +2374,29 @@ class TestInvestmentProjectVersioning(APITestMixin):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert Version.objects.count() == 0
+
+    def test_empty_update_doesnt_show_changes(self):
+        """Test that an empty update doesn't show changes."""
+        assert Version.objects.count() == 0
+
+        with reversion.create_revision():
+            project = InvestmentProjectFactory()
+            reversion.set_comment('Initial')
+
+        assert Version.objects.get_for_object(project).count() == 1
+
+        response = self.api_client.patch(
+            reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk}),
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        versions = Version.objects.get_for_object(project)
+        assert len(versions) == 2
+
+        changes = diff_versions(
+            InvestmentProject._meta, versions[0].field_dict, versions[1].field_dict,
+        )
+        assert changes == {}
 
     def test_update_creates_a_new_version(self):
         """Test that updating an investment project creates a new version."""


### PR DESCRIPTION
### Description of change

If there was no change to `country_investment_originates_from`, the investment project could still be updated and getting unnecessary entry in audit log.
This should fix it.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
