### PR TITLE
CDS-277 Add validation to make postcode mandatory for us/canadian companies

### DIFF
--- a/changelog/address-validation.feature.md
+++ b/changelog/address-validation.feature.md
@@ -1,0 +1,1 @@
+ New address validation has been added to make postcode a required field for US and Canadian company addresses.

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -382,11 +382,13 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         required=False,
         allow_null=True,
         area_can_be_required=True,
+        postcode_can_be_required=True,
     )
     address = AddressSerializer(
         source_model=Company,
         address_source_prefix='address',
         area_can_be_required=True,
+        postcode_can_be_required=True,
     )
     export_countries = CompanyExportCountrySerializer(many=True, read_only=True)
 

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -1420,7 +1420,7 @@ class TestAddCompany(APITestMixin):
     """Tests for adding a company."""
 
     @pytest.mark.parametrize(
-        'data, expected_response, feature_flags',
+        'data,expected_response,feature_flags',
         (
             # uk company
             (

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -1856,7 +1856,7 @@ class TestAddCompany(APITestMixin):
                         'country': {
                             'id': Country.united_states.value.id,
                         },
-                        'address_area': 'Burbank',
+                        'address_area': AdministrativeArea.alabama.value.id,
                     },
                 },
                 {
@@ -1878,7 +1878,7 @@ class TestAddCompany(APITestMixin):
                         'country': {
                             'id': Country.canada.value.id,
                         },
-                        'address_area': 'Quebec',
+                        'address_area': AdministrativeArea.quebec.value.id,
                     },
                 },
                 {

--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -56,6 +56,14 @@ class AdministrativeArea(Enum):
         Country.united_states.value.id,
     )
 
+    # Canada
+    alberta = AdministrativeAreaConstant(
+        'Alberta',
+        '75e337c3-23c9-4294-8085-6b1e8c43eb07',
+        'AB',
+        Country.canada.value.id,
+    )
+
 
 class SectorCluster(Enum):
     """Sector clusters."""

--- a/datahub/core/serializers.py
+++ b/datahub/core/serializers.py
@@ -381,7 +381,7 @@ class AddressSerializer(serializers.ModelSerializer):
         self.postcode_can_be_required = postcode_can_be_required
         self.address_source_prefix = address_source_prefix
 
-    def area_validator(self, validators):
+    def add_area_validator(self, validators):
         """
         Mark area as required for US and Canadian companies.
         """
@@ -401,7 +401,7 @@ class AddressSerializer(serializers.ModelSerializer):
             ),
         )
 
-    def postcode_validator(self, validators):
+    def add_postcode_validator(self, validators):
         """
         Mark postcode as required for US and Canadian companies.
         """
@@ -434,13 +434,13 @@ class AddressSerializer(serializers.ModelSerializer):
             self.area_can_be_required
             and is_feature_flag_active('address-area-company-required-field')
         ):
-            self.area_validator(validators)
+            self.add_area_validator(validators)
 
         if (
             self.postcode_can_be_required
             and is_feature_flag_active('address-postcode-company-required-field')
         ):
-            self.postcode_validator(validators)
+            self.add_postcode_validator(validators)
         return validators
 
     def run_validation(self, data=serializers.empty):

--- a/datahub/core/serializers.py
+++ b/datahub/core/serializers.py
@@ -355,7 +355,8 @@ class AddressSerializer(serializers.ModelSerializer):
 
     def __init__(
             self, source_model, *args,
-            address_source_prefix='address', area_can_be_required=False, **kwargs,
+            address_source_prefix='address', area_can_be_required=False,
+            postcode_can_be_required=False, **kwargs,
     ):
         """
         Initialises the serializer.
@@ -377,36 +378,69 @@ class AddressSerializer(serializers.ModelSerializer):
             field.source_attrs = field.source.split('.')
 
         self.area_can_be_required = area_can_be_required
+        self.postcode_can_be_required = postcode_can_be_required
         self.address_source_prefix = address_source_prefix
+
+    def area_validator(self, validators):
+        """
+        Mark area as required for US and Canadian companies.
+        """
+        validators.append(
+            RulesBasedValidator(
+                ValidationRule(
+                    'required',
+                    OperatorRule(f'{self.address_source_prefix}_area', bool),
+                    when=InRule(
+                        f'{self.address_source_prefix}_country',
+                        (
+                            CountryEnum.united_states.value.id,
+                            CountryEnum.canada.value.id,
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    def postcode_validator(self, validators):
+        """
+        Mark postcode as required for US and Canadian companies.
+        """
+        validators.append(
+            RulesBasedValidator(
+                ValidationRule(
+                    'required',
+                    OperatorRule(f'{self.address_source_prefix}_postcode', bool),
+                    when=InRule(
+                        f'{self.address_source_prefix}_country',
+                        (
+                            CountryEnum.united_states.value.id,
+                            CountryEnum.canada.value.id,
+                        ),
+                    ),
+                ),
+            ),
+        )
 
     def get_validators(self):
         """
-        Append ValidationRule for area depending on feature flag/context
+        Append ValidationRule for area/postcode depending on feature flag/context
 
-        Only mark area required if country is US/Canada & called from context where area is safe
-        to require, and if feature flag enabled. Currently the only context where area is safe to
-        require is CompanySerializer
+        Only mark area/postcode required if country is US/Canada & called from context where area
+        is safe to require, and if feature flag enabled. Currently the only context where area is
+        safe to require is CompanySerializer
         """
         validators = super().get_validators()
         if (
             self.area_can_be_required
             and is_feature_flag_active('address-area-company-required-field')
         ):
-            validators.append(
-                RulesBasedValidator(
-                    ValidationRule(
-                        'required',
-                        OperatorRule(f'{self.address_source_prefix}_area', bool),
-                        when=InRule(
-                            f'{self.address_source_prefix}_country',
-                            (
-                                CountryEnum.united_states.value.id,
-                                CountryEnum.canada.value.id,
-                            ),
-                        ),
-                    ),
-                ),
-            )
+            self.area_validator(validators)
+
+        if (
+            self.postcode_can_be_required
+            and is_feature_flag_active('address-postcode-company-required-field')
+        ):
+            self.postcode_validator(validators)
         return validators
 
     def run_validation(self, data=serializers.empty):


### PR DESCRIPTION
### Description of change

This PR adds new validation on company address fields which make postcode mandatory for both US and Canadian addresses.

This is currently placed behind feature-flag: `address-postcode-company-required-field`

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
