### PR TITLE
Allow investment projects to be queried by financial year

### DIFF
--- a/changelog/investment/financial_year_admin.feature.md
+++ b/changelog/investment/financial_year_admin.feature.md
@@ -1,0 +1,1 @@
+The financial year for an investment project can now be seen as a read only field on the admin page.

--- a/changelog/investment/financial_year_search_filter.feature.md
+++ b/changelog/investment/financial_year_search_filter.feature.md
@@ -1,0 +1,8 @@
+Financial year filters can now be applied to the search investments endpoint.
+
+`POST /v3/search/investment_project { "financial_year_start": [<years>] }`
+
+For example, to get investment projects from financial years 2017-18 and 2020-21, you can call:
+`POST /v3/search/investment_project { "financial_year_start": ["2017", "2020"] }`
+
+Projects in the "Prospect" stage appear for all financial years from when they are created. Other projects use their actual land date, falling back to estimated land date if that has not been set.

--- a/datahub/investment/project/admin.py
+++ b/datahub/investment/project/admin.py
@@ -60,6 +60,7 @@ class InvestmentProjectAdmin(BaseModelAdminMixin, VersionAdmin):
         'comments',
         'created',
         'modified',
+        'financial_year_verbose',
     )
     list_display = (
         'name',
@@ -72,6 +73,11 @@ class InvestmentProjectAdmin(BaseModelAdminMixin, VersionAdmin):
         'modified_on',
         'modified_by',
     )
+
+    def financial_year_verbose(self, obj):
+        """Financial year in YYYY-YY format, for example 2021-22."""
+        return obj.financial_year_verbose
+    financial_year_verbose.short_description = 'Financial year'
 
     def save_model(self, request, obj, form, change):
         """

--- a/datahub/investment/project/test/test_models.py
+++ b/datahub/investment/project/test/test_models.py
@@ -1,6 +1,6 @@
 """Tests for investment models."""
 
-from datetime import datetime
+from datetime import date, datetime
 from uuid import UUID
 
 import pytest
@@ -15,6 +15,7 @@ from datahub.investment.project.test.factories import (
     InvestmentProjectFactory,
     InvestmentProjectTeamMemberFactory,
 )
+
 
 pytestmark = pytest.mark.django_db
 
@@ -192,3 +193,69 @@ def test_stage_log_added_when_investment_project_is_created():
             datetime(2017, 4, 28, 17, 35, tzinfo=utc),
         ),
     ]
+
+
+@freeze_time(datetime(2017, 4, 28, 17, 35, tzinfo=utc))
+def test_prospect_financial_year():
+    """Prospects should use created date to determine financial year."""
+    project = InvestmentProjectFactory(
+        stage_id=constants.InvestmentProjectStage.prospect.value.id,
+        estimated_land_date=date(2018, 4, 28),
+        actual_land_date=date(2020, 3, 28),
+    )
+    assert project.financial_year == 2017
+
+
+@freeze_time(datetime(2017, 4, 28, 17, 35, tzinfo=utc))
+def test_non_prospect_financial_year_estimated_land_date():
+    """Use estimated land date when actual land date is not set."""
+    project = InvestmentProjectFactory(
+        stage_id=constants.InvestmentProjectStage.active.value.id,
+        estimated_land_date=date(2018, 4, 28),
+        actual_land_date=None,
+    )
+    assert project.financial_year == 2018
+
+
+@freeze_time(datetime(2017, 4, 28, 17, 35, tzinfo=utc))
+def test_non_prospect_financial_year_actual_land_date():
+    """Use actual land date when it is set."""
+    project = InvestmentProjectFactory(
+        stage_id=constants.InvestmentProjectStage.won.value.id,
+        estimated_land_date=date(2018, 4, 28),
+        actual_land_date=date(2020, 3, 28),
+    )
+    assert project.financial_year == 2019
+
+
+@freeze_time(datetime(2017, 4, 28, 17, 35, tzinfo=utc))
+def test_prospect_financial_year_verbose():
+    """Prospects should use created date to determine financial year."""
+    project = InvestmentProjectFactory(
+        stage_id=constants.InvestmentProjectStage.prospect.value.id,
+        estimated_land_date=date(2018, 4, 28),
+        actual_land_date=date(2020, 3, 28),
+    )
+    assert project.financial_year_verbose == '2017-18 (onwards)'
+
+
+@freeze_time(datetime(2017, 4, 28, 17, 35, tzinfo=utc))
+def test_non_prospect_financial_year_verbose_estimated_land_date():
+    """Use estimated land date when actual land date is not set."""
+    project = InvestmentProjectFactory(
+        stage_id=constants.InvestmentProjectStage.active.value.id,
+        estimated_land_date=date(2018, 4, 28),
+        actual_land_date=None,
+    )
+    assert project.financial_year_verbose == '2018-19'
+
+
+@freeze_time(datetime(2017, 4, 28, 17, 35, tzinfo=utc))
+def test_non_prospect_financial_year_verbose_actual_land_date():
+    """Use actual land date when it is set."""
+    project = InvestmentProjectFactory(
+        stage_id=constants.InvestmentProjectStage.won.value.id,
+        estimated_land_date=date(2018, 4, 28),
+        actual_land_date=date(2020, 3, 28),
+    )
+    assert project.financial_year_verbose == '2019-20'

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -35,6 +35,7 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
     stage = SingleOrListField(child=StringUUIDField(), required=False)
     status = SingleOrListField(child=serializers.CharField(), required=False)
     uk_region_location = SingleOrListField(child=StringUUIDField(), required=False)
+    financial_year_start = SingleOrListField(child=serializers.IntegerField(), required=False)
     level_of_involvement_simplified = SingleOrListField(
         child=serializers.ChoiceField(choices=InvestmentProject.Involvement.choices),
         required=False,

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -87,9 +87,9 @@ class SearchInvestmentProjectAPIViewMixin:
         ],
     }
 
-    def get_base_query(self, request, validated_data):
-        """Apply financial year filter to the base query."""
-        financial_year_filters = [
+    def get_extra_filters(self, validated_data):
+        """Apply financial year filter."""
+        return Bool(should=[
             Bool(should=[
                 # Non-prospects use actual land date, falling back to estimated land date
                 Bool(
@@ -117,10 +117,7 @@ class SearchInvestmentProjectAPIViewMixin:
                 ]),
             ])
             for financial_year_start in validated_data.get('financial_year_start', [])
-        ]
-        return super().get_base_query(request, validated_data).filter(
-            Bool(should=financial_year_filters),
-        )
+        ])
 
 
 @register_v3_view()

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -1,5 +1,14 @@
-from django.db.models import Case, Max, When
+import datetime
 
+from django.db.models import Case, Max, When
+from elasticsearch_dsl.query import (
+    Bool,
+    Exists,
+    Range,
+    Term,
+)
+
+from datahub.core.constants import InvestmentProjectStage
 from datahub.core.query_utils import (
     get_aggregate_subquery,
     get_choices_as_case_expression,
@@ -77,6 +86,41 @@ class SearchInvestmentProjectAPIViewMixin:
             'country_investment_originates_from.id',
         ],
     }
+
+    def get_base_query(self, request, validated_data):
+        """Apply financial year filter to the base query."""
+        financial_year_filters = [
+            Bool(should=[
+                # Non-prospects use actual land date, falling back to estimated land date
+                Bool(
+                    should=[
+                        Bool(
+                            must=Range(estimated_land_date={
+                                'gte': datetime.date(year=financial_year_start, month=4, day=1),
+                                'lt': datetime.date(year=financial_year_start + 1, month=4, day=1),
+                            }),
+                            must_not=Exists(field='actual_land_date'),
+                        ),
+                        Range(actual_land_date={
+                            'gte': datetime.date(year=financial_year_start, month=4, day=1),
+                            'lt': datetime.date(year=financial_year_start + 1, month=4, day=1),
+                        }),
+                    ],
+                    must_not=Term(**{'stage.id': InvestmentProjectStage.prospect.value.id}),
+                ),
+                # Prospects appear in all financial years from the created date
+                Bool(must=[
+                    Range(created_on={
+                        'lte': datetime.date(year=financial_year_start, month=4, day=1),
+                    }),
+                    Term(**{'stage.id': InvestmentProjectStage.prospect.value.id}),
+                ]),
+            ])
+            for financial_year_start in validated_data.get('financial_year_start', [])
+        ]
+        return super().get_base_query(request, validated_data).filter(
+            Bool(should=financial_year_filters),
+        )
 
 
 @register_v3_view()

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -215,7 +215,7 @@ class SearchAPIView(APIView):
             *(self.fields_to_exclude or ()),
         )
 
-        return get_search_by_entities_query(
+        query = get_search_by_entities_query(
             entities=entities,
             term=validated_data['original_query'],
             filter_data=filter_data,
@@ -225,6 +225,15 @@ class SearchAPIView(APIView):
             fields_to_include=self.fields_to_include,
             fields_to_exclude=fields_to_exclude,
         )
+
+        extra_filters = self.get_extra_filters(validated_data)
+        if extra_filters:
+            return query.filter(extra_filters)
+        return query
+
+    def get_extra_filters(self, validated_data):
+        """Get any extra filters to apply to the base query."""
+        return None
 
     def post(self, request, format=None):
         """Performs search."""


### PR DESCRIPTION
### Description of change

1. Financial year filters can now be applied to the search investments endpoint.

`POST /v3/search/investment_project { "financial_year_start": [<years>] }`

For example, to get investment projects from financial years 2017-18 and 2020-21, you can call:
`POST /v3/search/investment_project { "financial_year_start": ["2017", "2020"] }`

Projects in the "Prospect" stage appear for all financial years from when they are created. Other projects use their actual land date, falling back to estimated land date if that has not been set.

2. The financial year for an investment project can now be seen as a read only field on the admin page.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
