### PR TITLE
Ensure the investigation address area serialization is tested

### DIFF
--- a/changelog/company_investigation_area_tests.feature.md
+++ b/changelog/company_investigation_area_tests.feature.md
@@ -1,0 +1,1 @@
+Requesting address areas for company investigations is now tested

--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -4,9 +4,7 @@ import pytest
 from django.utils.timezone import utc
 from freezegun import freeze_time
 
-from datahub.company.constants import BusinessTypeConstant
 from datahub.company.test.factories import CompanyFactory
-from datahub.core.constants import Country, Sector, UKRegion
 from datahub.dnb_api.constants import (
     FEATURE_FLAG_DNB_COMPANY_UPDATES,
 )
@@ -129,31 +127,6 @@ def dnb_company_search_datahub_companies():
             subject='Meeting with John Smith',
             company=company,
         )
-
-
-@pytest.fixture
-def investigation_payload():
-    """
-    Valid DNB company investigation payload.
-    """
-    return {
-        'business_type': BusinessTypeConstant.company.value.id,
-        'name': 'Test Company',
-        'website': 'http://www.test.com',
-        'telephone_number': '12345678',
-        'address': {
-            'line_1': 'Foo',
-            'line_2': 'Bar',
-            'town': 'Baz',
-            'county': 'Qux',
-            'country': {
-                'id': Country.united_kingdom.value.id,
-            },
-            'postcode': 'AB5 XY2',
-        },
-        'sector': Sector.renewable_energy_wind.value.id,
-        'uk_region': UKRegion.east_midlands.value.id,
-    }
 
 
 @pytest.fixture

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1989,6 +1989,8 @@ class TestCompanyInvestigationView(APITestMixin):
                 'address_county': 'Greater London',
                 'address_postcode': 'W1 0TN',
                 'address_country': 'GB',
+                'address_area_name': 'Texas',
+                'address_area_abbrev_name': 'TX',
             },
         }
         dnb_response = {
@@ -2018,6 +2020,8 @@ class TestCompanyInvestigationView(APITestMixin):
                     'county': 'Greater London',
                     'postcode': 'W1 0TN',
                     'country': constants.Country.united_kingdom.value.id,
+                    'area_name': 'Texas',
+                    'area_abbrev_name': 'TX',
                 },
             },
         )


### PR DESCRIPTION
### Description of change

Makes sure company investigation address areas are stored via testing.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
