### PR TITLE
Tweak fuzzy search matching to require 70% match on name

### DIFF
--- a/changelog/fuzzy-search-tweak.bugfix.md
+++ b/changelog/fuzzy-search-tweak.bugfix.md
@@ -1,0 +1,1 @@
+Tweaks fuzzy search matching to require at least a 70% match on name (previously 50%)

--- a/conftest.py
+++ b/conftest.py
@@ -14,9 +14,11 @@ from datahub.core.constants import AdministrativeArea
 from datahub.core.test_utils import HawkAPITestClient
 from datahub.dnb_api.utils import format_dnb_company
 from datahub.documents.utils import get_s3_client_for_bucket
+from datahub.feature_flag.models import FeatureFlag
 from datahub.metadata.test.factories import SectorFactory
 from datahub.search.apps import get_search_app_by_model, get_search_apps
 from datahub.search.bulk_sync import sync_objects
+from datahub.search.constants import FUZZY_SEARCH_FEATURE_FLAG
 from datahub.search.elasticsearch import (
     alias_exists,
     create_index,
@@ -468,6 +470,15 @@ def formatted_dnb_company_area(dnb_response_uk):
         address_area_abbrev_name=AdministrativeArea.texas.value.area_code,
     )
     return format_dnb_company(dnb_response_area)
+
+
+@pytest.fixture
+def fuzzy_search_feature():
+    """Enable the fuzzy search feature flag"""
+    return FeatureFlag.objects.update_or_create(
+        code=FUZZY_SEARCH_FEATURE_FLAG,
+        defaults={'is_active': True},
+    )
 
 
 def pytest_addoption(parser):

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -279,7 +279,7 @@ def _build_fuzzy_term_query(term, fields=None):
         Match(**{
             field: {
                 'query': term,
-                'minimum_should_match': '50%' if field == 'name.trigram' else '70%',
+                'minimum_should_match': '70%',
                 'boost': 1.5 if field == 'name.trigram' else 1,
             },
         })

--- a/datahub/search/test/conftest.py
+++ b/datahub/search/test/conftest.py
@@ -1,9 +1,7 @@
 import pytest
 
 from datahub.core.test_utils import create_test_user
-from datahub.feature_flag.models import FeatureFlag
 from datahub.search.apps import get_search_apps
-from datahub.search.constants import FUZZY_SEARCH_FEATURE_FLAG
 from datahub.search.views import v3_view_registry, v4_view_registry
 
 
@@ -33,12 +31,3 @@ def pytest_generate_tests(metafunc):
 def search_support_user():
     """A user with permissions for search_support views."""
     return create_test_user(permission_codenames=['view_simplemodel', 'view_relatedmodel'])
-
-
-@pytest.fixture
-def fuzzy_search_feature():
-    """Enable the fuzzy search feature flag"""
-    return FeatureFlag.objects.update_or_create(
-        code=FUZZY_SEARCH_FEATURE_FLAG,
-        defaults={'is_active': True},
-    )

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -226,7 +226,7 @@ def test_build_term_query(term, expected):
                             'match': {
                                 'name.trigram': {
                                     'query': 'hello',
-                                    'minimum_should_match': '50%',
+                                    'minimum_should_match': '70%',
                                     'boost': 1.5,
                                 },
                             },

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -216,7 +216,7 @@ class TestBasicSearch(APITestMixin):
         SimpleModel.objects.create(name='The Risk Advisory Group')
         SimpleModel.objects.create(name='The Advisory Group')
         SimpleModel.objects.create(name='The Advisory')
-        SimpleModel.objects.create(name='The Adivsory')
+        SimpleModel.objects.create(name='The Advasory')
         SimpleModel.objects.create(name='The Advisories')
         SimpleModel.objects.create(name='The Group')
 
@@ -244,7 +244,7 @@ class TestBasicSearch(APITestMixin):
             'The Advisory Group',
             'The Risk Advisory Group',
             'The Advisories',
-            'The Adivsory',
+            'The Advasory',
         ] == [result['name'] for result in response.data['results']]
 
     def test_fuzzy_quality_cross_fields(


### PR DESCRIPTION
### Description of change

Fuzzy search matching was returning results that were not very close to the search term - this makes matching a bit stricter.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
