### PR TITLE
Fix complete company referral when using interaction companies field

### DIFF
--- a/changelog/interaction/company-complete-referral.bugfix.md
+++ b/changelog/interaction/company-complete-referral.bugfix.md
@@ -1,0 +1,1 @@
+A bug has been fixed where it was not possible to close a company referral when using the new interaction companies field.

--- a/datahub/company_referral/test/test_complete_view.py
+++ b/datahub/company_referral/test/test_complete_view.py
@@ -363,7 +363,7 @@ class TestCompleteCompanyReferral(APITestMixin):
                     'kind': Interaction.Kind.INTERACTION,
                     'communication_channel': lambda: random_obj_for_model(CommunicationChannel),
                     # Any company in the request body should be ignored
-                    'company': CompanyFactory,
+                    'companies': [CompanyFactory],
                 },
                 id='company-is-ignored',
             ),
@@ -372,6 +372,7 @@ class TestCompleteCompanyReferral(APITestMixin):
                     'kind': Interaction.Kind.SERVICE_DELIVERY,
                     'is_event': True,
                     'event': EventFactory,
+                    'company': CompanyFactory,
                 },
                 id='service-delivery',
             ),
@@ -411,7 +412,6 @@ class TestCompleteCompanyReferral(APITestMixin):
         interaction_data = Interaction.objects.values().get(pk=referral.interaction_id)
         expected_interaction_data = {
             # Automatically set fields
-            'company_id': referral.company_id,
             'created_by_id': self.user.pk,
             'created_on': FROZEN_DATETIME,
             'id': referral.interaction_id,
@@ -446,10 +446,14 @@ class TestCompleteCompanyReferral(APITestMixin):
             'archived_reason': None,
             'large_capital_opportunity_id': None,
             'has_related_trade_agreements': None,
+
+            # TODO: a legacy field, remove once interaction.company field is removed
+            'company_id': referral.company_id,
         }
         assert interaction_data == expected_interaction_data
 
         assert list(referral.interaction.contacts.all()) == [contact]
+        assert list(referral.interaction.companies.all()) == [referral.company]
 
         participant = referral.interaction.dit_participants.get()
         assert participant.adviser == self.user

--- a/datahub/company_referral/views.py
+++ b/datahub/company_referral/views.py
@@ -62,11 +62,14 @@ class CompanyReferralViewSet(CoreViewSet):
             'referral': referral,
             'user': request.user,
         }
+        # TODO: remove once interaction.company field is removed
+        for unwanted_key in ('company', 'companies'):
+            if unwanted_key in request.data:
+                del request.data[unwanted_key]
+
         data = {
             **request.data,
-            'company': {
-                'id': referral.company.pk,
-            },
+            'companies': [{'id': referral.company.pk}],
         }
         serializer = CompleteCompanyReferralSerializer(
             data=data,


### PR DESCRIPTION
### Description of change

This fixes a bug where using a new interaction `companies` field when requesting to close a company referral would result in the Interaction serialiser filled with both `company` and `companies` field causing an error.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
