### PR TITLE
Fix a bug when the testfixtureapi/reset-fixtures endpoint was not working

### DIFF
--- a/datahub/testfixtureapi/views.py
+++ b/datahub/testfixtureapi/views.py
@@ -20,15 +20,15 @@ from datahub.company_referral.models import CompanyReferral
 from datahub.event.models import Event
 from datahub.feature_flag.models import FeatureFlag
 from datahub.interaction.models import Interaction, InteractionDITParticipant
+from datahub.investment.investor_profile.models import LargeCapitalInvestorProfile
+from datahub.investment.opportunity.models import LargeCapitalOpportunity
 from datahub.investment.project.models import (
     InvestmentProject,
     InvestmentProjectStageLog,
     InvestmentProjectTeamMember,
 )
 from datahub.investment.project.proposition.models import Proposition
-from datahub.investment.investor_profile.models import LargeCapitalInvestorProfile
 from datahub.oauth.cache import add_token_data_to_cache
-from datahub.investment.opportunity.models import LargeCapitalOpportunity
 
 logger = logging.getLogger(__name__)
 

--- a/datahub/testfixtureapi/views.py
+++ b/datahub/testfixtureapi/views.py
@@ -26,7 +26,9 @@ from datahub.investment.project.models import (
     InvestmentProjectTeamMember,
 )
 from datahub.investment.project.proposition.models import Proposition
+from datahub.investment.investor_profile.models import LargeCapitalInvestorProfile
 from datahub.oauth.cache import add_token_data_to_cache
+from datahub.investment.opportunity.models import LargeCapitalOpportunity
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +58,8 @@ def reset_fixtures(request):
         raise Http404
 
     with transaction.atomic():
+        LargeCapitalInvestorProfile.objects.all().delete()
+        LargeCapitalOpportunity.objects.all().delete()
         InvestmentProject.objects.all().delete()
         InvestmentProjectStageLog.objects.all().delete()
         InvestmentProjectTeamMember.objects.all().delete()


### PR DESCRIPTION

### Description of change

Fixes a bug when the `/testfixtureapi/reset-fixtures/` endpoint was throwing a `ProtectedError`.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
