### PR TITLE
Firebreak #4 Add initial command for bringing up dnb-service/data-hub-api/data-hub-frontend on same network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,11 @@ fix-us-areas:
 
 fix-ca-areas:
 	docker-compose run api python manage.py fix_ca_company_address
+
+start-frontend-api-dnb:
+	$(MAKE) -C ../dnb-service start-dnb-for-data-hub-api
+	$(MAKE) -C ../data-hub-frontend start-dev
+
+stop-frontend-api-dnb:
+	$(MAKE) -C ../dnb-service stop-dnb-for-data-hub-api
+	$(MAKE) -C ../data-hub-frontend stop-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,6 @@ services:
   api:
     build:
       context: .
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
### Description of change

* Add `make` commands to start and stop a ecosystem consisting of `data-hub-api`/`data-hub-frontend` (using existing `make start-dev` command) and `dnb-service` (requires this PR https://github.com/uktrade/dnb-service/pull/103 to be merged)
* Also remove `extra_hosts` parameter from docker-compose.yml, as this places constraints on the version of docker which can be used

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
