### PR TITLE
Adds land date financial year filter

### DIFF
--- a/changelog/investment/land_date_financial_year_filter.feature.md
+++ b/changelog/investment/land_date_financial_year_filter.feature.md
@@ -1,0 +1,8 @@
+Land date financial year filters can now be applied to the search investments endpoint.
+
+`POST /v3/search/investment_project { "land_date_financial_year_start": [<years>] }`
+
+For example, to get investment projects from financial years 2017-18 and 2020-21, you can call:
+`POST /v3/search/investment_project { "land_date_financial_year_start": ["2017", "2020"] }`
+
+Unlike the `financial_year_start` filter, there is no special behaviour for projects in the "Prospect" stage. All projects use their actual land date, falling back to estimated land date if that has not been set.

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -36,6 +36,10 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
     status = SingleOrListField(child=serializers.CharField(), required=False)
     uk_region_location = SingleOrListField(child=StringUUIDField(), required=False)
     financial_year_start = SingleOrListField(child=serializers.IntegerField(), required=False)
+    land_date_financial_year_start = SingleOrListField(
+        child=serializers.IntegerField(),
+        required=False,
+    )
     level_of_involvement_simplified = SingleOrListField(
         child=serializers.ChoiceField(choices=InvestmentProject.Involvement.choices),
         required=False,


### PR DESCRIPTION
### Description of change

Adds a filter for `land_date_financial_year_start` to the investments serahc endpoint. This is based on actual land date, falling back to estimated land date if not present.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
