### PR TITLE
Disable trade agreement policy areas

### DIFF
--- a/changelog/interaction/update-policy-areas.bugfix.md
+++ b/changelog/interaction/update-policy-areas.bugfix.md
@@ -1,0 +1,3 @@
+Trade agreement related policy areas disabled.
+
+Trade agreements mistakenly added to the policy areas metadata table were disabled.

--- a/datahub/interaction/migrations/0078_update_policy_areas.py
+++ b/datahub/interaction/migrations/0078_update_policy_areas.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+from datahub.core.migration_utils import load_yaml_data_in_migration
+from pathlib import PurePath
+
+def load_new_trade_agreements(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0078_update_policy_areas.yaml',
+    )
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('interaction', '0077_add_new_policy_areas'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=load_new_trade_agreements,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/datahub/interaction/migrations/0078_update_policy_areas.yaml
+++ b/datahub/interaction/migrations/0078_update_policy_areas.yaml
@@ -1,0 +1,19 @@
+- model: interaction.policyarea
+  pk: 2ffd1879-5ddb-4751-93ef-a46419bcfa1f
+  fields: {disabled_on: '2022-01-15T00:00:00', name: 'Free Trade Agreements: Gulf Cooperation Council (GCC)', order: 2410.0}
+
+- model: interaction.policyarea
+  pk: 2ffd29d9-10d4-4057-8b1b-1ec5fe15a926
+  fields: {disabled_on: '2022-01-15T00:00:00', name: 'UK-Singapore Digital Economy Agreement', order: 2410.0}
+
+- model: interaction.policyarea
+  pk: 87f6ba45-5a55-4acb-969e-aef50cde2186
+  fields: {disabled_on: '2022-01-15T00:00:00', name: 'UK-Canada Trade Continuity Agreement', order: 2410.0}
+
+- model: interaction.policyarea
+  pk: fb4dbede-20ec-4a51-8f2f-1f37d5be2a27
+  fields: {disabled_on: '2022-01-15T00:00:00', name: 'UK-Mexico Trade Continuity Agreement', order: 2410.0}
+
+- model: interaction.policyarea
+  pk: cb7e4179-c794-44c1-9b87-2336497af952
+  fields: {disabled_on: '2022-01-15T00:00:00', name: 'UK-Iceland, Liechtenstein and Norway Free Trade Agreement', order: 2410.0}


### PR DESCRIPTION
### Description of change

This PR disables five policy areas related to trade agreements which were mistakenly added to the policy areas metadata table, rather than the trade agreements one. They are set to be disabled from midnight tomorrow (15th Jan). They were added to the trade agreements table in PR #3885 .

**Next steps**
- After this migration is released, migrate the interactions that have used any of these policy areas to use the trade agreements instead
- Once migrated, delete these policy areas

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
