### PR TITLE
CDS-336 Add `turnover_gbp` to `/v4/datasets/companies-dataset`

### DIFF
--- a/changelog/company/add_turnover_gbp_dataset.api.md
+++ b/changelog/company/add_turnover_gbp_dataset.api.md
@@ -1,0 +1,1 @@
+Add `turnover_gbp` field to GET responses for `/v4/dataset/companies-dataset` which represents the turnover (stored and returned by API in USD) converted to Great British Pounds (GBP) using the latest exchange rate stored in Data Hub API

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -529,8 +529,10 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         """
         :returns: Turnover value in GBP if turnover is not None, otherwise return None
         """
-        if obj.turnover:
+        if obj.turnover is not None:
             return convert_usd_to_gbp(obj.turnover)
+        else:
+            return None
 
     def create(self, validated_data):
         """

--- a/datahub/dataset/company/test/test_views.py
+++ b/datahub/dataset/company/test/test_views.py
@@ -85,7 +85,11 @@ def get_expected_data_from_company(company):
         'vat_number': company.vat_number,
         'website': company.website,
     }
-    #TODO
+    if data['turnover']:
+        data['turnover_gbp'] = convert_usd_to_gbp(data['turnover'])
+    else:
+        data['turnover_gbp'] = None
+
     return data
 
 
@@ -118,11 +122,18 @@ class TestCompaniesDatasetViewSet(BaseDatasetViewTest):
         expected_result = get_expected_data_from_company(company)
         assert result == expected_result
 
+    @pytest.mark.parametrize(
+        'company_factory', (
+            CompanyWithAreaFactory,
+            ArchivedCompanyFactory,
+        ),
+    )
     def test_turnover_null(self, data_flow_api_client, company_factory):
-        # Setup
+        """Test that endpoint returns with expected data for a null turnover value"""
         company = company_factory()
         company.created_by = None
         company.created_on = None
+        company.turnover = None
         company.save()
 
         response = data_flow_api_client.get(self.view_url)

--- a/datahub/dataset/company/test/test_views.py
+++ b/datahub/dataset/company/test/test_views.py
@@ -85,7 +85,7 @@ def get_expected_data_from_company(company):
         'vat_number': company.vat_number,
         'website': company.website,
     }
-    if data['turnover']:
+    if data['turnover'] is not None:
         data['turnover_gbp'] = convert_usd_to_gbp(data['turnover'])
     else:
         data['turnover_gbp'] = None

--- a/datahub/dataset/company/test/test_views.py
+++ b/datahub/dataset/company/test/test_views.py
@@ -11,6 +11,7 @@ from datahub.company.test.factories import (
 )
 from datahub.core.test_utils import format_date_or_datetime, get_attr_or_none
 from datahub.dataset.core.test import BaseDatasetViewTest
+from datahub.metadata.utils import convert_usd_to_gbp
 
 
 def get_expected_data_from_company(company):
@@ -80,6 +81,7 @@ def get_expected_data_from_company(company):
         'export_sub_segment': company.export_sub_segment,
         'trading_names': company.trading_names,
         'turnover': company.turnover,
+        'turnover_gbp': convert_usd_to_gbp(company.turnover),
         'uk_region__name': get_attr_or_none(company, 'uk_region.name'),
         'vat_number': company.vat_number,
         'website': company.website,

--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -67,4 +67,6 @@ class CompaniesDatasetView(BaseDatasetView):
         for data in dataset:
             if data.get('turnover'):
                 data['turnover_gbp'] = convert_usd_to_gbp(data['turnover'])
+            else:
+                data['turnover_gbp'] = None
         return super()._enrich_data(dataset)

--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -65,7 +65,7 @@ class CompaniesDatasetView(BaseDatasetView):
 
     def _enrich_data(self, dataset):
         for data in dataset:
-            if data.get('turnover'):
+            if data.get('turnover') is not None:
                 data['turnover_gbp'] = convert_usd_to_gbp(data['turnover'])
             else:
                 data['turnover_gbp'] = None

--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -1,6 +1,7 @@
 from datahub.company.models import Company
 from datahub.dataset.core.views import BaseDatasetView
 from datahub.metadata.query_utils import get_sector_name_subquery
+from datahub.metadata.utils import convert_usd_to_gbp
 
 
 class CompaniesDatasetView(BaseDatasetView):
@@ -61,3 +62,9 @@ class CompaniesDatasetView(BaseDatasetView):
             'vat_number',
             'website',
         )
+
+    def _enrich_data(self, dataset):
+        for data in dataset:
+            if data.get('turnover'):
+                data['turnover_gbp'] = convert_usd_to_gbp(data['turnover'])
+        return super()._enrich_data(dataset)


### PR DESCRIPTION
### Description of change

* Add `turnover_gbp` field to GET responses for `/v4/dataset/companies-dataset` which represents the turnover (stored and returned by API in USD) converted to Great British Pounds (GBP) using the latest exchange rate stored in Data Hub API

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
