### PR TITLE
Add new trade agreements to metadata

### DIFF
--- a/changelog/update-trade-agreements.feature.md
+++ b/changelog/update-trade-agreements.feature.md
@@ -1,0 +1,1 @@
+Three new trade agreements were added to trade agreements metadata.

--- a/datahub/metadata/migrations/0022_update_trade_agreements.py
+++ b/datahub/metadata/migrations/0022_update_trade_agreements.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_trade_agreements(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0022_update_trade_agreements.yaml'
+    )
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0021_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_trade_agreements, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0022_update_trade_agreements.yaml
+++ b/datahub/metadata/migrations/0022_update_trade_agreements.yaml
@@ -1,0 +1,11 @@
+- model: metadata.tradeagreement
+  pk: aec42ee7-520a-4a17-af3f-da390a016841
+  fields: {disabled_on: null, name: 'Free Trade Agreements: Gulf Cooperation Council (GCC)'}
+
+- model: metadata.tradeagreement
+  pk: 21b4f851-6adc-49b1-815e-db87cba71953
+  fields: {disabled_on: null, name: 'UK-Singapore Digital Economy Agreement'}
+
+- model: metadata.tradeagreement
+  pk: ce32d8de-719c-4d7c-b125-5e03e82951d0
+  fields: {disabled_on: null, name: 'UK-Iceland, Liechtenstein and Norway Free Trade Agreement'}


### PR DESCRIPTION
### Description of change

This PR adds three new trade agreements to the trade agreement metadata table via a migration.

These were previously added to the interaction.policy_area metadata table by mistake, and will be removed from that table in a following PR.

I have not added these to the [fixtures/metadata/trade_agreements.yaml](https://github.com/uktrade/data-hub-api/blob/develop/fixtures/metadata/trade_agreements.yaml) file, as they will be included in all environments by adding through a migration. The agreements listed in this fixture file (bar one) appear to be ones that were added manually in django admin rather than via a migration.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
