### PR TITLE
Remove old Trade Agreements feature flag from Django Admin

### DIFF
--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -1852,15 +1852,6 @@
     created_by: 7bad8082-4978-4fe8-a018-740257f01637
     created_on: '2018-01-23T00:00:00Z'
 
-- model: feature_flag.featureflag
-  pk: cda004cd-9644-42e2-90e5-9a61575dd510
-  fields:
-    code: trade-agreement-interaction
-    description: This is a flag to show trade agreement interactions
-    is_active: true
-    created_by: 7bad8082-4978-4fe8-a018-740257f01637
-    created_on: '2021-03-26T00:00:00Z'
-
 - model: investor_profile.largecapitalinvestorprofile
   pk: 04d9215f-f9f9-4183-af85-326e7cf5482b
   fields:


### PR DESCRIPTION
### Description of change

The feature flag `trade-agreement-interaction` is no longer being used so it can be deleted from Django Admin. 

### Checklist
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
