### PR TITLE
Revert back to elastic search version 7.13.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,4 +23,7 @@ updates:
   - dependency-name: django
     versions:
     - "> 3.1.12"
+  - dependency-name: elasticsearch
+    versions:
+    - ">= 7.14.0"
   rebase-strategy: disabled

--- a/requirements.in
+++ b/requirements.in
@@ -38,7 +38,7 @@ django-redis==5.0.0
 redis==3.5.3
 
 # ES
-elasticsearch==7.14.0
+elasticsearch==7.13.4
 elasticsearch-dsl==7.4.0
 
 # ES APM

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ apipkg==1.5
     # via execnet
 appdirs==1.4.4
     # via virtualenv
+appnope==0.1.2
+    # via ipython
 argh==0.26.2
     # via watchdog
 asgiref==3.3.4
@@ -55,13 +57,13 @@ chardet==4.0.0
     #   aiohttp
 charset-normalizer==2.0.3
     # via requests
+click-default-group==1.2.2
+    # via towncrier
 click==7.1.2
     # via
     #   click-default-group
     #   pip-tools
     #   towncrier
-click-default-group==1.2.2
-    # via towncrier
 coverage==5.5
     # via pytest-cov
 cryptography==3.4.7
@@ -70,17 +72,6 @@ decorator==5.0.7
     # via ipython
 distlib==0.3.1
     # via virtualenv
-django==3.1.12
-    # via
-    #   -r requirements.in
-    #   django-axes
-    #   django-debug-toolbar
-    #   django-extensions
-    #   django-filter
-    #   django-mptt
-    #   django-redis
-    #   django-reversion
-    #   djangorestframework
 django-axes==5.20.0
     # via -r requirements.in
 django-debug-toolbar==3.2.2
@@ -103,18 +94,29 @@ django-redis==5.0.0
     # via -r requirements.in
 django-reversion==4.0.0
     # via -r requirements.in
+django==3.1.12
+    # via
+    #   -r requirements.in
+    #   django-axes
+    #   django-debug-toolbar
+    #   django-extensions
+    #   django-filter
+    #   django-mptt
+    #   django-redis
+    #   django-reversion
+    #   djangorestframework
 djangorestframework==3.12.4
     # via -r requirements.in
 docopt==0.6.2
     # via notifications-python-client
 elastic-apm==6.3.3
     # via -r requirements.in
-elasticsearch==7.14.0
+elasticsearch-dsl==7.4.0
+    # via -r requirements.in
+elasticsearch==7.13.4
     # via
     #   -r requirements.in
     #   elasticsearch-dsl
-elasticsearch-dsl==7.4.0
-    # via -r requirements.in
 execnet==1.8.0
     # via pytest-xdist
 factory-boy==3.2.0
@@ -123,18 +125,6 @@ faker==8.1.2
     # via factory-boy
 filelock==3.0.12
     # via virtualenv
-flake8==3.9.2
-    # via
-    #   -r requirements.in
-    #   flake8-bugbear
-    #   flake8-commas
-    #   flake8-debugger
-    #   flake8-docstrings
-    #   flake8-polyfill
-    #   flake8-print
-    #   flake8-quotes
-    #   flake8-string-format
-    #   pep8-naming
 flake8-bugbear==21.4.3
     # via -r requirements.in
 flake8-commas==2.0.0
@@ -153,6 +143,18 @@ flake8-quotes==3.2.0
     # via -r requirements.in
 flake8-string-format==0.3.0
     # via -r requirements.in
+flake8==3.9.2
+    # via
+    #   -r requirements.in
+    #   flake8-bugbear
+    #   flake8-commas
+    #   flake8-debugger
+    #   flake8-docstrings
+    #   flake8-polyfill
+    #   flake8-print
+    #   flake8-quotes
+    #   flake8-string-format
+    #   pep8-naming
 freezegun==1.1.0
     # via -r requirements.in
 gevent==21.8.0
@@ -173,10 +175,10 @@ incremental==21.3.0
     # via towncrier
 iniconfig==1.1.1
     # via pytest
-ipython==7.26.0
-    # via -r requirements.in
 ipython-genutils==0.2.0
     # via traitlets
+ipython==7.26.0
+    # via -r requirements.in
 jedi==0.18.0
     # via ipython
 jinja2==2.11.3
@@ -259,13 +261,6 @@ pyjwt==2.1.0
     # via notifications-python-client
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.4
-    # via
-    #   -r requirements.in
-    #   pytest-cov
-    #   pytest-django
-    #   pytest-forked
-    #   pytest-xdist
 pytest-cov==2.12.1
     # via -r requirements.in
 pytest-django==4.4.0
@@ -274,6 +269,13 @@ pytest-forked==1.3.0
     # via pytest-xdist
 pytest-xdist==2.3.0
     # via -r requirements.in
+pytest==6.2.4
+    # via
+    #   -r requirements.in
+    #   pytest-cov
+    #   pytest-django
+    #   pytest-forked
+    #   pytest-xdist
 python-dateutil==2.8.2
     # via
     #   -r requirements.in
@@ -297,6 +299,10 @@ redis==3.5.3
     #   -r requirements.in
     #   celery
     #   django-redis
+requests-futures==1.0.0
+    # via piprot
+requests-mock==1.9.3
+    # via -r requirements.in
 requests==2.26.0
     # via
     #   -r requirements.in
@@ -306,10 +312,6 @@ requests==2.26.0
     #   requests-mock
     #   requests-toolbelt
     #   simple-salesforce
-requests-futures==1.0.0
-    # via piprot
-requests-mock==1.9.3
-    # via -r requirements.in
 requests_toolbelt==0.9.1
     # via -r requirements.in
 s3transfer==0.5.0


### PR DESCRIPTION
### Description of change

This PR reverts our elasticsearch version back to 7.13.4 from 7.14.0.

Elasticsearch 7.14.0 and above will only be compatible with paid for elasticsearch clusters, rather than open-sourced versions which we currently use. Therefore upgrading to 7.14.0 is not compatible with our infrastructure.

The [Opensearch](https://github.com/opensearch-project) organisation will be forking elastic's repositories so that they continue to be compatible with open source clusters, however until that has happened for elasticsearch-py, we will not be able to upgrade further. [Article with more details](https://aws.amazon.com/blogs/opensource/keeping-clients-of-opensearch-and-elasticsearch-compatible-with-open-source/) and [issue on elasticsearch-py](https://github.com/elastic/elasticsearch-py/issues/1639).


**NOTE: the changes in ordering of `requirements.txt` have come from running `pip-compile --output-file=requirements.txt` and I believe are correcting ordering done by dependabot.
### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
