### PR TITLE
Dependabot weekly updates

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -82,7 +82,7 @@ pep8-naming==0.12.1
 pydocstyle==6.1.1
 
 gunicorn==20.1.0
-gevent==21.1.2
+gevent==21.8.0
 mohawk==1.1.0
 requests==2.26.0
 requests_toolbelt==0.9.1

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ python-dateutil==2.8.2
 psycopg2==2.9.1
 psycogreen==1.0.2
 
-boto3==1.18.11
+boto3==1.18.16
 
 notifications-python-client==6.2.1
 

--- a/requirements.in
+++ b/requirements.in
@@ -65,7 +65,7 @@ piprot==0.9.11
 semantic_version==2.8.5
 towncrier==21.3.0
 watchdog[watchmedo]==2.1.3
-pre-commit==2.13.0
+pre-commit==2.14.0
 
 
 # Code static analysis

--- a/requirements.in
+++ b/requirements.in
@@ -38,7 +38,7 @@ django-redis==5.0.0
 redis==3.5.3
 
 # ES
-elasticsearch==7.13.4
+elasticsearch==7.14.0
 elasticsearch-dsl==7.4.0
 
 # ES APM

--- a/requirements.in
+++ b/requirements.in
@@ -78,7 +78,7 @@ flake8-docstrings==1.6.0
 flake8-print==4.0.0
 flake8-quotes==3.2.0
 flake8-string-format==0.3.0
-pep8-naming==0.12.0
+pep8-naming==0.12.1
 pydocstyle==6.1.1
 
 gunicorn==20.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -213,7 +213,7 @@ parso==0.8.2
     # via jedi
 pep517==0.10.0
     # via pip-tools
-pep8-naming==0.12.0
+pep8-naming==0.12.1
     # via -r requirements.in
 pexpect==4.8.0
     # via ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,7 @@ docopt==0.6.2
     # via notifications-python-client
 elastic-apm==6.3.3
     # via -r requirements.in
-elasticsearch==7.13.4
+elasticsearch==7.14.0
     # via
     #   -r requirements.in
     #   elasticsearch-dsl

--- a/requirements.txt
+++ b/requirements.txt
@@ -225,7 +225,7 @@ piprot==0.9.11
     # via -r requirements.in
 pluggy==0.13.1
     # via pytest
-pre-commit==2.13.0
+pre-commit==2.14.0
     # via -r requirements.in
 prompt-toolkit==3.0.18
     # via ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,9 @@ billiard==3.6.4.0
     # via
     #   -r requirements.in
     #   celery
-boto3==1.18.11
+boto3==1.18.16
     # via -r requirements.in
-botocore==1.21.11
+botocore==1.21.16
     # via
     #   boto3
     #   s3transfer

--- a/requirements.txt
+++ b/requirements.txt
@@ -155,9 +155,9 @@ flake8-string-format==0.3.0
     # via -r requirements.in
 freezegun==1.1.0
     # via -r requirements.in
-gevent==21.1.2
+gevent==21.8.0
     # via -r requirements.in
-greenlet==1.0.0
+greenlet==1.1.1
     # via gevent
 gunicorn==20.1.0
     # via -r requirements.in


### PR DESCRIPTION
### Description of change

This PR contains this week's dependabot updates which includes the following:

- Bump boto3 from 1.18.11 to 1.18.16 
- Bump pep8-naming from 0.12.0 to 0.12.1
- Bump gevent from 21.1.2 to 21.8.0
- Bump elasticsearch from 7.13.4 to 7.14.0
- Bump pre-commit from 2.13.0 to 2.14.0

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
