### PR TITLE
CDS-311 Add --reuse-db to addopts to reduce upfront timecost of db tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ds=config.settings.test
+addopts = --ds=config.settings.test --reuse-db
 junit_family=xunit2
 norecursedirs = env
 filterwarnings =


### PR DESCRIPTION
### Description of change

So, after looking through the profiling output of the database-dependent tests in data-hub-api, it looks like there is an upfront cost to creating the schema of the database that the tests are to be run on of about ~40 seconds.

This marries up with the observations myself and others have made; that there is a large wait time when running even a single database-dependent test in datahub API, so reducing or removing this overhead would seem to be a valuable exercise.

So, django-pytest provides a flag to its testing command to keep the test database after the tests have executed, and if the database exists, reuse it in the current execution: `--reuse-db`
Setting this flag on two concurrent runs caused the test suite execution time of `pytest datahub/dataset/interaction/test/` to drop from 42.85s to 6.12s
This flag has been known about for a while, but people often forget to set it. Fortunately pytest allows you to specify default command line flags in the pytest.ini file by appending them to the `addopts` configuration option. This will allow the database to be reused by default. This can be overwritten by appending `--create-db` to the command line invocation of pytest

If additional migrations have been added since the previous test execution, these seem to be applied even with `--reuse-db` set

In CircleCI, the behavior will remain unchanged as we're always creating a new database as part of each CI execution

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
