### PR TITLE
Interaction companies API

### DIFF
--- a/changelog/interaction/interaction-companies.api.md
+++ b/changelog/interaction/interaction-companies.api.md
@@ -1,0 +1,3 @@
+A new `companies` field has been added to Interaction API. The field is being mirrored with the existing `company` field.
+Both `company` and `companies` cannot be set at the same time.
+If multiple companies are provided, the first one will be copied to `company` field. Refer to the API documentation for the schema.

--- a/changelog/interaction/interaction-company.deprecation.md
+++ b/changelog/interaction/interaction-company.deprecation.md
@@ -1,0 +1,1 @@
+The `company` field is now deprecated for Interactions.

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -373,6 +373,7 @@ MAPPING = {
         'factory': CompanyInteractionFactory,
         'implicitly_deletable_models': {
             'interaction.Interaction_contacts',
+            'interaction.Interaction_companies',
             'interaction.InteractionDITParticipant',
             'interaction.InteractionExportCountry',
         },

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -49,9 +49,10 @@ INVESTMENT_PROJECT_COMPANY_FIELDS = (
 )
 
 FIELD_TO_DESCRIPTION_MAPPING = {
-    'investor_company': ' as investor company ',
-    'intermediate_company': ' as intermediate company ',
-    'uk_company': ' as UK company ',
+    'companies': ' as one of participating companies',
+    'investor_company': ' as investor company',
+    'intermediate_company': ' as intermediate company',
+    'uk_company': ' as UK company',
 }
 
 MergeEntrySummary = namedtuple(
@@ -64,27 +65,34 @@ MergeEntrySummary = namedtuple(
 )
 
 
-def _default_object_updater(obj, field, target_company):
+def _default_object_updater(obj, field, target_company, source_company):
+    item = getattr(obj, field)
+    # if the field is m2m, replace the source company with a target company
+    if isinstance(item, models.Manager):
+        item.remove(source_company)
+        item.add(target_company)
+        return
+
     setattr(obj, field, target_company)
     obj.save(update_fields=(field,))
 
 
-def _company_list_item_updater(list_item, field, target_company):
+def _company_list_item_updater(list_item, field, target_company, source_company):
     # If there is already a list item for the target company, delete this list item instead
     # as duplicates are not allowed
     if CompanyListItem.objects.filter(list_id=list_item.list_id, company=target_company).exists():
         list_item.delete()
     else:
-        _default_object_updater(list_item, field, target_company)
+        _default_object_updater(list_item, field, target_company, source_company)
 
 
-def _pipeline_item_updater(pipeline_item, field, target_company):
+def _pipeline_item_updater(pipeline_item, field, target_company, source_company):
     # If there is already a pipeline item for the adviser for the target company
     # delete this item instead as the same company can't be added for the same adviser again
     if PipelineItem.objects.filter(adviser=pipeline_item.adviser, company=target_company).exists():
         pipeline_item.delete()
     else:
-        _default_object_updater(pipeline_item, field, target_company)
+        _default_object_updater(pipeline_item, field, target_company, source_company)
 
 
 class MergeConfiguration(NamedTuple):
@@ -205,7 +213,7 @@ def _update_objects(configuration: MergeConfiguration, source, target):
 
     for field, filtered_objects in _get_objects_from_configuration(configuration, source):
         for obj in filtered_objects.iterator():
-            configuration.object_updater(obj, field, target)
+            configuration.object_updater(obj, field, target, source)
             objects_updated[field] += 1
     return objects_updated
 

--- a/datahub/company/test/test_merge.py
+++ b/datahub/company/test/test_merge.py
@@ -135,7 +135,7 @@ class TestDuplicateCompanyMerger:
                     CompanyListItem: {'company': 0},
                     CompanyReferral: {'company': 0},
                     Contact: {'company': 3},
-                    Interaction: {'company': 3, 'companies': 0},
+                    Interaction: {'company': 3, 'companies': 3},
                     InvestmentProject: {
                         field: 0 for field in INVESTMENT_PROJECT_COMPANY_FIELDS
                     },
@@ -319,7 +319,10 @@ class TestDuplicateCompanyMerger:
             CompanyListItem: {'company': len(source_company_list_items)},
             CompanyReferral: {'company': len(source_referrals)},
             Contact: {'company': len(source_contacts)},
-            Interaction: {'company': len(source_interactions), 'companies': 0},
+            Interaction: {
+                'company': len(source_interactions),
+                'companies': len(source_interactions),
+            },
             InvestmentProject: {
                 field: 0 for field in INVESTMENT_PROJECT_COMPANY_FIELDS
             },

--- a/datahub/company_referral/test/test_complete_view.py
+++ b/datahub/company_referral/test/test_complete_view.py
@@ -287,6 +287,12 @@ class TestCompleteCompanyReferral(APITestMixin):
                 'id': str(interaction.company.pk),
                 'name': interaction.company.name,
             },
+            'companies': [
+                {
+                    'id': str(interaction.company.pk),
+                    'name': interaction.company.name,
+                },
+            ],
             'contacts': [
                 {
                     'id': str(contact.pk),

--- a/datahub/core/validate_utils.py
+++ b/datahub/core/validate_utils.py
@@ -48,7 +48,6 @@ class DataCombiner:
         Requires the model class to be available.
         """
         field_info = _get_model_field_info(self.model)
-
         if field_name in field_info.relations:
             if field_info.relations[field_name].to_many:
                 value = self.get_value_to_many(field_name)

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -76,7 +76,7 @@ class InteractionFactoryBase(factory.django.DjangoModelFactory):
         """
         Add support for setting `companies`.
         """
-        return []
+        return [self.company] if self.company else []
 
     @to_many_field
     def dit_participants(self, **kwargs):

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -396,6 +396,9 @@ class TestUpdateInteraction(APITestMixin):
                 'company': CompanyFactory,
             },
             {
+                'companies': [CompanyFactory],
+            },
+            {
                 'contacts': [ContactFactory],
             },
         ),

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -139,6 +139,10 @@ class TestAddServiceDelivery(APITestMixin):
                 'id': str(company.pk),
                 'name': company.name,
             },
+            'companies': [{
+                'id': str(company.pk),
+                'name': company.name,
+            }],
             'contacts': [{
                 'id': str(contact.pk),
                 'name': contact.name,


### PR DESCRIPTION
### Description of change

This adds `companies` field support to Interaction API alongside the existing `company` field.

It doesn't change the behaviour when existing `company` field is used, so existing services should operate as normal.

Until the support for `companies` field is implemented in the dependent services, the `company` data will be mirrored with `companies`. 

When multiple companies are added to the interaction, only the first one will be stored in `company`. 

An attempt to post both `company` and `companies` will result in a validation error.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
