### PR TITLE
Dependabot updates 04/10/2021

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,7 @@ django-axes==5.25.0
 django-environ==0.7.0
 django-extensions==3.1.3
 django-filter==21.1
-django-mptt==0.13.3
+django-mptt==0.13.4
 django-pglocks==1.0.4
 django-reversion==4.0.0
 uritemplate==3.0.1  # required for DRF schema features

--- a/requirements.in
+++ b/requirements.in
@@ -64,7 +64,7 @@ pip-tools==6.3.0
 piprot==0.9.11
 semantic_version==2.8.5
 towncrier==21.3.0
-watchdog[watchmedo]==2.1.5
+watchdog[watchmedo]==2.1.6
 pre-commit==2.15.0
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -70,7 +70,7 @@ pre-commit==2.15.0
 
 # Code static analysis
 flake8==3.9.2
-flake8-bugbear==21.9.1
+flake8-bugbear==21.9.2
 flake8-commas==2.0.0
 flake8-debugger==4.0.0
 flake8-import-order==0.18.1

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ python-dateutil==2.8.2
 psycopg2==2.9.1
 psycogreen==1.0.2
 
-boto3==1.18.48
+boto3==1.18.53
 
 notifications-python-client==6.2.1
 

--- a/requirements.in
+++ b/requirements.in
@@ -86,5 +86,5 @@ gevent==21.8.0
 mohawk==1.1.0
 requests==2.26.0
 requests_toolbelt==0.9.1
-sentry_sdk==1.4.1
+sentry_sdk==1.4.3
 simple_salesforce==1.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,7 +90,7 @@ django-ipware==4.0.0
     # via django-axes
 django-js-asset==1.2.2
     # via django-mptt
-django-mptt==0.13.3
+django-mptt==0.13.4
     # via -r requirements.in
 django-pglocks==1.0.4
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,8 +8,6 @@ aiohttp==3.7.4.post0
     # via slackclient
 amqp==2.6.1
     # via kombu
-argh==0.26.2
-    # via watchdog
 asgiref==3.4.1
     # via django
 async-timeout==3.0.1
@@ -374,7 +372,7 @@ vine==1.3.0
     #   celery
 virtualenv==20.8.1
     # via pre-commit
-watchdog[watchmedo]==2.1.5
+watchdog[watchmedo]==2.1.6
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,9 +27,9 @@ billiard==3.6.4.0
     # via
     #   -r requirements.in
     #   celery
-boto3==1.18.48
+boto3==1.18.53
     # via -r requirements.in
-botocore==1.21.48
+botocore==1.21.53
     # via
     #   boto3
     #   s3transfer

--- a/requirements.txt
+++ b/requirements.txt
@@ -130,7 +130,7 @@ flake8==3.9.2
     #   flake8-quotes
     #   flake8-string-format
     #   pep8-naming
-flake8-bugbear==21.9.1
+flake8-bugbear==21.9.2
     # via -r requirements.in
 flake8-commas==2.0.0
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -311,7 +311,7 @@ s3transfer==0.5.0
     # via boto3
 semantic_version==2.8.5
     # via -r requirements.in
-sentry_sdk==1.4.1
+sentry_sdk==1.4.3
     # via -r requirements.in
 simple_salesforce==1.11.4
     # via -r requirements.in


### PR DESCRIPTION
### Description of change

Includes the following dependency updates:
- Bump watchdog[watchmedo] from 2.1.5 to 2.1.6
- Bump django-mptt from 0.13.3 to 0.13.4
- Bump sentry-sdk from 1.4.1 to 1.4.3
- Bump flake8-bugbear from 21.9.1 to 21.9.2
- Bump boto3 from 1.18.48 to 1.18.53


### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
