### PR TITLE
Add autocomplete to opportunities endpoint

### DIFF
--- a/changelog/investment/add-autocomplete-to-opportunities-endpoint.feature.md
+++ b/changelog/investment/add-autocomplete-to-opportunities-endpoint.feature.md
@@ -1,0 +1,1 @@
+It is now possible to provide autocomplete queries to the opportunities endpoint, by passing the autocomplete param `GET /v4/large-capital-opportunity?autocomplete=<query>`

--- a/datahub/investment/opportunity/test/test_views.py
+++ b/datahub/investment/opportunity/test/test_views.py
@@ -140,6 +140,20 @@ class TestLargeCapitalOpportunityListView(APITestMixin):
         )
         assert response_data['results'][0]['id'] == str(large_capital_opportunity.pk)
 
+    def test_autocomplete_large_capital_opportunities(self):
+        """Test that the opportunities viewset can autocomplete."""
+        LargeCapitalOpportunityFactory(name='Apple')
+        LargeCapitalOpportunityFactory(name='Auburn')
+        LargeCapitalOpportunityFactory(name='Boom')
+        LargeCapitalOpportunityFactory(name='Crush')
+        url = reverse(viewname='api-v4:large-capital-opportunity:collection')
+        response = self.api_client.get(url, data={'autocomplete': 'A'})
+        assert response.status_code == status.HTTP_200_OK
+        opportunities = response.json()['results']
+        assert len(opportunities) == 2
+        assert opportunities[0]['name'] == 'Apple'
+        assert opportunities[1]['name'] == 'Auburn'
+
 
 class TestUpdateLargeCapitalOpportunityView(APITestMixin):
     """Test updating a large capital opportunity."""

--- a/datahub/investment/opportunity/views.py
+++ b/datahub/investment/opportunity/views.py
@@ -1,9 +1,20 @@
-from django_filters.rest_framework import DjangoFilterBackend
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 
 from datahub.core.audit import AuditViewSet
+from datahub.core.autocomplete import AutocompleteFilter
 from datahub.core.viewsets import CoreViewSet
 from datahub.investment.opportunity.models import LargeCapitalOpportunity
 from datahub.investment.opportunity.serializers import LargeCapitalOpportunitySerializer
+
+
+class LargeCapitalOpportunityFilterSet(FilterSet):
+    """Large Capital Opportunity filter."""
+
+    autocomplete = AutocompleteFilter(search_fields=('name',))
+
+    class Meta:
+        model = LargeCapitalOpportunity
+        fields = ['investment_projects__id']
 
 
 class LargeCapitalOpportunityViewSet(CoreViewSet):
@@ -11,7 +22,7 @@ class LargeCapitalOpportunityViewSet(CoreViewSet):
 
     serializer_class = LargeCapitalOpportunitySerializer
     filter_backends = (DjangoFilterBackend,)
-    filterset_fields = ('investment_projects__id',)
+    filterset_class = LargeCapitalOpportunityFilterSet
     queryset = LargeCapitalOpportunity.objects.all()
 
 


### PR DESCRIPTION
### Description of change

This PR brings in autocomplete functionality to the large capital opportunities endpoint. This is so I can add a typeahead to the interactions form to link an interaction to a UK opportunity!

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
