### PR TITLE
Add proposition development service type

### DIFF
--- a/changelog/interaction/proposition-development-service.feature.md
+++ b/changelog/interaction/proposition-development-service.feature.md
@@ -1,0 +1,1 @@
+New service 'Proposition Development' added for 'other' interactions.

--- a/datahub/metadata/migrations/0021_update_services.py
+++ b/datahub/metadata/migrations/0021_update_services.py
@@ -1,0 +1,33 @@
+from pathlib import PurePath
+
+import mptt
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0021_update_services.yaml'
+    )
+
+
+def rebuild_tree(apps, _):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0020_update_referral_source_activities'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0021_update_services.yaml
+++ b/datahub/metadata/migrations/0021_update_services.yaml
@@ -1,0 +1,12 @@
+- model: metadata.service
+  pk: 329353bb-a152-49bf-b4fc-fc0f5f4a0f6a
+  fields:
+    disabled_on:
+    order: 440.0
+    segment: Proposition Development
+    parent:
+    contexts: ["other_interaction"]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0


### PR DESCRIPTION
### Description of change

This PR adds a new service type `Proposition Development` for 'other' interactions.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
