### PR TITLE
Add new Capital Investment specific programme

### DIFF
--- a/datahub/investment/project/fixtures/specific_programmes.yaml
+++ b/datahub/investment/project/fixtures/specific_programmes.yaml
@@ -73,3 +73,6 @@
 - model: investment.specificprogramme
   pk: a7dd7b74-7c50-e411-985c-e4115bead28a
   fields: {disabled_on: "2015-03-02T08:57:05Z", name: "Emerging Markets Contract (Russia)"}
+- model: investment.specificprogramme
+  pk: bf6de1aa-85b5-4228-9bff-0b562caeb320
+  fields: {disabled_on: null, name: "International Capital Investment Support"}

--- a/datahub/investment/project/migrations/0005_update_specific_programmes.py
+++ b/datahub/investment/project/migrations/0005_update_specific_programmes.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def update_specific_programmes(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps, PurePath(__file__).parent / "0005_update_specific_programmes.yaml"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("investment", "0004_auto_20210922_1706"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_specific_programmes, migrations.RunPython.noop),
+    ]

--- a/datahub/investment/project/migrations/0005_update_specific_programmes.yaml
+++ b/datahub/investment/project/migrations/0005_update_specific_programmes.yaml
@@ -1,0 +1,3 @@
+- model: investment.specificprogramme
+  pk: bf6de1aa-85b5-4228-9bff-0b562caeb320
+  fields: {disabled_on: null, name: "International Capital Investment Support"}


### PR DESCRIPTION
### Description of change

This PR adds a new option to the `SpecificInvestmentProgramme` investment metadata model, it includes:
- A yaml file with the new `International Capital Investment Support` programme
- A migration file to load this new programme
- An update to the specific programme fixture file, which will ensure the new programme is loaded when the `loadinitialmetadata` command is run

### To test

- Run branch locally
- Bring API down and up again to load metadata/run migration
- Go to `/admin/investment/specificprogramme/`
- You should see `International Capital Investment Support` in the list

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
