### PR TITLE
CDS-248 Added new EU-UK trade agreement to metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 ADD . /app/
 
-CMD ./start.sh
+CMD ./start-dev.sh

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ shellplus:
 	docker-compose run api python manage.py shell_plus --ipython
 
 load-metadata:
-	docker-compose run api python manage.py loadinitialmetadata
+	docker-compose run api python manage.py loadinitialmetadata --force
 
 setup-flake8-hook:
 	python3 -m venv env

--- a/changelog/add-new-trade-agreement-to-metadata.feature.md
+++ b/changelog/add-new-trade-agreement-to-metadata.feature.md
@@ -1,0 +1,1 @@
+It is now possible to view a new trade agreement `EU-UK Trade Co-operation Agreement` in trade agreements metadata.

--- a/conftest.py
+++ b/conftest.py
@@ -45,9 +45,8 @@ def pytest_sessionstart(session):
 @pytest.fixture(scope='session')
 def django_db_setup(pytestconfig, django_db_setup, django_db_blocker):
     """Fixture for DB setup."""
-    reuse_db = pytestconfig.getoption('reuse_db')
     with django_db_blocker.unblock():
-        call_command('loadinitialmetadata', force=reuse_db)
+        call_command('loadinitialmetadata', force=True)
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/datahub/metadata/migrations/0016_update_trade_agreements.py
+++ b/datahub/metadata/migrations/0016_update_trade_agreements.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_trade_agreements(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0016_update_trade_agreements.yaml'
+    )
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0015_remove_puerto_rico'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_trade_agreements, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0016_update_trade_agreements.yaml
+++ b/datahub/metadata/migrations/0016_update_trade_agreements.yaml
@@ -1,0 +1,3 @@
+- model: metadata.tradeagreement
+  pk: 72b0f84a-77cd-4216-841f-0a75b56f8174
+  fields: {disabled_on: null, name: 'EU-UK Trade Co-operation Agreement'}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - redis
       - celery
       - es-apm
-    command: /app/start.sh
+    command: /app/start-dev.sh
 
   celery:
     build:

--- a/fixtures/metadata/trade_agreements.yaml
+++ b/fixtures/metadata/trade_agreements.yaml
@@ -22,3 +22,6 @@
 - model: metadata.tradeagreement
   pk: 20e08a38-95a8-4250-bd5b-9d7f0dfc9387
   fields: {disabled_on: null, name: 'UK-United States Mutual Recognition Agreement'}
+- model: metadata.tradeagreement
+  pk: 72b0f84a-77cd-4216-841f-0a75b56f8174
+  fields: {disabled_on: null, name: 'EU-UK Trade Co-operation Agreement'}

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -4,7 +4,7 @@ python /app/manage.py migrate --database mi --noinput
 python /app/manage.py migrate_es
 # Load initial metadata - ignore errors as we may have already loaded it in to
 # this DB
-python /app/manage.py loadinitialmetadata || true
+python /app/manage.py loadinitialmetadata --force
 # Load initial revisions - ignore errors as we may have already loaded it in to
 # this DB
 python /app/manage.py loaddata /app/fixtures/test_data.yaml || true


### PR DESCRIPTION
### Description of change
A new EU-UK trade agreement has been added to trade agreements metadata via a migration. 

We had an issue with getting the migration to work on local development environments and Circle CI due to the migrations running before the `loadinitialmetadata` command. This led to the following error: `failed on setup with "datahub.core.management.commands.loadinitialmetadata.ExistingDataFoundError: Cannot run loadinitialmetadata when metadata already exists. Existing data found for the metadata.tradeagreement model."`

To get round this issue, we have added a `--force` flag wherever `loadinitialmetadata` is called.

The places where `loadinitialmetadata` are called are only used in the development environment so there shouldn't be any implications on production. 

`start.sh` has also been renamed to `start-dev.sh` to ensure it will not be run on production by accident.

Any thoughts on whether we should just default `loadinitialmetadata` to force are welcome. 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
