### PR TITLE
Bump Django to 3.1.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ django-redis==5.0.0
     # via -r requirements.in
 django-reversion==3.0.9
     # via -r requirements.in
-django==3.1.8
+django==3.1.12
     # via
     #   -r requirements.in
     #   django-axes


### PR DESCRIPTION
### Description of change

Django needs upgrade because vulnerability - https://github.com/uktrade/data-hub-api/security/dependabot/requirements.txt/Django/open