### PR TITLE
Revert Django back to 3.1.12

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # Django and django related
-django==3.1.8
+django==3.1.12
 djangorestframework==3.12.4
 django-axes==5.18.0
 django-environ==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,7 +93,7 @@ django-redis==5.0.0
     # via -r requirements.in
 django-reversion==3.0.9
     # via -r requirements.in
-django==3.1.8
+django==3.1.12
     # via
     #   -r requirements.in
     #   django-axes


### PR DESCRIPTION
### Description of change

Dependabot has reverted Django back to 3.1.8 (which is vulnerable), this PR restores it to the secure 3.1.12.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
