### PR TITLE
Reverse dependency on api-celery in dev to fix race condition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
       - mi-postgres
       - es
       - redis
-      - celery
       - es-apm
     command: /app/start-dev.sh
 
@@ -24,8 +23,10 @@ services:
       context: .
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://es-apm:8200 -wait tcp://redis:6379 -timeout 180s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://es-apm:8200 -wait tcp://redis:6379 -wait tcp://api:8000 -timeout 300s
     env_file: .env
+    depends_on:
+      - api
     command: watchmedo auto-restart -d . -R -p '*.py' -- celery worker -A config -l info -Q celery -B
 
   postgres:


### PR DESCRIPTION
### Description of change

If celery container comes up before database schema is populated it will
crash silently on `psycopg2.errors.UndefinedTable` exception.
This means that the `datahub.search.tasks.sync_object_task` tasks to
populate the elasticsearch won't run and any search in dev will return
0 results
Therefore we reverse the dependency between API and celery, and wait
for the webserver to come up before starting celery
It would be good if there was some condition we could test against that
happens just after database population instead of waiting till the
webserver finishes coming up, but I don't think there is such a
condition
We also increase timeout so that celery doesn't just time out on
slow/busy computers


### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
