### PR TITLE
Prevent blank investment projects attempting to sync to elastic search

### DIFF
--- a/changelog/investment/es-sync-signal-fix.bugfix.md
+++ b/changelog/investment/es-sync-signal-fix.bugfix.md
@@ -1,0 +1,1 @@
+Logic was added to make sure only interactions with an investment project related to them trigger the syncing of an investment project to elastic search.

--- a/datahub/search/investment/signals.py
+++ b/datahub/search/investment/signals.py
@@ -29,7 +29,7 @@ def investment_project_sync_es(instance):
 
 def investment_project_sync_es_interaction_change(instance):
     """
-    Sync investment projects in elastic search when related investments change.
+    Sync investment projects in elastic search when related interactions change.
 
     When an interaction changes, the elastic search index is also updated for
     the related investment project. The previous version also needs to be
@@ -51,7 +51,7 @@ def investment_project_sync_es_interaction_change(instance):
     ):
         pks.append(previous_version.field_dict['investment_project_id'])
 
-    for pk in set(pks):
+    for pk in set([pk for pk in pks if pk is not None]):
         sync_object_async(InvestmentSearchApp, pk)
 
 


### PR DESCRIPTION
### Description of change

This PR fixes a bug which was found in Sentry - [list of instances of this happening](https://sentry.ci.uktrade.digital/organizations/dit/issues/36982/events/c640b3e88f174b0896c817bd01456f2c/events/?environment=production&project=69&statsPeriod=90d). 

Currently, when an interaction is saved, the post-save signal `investment_project_sync_es_interaction_change` gets the primary key of the related investment project and the primary key of any of its previous versions, and then schedules the task `sync_object_async` for each of those primary keys.

However, the signal doesn't prevent this happening when there is no investment project linked to the interaction which has just been saved. This has lead to many tasks failing with the error `InvestmentProject.DoesNotExist: InvestmentProject matching query does not exist.`. 

This PR adds an if statement which first checks whether the interaction has an investment_project linked and returns if it doesn't, or syncs that investment project to elastic search if it does.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
