### PR TITLE
Update Postgres images to v12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,6 @@ workflows:
       - build:
           publish_coverage: true
           python_image: python:3.8
-          postgres_image: postgres:10
+          postgres_image: postgres:12
           es_image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
           es_apm_image: docker.elastic.co/apm/apm-server:7.7.1

--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ There is now a `make` command to bring up the three environments on a single doc
 Dependencies:
 
 -   Python 3.8.x
--   PostgreSQL 10
+-   PostgreSQL 12
 -   redis 3.2
--   Elasticsearch 6.8
+-   Elasticsearch 7.10
 
 1.  Clone the repository:
 

--- a/docker-compose-minimal.yml
+++ b/docker-compose-minimal.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   postgres:
-    image: postgres:10
+    image: postgres:12
     restart: always
     environment:
       - POSTGRES_MULTIPLE_DATABASES=datahub,mi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     command: watchmedo auto-restart -d . -R -p '*.py' -- celery worker -A config -l info -Q celery -B
 
   postgres:
-    image: postgres:10
+    image: postgres:12
     restart: always
     environment:
       - POSTGRES_DB=datahub


### PR DESCRIPTION
### Description of change

The Postgres images for CircleCI and Docker were set to v10, when we are now using v12.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
