### PR TITLE
Dependabot 20/09/2021

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 # Django and django related
 django==3.1.12
 djangorestframework==3.12.4
-django-axes==5.24.0
+django-axes==5.25.0
 django-environ==0.7.0
 django-extensions==3.1.3
 django-filter==2.4.0

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ python-dateutil==2.8.2
 psycopg2==2.9.1
 psycogreen==1.0.2
 
-boto3==1.18.40
+boto3==1.18.44
 
 notifications-python-client==6.2.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,9 @@ billiard==3.6.4.0
     # via
     #   -r requirements.in
     #   celery
-boto3==1.18.40
+boto3==1.18.44
     # via -r requirements.in
-botocore==1.21.40
+botocore==1.21.44
     # via
     #   boto3
     #   s3transfer

--- a/requirements.txt
+++ b/requirements.txt
@@ -80,7 +80,7 @@ django==3.1.12
     #   django-redis
     #   django-reversion
     #   djangorestframework
-django-axes==5.24.0
+django-axes==5.25.0
     # via -r requirements.in
 django-debug-toolbar==3.2.2
     # via -r requirements.in


### PR DESCRIPTION
### Description of change

Dependabot PRs automatically generated this week:

- Bump boto3 from 1.18.40 to 1.18.44
- Bump django-axes from 5.24.0 to 5.25.0

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
