### PR TITLE
Feature/add autocomplete to companies endpoint

### DIFF
--- a/changelog/company/feature/add-autocomplete-to-companies-endpoint.feature.md
+++ b/changelog/company/feature/add-autocomplete-to-companies-endpoint.feature.md
@@ -1,0 +1,1 @@
+It is now possible to provide autocomplete queries to the companies endpoint, by passing the autocomplete param `GET /v4/company?autocomplete=<query>`

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -58,6 +58,20 @@ class TestListCompanies(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['count'] == 2
 
+    def test_autocomplete_companies(self):
+        """Test that the companies viewset can autocomplete."""
+        CompanyFactory(name='Apple')
+        CompanyFactory(name='Auburn')
+        CompanyFactory(name='Boom')
+        CompanyFactory(name='Crush')
+        url = reverse(viewname='api-v4:company:collection')
+        response = self.api_client.get(url, data={'autocomplete': 'A'})
+        assert response.status_code == status.HTTP_200_OK
+        companies = response.json()['results']
+        assert len(companies) == 2
+        assert companies[0]['name'] == 'Apple'
+        assert companies[1]['name'] == 'Auburn'
+
     def test_filter_by_global_headquarters(self):
         """Test filtering by global_headquarters_id."""
         ghq = CompanyFactory()

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -67,6 +67,14 @@ from datahub.core.schemas import StubSchema
 from datahub.core.viewsets import CoreViewSet
 from datahub.investment.project.queryset import get_slim_investment_project_queryset
 
+class CompanyFilterSet(FilterSet):
+    """Company filter."""
+
+    autocomplete = AutocompleteFilter(search_fields=('name',))
+
+    class Meta:
+        model = Company
+        fields = ['global_headquarters_id', 'global_ultimate_duns_number']
 
 class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
     """Company view set."""
@@ -74,7 +82,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
     serializer_class = CompanySerializer
     unarchive_validators = (NotATransferredCompanyValidator(),)
     filter_backends = (DjangoFilterBackend, OrderingFilter)
-    filterset_fields = ('global_headquarters_id', 'global_ultimate_duns_number')
+    filterset_class = CompanyFilterSet
     ordering_fields = ('name', 'created_on')
     queryset = Company.objects.select_related(
         'address_country',

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -67,6 +67,7 @@ from datahub.core.schemas import StubSchema
 from datahub.core.viewsets import CoreViewSet
 from datahub.investment.project.queryset import get_slim_investment_project_queryset
 
+
 class CompanyFilterSet(FilterSet):
     """Company filter."""
 
@@ -75,6 +76,7 @@ class CompanyFilterSet(FilterSet):
     class Meta:
         model = Company
         fields = ['global_headquarters_id', 'global_ultimate_duns_number']
+
 
 class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
     """Company view set."""


### PR DESCRIPTION
### Description of change

This PR brings in autocomplete functionality to the companies endpoint. it's required for the UK Opportunities details form in the front end. 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
