### PR TITLE
Add a user feature flag to enable Fuzzy search to users

### DIFF
--- a/changelog/add-fuzzy-user-feature-flag.feature.md
+++ b/changelog/add-fuzzy-user-feature-flag.feature.md
@@ -1,0 +1,1 @@
+A user feature flag has been added, so that users with this flag can access the fuzzy search functionality on the search endpoints.

--- a/conftest.py
+++ b/conftest.py
@@ -11,14 +11,14 @@ from elasticsearch.helpers.test import get_test_client
 from pytest_django.lazy_django import skip_if_no_django
 
 from datahub.core.constants import AdministrativeArea
-from datahub.core.test_utils import HawkAPITestClient
+from datahub.core.test_utils import create_test_user, HawkAPITestClient
 from datahub.dnb_api.utils import format_dnb_company
 from datahub.documents.utils import get_s3_client_for_bucket
-from datahub.feature_flag.models import FeatureFlag
+from datahub.feature_flag.models import UserFeatureFlag
 from datahub.metadata.test.factories import SectorFactory
 from datahub.search.apps import get_search_app_by_model, get_search_apps
 from datahub.search.bulk_sync import sync_objects
-from datahub.search.constants import FUZZY_SEARCH_FEATURE_FLAG
+from datahub.search.constants import FUZZY_SEARCH_USER_FEATURE_FLAG
 from datahub.search.elasticsearch import (
     alias_exists,
     create_index,
@@ -473,12 +473,25 @@ def formatted_dnb_company_area(dnb_response_uk):
 
 
 @pytest.fixture
-def fuzzy_search_feature():
-    """Enable the fuzzy search feature flag"""
-    return FeatureFlag.objects.update_or_create(
-        code=FUZZY_SEARCH_FEATURE_FLAG,
+def fuzzy_search_user_feature():
+    """Enable the fuzzy search user feature flag"""
+    return UserFeatureFlag.objects.update_or_create(
+        code=FUZZY_SEARCH_USER_FEATURE_FLAG,
         defaults={'is_active': True},
-    )
+    )[0]
+
+
+@pytest.fixture
+def search_support_user():
+    """A user with permissions for search_support views."""
+    return create_test_user(permission_codenames=['view_simplemodel', 'view_relatedmodel'])
+
+
+@pytest.fixture
+def fuzzy_search_user(search_support_user, fuzzy_search_user_feature):
+    """A search support user with Fuzzy search permissions."""
+    search_support_user.features.add(fuzzy_search_user_feature)
+    return search_support_user
 
 
 def pytest_addoption(parser):

--- a/datahub/feature_flag/test/test_utils.py
+++ b/datahub/feature_flag/test/test_utils.py
@@ -3,10 +3,12 @@ from unittest.mock import Mock
 import pytest
 from django.http import Http404
 
-from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.company.test.factories import AdviserFactory
+from datahub.feature_flag.test.factories import FeatureFlagFactory, UserFeatureFlagFactory
 from datahub.feature_flag.utils import (
     feature_flagged_view,
     is_feature_flag_active,
+    is_user_feature_flag_active,
 )
 
 # mark the whole module for db use
@@ -57,3 +59,31 @@ class TestFeatureFlaggedView:
         mock = Mock()
         feature_flagged_view('test-feature-flag')(mock)()
         mock.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    'code,user,is_active,lookup,expected',
+    (
+        ('test_user_flag', 'flagged_user', True, 'test_user_flag', True),
+        ('test_user_flag', 'unflagged_user', True, 'test_user_flag', False),
+        ('test_user_flag', 'flagged_user', False, 'test_user_flag', False),
+        ('test_user_flag', 'unflagged_user', False, 'test_user_flag', False),
+        ('', 'unflagged_user', None, 'test_user_flag', False),
+        ('test_user_flag', 'flagged_user', True, 'test', False),
+        ('test_user_flag', 'unflagged_user', True, 'test', False),
+    ),
+)
+def test_is_user_feature_flag(code, user, is_active, lookup, expected):
+    """Tests if is_user_feature_flag returns correct state of feature flag."""
+    if code != '':
+        flag = UserFeatureFlagFactory(code=code, is_active=is_active)
+
+    if user == 'flagged_user':
+        advisor = AdviserFactory()
+        advisor.features.set([flag])
+
+    if user == 'unflagged_user':
+        advisor = AdviserFactory()
+
+    result = is_user_feature_flag_active(lookup, advisor)
+    assert result is expected

--- a/datahub/feature_flag/utils.py
+++ b/datahub/feature_flag/utils.py
@@ -14,6 +14,15 @@ def is_feature_flag_active(code):
     return FeatureFlag.objects.filter(code=code, is_active=True).exists()
 
 
+def is_user_feature_flag_active(code, user):
+    """
+    Tells if given user feature flag is active for the specified user.
+
+    If user feature flag doesn't exist, it returns False.
+    """
+    return user.features.filter(code=code, is_active=True).exists()
+
+
 def feature_flagged_view(code):
     """
     Decorator to put a view behind a feature flag.

--- a/datahub/search/constants.py
+++ b/datahub/search/constants.py
@@ -1,1 +1,1 @@
-FUZZY_SEARCH_FEATURE_FLAG = 'fuzzy-search'
+FUZZY_SEARCH_USER_FEATURE_FLAG = 'user-fuzzy-search'

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -27,7 +27,6 @@ from datahub.core.test_utils import (
     join_attr_values,
     random_obj_for_queryset,
 )
-from datahub.feature_flag.models import FeatureFlag
 from datahub.investment.project.constants import Involvement, LikelihoodToLand
 from datahub.investment.project.models import InvestmentProject, InvestmentProjectPermission
 from datahub.investment.project.test.factories import (
@@ -39,7 +38,6 @@ from datahub.investment.project.test.factories import (
 )
 from datahub.metadata.models import Sector
 from datahub.metadata.test.factories import TeamFactory
-from datahub.search.constants import FUZZY_SEARCH_FEATURE_FLAG
 from datahub.search.investment import InvestmentSearchApp
 from datahub.search.investment.views import SearchInvestmentExportAPIView
 
@@ -1552,12 +1550,8 @@ class TestBasicSearch(APITestMixin):
         assert response.data['count'] == 1
         assert response.data['results'][0]['project_code'] == investment_project.project_code
 
-    def test_similar_project_code_search(self, es_with_collector, fuzzy_search_feature):
+    def test_similar_project_code_search(self, es_with_collector):
         """Projects with similar project codes should not be shown in results."""
-        FeatureFlag.objects.update_or_create(
-            code=FUZZY_SEARCH_FEATURE_FLAG,
-            defaults={'is_active': True},
-        )
         investment_project = InvestmentProjectFactory(
             cdms_project_code='TEST-00001234',
         )
@@ -1579,7 +1573,7 @@ class TestBasicSearch(APITestMixin):
         assert response.data['count'] == 1
         assert response.data['results'][0]['project_code'] == investment_project.project_code
 
-    def test_similar_project_name_to_code_search(self, es_with_collector, fuzzy_search_feature):
+    def test_similar_project_name_to_code_search(self, es_with_collector):
         """Projects with numeric names should not match on project codes."""
         investment_project = InvestmentProjectFactory(
             cdms_project_code='DHP-00000048',

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -13,9 +13,7 @@ from elasticsearch_dsl.query import (
     Term,
 )
 
-from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.search.apps import EXCLUDE_ALL, get_global_search_apps_as_mapping
-from datahub.search.constants import FUZZY_SEARCH_FEATURE_FLAG
 
 MAX_RESULTS = 10000
 
@@ -33,6 +31,7 @@ def get_basic_search_query(
         offset=0,
         limit=100,
         fields_to_exclude=None,
+        fuzzy=False,
 ):
     """
     Performs basic search for the given term in the given entity using the SEARCH_FIELDS.
@@ -53,7 +52,7 @@ def get_basic_search_query(
     # and the same query is always generated with the same inputs
     fields = sorted(fields)
 
-    query = _build_term_query(term, fields=fields)
+    query = _build_term_query(term, fields=fields, fuzzy=fuzzy)
     search = Search(index=indices).query(query)
 
     permission_query = _build_global_permission_query(permission_filters_by_entity)
@@ -222,7 +221,7 @@ def _build_entity_permission_query(permission_filters):
     return MatchNone()
 
 
-def _build_term_query(term, fields=None):
+def _build_term_query(term, fields=None, fuzzy=False):
     """
     Builds a term query depending on the active feature flags.
 
@@ -232,7 +231,7 @@ def _build_term_query(term, fields=None):
     TODO: once the new search has been trialled and accepted, remove
     the feature flag and use fuzzy matching.
     """
-    if is_feature_flag_active(FUZZY_SEARCH_FEATURE_FLAG):
+    if fuzzy:
         return _build_fuzzy_term_query(term, fields)
     else:
         return _build_basic_term_query(term, fields)

--- a/datahub/search/test/conftest.py
+++ b/datahub/search/test/conftest.py
@@ -1,6 +1,3 @@
-import pytest
-
-from datahub.core.test_utils import create_test_user
 from datahub.search.apps import get_search_apps
 from datahub.search.views import v3_view_registry, v4_view_registry
 
@@ -25,9 +22,3 @@ def pytest_generate_tests(metafunc):
             views,
             ids=[view.__class__.__name__ for view in views],
         )
-
-
-@pytest.fixture
-def search_support_user():
-    """A user with permissions for search_support views."""
-    return create_test_user(permission_codenames=['view_simplemodel', 'view_relatedmodel'])

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -202,7 +202,6 @@ class TestBasicSearch(APITestMixin):
             'The Risk Advisory Group',
         ] == [result['name'] for result in response.data['results']]
 
-    @pytest.mark.me
     @pytest.mark.parametrize(
         'name,search_term,should_match',
         (
@@ -217,9 +216,8 @@ class TestBasicSearch(APITestMixin):
     )
     def test_fuzzy_quality(
         self,
-        fuzzy_search_feature,
         es_with_collector,
-        search_support_user,
+        fuzzy_search_user,
         name,
         search_term,
         should_match,
@@ -233,7 +231,7 @@ class TestBasicSearch(APITestMixin):
         es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:basic')
-        api_client = self.create_api_client(user=search_support_user)
+        api_client = self.create_api_client(user=fuzzy_search_user)
 
         response = api_client.get(
             url,
@@ -253,9 +251,8 @@ class TestBasicSearch(APITestMixin):
 
     def test_fuzzy_quality_cross_fields(
         self,
-        fuzzy_search_feature,
         es_with_collector,
-        search_support_user,
+        fuzzy_search_user,
     ):
         """
         Tests quality of results for fuzzy matching across multiple fields.
@@ -279,7 +276,7 @@ class TestBasicSearch(APITestMixin):
         term = 'The Advisory Canada'
 
         url = reverse('api-v3:search:basic')
-        api_client = self.create_api_client(user=search_support_user)
+        api_client = self.create_api_client(user=fuzzy_search_user)
 
         response = api_client.get(
             url,

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -12,7 +12,9 @@ from rest_framework.schemas.openapi import AutoSchema
 from rest_framework.views import APIView
 
 from datahub.core.csv import create_csv_response
+from datahub.feature_flag.utils import is_user_feature_flag_active
 from datahub.search.apps import get_global_search_apps_as_mapping
+from datahub.search.constants import FUZZY_SEARCH_USER_FEATURE_FLAG
 from datahub.search.execute_query import execute_search_query
 from datahub.search.permissions import (
     has_permissions_for_app,
@@ -125,6 +127,10 @@ class SearchBasicAPIView(APIView):
             *(self.fields_to_exclude or ()),
         )
 
+        fuzzy_search_enabled = is_user_feature_flag_active(
+            user=request.user,
+            code=FUZZY_SEARCH_USER_FEATURE_FLAG,
+        )
         query = get_basic_search_query(
             entity=validated_params['entity'],
             term=validated_params['term'],
@@ -132,6 +138,7 @@ class SearchBasicAPIView(APIView):
             offset=validated_params['offset'],
             limit=validated_params['limit'],
             fields_to_exclude=fields_to_exclude,
+            fuzzy=fuzzy_search_enabled,
         )
 
         results = execute_search_query(query)


### PR DESCRIPTION
### Description of change

Fuzzy search is going to be released to a small number of users to test how accurate the responses are. The first step of doing this is adding a user feature flag that we can release to the users, to allow them to get the search feature. This PR adds the logic that enables the fuzzy search to work for users with the flag, and a couple of tests. 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
