### PR TITLE
Add Green Investment field to investment fixtures

### DIFF
--- a/changelog/investment/add-green-investment.feature.md
+++ b/changelog/investment/add-green-investment.feature.md
@@ -1,0 +1,1 @@
+The field `Green Investment` was added as an investment business activity.

--- a/fixtures/metadata/investment.yaml
+++ b/fixtures/metadata/investment.yaml
@@ -78,6 +78,9 @@
   pk: 257f720f-42df-4f85-8e43-c83e4e03dc79
   fields: {name: "Global headquarters"}
 - model: metadata.investmentbusinessactivity
+  pk: 70ec722d-4318-453e-bbff-ffcb97fbde4a
+  fields: {name: "Green Investment"}
+- model: metadata.investmentbusinessactivity
   pk: 30348f9d-a82e-4215-ba3f-85cbbd14763a
   fields: {name: "Knowledge centre"}
 - model: metadata.investmentbusinessactivity


### PR DESCRIPTION
### Description of change

In October this year there is a Global Investment summit. DIT want to be able to announce the amount of green investment we have secured. In order to do this we need to be able to indicate which projects are in this category.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
