### PR TITLE
Add summaries to investment search endpoint

### DIFF
--- a/changelog/investment/search-investment-summary.feature.md
+++ b/changelog/investment/search-investment-summary.feature.md
@@ -1,0 +1,43 @@
+Summary counts for each project stage can now be requested from the investment search endpoint.
+
+```
+POST /v3/search/investment_project
+{
+    "show_summary": true,
+    ...filters
+}
+
+=>
+
+{
+    "count": 4,
+    "results": ...,
+    "summary": {
+        "prospect": {
+            "label": "Prospect",
+            "id": <uuid>,
+            "value": 3
+        },
+        "assign_pm": {
+            "label": "Assign PM",
+            "id": <uuid>,
+            "value": 0
+        },
+        "active": {
+            "label": "Active",
+            "id": <uuid>,
+            "value": 1
+        },
+        "verify_win": {
+            "label": "Verify Win",
+            "id": <uuid>,
+            "value": 0
+        },
+        "won": {
+            "label": "Won",
+            "id": <uuid>,
+            "value": 0
+        }
+    }
+}
+```

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -43,6 +43,8 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
     gross_value_added_start = serializers.IntegerField(required=False, min_value=0)
     gross_value_added_end = serializers.IntegerField(required=False, min_value=0)
 
+    show_summary = serializers.BooleanField(required=False, default=False)
+
     SORT_BY_FIELDS = (
         'created_on',
         'estimated_land_date',


### PR DESCRIPTION
### Description of change

Adds a summary to the investment search endpoint when the `show_summary` data param is set to true. This includes a count of projects in each stage.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
