### PR TITLE
Fix investment summary totals for team members

### DIFF
--- a/changelog/investment/investment-summary-totals-fix.bugfix.md
+++ b/changelog/investment/investment-summary-totals-fix.bugfix.md
@@ -1,3 +1,3 @@
-Fixes the investment summary totals api endpoint `api-proxy/v4/adviser/<adviser_id>/investment-summary` 
+Fixes the investment summary totals api endpoint GET `api-proxy/v4/adviser/<adviser_id>/investment-summary` 
 
 This ensures that projects are counted correctly when advisers are team members on a project.

--- a/changelog/investment/investment-summary-totals-fix.bugfix.md
+++ b/changelog/investment/investment-summary-totals-fix.bugfix.md
@@ -1,0 +1,3 @@
+Fixes the investment summary totals api endpoint `api-proxy/v4/adviser/<adviser_id>/investment-summary` 
+
+This ensures that projects are counted correctly when advisers are team members on a project.


### PR DESCRIPTION
### Description of change

The investment summary on the new personalised dashboard was not including counts of projects where a user was a team member - please see JIRA ticket here: https://uktrade.atlassian.net/browse/CRMD-47

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
