### PR TITLE
Update sample env with dummy CONSENT_SERVICE_* vars which are required

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -79,3 +79,8 @@ DNB_SERVICE_TOKEN=cc373a2a49ce7143817a9d036fa2a0be92da0d6a
 
 # Python specific env vars
 PYTHONUNBUFFERED=1
+
+# Consent Service settings
+CONSENT_SERVICE_BASE_URL=http://mock-third-party-services:8555
+CONSENT_SERVICE_HAWK_ID=dummyId
+CONSENT_SERVICE_HAWK_KEY=dummyKey


### PR DESCRIPTION
### Description of change

Adds dummy CONSENT_SERVICE_* env vars to the sample env.
These dummy environment variables are required to view contact details when running locally.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
