### PR TITLE
Dependabot updates 06/09/21

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -65,7 +65,7 @@ piprot==0.9.11
 semantic_version==2.8.5
 towncrier==21.3.0
 watchdog[watchmedo]==2.1.5
-pre-commit==2.14.1
+pre-commit==2.15.0
 
 
 # Code static analysis

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ python-dateutil==2.8.2
 psycopg2==2.9.1
 psycogreen==1.0.2
 
-boto3==1.18.31
+boto3==1.18.36
 
 notifications-python-client==6.2.1
 

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@
 django==3.1.12
 djangorestframework==3.12.4
 django-axes==5.21.0
-django-environ==0.4.5
+django-environ==0.6.0
 django-extensions==3.1.3
 django-filter==2.4.0
 django-mptt==0.13.2

--- a/requirements.in
+++ b/requirements.in
@@ -50,7 +50,7 @@ billiard==3.6.4.0  # Not used directly, but pinned as it has been a source of br
 kombu==4.6.11  # Not used directly, but pinned as it has been a source of breakage in the past
 
 # Testing and dev
-pytest==6.2.4
+pytest==6.2.5
 pytest-django==4.4.0
 pytest-cov==2.12.1
 pytest-xdist==2.3.0

--- a/requirements.in
+++ b/requirements.in
@@ -42,7 +42,7 @@ elasticsearch==7.13.4
 elasticsearch-dsl==7.4.0
 
 # ES APM
-elastic-apm==6.3.3
+elastic-apm==6.4.0
 
 # Celery
 celery[redis]==4.4.7

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Django and django related
 django==3.1.12
 djangorestframework==3.12.4
-django-axes==5.21.0
+django-axes==5.23.0
 django-environ==0.6.0
 django-extensions==3.1.3
 django-filter==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ django==3.1.12
     #   django-redis
     #   django-reversion
     #   djangorestframework
-django-axes==5.21.0
+django-axes==5.23.0
     # via -r requirements.in
 django-debug-toolbar==3.2.2
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,7 +84,7 @@ django-axes==5.21.0
     # via -r requirements.in
 django-debug-toolbar==3.2.2
     # via -r requirements.in
-django-environ==0.4.5
+django-environ==0.6.0
     # via -r requirements.in
 django-extensions==3.1.3
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -106,7 +106,7 @@ djangorestframework==3.12.4
     # via -r requirements.in
 docopt==0.6.2
     # via notifications-python-client
-elastic-apm==6.3.3
+elastic-apm==6.4.0
     # via -r requirements.in
 elasticsearch==7.13.4
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -258,7 +258,7 @@ pyjwt==2.1.0
     # via notifications-python-client
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements.in
     #   pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -224,7 +224,7 @@ piprot==0.9.11
     # via -r requirements.in
 pluggy==0.13.1
     # via pytest
-pre-commit==2.14.1
+pre-commit==2.15.0
     # via -r requirements.in
 prompt-toolkit==3.0.18
     # via ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,9 @@ billiard==3.6.4.0
     # via
     #   -r requirements.in
     #   celery
-boto3==1.18.31
+boto3==1.18.36
     # via -r requirements.in
-botocore==1.21.31
+botocore==1.21.36
     # via
     #   boto3
     #   s3transfer


### PR DESCRIPTION
### Description of change

This PR combines this week's dependabot updates, including:

- Bump elastic-apm from 6.3.3 to 6.4.0
- Bump pre-commit from 2.14.1 to 2.15.0
- Bump django-environ from 0.4.5 to 0.6.0
- Bump pytest from 6.2.4 to 6.2.5
- Bump boto3 from 1.18.31 to 1.18.36
- Bump django-axes from 5.21.0 to 5.23.0 

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
