### PR TITLE
CDS-201 Modify `company-change-request`/`company-investigation` `area` payload

### DIFF
--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -2,3 +2,4 @@ from config.settings.common_sentry import *
 
 # DRF
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += ['rest_framework.authentication.SessionAuthentication']
+DEBUG_PROPAGATE_EXCEPTIONS = True

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -63,3 +63,4 @@ LOGGING = {
         },
     },
 }
+DEBUG_PROPAGATE_EXCEPTIONS = True

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -19,7 +19,14 @@ from datahub.company.test.factories import (
     CompanyFactory,
 )
 from datahub.company.test.utils import address_area_or_none
-from datahub.core.constants import Country, EmployeeRange, HeadquarterType, TurnoverRange, UKRegion
+from datahub.core.constants import (
+    AdministrativeArea,
+    Country,
+    EmployeeRange,
+    HeadquarterType,
+    TurnoverRange,
+    UKRegion,
+)
 from datahub.core.test_utils import (
     APITestMixin,
     create_test_user,
@@ -1313,7 +1320,6 @@ class TestAddCompany(APITestMixin):
                     'address': {
                         'line_1': '75 Stramford Road',
                         'town': 'London',
-                        'area': None,
                         'country': {
                             'id': Country.united_kingdom.value.id,
                         },
@@ -1357,7 +1363,9 @@ class TestAddCompany(APITestMixin):
                     'address': {
                         'line_1': '75 Stramford Road',
                         'town': 'Cordova',
-                        'area': None,
+                        'area': {
+                            'id': AdministrativeArea.texas.value.id,
+                        },
                         'country': {
                             'id': Country.united_states.value.id,
                         },
@@ -1370,7 +1378,10 @@ class TestAddCompany(APITestMixin):
                         'town': 'Cordova',
                         'county': '',
                         'postcode': '',
-                        'area': None,
+                        'area': {
+                            'id': AdministrativeArea.texas.value.id,
+                            'name': AdministrativeArea.texas.value.name,
+                        },
                         'country': {
                             'id': Country.united_states.value.id,
                             'name': Country.united_states.value.name,
@@ -1434,7 +1445,9 @@ class TestAddCompany(APITestMixin):
                     'registered_address': {
                         'line_1': '1 Hello st.',
                         'town': 'Dublin',
-                        'area': None,
+                        'area': {
+                            'id': AdministrativeArea.texas.value.id,
+                        },
                         'country': {
                             'id': Country.ireland.value.id,
                         },
@@ -1447,7 +1460,10 @@ class TestAddCompany(APITestMixin):
                         'town': 'Dublin',
                         'county': '',
                         'postcode': '',
-                        'area': None,
+                        'area': {
+                            'id': AdministrativeArea.texas.value.id,
+                            'name': AdministrativeArea.texas.value.name,
+                        },
                         'country': {
                             'id': Country.ireland.value.id,
                             'name': Country.ireland.value.name,

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -2155,7 +2155,7 @@ class TestCompanyInvestigationView(APITestMixin):
                     'line_2': 'Someplace',
                     'town': 'Beverly Hills',
                     'county': 'Los Angeles',
-                    'address_area': {
+                    'area': {
                         'id': constants.AdministrativeArea.new_york.value.id,
                     },
                     'postcode': '91012',

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1542,7 +1542,7 @@ class TestCompanyChangeRequestView(APITestMixin):
         """
         CompanyFactory(
             duns_number='123456789',
-            address_area_id=address_area_id
+            address_area_id=address_area_id,
         )
 
         requests_mock.post(
@@ -1673,7 +1673,7 @@ class TestCompanyChangeRequestView(APITestMixin):
         address_area_id = constants.AdministrativeArea.texas.value.id
         company = CompanyFactory(
             duns_number='123456789',
-            address_area_id=address_area_id
+            address_area_id=address_area_id,
         )
         requests_mock.post(
             DNB_CHANGE_REQUEST_URL,
@@ -1691,8 +1691,8 @@ class TestCompanyChangeRequestView(APITestMixin):
                     'address_country': company.address_country.iso_alpha2_code,
                     'address_postcode': company.address_postcode,
                     'address_area': {
-                        'id': address_area_id
-                    }
+                        'id': address_area_id,
+                    },
                 },
             },
         )
@@ -1722,7 +1722,7 @@ class TestCompanyChangeRequestView(APITestMixin):
                 'address_area': {
                     'name': constants.AdministrativeArea.texas.value.name,
                     'abbrev_name': constants.AdministrativeArea.texas.value.area_code,
-                }
+                },
             },
         }
 

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -26,6 +26,7 @@ from datahub.dnb_api.utils import (
     DNBServiceTimeoutError,
     format_dnb_company,
 )
+from datahub.feature_flag.test.factories import FeatureFlagFactory
 from datahub.interaction.models import InteractionPermission
 from datahub.metadata.models import Country
 
@@ -2109,6 +2110,8 @@ class TestCompanyInvestigationView(APITestMixin):
         The endpoint should return 200 as well as a valid response when it is hit with a valid
         payload of full investigation details.
         """
+        FeatureFlagFactory(code='company-area-investigation-request')
+
         company = CompanyFactory(
             address_area_id=constants.AdministrativeArea.new_york.value.id,
         )

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -37,6 +37,7 @@ from datahub.dnb_api.utils import (
     request_changes,
     search_dnb,
 )
+from datahub.feature_flag.utils import is_feature_flag_active
 
 
 logger = logging.getLogger(__name__)
@@ -335,6 +336,8 @@ class DNBCompanyInvestigationView(APIView):
 
         data = {'company_details': investigation_serializer.validated_data}
         company = data['company_details'].pop('company')
+        if not is_feature_flag_active('company-area-investigation-request'):
+            data['company_details'].pop('address_area', None)
 
         try:
             response = create_investigation(data)


### PR DESCRIPTION
### Description of change

The representation of `area` within the payload of the `company-investigation`/`company-change-request` endpoints has had to change from what was originally envisioned due to the fact that the frontend only has access to (and should only be sending down) the `AdministrativeArea` id field.

This change moves the functionality for loading the `name`/`abbrev_name` from the frontend to the backend, and ensures the prophegation of the data to the `dnb-service` 

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
