### PR TITLE
Added ECS log formatter

### DIFF
--- a/config/settings/common_logging.py
+++ b/config/settings/common_logging.py
@@ -1,4 +1,6 @@
+import sys
 import sentry_sdk
+from django_log_formatter_ecs import ECSFormatter
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -8,26 +10,34 @@ from config.settings.common import *
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
-    'root': {
-        'level': 'INFO',
-        'handlers': ['console'],
-    },
     'formatters': {
         'verbose': {
             'format': '%(asctime)s [%(levelname)s] [%(name)s] %(message)s'
         },
-    },
-    'handlers': {
-        'console': {
-            'level': 'DEBUG',
-            'class': 'logging.StreamHandler',
-            'formatter': 'verbose'
+        'ecs_formatter': {
+            '()': ECSFormatter,
         },
     },
+    'handlers': {
+        'ecs': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'ecs_formatter',
+            'stream': sys.stdout,
+        },
+    },
+    'root': {
+        'level': 'INFO',
+        'handlers': ['ecs'],
+    },
     'loggers': {
+        'django': {
+            'level': 'INFO',
+            'handlers': ['ecs'],
+            'propagate': False,
+        },
         'django.db.backends': {
             'level': 'ERROR',
-            'handlers': ['console'],
+            'handlers': ['ecs'],
             'propagate': False,
         },
     },

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,4 +1,4 @@
-from config.settings.common_sentry import *
+from config.settings.common_logging import *
 
 # DRF
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += ['rest_framework.authentication.SessionAuthentication']

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,3 +1,3 @@
-from config.settings.common_sentry import *
+from config.settings.common_logging import *
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -1,4 +1,4 @@
-from config.settings.common_sentry import *
+from config.settings.common_logging import *
 
 # DRF
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += ['rest_framework.authentication.SessionAuthentication']

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ django-axes==5.27.0
 django-environ==0.8.1
 django-extensions==3.1.5
 django-filter==21.1
+django-log-formatter-ecs==0.0.5
 django-mptt==0.13.4
 django-pglocks==1.0.4
 django-reversion==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,10 +86,14 @@ django-extensions==3.1.5
     # via -r requirements.in
 django-filter==21.1
     # via -r requirements.in
-django-ipware==4.0.0
-    # via django-axes
+django-ipware==3.0.7
+    # via
+    #   django-axes
+    #   django-log-formatter-ecs
 django-js-asset==1.2.2
     # via django-mptt
+django-log-formatter-ecs==0.0.5
+    # via -r requirements.in
 django-mptt==0.13.4
     # via -r requirements.in
 django-pglocks==1.0.4


### PR DESCRIPTION
### Description of change
The SOC team wants to start receiving all datahub logs and these need to be in Elastic ECS format. This change implements [django-log-formatter-ecs](https://github.com/uktrade/django-log-formatter-ecs).