### PR TITLE
Add interaction companies to search

### DIFF
--- a/changelog/interaction/companies-in-interaction-search.api.md
+++ b/changelog/interaction/companies-in-interaction-search.api.md
@@ -1,0 +1,1 @@
+`GET /v3/search`, `POST /v3/search/interaction`: `companies` was added as an array field in search results. This field is intended to replace the `company` field.

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -34,6 +34,7 @@ class InteractionSearchApp(SearchApp):
         'event',
     ).prefetch_related(
         'contacts',
+        'companies',
         'policy_areas',
         'policy_issue_types',
         Prefetch(

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -58,6 +58,13 @@ def _export_countries_list(export_countries):
     ]
 
 
+def _companies_list(companies):
+    return [
+        dict_utils.company_dict(company)
+        for company in companies.all()
+    ]
+
+
 class _DITParticipant(InnerDoc):
     adviser = Object(Person)
     team = Object(IDNameTrigram)
@@ -68,6 +75,7 @@ class Interaction(BaseESModel):
 
     id = Keyword()
     company = fields.company_field()
+    companies = fields.company_field()
     company_sector = fields.sector_field()
     company_one_list_group_tier = fields.id_unindexed_name_field()
     communication_channel = fields.id_unindexed_name_field()
@@ -99,6 +107,7 @@ class Interaction(BaseESModel):
 
     MAPPINGS = {
         'company': dict_utils.company_dict,
+        'companies': _companies_list,
         'communication_channel': dict_utils.id_name_dict,
         'contacts': dict_utils.contact_or_adviser_list_of_dicts,
         'dit_participants': _dit_participant_list,

--- a/datahub/search/interaction/test/test_models.py
+++ b/datahub/search/interaction/test/test_models.py
@@ -30,6 +30,7 @@ def test_interaction_to_dict(es, factory_cls):
 
     result = Interaction.db_object_to_dict(interaction)
     result['contacts'].sort(key=itemgetter('id'))
+    result['companies'].sort(key=itemgetter('id'))
     result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
     result['export_countries'].sort(key=lambda export_country: export_country['country']['id'])
     result['policy_areas'].sort(key=itemgetter('id'))
@@ -45,6 +46,13 @@ def test_interaction_to_dict(es, factory_cls):
             'name': interaction.company.name,
             'trading_names': interaction.company.trading_names,
         } if interaction.company else None,
+        'companies': [
+            {
+                'id': str(company.pk),
+                'name': company.name,
+                'trading_names': company.trading_names,
+            } for company in sorted(interaction.companies.all(), key=attrgetter('id'))
+        ],
         'company_sector': {
             'id': str(interaction.company.sector.pk),
             'name': interaction.company.sector.name,
@@ -141,6 +149,7 @@ def test_service_delivery_to_dict(es):
 
     result = Interaction.db_object_to_dict(interaction)
     result['contacts'].sort(key=itemgetter('id'))
+    result['companies'].sort(key=itemgetter('id'))
     result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
 
     assert result == {
@@ -153,6 +162,13 @@ def test_service_delivery_to_dict(es):
             'name': interaction.company.name,
             'trading_names': interaction.company.trading_names,
         },
+        'companies': [
+            {
+                'id': str(company.pk),
+                'name': company.name,
+                'trading_names': company.trading_names,
+            } for company in sorted(interaction.companies.all(), key=attrgetter('id'))
+        ],
         'company_sector': {
             'id': str(interaction.company.sector.pk),
             'name': interaction.company.sector.name,

--- a/datahub/search/interaction/test/test_views.py
+++ b/datahub/search/interaction/test/test_views.py
@@ -295,6 +295,7 @@ class TestInteractionEntitySearchView(APITestMixin):
 
         for result in results:
             result['contacts'].sort(key=itemgetter('id'))
+            result['companies'].sort(key=itemgetter('id'))
             result['dit_participants'].sort(
                 key=lambda dit_participant: dit_participant['adviser']['id'],
             )
@@ -308,6 +309,11 @@ class TestInteractionEntitySearchView(APITestMixin):
                 'name': interaction.company.name,
                 'trading_names': interaction.company.trading_names,
             },
+            'companies': [{
+                'id': str(company.pk),
+                'name': company.name,
+                'trading_names': company.trading_names,
+            } for company in sorted(interaction.companies.all(), key=attrgetter('id'))],
             'company_sector': {
                 'id': str(interaction.company.sector.pk),
                 'name': interaction.company.sector.name,
@@ -1290,6 +1296,7 @@ class TestInteractionBasicSearch(APITestMixin):
 
         for result in results:
             result['contacts'].sort(key=itemgetter('id'))
+            result['companies'].sort(key=itemgetter('id'))
             result['dit_participants'].sort(
                 key=lambda dit_participant: dit_participant['adviser']['id'],
             )
@@ -1303,6 +1310,13 @@ class TestInteractionBasicSearch(APITestMixin):
                 'name': interaction.company.name,
                 'trading_names': interaction.company.trading_names,
             },
+            'companies': [
+                {
+                    'id': str(company.pk),
+                    'name': company.name,
+                    'trading_names': company.trading_names,
+                } for company in sorted(interaction.companies.all(), key=attrgetter('id'))
+            ],
             'company_one_list_group_tier': {
                 'id': interaction.company.get_one_list_group_tier().pk,
                 'name': interaction.company.get_one_list_group_tier().name,


### PR DESCRIPTION
### Description of change

This adds a new `companies` field to Interaction search model and search API responses.

This field is intended to replace the `company` field.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
