### PR TITLE
feat: remove unused field in Activity Stream endpoints

### DIFF
--- a/changelog/company/remove-previous-from-activity-stream-endpoint.removal.md
+++ b/changelog/company/remove-previous-from-activity-stream-endpoint.removal.md
@@ -1,0 +1,1 @@
+The `previous` key in the `company_referral` Activty Stream endpoint has been removed.

--- a/changelog/interaction/remove-previous-from-activity-stream-endpoint.removal.md
+++ b/changelog/interaction/remove-previous-from-activity-stream-endpoint.removal.md
@@ -1,0 +1,1 @@
+The `previous` key in the `interaction` Activty Stream endpoint has been removed.

--- a/changelog/investment/remove-previous-from-investment-activity-stream-endpoint.removal.md
+++ b/changelog/investment/remove-previous-from-investment-activity-stream-endpoint.removal.md
@@ -1,0 +1,1 @@
+The `previous` key in the `investment` Activty Stream endpoint has been removed.

--- a/changelog/investment/remove-previous-from-investor-profile-activity-stream-endpoint.removal.md
+++ b/changelog/investment/remove-previous-from-investor-profile-activity-stream-endpoint.removal.md
@@ -1,0 +1,1 @@
+The `previous` key in the `investor_profile` Activty Stream endpoint has been removed.

--- a/changelog/investment/remove-previous-from-large-capital-opportunity-activity-stream-endpoint.md
+++ b/changelog/investment/remove-previous-from-large-capital-opportunity-activity-stream-endpoint.md
@@ -1,0 +1,1 @@
+The `previous` key in the `large-capital-opportunity` Activty Stream endpoint has been removed.

--- a/changelog/investment/remove-previous-from-opportunity-activity-stream-endpoint.removal.md
+++ b/changelog/investment/remove-previous-from-opportunity-activity-stream-endpoint.removal.md
@@ -1,0 +1,1 @@
+The `previous` key in the `opportunity` Activty Stream endpoint has been removed.

--- a/changelog/omis/remove-previous-from-omis-activity-stream-endpoint.removal.md
+++ b/changelog/omis/remove-previous-from-omis-activity-stream-endpoint.removal.md
@@ -1,0 +1,1 @@
+The `previous` key in the `omis` Activty Stream endpoint has been removed.

--- a/datahub/activity_stream/company_referral/test/test_views.py
+++ b/datahub/activity_stream/company_referral/test/test_views.py
@@ -28,7 +28,6 @@ def test_company_referral_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/company-referral',
         'partOf': 'http://testserver/v3/activity-stream/company-referral',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -109,7 +108,6 @@ def test_closed_company_referral_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/company-referral',
         'partOf': 'http://testserver/v3/activity-stream/company-referral',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -190,7 +188,6 @@ def test_complete_company_referral_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/company-referral',
         'partOf': 'http://testserver/v3/activity-stream/company-referral',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -288,7 +285,6 @@ def test_company_referral_activity_without_team_and_contact(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/company-referral',
         'partOf': 'http://testserver/v3/activity-stream/company-referral',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -34,7 +34,6 @@ def test_interaction_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/interaction',
         'partOf': 'http://testserver/v3/activity-stream/interaction',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -113,7 +112,6 @@ def test_interaction_investment_project_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/interaction',
         'partOf': 'http://testserver/v3/activity-stream/interaction',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -199,7 +197,6 @@ def test_service_delivery_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/interaction',
         'partOf': 'http://testserver/v3/activity-stream/interaction',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -277,7 +274,6 @@ def test_service_delivery_event_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/interaction',
         'partOf': 'http://testserver/v3/activity-stream/interaction',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/investment/test/test_views.py
+++ b/datahub/activity_stream/investment/test/test_views.py
@@ -28,7 +28,6 @@ def test_investment_project_added(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/investment/project-added',
         'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -100,7 +99,6 @@ def test_investment_project_with_pm_added(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/investment/project-added',
         'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -175,7 +173,6 @@ def test_investment_project_verify_win_added(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/investment/project-added',
         'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -251,7 +248,6 @@ def test_investment_project_added_with_gva(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/investment/project-added',
         'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/investor_profile/test/test_views.py
+++ b/datahub/activity_stream/investor_profile/test/test_views.py
@@ -30,7 +30,6 @@ def test_large_capital_investor_profile_activity(api_client):
             'http://testserver/v3/activity-stream/investment/large-capital-investor-profiles',
         'partOf':
             'http://testserver/v3/activity-stream/investment/large-capital-investor-profiles',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -83,7 +82,6 @@ def test_complete_large_capital_investor_profile_activity(api_client):
         'id': 'http://testserver/v3/activity-stream/investment/large-capital-investor-profiles',
         'partOf':
             'http://testserver/v3/activity-stream/investment/large-capital-investor-profiles',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/omis/test/test_views.py
+++ b/datahub/activity_stream/omis/test/test_views.py
@@ -32,7 +32,6 @@ def test_omis_order_added_activity(api_client, order_overrides):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/omis/order-added',
         'partOf': 'http://testserver/v3/activity-stream/omis/order-added',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/opportunity/test/test_views.py
+++ b/datahub/activity_stream/opportunity/test/test_views.py
@@ -29,7 +29,6 @@ def test_large_capital_opportunity_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity',
         'partOf': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {
@@ -85,7 +84,6 @@ def test_complete_large_capital_opportunity_activity(api_client):
         'type': 'OrderedCollectionPage',
         'id': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity',
         'partOf': 'http://testserver/v3/activity-stream/investment/large-capital-opportunity',
-        'previous': None,
         'next': None,
         'orderedItems': [
             {

--- a/datahub/activity_stream/pagination.py
+++ b/datahub/activity_stream/pagination.py
@@ -52,6 +52,5 @@ class ActivityCursorPagination(CursorPagination):
                 'partOf': self.base_url,
                 'orderedItems': data,
                 'next': self.get_next_link(),
-                'previous': self.get_previous_link(),
             },
         )

--- a/datahub/activity_stream/test/test_cursor_pagination.py
+++ b/datahub/activity_stream/test/test_cursor_pagination.py
@@ -37,10 +37,4 @@ def test_cursor_pagination(factory, endpoint, api_client, monkeypatch):
 
     response = hawk.get(api_client, page_2_url)
     page_2_data = response.json()
-    page_1_url = page_2_data['previous']
     assert len(page_2_data['orderedItems']) == len(interactions) - page_size
-
-    response = hawk.get(api_client, page_1_url)
-    page_1_data_2 = response.json()
-    assert page_1_data['orderedItems'] == page_1_data_2['orderedItems']
-    assert page_1_data_2['next'] == page_2_url


### PR DESCRIPTION


### Description of change

The 'previous' field isn't being used by the ActivityStream, and so makes it harder to reason about what the Activity Stream does.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
