### PR TITLE
Publish companies in Interaction Activity Stream

### DIFF
--- a/changelog/interaction/activity-stream-interaction-companies.feature.md
+++ b/changelog/interaction/activity-stream-interaction-companies.feature.md
@@ -1,0 +1,1 @@
+The Activity Stream Interactions feed is now publishing `companies` field data instead of `company`.

--- a/datahub/activity_stream/interaction/serializers.py
+++ b/datahub/activity_stream/interaction/serializers.py
@@ -68,7 +68,7 @@ class InteractionActivitySerializer(ActivitySerializer):
                 'dit:archived': instance.archived,
                 'dit:subject': instance.subject,
                 'attributedTo': [
-                    self._get_company(instance.company),
+                    *self._get_companies(instance.companies),
                     *self._get_dit_participants(instance.dit_participants),
                     *self._get_contacts(instance.contacts),
                 ],

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -52,13 +52,16 @@ def test_interaction_activity(api_client):
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
                     'attributedTo': [
-                        {
-                            'id': f'dit:DataHubCompany:{interaction.company.pk}',
-                            'dit:dunsNumber': interaction.company.duns_number,
-                            'dit:companiesHouseNumber': interaction.company.company_number,
-                            'type': ['Organization', 'dit:Company'],
-                            'name': interaction.company.name,
-                        },
+                        *[
+                            {
+                                'id': f'dit:DataHubCompany:{company.pk}',
+                                'dit:dunsNumber': company.duns_number,
+                                'dit:companiesHouseNumber': company.company_number,
+                                'type': ['Organization', 'dit:Company'],
+                                'name': company.name,
+                            }
+                            for company in interaction.companies.order_by('pk')
+                        ],
                         *[
                             {
                                 'id': f'dit:DataHubAdviser:{participant.adviser.pk}',
@@ -128,13 +131,16 @@ def test_interaction_investment_project_activity(api_client):
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
                     'attributedTo': [
-                        {
-                            'id': f'dit:DataHubCompany:{interaction.company.pk}',
-                            'dit:dunsNumber': interaction.company.duns_number,
-                            'dit:companiesHouseNumber': interaction.company.company_number,
-                            'type': ['Organization', 'dit:Company'],
-                            'name': interaction.company.name,
-                        },
+                        *[
+                            {
+                                'id': f'dit:DataHubCompany:{company.pk}',
+                                'dit:dunsNumber': company.duns_number,
+                                'dit:companiesHouseNumber': company.company_number,
+                                'type': ['Organization', 'dit:Company'],
+                                'name': company.name,
+                            }
+                            for company in interaction.companies.order_by('pk')
+                        ],
                         *[
                             {
                                 'id': f'dit:DataHubAdviser:{participant.adviser.pk}',
@@ -210,13 +216,16 @@ def test_service_delivery_activity(api_client):
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
                     'attributedTo': [
-                        {
-                            'id': f'dit:DataHubCompany:{interaction.company.pk}',
-                            'dit:dunsNumber': interaction.company.duns_number,
-                            'dit:companiesHouseNumber': interaction.company.company_number,
-                            'type': ['Organization', 'dit:Company'],
-                            'name': interaction.company.name,
-                        },
+                        *[
+                            {
+                                'id': f'dit:DataHubCompany:{company.pk}',
+                                'dit:dunsNumber': company.duns_number,
+                                'dit:companiesHouseNumber': company.company_number,
+                                'type': ['Organization', 'dit:Company'],
+                                'name': company.name,
+                            }
+                            for company in interaction.companies.order_by('pk')
+                        ],
                         *[
                             {
                                 'id': f'dit:DataHubAdviser:{participant.adviser.pk}',
@@ -285,13 +294,16 @@ def test_service_delivery_event_activity(api_client):
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
                     'attributedTo': [
-                        {
-                            'id': f'dit:DataHubCompany:{interaction.company.pk}',
-                            'dit:dunsNumber': interaction.company.duns_number,
-                            'dit:companiesHouseNumber': interaction.company.company_number,
-                            'type': ['Organization', 'dit:Company'],
-                            'name': interaction.company.name,
-                        },
+                        *[
+                            {
+                                'id': f'dit:DataHubCompany:{company.pk}',
+                                'dit:dunsNumber': company.duns_number,
+                                'dit:companiesHouseNumber': company.company_number,
+                                'type': ['Organization', 'dit:Company'],
+                                'name': company.name,
+                            }
+                            for company in interaction.companies.order_by('pk')
+                        ],
                         *[
                             {
                                 'id': f'dit:DataHubAdviser:{participant.adviser.pk}',


### PR DESCRIPTION
### Description of change

The Activity Stream Interactions feed is now publishing `companies` field data instead of `company`.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
