### PR TITLE
CDS-177 Add related_trade_agreement_names to v4/dataset/interactions-dataset

### DIFF
--- a/changelog/interaction/add_related_trade_agreements_to_dataset.api.md
+++ b/changelog/interaction/add_related_trade_agreements_to_dataset.api.md
@@ -1,0 +1,3 @@
+Expose `related_trade_agreement_names` via GET `v4/dataset/interactions-dataset endpoint`
+
+This allows data workspace to ingest this information against each interaction

--- a/datahub/dataset/interaction/test/test_views.py
+++ b/datahub/dataset/interaction/test/test_views.py
@@ -8,6 +8,7 @@ from datahub.dataset.core.test import BaseDatasetViewTest
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
     CompanyInteractionFactoryWithPolicyFeedback,
+    CompanyInteractionFactoryWithRelatedTradeAgreements,
     EventServiceDeliveryFactory,
     InvestmentProjectInteractionFactory,
     ServiceDeliveryFactory,
@@ -64,6 +65,10 @@ def get_expected_data_from_interaction(interaction):
             [x.name for x in interaction.policy_issue_types.all()]
             if interaction.policy_areas.exists() else None
         ),
+        'related_trade_agreement_names': (
+            [x.name for x in interaction.related_trade_agreements.all()]
+            if interaction.related_trade_agreements.exists() else None
+        ),
         'sector': get_attr_or_none(interaction, 'company.sector.name'),
         'service_delivery_status__name': get_attr_or_none(
             interaction,
@@ -83,7 +88,7 @@ class TestInteractionsDatasetViewSet(BaseDatasetViewTest):
     """
 
     view_url = reverse('api-v4:dataset:interactions-dataset')
-    factory = CompanyInteractionFactory
+    factory = CompanyInteractionFactoryWithRelatedTradeAgreements
 
     @pytest.mark.parametrize(
         'interaction_factory', (

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -35,6 +35,12 @@ class InteractionsDatasetView(BaseDatasetView):
                 'policyarea__name',
                 ordering=('policyarea__order',),
             ),
+            related_trade_agreement_names=get_array_agg_subquery(
+                Interaction.related_trade_agreements.through,
+                'interaction',
+                'tradeagreement__name',
+                ordering=('tradeagreement__name',),
+            ),
             policy_issue_type_names=get_array_agg_subquery(
                 Interaction.policy_issue_types.through,
                 'interaction',
@@ -63,6 +69,7 @@ class InteractionsDatasetView(BaseDatasetView):
             'policy_area_names',
             'policy_feedback_notes',
             'policy_issue_type_names',
+            'related_trade_agreement_names',
             'sector',
             'service_delivery_status__name',
             'service_delivery',

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -16,7 +16,7 @@ from datahub.interaction.models import (
 )
 from datahub.investment.opportunity.test.factories import LargeCapitalOpportunityFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
-from datahub.metadata.models import Country
+from datahub.metadata.models import Country, TradeAgreement
 from datahub.metadata.test.factories import ServiceFactory
 
 
@@ -160,6 +160,19 @@ class LargeCapitalOpportunityInteractionFactory(InteractionFactoryBase):
     kind = Interaction.Kind.INTERACTION
     theme = Interaction.Theme.LARGE_CAPITAL_OPPORTUNITY
     large_capital_opportunity = factory.SubFactory(LargeCapitalOpportunityFactory)
+
+
+class CompanyInteractionFactoryWithRelatedTradeAgreements(CompanyInteractionFactory):
+    """Factory for creating a company interaction with related_trade_agreements"""
+
+    has_related_trade_agreements = True
+
+    @to_many_field
+    def related_trade_agreements(self):
+        """
+        related_trade_agreements field.
+        """
+        return TradeAgreement.objects.all()[:3]
 
 
 class ServiceDeliveryFactory(InteractionFactoryBase):


### PR DESCRIPTION


### Description of change

* Functionality and tests for adding `related_trade_agreement_names` to `v4/dataset/interactions-dataset` endpoint 
* Added new `CompanyInteractionFactoryWithTradeAgreeement` factory to facilitate testing

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
