### PR TITLE
Fixed service admin search fields

### DIFF
--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -148,6 +148,7 @@ class ServiceAdmin(MPTTModelAdmin, ReadOnlyMetadataAdmin):
 
     fields = ('id', 'segment', 'parent', 'contexts', 'order', 'disabled_on')
     list_display = ('segment', 'get_contexts_display', 'order', 'disabled_on')
+    search_fields = ('pk', 'segment')
     list_filter = (
         DisabledOnFilter,
         ServiceContextFilter,


### PR DESCRIPTION
### Description of change
Django admin was unable to resolve keyword `name` into field when searching for `Service`. This change should address this issue.

```
FieldError
Cannot resolve keyword 'name' into field. Choices are: ...
```

[link to sentry issue](https://sentry.ci.uktrade.digital/organizations/dit/issues/38879/)