### PR TITLE
feat: Activity stream endpoints with empty last page

### DIFF
--- a/changelog/company/last-page-in-activity-stream-endpoint-empty.feature.md
+++ b/changelog/company/last-page-in-activity-stream-endpoint-empty.feature.md
@@ -1,0 +1,1 @@
+The `company_referral` Activity Stream endpoint goes one page further to an empty page.

--- a/changelog/company/remove-unused-keys-from-activity-stream-endpoint.feature.md
+++ b/changelog/company/remove-unused-keys-from-activity-stream-endpoint.feature.md
@@ -1,0 +1,1 @@
+Unused keys `id` and `partOf` in the `company_referral` Activity Stream endpoint have been removed.

--- a/changelog/interaction/last-page-in-activity-stream-endpoint-empty.feature.md
+++ b/changelog/interaction/last-page-in-activity-stream-endpoint-empty.feature.md
@@ -1,0 +1,1 @@
+The `interaction` Activity Stream endpoint goes one page further to an empty page.

--- a/changelog/interaction/remove-unused-keys-from-activity-stream-endpoint.feature.md
+++ b/changelog/interaction/remove-unused-keys-from-activity-stream-endpoint.feature.md
@@ -1,0 +1,1 @@
+Unused keys `id` and `partOf` in the `interaction` Activity Stream endpoint have been removed.

--- a/changelog/investment/last-page-in-investment-activity-stream-endpoint-empty.feature.md
+++ b/changelog/investment/last-page-in-investment-activity-stream-endpoint-empty.feature.md
@@ -1,0 +1,1 @@
+The `investment/project-added` Activity Stream endpoint goes one page further to an empty page.

--- a/changelog/investment/last-page-in-investor-profile-activity-stream-endpoint-empty.feature.md
+++ b/changelog/investment/last-page-in-investor-profile-activity-stream-endpoint-empty.feature.md
@@ -1,0 +1,1 @@
+The `investment/large-capital-investor-profiles` Activity Stream endpoint goes one page further to an empty page.

--- a/changelog/investment/last-page-in-large-capital-opportunity-activity-stream-endpoint-empty.feature.md
+++ b/changelog/investment/last-page-in-large-capital-opportunity-activity-stream-endpoint-empty.feature.md
@@ -1,0 +1,1 @@
+The `investment/large-capital-opportunity` Activty Stream endpoint goes one page further to an empty page.

--- a/changelog/investment/last-page-in-opportunity-activity-stream-endpoint-empty.feature.md
+++ b/changelog/investment/last-page-in-opportunity-activity-stream-endpoint-empty.feature.md
@@ -1,0 +1,1 @@
+The `opportunity` Activity Stream endpoint goes one page further to an empty page.

--- a/changelog/investment/remove-unused-keys-from-investment-activity-stream-endpoint.feature.md
+++ b/changelog/investment/remove-unused-keys-from-investment-activity-stream-endpoint.feature.md
@@ -1,0 +1,1 @@
+Unused keys `id` and `partOf` in the `investment/project-added` Activity Stream endpoint have been removed.

--- a/changelog/investment/remove-unused-keys-from-investor-profile-activity-stream-endpoint.feature.md
+++ b/changelog/investment/remove-unused-keys-from-investor-profile-activity-stream-endpoint.feature.md
@@ -1,0 +1,1 @@
+Unused keys `id` and `partOf` in the `investment/large-capital-investor-profiles` Activity Stream endpoint have been removed.

--- a/changelog/investment/remove-unused-keys-from-large-capital-opportunity-activity-stream-endpoint.feature.md
+++ b/changelog/investment/remove-unused-keys-from-large-capital-opportunity-activity-stream-endpoint.feature.md
@@ -1,0 +1,1 @@
+Unused keys `id` and `partOf` in the `investment/large-capital-opportunity` Activity Stream endpoint have been removed.

--- a/changelog/investment/remove-unused-keys-from-opportunity-activity-stream-endpoint.feature.md
+++ b/changelog/investment/remove-unused-keys-from-opportunity-activity-stream-endpoint.feature.md
@@ -1,0 +1,1 @@
+Unused keys `id` and `partOf` in the `opportunity` Activity Stream endpoint have been removed.

--- a/changelog/omis/last-page-in-omis-activity-stream-endpoint-empty.feature.md
+++ b/changelog/omis/last-page-in-omis-activity-stream-endpoint-empty.feature.md
@@ -1,0 +1,1 @@
+The `omis/order-added` Activity Stream endpoint goes one page further to an empty page.

--- a/changelog/omis/remove-unused-keys-from-activity-stream-endpoint.feature.md
+++ b/changelog/omis/remove-unused-keys-from-activity-stream-endpoint.feature.md
@@ -1,0 +1,1 @@
+Unused keys `id` and `partOf` in the `omis/order-added` Activity Stream endpoint have been removed.

--- a/datahub/activity_stream/company_referral/test/test_views.py
+++ b/datahub/activity_stream/company_referral/test/test_views.py
@@ -22,8 +22,9 @@ def test_company_referral_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         company_referral = CompanyReferralFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -31,7 +32,9 @@ def test_company_referral_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Company Referral Activities',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/company-referral'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(company_referral.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubCompanyReferral:{company_referral.id}:Announce',
@@ -103,8 +106,9 @@ def test_closed_company_referral_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         company_referral = ClosedCompanyReferralFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -112,7 +116,9 @@ def test_closed_company_referral_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Company Referral Activities',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/company-referral'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(company_referral.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubCompanyReferral:{company_referral.id}:Announce',
@@ -184,8 +190,9 @@ def test_complete_company_referral_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         company_referral = CompleteCompanyReferralFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -193,7 +200,9 @@ def test_complete_company_referral_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Company Referral Activities',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/company-referral'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(company_referral.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubCompanyReferral:{company_referral.id}:Announce',
@@ -281,9 +290,10 @@ def test_company_referral_activity_without_team_and_contact(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         recipient = AdviserFactory(dit_team=None)
         company_referral = CompanyReferralFactory(recipient=recipient, contact=None)
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -291,7 +301,9 @@ def test_company_referral_activity_without_team_and_contact(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Company Referral Activities',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/company-referral'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(company_referral.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubCompanyReferral:{company_referral.id}:Announce',
@@ -350,11 +362,15 @@ def test_company_referrals_ordering(api_client):
     """
     company_referrals = []
 
-    # We create 2 interactions with the same modified_on time
-    with freeze_time():
+    with freeze_time() as frozen_datetime:
         company_referrals += CompanyReferralFactory.create_batch(2)
-    company_referrals += CompanyReferralFactory.create_batch(8)
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+
+        frozen_datetime.tick(datetime.timedelta(microseconds=1))
+        company_referrals += CompanyReferralFactory.create_batch(8)
+
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+
     assert response.status_code == status.HTTP_200_OK
 
     sorted_company_referral_ids = [

--- a/datahub/activity_stream/company_referral/test/test_views.py
+++ b/datahub/activity_stream/company_referral/test/test_views.py
@@ -31,8 +31,6 @@ def test_company_referral_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Company Referral Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/company-referral',
-        'partOf': 'http://testserver/v3/activity-stream/company-referral',
         'next': None,
         'orderedItems': [
             {
@@ -114,8 +112,6 @@ def test_closed_company_referral_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Company Referral Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/company-referral',
-        'partOf': 'http://testserver/v3/activity-stream/company-referral',
         'next': None,
         'orderedItems': [
             {
@@ -197,8 +193,6 @@ def test_complete_company_referral_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Company Referral Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/company-referral',
-        'partOf': 'http://testserver/v3/activity-stream/company-referral',
         'next': None,
         'orderedItems': [
             {
@@ -297,8 +291,6 @@ def test_company_referral_activity_without_team_and_contact(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Company Referral Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/company-referral',
-        'partOf': 'http://testserver/v3/activity-stream/company-referral',
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/company_referral/test/test_views.py
+++ b/datahub/activity_stream/company_referral/test/test_views.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from freezegun import freeze_time
 from rest_framework import status
@@ -19,8 +21,11 @@ def test_company_referral_activity(api_client):
     Get a list of company referrals and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    company_referral = CompanyReferralFactory()
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        company_referral = CompanyReferralFactory()
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
@@ -99,8 +104,11 @@ def test_closed_company_referral_activity(api_client):
     Get a list of closed company referrals and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    company_referral = ClosedCompanyReferralFactory()
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        company_referral = ClosedCompanyReferralFactory()
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
@@ -179,8 +187,11 @@ def test_complete_company_referral_activity(api_client):
     Get a list of completed company referrals and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    company_referral = CompleteCompanyReferralFactory()
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        company_referral = CompleteCompanyReferralFactory()
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
@@ -275,9 +286,12 @@ def test_company_referral_activity_without_team_and_contact(api_client):
     Get a list of company referrals and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    recipient = AdviserFactory(dit_team=None)
-    company_referral = CompanyReferralFactory(recipient=recipient, contact=None)
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        recipient = AdviserFactory(dit_team=None)
+        company_referral = CompanyReferralFactory(recipient=recipient, contact=None)
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:company-referrals'))
+
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',

--- a/datahub/activity_stream/company_referral/views.py
+++ b/datahub/activity_stream/company_referral/views.py
@@ -7,12 +7,8 @@ from datahub.company_referral.models import CompanyReferral
 class CompanyReferralCursorPagination(ActivityCursorPagination):
     """
     Cursor pagination for Company Referral.
-
-    `modified_on` is mutable. Most recently updated company referrals would be consumed first,
-    so they get a chance to appear in the Activity Feed quicker.
     """
 
-    ordering = ('modified_on', 'id')
     summary = 'Company Referral Activities'
 
 

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -36,8 +36,6 @@ def test_interaction_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/interaction',
-        'partOf': 'http://testserver/v3/activity-stream/interaction',
         'next': None,
         'orderedItems': [
             {
@@ -116,8 +114,6 @@ def test_interaction_investment_project_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/interaction',
-        'partOf': 'http://testserver/v3/activity-stream/interaction',
         'next': None,
         'orderedItems': [
             {
@@ -203,8 +199,6 @@ def test_service_delivery_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/interaction',
-        'partOf': 'http://testserver/v3/activity-stream/interaction',
         'next': None,
         'orderedItems': [
             {
@@ -282,8 +276,6 @@ def test_service_delivery_event_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/interaction',
-        'partOf': 'http://testserver/v3/activity-stream/interaction',
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from freezegun import freeze_time
 from rest_framework import status
@@ -24,10 +26,12 @@ def test_interaction_activity(api_client):
     Get a list of interactions and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    interaction = CompanyInteractionFactory()
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        interaction = CompanyInteractionFactory()
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
@@ -101,11 +105,13 @@ def test_interaction_investment_project_activity(api_client):
     Get a list of interactions and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    interaction = InvestmentProjectInteractionFactory()
-    project = interaction.investment_project
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        interaction = InvestmentProjectInteractionFactory()
+        project = interaction.investment_project
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
@@ -187,10 +193,12 @@ def test_service_delivery_activity(api_client):
     Get a list of interactions and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    interaction = ServiceDeliveryFactory()
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        interaction = ServiceDeliveryFactory()
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
@@ -263,11 +271,13 @@ def test_service_delivery_event_activity(api_client):
     Get a list of interactions and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    interaction = EventServiceDeliveryFactory()
-    event = interaction.event
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        interaction = EventServiceDeliveryFactory()
+        event = interaction.event
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -27,8 +27,9 @@ def test_interaction_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         interaction = CompanyInteractionFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -36,7 +37,9 @@ def test_interaction_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/interaction'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(interaction.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubInteraction:{interaction.id}:Announce',
@@ -104,9 +107,10 @@ def test_interaction_investment_project_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         interaction = InvestmentProjectInteractionFactory()
         project = interaction.investment_project
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -114,7 +118,9 @@ def test_interaction_investment_project_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/interaction'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(interaction.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubInteraction:{interaction.id}:Announce',
@@ -190,8 +196,9 @@ def test_service_delivery_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         interaction = ServiceDeliveryFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -199,7 +206,9 @@ def test_service_delivery_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/interaction'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(interaction.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubInteraction:{interaction.id}:Announce',
@@ -266,9 +275,10 @@ def test_service_delivery_event_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         interaction = EventServiceDeliveryFactory()
         event = interaction.event
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -276,7 +286,9 @@ def test_service_delivery_event_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Interaction Activities',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/interaction'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(interaction.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubInteraction:{interaction.id}:Announce',
@@ -368,11 +380,15 @@ def test_interaction_ordering(api_client):
     """
     interactions = []
 
-    # We create 2 interactions with the same modified_on time
-    with freeze_time():
+    with freeze_time() as frozen_datetime:
         interactions += CompanyInteractionFactory.create_batch(2)
-    interactions += CompanyInteractionFactory.create_batch(8)
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
+
+        frozen_datetime.tick(datetime.timedelta(microseconds=1))
+        interactions += CompanyInteractionFactory.create_batch(8)
+
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
+
     assert response.status_code == status.HTTP_200_OK
 
     sorted_interaction_ids = [
@@ -391,9 +407,13 @@ def test_contacts_ordering(api_client):
     """
     Test that contacts are ordered by `pk`
     """
-    contacts = ContactFactory.create_batch(5)
-    CompanyInteractionFactory(contacts=contacts)
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
+    with freeze_time() as frozen_datetime:
+        contacts = ContactFactory.create_batch(5)
+        CompanyInteractionFactory(contacts=contacts)
+
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
+
     assert response.status_code == status.HTTP_200_OK
 
     sorted_contact_ids = [
@@ -414,9 +434,13 @@ def test_dit_participant_ordering(api_client):
     """
     Test that dit_participants are ordered by `pk`
     """
-    interaction = CompanyInteractionFactory(dit_participants=[])
-    InteractionDITParticipantFactory.create_batch(5, interaction=interaction)
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
+    with freeze_time() as frozen_datetime:
+        interaction = CompanyInteractionFactory(dit_participants=[])
+        InteractionDITParticipantFactory.create_batch(5, interaction=interaction)
+
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
+
     assert response.status_code == status.HTTP_200_OK
 
     sorted_participant_ids = [
@@ -437,13 +461,16 @@ def test_null_adviser(api_client):
     """
     Test that we can handle dit_participant.adviser being None
     """
-    interaction = CompanyInteractionFactory(dit_participants=[])
-    InteractionDITParticipantFactory(
-        interaction=interaction,
-        adviser=None,
-        team=TeamFactory(),
-    )
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
+    with freeze_time() as frozen_datetime:
+        interaction = CompanyInteractionFactory(dit_participants=[])
+        InteractionDITParticipantFactory(
+            interaction=interaction,
+            adviser=None,
+            team=TeamFactory(),
+        )
+
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:interactions'))
     assert response.status_code == status.HTTP_200_OK
 
 

--- a/datahub/activity_stream/interaction/views.py
+++ b/datahub/activity_stream/interaction/views.py
@@ -7,13 +7,8 @@ from datahub.interaction.queryset import get_base_interaction_queryset
 class InteractionCursorPagination(ActivityCursorPagination):
     """
     Cursor pagination for interaction.
-
-    `modified_on` is no unchanging but we have decided to use it because the benefits of being
-    able to generate the last page of interactions in under 10s far outweigh the fact that
-    sometimes the last page will not contain all the updates.
     """
 
-    ordering = ('modified_on', 'id')
     summary = 'Interaction Activities'
 
 

--- a/datahub/activity_stream/investment/test/test_views.py
+++ b/datahub/activity_stream/investment/test/test_views.py
@@ -31,8 +31,6 @@ def test_investment_project_added(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/investment/project-added',
-        'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
         'next': None,
         'orderedItems': [
             {
@@ -104,8 +102,6 @@ def test_investment_project_with_pm_added(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/investment/project-added',
-        'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
         'next': None,
         'orderedItems': [
             {
@@ -180,8 +176,6 @@ def test_investment_project_verify_win_added(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/investment/project-added',
-        'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
         'next': None,
         'orderedItems': [
             {
@@ -257,8 +251,6 @@ def test_investment_project_added_with_gva(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/investment/project-added',
-        'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/investment/test/test_views.py
+++ b/datahub/activity_stream/investment/test/test_views.py
@@ -1,4 +1,7 @@
+import datetime
+
 import pytest
+from freezegun import freeze_time
 from rest_framework import status
 
 from datahub.activity_stream.test import hawk
@@ -18,10 +21,12 @@ def test_investment_project_added(api_client):
     Get a list of investment project and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    project = InvestmentProjectFactory()
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        project = InvestmentProjectFactory()
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
@@ -89,10 +94,12 @@ def test_investment_project_with_pm_added(api_client):
     Investment Project with PM will have fields such as totalInvestment and
     numberNewJobs.
     """
-    project = AssignPMInvestmentProjectFactory()
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        project = AssignPMInvestmentProjectFactory()
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
@@ -163,10 +170,12 @@ def test_investment_project_verify_win_added(api_client):
     numberNewJobs and foreignEquityInvestment.
 
     """
-    project = VerifyWinInvestmentProjectFactory()
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        project = VerifyWinInvestmentProjectFactory()
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
@@ -234,14 +243,16 @@ def test_investment_project_added_with_gva(api_client):
     This test adds the necessary fields to compute gross_value_added property
     and tests if its included in the response.
     """
-    project = InvestmentProjectFactory(
-        foreign_equity_investment=10000,
-        sector_id=constants.Sector.aerospace_assembly_aircraft.value.id,
-        investment_type_id=constants.InvestmentType.fdi.value.id,
-    )
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        project = InvestmentProjectFactory(
+            foreign_equity_investment=10000,
+            sector_id=constants.Sector.aerospace_assembly_aircraft.value.id,
+            investment_type_id=constants.InvestmentType.fdi.value.id,
+        )
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',

--- a/datahub/activity_stream/investment/test/test_views.py
+++ b/datahub/activity_stream/investment/test/test_views.py
@@ -22,8 +22,9 @@ def test_investment_project_added(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         project = InvestmentProjectFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -31,7 +32,9 @@ def test_investment_project_added(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/investment/project-added'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(project.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubInvestmentProject:{project.id}:Add',
@@ -93,8 +96,9 @@ def test_investment_project_with_pm_added(api_client):
     numberNewJobs.
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         project = AssignPMInvestmentProjectFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -102,7 +106,9 @@ def test_investment_project_with_pm_added(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/investment/project-added'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(project.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubInvestmentProject:{project.id}:Add',
@@ -167,8 +173,9 @@ def test_investment_project_verify_win_added(api_client):
 
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         project = VerifyWinInvestmentProjectFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -176,7 +183,9 @@ def test_investment_project_verify_win_added(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/investment/project-added'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(project.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubInvestmentProject:{project.id}:Add',
@@ -238,12 +247,13 @@ def test_investment_project_added_with_gva(api_client):
     and tests if its included in the response.
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         project = InvestmentProjectFactory(
             foreign_equity_investment=10000,
             sector_id=constants.Sector.aerospace_assembly_aircraft.value.id,
             investment_type_id=constants.InvestmentType.fdi.value.id,
         )
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -251,7 +261,9 @@ def test_investment_project_added_with_gva(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Investment Activities Added',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/investment/project-added'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(project.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubInvestmentProject:{project.id}:Add',

--- a/datahub/activity_stream/investment/views.py
+++ b/datahub/activity_stream/investment/views.py
@@ -12,7 +12,6 @@ class IProjectCreatedPagination(ActivityCursorPagination):
     Investment Project added CursorPagination for activity stream.
     """
 
-    ordering = ('modified_on', 'id')
     summary = 'Investment Activities Added'
 
 

--- a/datahub/activity_stream/investor_profile/test/test_views.py
+++ b/datahub/activity_stream/investor_profile/test/test_views.py
@@ -31,10 +31,6 @@ def test_large_capital_investor_profile_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Large Capital Investor Profile Activities',
         'type': 'OrderedCollectionPage',
-        'id':
-            'http://testserver/v3/activity-stream/investment/large-capital-investor-profiles',
-        'partOf':
-            'http://testserver/v3/activity-stream/investment/large-capital-investor-profiles',
         'next': None,
         'orderedItems': [
             {
@@ -86,9 +82,6 @@ def test_complete_large_capital_investor_profile_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Large Capital Investor Profile Activities',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/investment/large-capital-investor-profiles',
-        'partOf':
-            'http://testserver/v3/activity-stream/investment/large-capital-investor-profiles',
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/investor_profile/test/test_views.py
+++ b/datahub/activity_stream/investor_profile/test/test_views.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pytest
 from freezegun import freeze_time
 from rest_framework import status
@@ -17,10 +19,13 @@ def test_large_capital_investor_profile_activity(api_client):
     Get a list of large capital investor profiles and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    investor_profile = LargeCapitalInvestorProfileFactory()
-    response = hawk.get(
-        api_client, get_url('api-v3:activity-stream:large-capital-investor-profiles'),
-    )
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        investor_profile = LargeCapitalInvestorProfileFactory()
+        response = hawk.get(
+            api_client, get_url('api-v3:activity-stream:large-capital-investor-profiles'),
+        )
+
     assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
@@ -66,10 +71,12 @@ def test_complete_large_capital_investor_profile_activity(api_client):
     is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    investor_profile = CompleteLargeCapitalInvestorProfileFactory()
-    response = hawk.get(
-        api_client, get_url('api-v3:activity-stream:large-capital-investor-profiles'),
-    )
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        investor_profile = CompleteLargeCapitalInvestorProfileFactory()
+        response = hawk.get(
+            api_client, get_url('api-v3:activity-stream:large-capital-investor-profiles'),
+        )
 
     def get_multiple_names(values):
         return [{'name': value.name} for value in values]

--- a/datahub/activity_stream/investor_profile/views.py
+++ b/datahub/activity_stream/investor_profile/views.py
@@ -9,12 +9,8 @@ from datahub.investment.investor_profile.models import LargeCapitalInvestorProfi
 class LargeCapitalInvestorProfileCursorPagination(ActivityCursorPagination):
     """
     Cursor pagination for Large Capital Investor Profile.
-
-    `modified_on` is mutable. Most recently updated company referrals would be consumed first,
-    so they get a chance to appear in the Activity Feed quicker.
     """
 
-    ordering = ('modified_on', 'id')
     summary = 'Large Capital Investor Profile Activities'
 
 

--- a/datahub/activity_stream/omis/test/test_views.py
+++ b/datahub/activity_stream/omis/test/test_views.py
@@ -26,8 +26,9 @@ def test_omis_order_added_activity(api_client, order_overrides):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         order = OrderFactory(**order_overrides)
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:omis-order-added'))
 
     assert response.status_code == status.HTTP_200_OK
@@ -36,7 +37,9 @@ def test_omis_order_added_activity(api_client, order_overrides):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'OMIS Order Added Activity',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/omis/order-added'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(order.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubOMISOrder:{order.id}:Add',

--- a/datahub/activity_stream/omis/test/test_views.py
+++ b/datahub/activity_stream/omis/test/test_views.py
@@ -1,4 +1,7 @@
+import datetime
+
 import pytest
+from freezegun import freeze_time
 from rest_framework import status
 
 from datahub.activity_stream.test import hawk
@@ -22,8 +25,11 @@ def test_omis_order_added_activity(api_client, order_overrides):
     Get a list of OMIS Orders added and test the JSON returned is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    order = OrderFactory(**order_overrides)
-    response = hawk.get(api_client, get_url('api-v3:activity-stream:omis-order-added'))
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        order = OrderFactory(**order_overrides)
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:omis-order-added'))
+
     assert response.status_code == status.HTTP_200_OK
 
     expected_data = {

--- a/datahub/activity_stream/omis/test/test_views.py
+++ b/datahub/activity_stream/omis/test/test_views.py
@@ -36,8 +36,6 @@ def test_omis_order_added_activity(api_client, order_overrides):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'OMIS Order Added Activity',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/omis/order-added',
-        'partOf': 'http://testserver/v3/activity-stream/omis/order-added',
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/omis/views.py
+++ b/datahub/activity_stream/omis/views.py
@@ -11,7 +11,6 @@ class OMISOrderAddedPagination(ActivityCursorPagination):
     OMIS Order added pagination for activity stream.
     """
 
-    ordering = ('modified_on', 'id')
     summary = 'OMIS Order Added Activity'
 
 

--- a/datahub/activity_stream/opportunity/test/test_views.py
+++ b/datahub/activity_stream/opportunity/test/test_views.py
@@ -32,8 +32,6 @@ def test_large_capital_opportunity_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Large Capital Opportunity Activities Added',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity',
-        'partOf': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity',
         'next': None,
         'orderedItems': [
             {
@@ -89,8 +87,6 @@ def test_complete_large_capital_opportunity_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Large Capital Opportunity Activities Added',
         'type': 'OrderedCollectionPage',
-        'id': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity',
-        'partOf': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity',
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/opportunity/test/test_views.py
+++ b/datahub/activity_stream/opportunity/test/test_views.py
@@ -20,8 +20,9 @@ def test_large_capital_opportunity_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         opportunity = LargeCapitalOpportunityFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(
             api_client,
             get_url('api-v3:activity-stream:large-capital-opportunity'),
@@ -32,7 +33,9 @@ def test_large_capital_opportunity_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Large Capital Opportunity Activities Added',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(opportunity.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubLargeCapitalOpportunity:{opportunity.id}:Announce',
@@ -72,8 +75,9 @@ def test_complete_large_capital_opportunity_activity(api_client):
     https://www.w3.org/TR/activitystreams-core/
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         opportunity = CompleteLargeCapitalOpportunityFactory()
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(
             api_client,
             get_url('api-v3:activity-stream:large-capital-opportunity'),
@@ -87,7 +91,9 @@ def test_complete_large_capital_opportunity_activity(api_client):
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Large Capital Opportunity Activities Added',
         'type': 'OrderedCollectionPage',
-        'next': None,
+        'next': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity'
+                + '?cursor=2012-07-12T15%3A06%3A03.000000%2B00%3A00'
+                + f'&cursor={str(opportunity.id)}',
         'orderedItems': [
             {
                 'id': f'dit:DataHubLargeCapitalOpportunity:{opportunity.id}:Announce',

--- a/datahub/activity_stream/opportunity/test/test_views.py
+++ b/datahub/activity_stream/opportunity/test/test_views.py
@@ -1,4 +1,7 @@
+import datetime
+
 import pytest
+from freezegun import freeze_time
 from rest_framework import status
 
 from datahub.activity_stream.test import hawk
@@ -16,13 +19,15 @@ def test_large_capital_opportunity_activity(api_client):
     Get a list of large capital opportunities and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    opportunity = LargeCapitalOpportunityFactory()
-    response = hawk.get(
-        api_client,
-        get_url('api-v3:activity-stream:large-capital-opportunity'),
-    )
-    assert response.status_code == status.HTTP_200_OK
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        opportunity = LargeCapitalOpportunityFactory()
+        response = hawk.get(
+            api_client,
+            get_url('api-v3:activity-stream:large-capital-opportunity'),
+        )
 
+    assert response.status_code == status.HTTP_200_OK
     assert response.json() == {
         '@context': 'https://www.w3.org/ns/activitystreams',
         'summary': 'Large Capital Opportunity Activities Added',
@@ -68,11 +73,13 @@ def test_complete_large_capital_opportunity_activity(api_client):
     Get a list of large capital opportunities and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
     """
-    opportunity = CompleteLargeCapitalOpportunityFactory()
-    response = hawk.get(
-        api_client,
-        get_url('api-v3:activity-stream:large-capital-opportunity'),
-    )
+    start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+    with freeze_time(start):
+        opportunity = CompleteLargeCapitalOpportunityFactory()
+        response = hawk.get(
+            api_client,
+            get_url('api-v3:activity-stream:large-capital-opportunity'),
+        )
 
     def get_multiple_names(values):
         return [{'name': value.name} for value in values]

--- a/datahub/activity_stream/opportunity/views.py
+++ b/datahub/activity_stream/opportunity/views.py
@@ -9,11 +9,8 @@ from datahub.investment.opportunity.models import LargeCapitalOpportunity
 class LargeCapitalOpportunityPagination(ActivityCursorPagination):
     """
     Cursor pagination for Large Capital Opportunity.
-    `modified_on` is mutable. Most recently updated opportunities would be consumed first,
-    so they get a chance to appear in the Activity Feed quicker.
     """
 
-    ordering = ('modified_on', 'id')
     summary = 'Large Capital Opportunity Activities Added'
 
 

--- a/datahub/activity_stream/pagination.py
+++ b/datahub/activity_stream/pagination.py
@@ -1,9 +1,17 @@
+import binascii
+import uuid
+from base64 import b64decode
+from datetime import datetime, timedelta
+from urllib.parse import parse_qs, parse_qsl, urlencode, urlparse, urlunparse
+
 from django.core.exceptions import ImproperlyConfigured
-from rest_framework.pagination import CursorPagination
+from django.db.models import F, Func, TextField
+from rest_framework.pagination import BasePagination
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 
 
-class ActivityCursorPagination(CursorPagination):
+class ActivityCursorPagination(BasePagination):
     """
     Cursor pagination for activities.
 
@@ -16,15 +24,15 @@ class ActivityCursorPagination(CursorPagination):
     decided to use cursor pagination here because we needed to render the last page quite
     frequently.
 
-    According to the docs (See ref), cursor pagination required an ordering field that amongst
-    other things:
+    The built-in Django Rest Framework Cursor pagination is not used, since it
 
-        "Should be an unchanging value, such as a timestamp, slug, or other
-        field that is only set once, on creation."
-
-    Ref: https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination
+    - has a lot of code that isn't applicable to this use case, which makes it tricky to extend or
+      debug, e.g. for peformance issues
+    - uses an almost-unique value + offset cursor that isn't needed when we have a completely
+      unique compound cursor: (modified_on, id)
     """
 
+    page_size = api_settings.PAGE_SIZE
     summary = None
 
     def _get_summary(self):
@@ -34,6 +42,76 @@ class ActivityCursorPagination(CursorPagination):
                 'or a `_get_summary()` method',
             )
         return self.summary
+
+    def _replace_query_param(self, url, key, vals):
+        """
+        Replaces all of the values of `key` of the query in `url` with `vals`
+
+        The DRF version of this function is not used, since it always replaces all of the values of
+        `key` with a single value.
+        """
+        parsed = urlparse(url)
+        return urlunparse(parsed._replace(query=urlencode(tuple(
+            (_key, val) for (_key, val) in parse_qsl(parsed.query, keep_blank_values=True)
+            if _key != key
+        ) + tuple((key, val) for val in vals))))
+
+    def paginate_queryset(self, queryset, request, view=None):
+        """
+        Returns a page of results based on the cursor query string parameter. Designed to make the
+        last page empty
+        """
+        # Extract cursor from query string. Inclues partial support for DRF's base64-encoded cursor
+        # of timestamp + offset, the previous pagination mechanism. This is so that at the time
+        # of deployment the Activity Stream can carry on from at most a few pages before where it
+        # was. Once this is live and working, the DRF support can be removed
+        try:
+            after_ts_str = parse_qs(b64decode(request.GET.getlist('cursor')[0]))[b'p'][0].decode()
+            after_id_str = '00000000-0000-0000-0000-000000000000'
+        except (IndexError, KeyError, binascii.Error):
+            after_ts_str, after_id_str = request.GET.getlist(
+                'cursor',
+                ('0001-01-01 00:00:00.000000+00:00', '00000000-0000-0000-0000-000000000000'),
+            )
+
+        after_ts = datetime.fromisoformat(after_ts_str)
+        after_id = uuid.UUID(after_id_str)
+
+        # Filter queryset to be after cursor.
+        #
+        # A composite/row/tuple lexicographic comparison is used to have the biggest chance of
+        # fully using a multicolumn index. When tested on interactions in production, these queries
+        # take ~50ms. If doing the comparison "manually", such queries take take ~1.5s+
+        #
+        # To do this in the Django ORM requires 'annotate', which itself requires a small hack: the
+        # setting of an output_field, which can be anything since we don't access the value.
+        modified_on_id = Func(F('modified_on'), F('id'), function='ROW', output_field=TextField())
+        after_ts_id = Func(after_ts, after_id, function='ROW')
+
+        # Mitigate the risk of timestamps being committed slightly out of order, which could result
+        # in activities being missed when the last page is polled
+        one_second_ago = datetime.now() - timedelta(seconds=1)
+
+        page = list(queryset
+                    .annotate(modified_on_id=modified_on_id)
+                    .filter(modified_on_id__gt=after_ts_id, modified_on__lt=one_second_ago)
+                    # Do not use ROW expressions in order_by: it seems to have an extremely
+                    # negative performance impact
+                    .order_by('modified_on', 'id')[:self.page_size])
+
+        # Build and store next link for all non-empty pages to be used in get_paginated_response
+        if not page:
+            self.next_link = None
+        else:
+            final_instance = page[-1]
+            next_after_ts_str = final_instance.modified_on.isoformat(timespec='microseconds')
+            next_after_id_str = str(final_instance.id)
+            self.next_link = self._replace_query_param(
+                request.build_absolute_uri(),
+                'cursor', (next_after_ts_str, next_after_id_str),
+            )
+
+        return page
 
     def get_paginated_response(self, data):
         """
@@ -46,6 +124,6 @@ class ActivityCursorPagination(CursorPagination):
                 'summary': self._get_summary(),
                 'type': 'OrderedCollectionPage',
                 'orderedItems': data,
-                'next': self.get_next_link(),
+                'next': self.next_link,
             },
         )

--- a/datahub/activity_stream/pagination.py
+++ b/datahub/activity_stream/pagination.py
@@ -27,9 +27,6 @@ class ActivityCursorPagination(CursorPagination):
 
     summary = None
 
-    def _get_url(self):
-        return self.encode_cursor(self.cursor) if self.cursor else self.base_url
-
     def _get_summary(self):
         if self.summary is None:
             raise ImproperlyConfigured(
@@ -48,8 +45,6 @@ class ActivityCursorPagination(CursorPagination):
                 '@context': 'https://www.w3.org/ns/activitystreams',
                 'summary': self._get_summary(),
                 'type': 'OrderedCollectionPage',
-                'id': self._get_url(),
-                'partOf': self.base_url,
                 'orderedItems': data,
                 'next': self.get_next_link(),
             },

--- a/datahub/activity_stream/test/test_cursor_pagination.py
+++ b/datahub/activity_stream/test/test_cursor_pagination.py
@@ -1,4 +1,6 @@
+import base64
 import datetime
+import urllib.parse
 
 import pytest
 from freezegun import freeze_time
@@ -31,8 +33,17 @@ def test_cursor_pagination(factory, endpoint, api_client, monkeypatch):
     )
 
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-    with freeze_time(start):
+    with freeze_time(start) as frozen_datetime:
         interactions = factory.create_batch(page_size + 1)
+        frozen_datetime.tick(datetime.timedelta(seconds=1))
+
+        response = hawk.get(api_client, get_url(endpoint))
+        assert response.status_code == status.HTTP_200_OK
+        page_0_data = response.json()
+        assert len(page_0_data['orderedItems']) == 0
+
+        frozen_datetime.tick(datetime.timedelta(microseconds=1))
+
         response = hawk.get(api_client, get_url(endpoint))
         assert response.status_code == status.HTTP_200_OK
 
@@ -42,4 +53,35 @@ def test_cursor_pagination(factory, endpoint, api_client, monkeypatch):
 
         response = hawk.get(api_client, page_2_url)
         page_2_data = response.json()
+        page_3_url = page_2_data['next']
         assert len(page_2_data['orderedItems']) == len(interactions) - page_size
+
+        response = hawk.get(api_client, page_3_url)
+        page_3_data = response.json()
+        assert len(page_3_data['orderedItems']) == 0
+        assert page_3_data['next'] is None
+
+        interactions = factory.create_batch(1)
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+
+        response = hawk.get(api_client, page_3_url)
+        page_3_post_update_data = response.json()
+        assert len(page_3_post_update_data['orderedItems']) == 1
+
+        page_4_url = page_3_post_update_data['next']
+        response = hawk.get(api_client, page_4_url)
+        page_4_data = response.json()
+        assert len(page_4_data['orderedItems']) == 0
+        assert page_4_data['next'] is None
+
+        # Assert that DRF's cursor works, to not break existing pagination just after deployment
+        now = datetime.datetime.now().isoformat(timespec='microseconds')
+        cursor = base64.b64encode((f'p={urllib.parse.quote(now)}').encode()).decode()
+
+        frozen_datetime.tick(datetime.timedelta(microseconds=1))
+        interactions = factory.create_batch(1)
+
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, f'{get_url(endpoint)}?cursor={cursor}')
+        page_drf_data = response.json()
+        assert len(page_drf_data['orderedItems']) == 1


### PR DESCRIPTION
### Description of change

Django Rest Framework's cursor pagination works "ok" for the Activity Stream, but it doesn't adhere to the "last page that's polled for updates should be empty until there is an update", which means to avoid repeatedly re-ingesting the exact same activities, the Activity Stream needs heuristic (and suspected buggy) work-arounds. This PR makes the last page of endpoints empty, so them the Activity Stream can have the work-arounds removed.

It also has a suspected performance improvement, since the cursor uses a tuple comparison, which is likely to mean multi-column indexes on (modified_on, id) will be utilised fully. Django Rest Framework's cursor pagination doesn't do that.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
