### PR TITLE
Add new service types

### DIFF
--- a/changelog/interaction/add-service-types.feature.md
+++ b/changelog/interaction/add-service-types.feature.md
@@ -1,0 +1,3 @@
+New service types have been added to Investment Interaction - Enquiry received:
+- Commonwealth Games 2022 – BATP Programme
+- Commonwealth Games 2022 – GEP Programme

--- a/datahub/metadata/migrations/0001_initial_services.yaml
+++ b/datahub/metadata/migrations/0001_initial_services.yaml
@@ -503,6 +503,30 @@
     tree_id: 56
     level: 1
 - model: metadata.service
+  pk: ed487b52-4675-4338-a904-2c27e95ee195
+  fields:
+    disabled_on:
+    order: 229.0
+    segment: Commonwealth Games 2022 – BATP Programme
+    parent: dfc1577f-217c-49a7-987d-a6f8a1c61698
+    contexts: ["investment_interaction"]
+    lft: 2
+    rght: 3
+    tree_id: 9
+    level: 1
+- model: metadata.service
+  pk: fc569da6-7341-4785-9a42-b4fb2114351d
+  fields:
+    disabled_on:
+    order: 230.0
+    segment: Commonwealth Games 2022 – GEP Programme
+    parent: dfc1577f-217c-49a7-987d-a6f8a1c61698
+    contexts: ["investment_interaction"]
+    lft: 2
+    rght: 3
+    tree_id: 9
+    level: 1
+- model: metadata.service
   pk: 3a0bba2b-3499-e211-a939-e4115bead28a
   fields:
     disabled_on:

--- a/datahub/metadata/migrations/0019_update_services.py
+++ b/datahub/metadata/migrations/0019_update_services.py
@@ -1,0 +1,33 @@
+from pathlib import PurePath
+
+import mptt
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0019_update_services.yaml'
+    )
+
+
+def rebuild_tree(apps, _):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0018_add_usd_exchange_rate'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0019_update_services.yaml
+++ b/datahub/metadata/migrations/0019_update_services.yaml
@@ -1,0 +1,24 @@
+- model: metadata.service
+  pk: ed487b52-4675-4338-a904-2c27e95ee195
+  fields:
+    disabled_on:
+    order: 229.0
+    segment: Commonwealth Games 2022 – BATP Programme
+    parent: dfc1577f-217c-49a7-987d-a6f8a1c61698
+    contexts: ["investment_interaction"]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0
+- model: metadata.service
+  pk: fc569da6-7341-4785-9a42-b4fb2114351d
+  fields:
+    disabled_on:
+    order: 230.0
+    segment: Commonwealth Games 2022 – GEP Programme
+    parent: dfc1577f-217c-49a7-987d-a6f8a1c61698
+    contexts: ["investment_interaction"]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0


### PR DESCRIPTION
### Description of change

New service types have been added to Investment Interaction - Enquiry received:
- Commonwealth Games 2022 – BATP Programme
- Commonwealth Games 2022 – GEP Programme

![new services 2022](https://user-images.githubusercontent.com/5889630/144889952-db438451-81ac-4d92-9a07-609d31a150f0.jpg)

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
