### PR TITLE
Filter administrative areas by country

### DIFF
--- a/changelog/filter-administrative-area.feature.md
+++ b/changelog/filter-administrative-area.feature.md
@@ -1,0 +1,2 @@
+It is now possible to filter administrative areas by country from the administrative area metadata endpoint by passing the country id as a param `GET /v4/metadata/administrative-area?country=<uuid>`
+

--- a/datahub/metadata/metadata.py
+++ b/datahub/metadata/metadata.py
@@ -16,6 +16,7 @@ registry.register(
 )
 
 registry.register(
+    filterset_fields=['country'],
     metadata_id='administrative-area',
     model=models.AdministrativeArea,
     queryset=models.AdministrativeArea.objects.select_related(

--- a/datahub/metadata/test/test_views.py
+++ b/datahub/metadata/test/test_views.py
@@ -160,6 +160,32 @@ def test_administrative_area_view(metadata_client):
     }
 
 
+def test_administrative_area_by_country_view(metadata_client):
+    """Test that the administrative area view is filtered by country."""
+    usa = Country.objects.get(id='81756b9a-5d95-e211-a939-e4115bead28a')
+    administrative_area = AdministrativeArea.objects.filter(
+        country=usa,
+    ).order_by('name').first()
+
+    url = reverse(viewname='api-v4:metadata:administrative-area')
+    response = metadata_client.get(url, params={'country': usa.id})
+
+    assert response.status_code == status.HTTP_200_OK
+    results = response.json()
+    # 50 States plus District of Columbia (DC)
+    assert len(results) == 51
+    assert results[0] == {
+        'id': str(administrative_area.pk),
+        'name': administrative_area.name,
+        'country': {
+            'id': str(administrative_area.country.pk),
+            'name': administrative_area.country.name,
+        },
+        'disabled_on': format_date_or_datetime(administrative_area.disabled_on),
+        'area_code': administrative_area.area_code,
+    }
+
+
 def test_country_view(metadata_client):
     """Test that the country view includes the country field."""
     country = Country.objects.filter(


### PR DESCRIPTION
### Description of change

The administrative area metadata api endpoint can now be filtered by country by specifying the uuid. Since this leverages the database and reduces the payload, this should be a lot more efficient than filtering the areas on the front end.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
