### PR TITLE
Update Elasticsearch images to match dependency version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,5 +136,5 @@ workflows:
           python_image: python:3.8
           postgres_image: postgres:10
           mi_postgres_image: postgres:9.6
-          es_image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+          es_image: docker.elastic.co/elasticsearch/elasticsearch:7.13.1
           es_apm_image: docker.elastic.co/apm/apm-server:7.7.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - POSTGRES_PASSWORD=mi
 
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.1
     environment:
       - discovery.type=single-node
       - http.port=9200

--- a/docs/Dependabot.md
+++ b/docs/Dependabot.md
@@ -6,9 +6,9 @@ This is the process we have identified for dealing with Dependabot PRs that save
 2. Open each Dependabot PR and check that the tests have passed. Re-run any failing tests as the majority of failures are caused by timeouts or flakiness. Codecov failures can be ignored. If the PR contains any persistently failing tests, create a maintenance ticket for it and move on (these will be picked up as part of live support or maintenance sprint).
 3. Once all tests have passed, edit the PR so that the base branch is the `chore/dependencies` one. You should now be able to merge the PR without needing to request reviews.
 4. Repeat steps 2 and 3 until all Dependabot PRs are either merged or identified as needing further work.
-5. After all the PRs have been merged, checkout the branch locally and carry out some basic smoke tests.
-6. Checkout the local frontend and run the e2e tests to ensure they still pass.
-7. Rebase the dependency branch against `develop` to remove all the merge commits, then push the changes and open a PR (you don't need to make a news fragment).
-8. If you are satisfied that everything is in order and all the tests have passed, request reviews as normal.
-
-If the Elasticsearch version has been updated, the version used in [the frontend e2e tests](https://github.com/uktrade/data-hub-frontend/blob/master/docker-compose.e2e.yml#L82) needs to be updated to match.
+5. After all the PRs have been merged, checkout the branch locally.
+6. If Elasticsearch was updated, update the versions used in [`docker-compose`](https://github.com/uktrade/data-hub-api/blob/develop/docker-compose.yml#L48) and [the CircleCI config](https://github.com/uktrade/data-hub-api/blob/develop/.circleci/config.yml#L139).
+7. Start up the API and carry out some basic smoke tests.
+8. Checkout the local frontend and run the e2e tests to ensure they still pass (you may need to update Elasticsearch [here](https://github.com/uktrade/data-hub-frontend/blob/master/docker-compose.e2e.yml#L82) before starting the tests).
+9. Rebase the dependency branch against `develop` to remove all the merge commits, then push the changes and open a PR (you don't need to make a news fragment).
+10. If you are satisfied that everything is in order and all the tests have passed, request reviews as normal.


### PR DESCRIPTION
### Description of change

The Elasticsearch dependency has been updated several times without updating the versions listed in `docker-compose` and the CircleCI config. The Dependabot docs have also been updated to include these extra changes.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
