### PR TITLE
Remove rest of mi-postgres references

### DIFF
--- a/changelog/changelog/mi-dashboard-cleanup.removal.md
+++ b/changelog/changelog/mi-dashboard-cleanup.removal.md
@@ -1,0 +1,1 @@
+Cleanup references around `mi_dashboard` app given it has been removed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,10 @@ services:
       - "8000:8000"
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://es-apm:8200 -wait tcp://redis:6379 -timeout 120s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -wait tcp://es-apm:8200 -wait tcp://redis:6379 -timeout 120s
     env_file: .env
     depends_on:
       - postgres
-      - mi-postgres
       - es
       - redis
       - es-apm
@@ -23,7 +22,7 @@ services:
       context: .
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://es-apm:8200 -wait tcp://redis:6379 -wait tcp://api:8000 -timeout 300s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -wait tcp://es-apm:8200 -wait tcp://redis:6379 -wait tcp://api:8000 -timeout 300s
     env_file: .env
     depends_on:
       - api
@@ -35,13 +34,6 @@ services:
     environment:
       - POSTGRES_DB=datahub
       - POSTGRES_PASSWORD=datahub
-
-  mi-postgres:
-    image: postgres:9.6
-    restart: always
-    environment:
-      - POSTGRES_DB=mi
-      - POSTGRES_PASSWORD=mi
 
   es:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -8,7 +8,7 @@ es_amp=""
 if [ "$ES_APM_ENABLED" = 'True' ] ; then
    es_amp="-wait tcp://es-apm:8200"
 fi
-dockerize -wait  tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200  -wait tcp://redis:6379 $es_amp
+dockerize -wait  tcp://postgres:5432 -wait tcp://es:9200  -wait tcp://redis:6379 $es_amp
 
 python /app/manage.py migrate
 python /app/manage.py migrate --database mi


### PR DESCRIPTION
### Description of change

Remove rest of mi-postgres references. These references are causing the frontend tests that rely on `start-uat` script which is currently failing because of these references.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
