### PR TITLE
Make sure investment search tests use fuzzy feature

### DIFF
--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -1550,8 +1550,10 @@ class TestBasicSearch(APITestMixin):
         assert response.data['count'] == 1
         assert response.data['results'][0]['project_code'] == investment_project.project_code
 
-    def test_similar_project_code_search(self, es_with_collector):
+    def test_similar_project_code_search(self, es_with_collector, fuzzy_search_user):
         """Projects with similar project codes should not be shown in results."""
+        fuzzy_search_user.is_superuser = True
+        fuzzy_search_user.save()
         investment_project = InvestmentProjectFactory(
             cdms_project_code='TEST-00001234',
         )
@@ -1560,21 +1562,23 @@ class TestBasicSearch(APITestMixin):
         )
         es_with_collector.flush_and_refresh()
 
+        api_client = self.create_api_client(user=fuzzy_search_user)
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(
+        response = api_client.get(
             url,
             data={
                 'term': investment_project.project_code,
                 'entity': 'investment_project',
             },
         )
-
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         assert response.data['results'][0]['project_code'] == investment_project.project_code
 
-    def test_similar_project_name_to_code_search(self, es_with_collector):
+    def test_similar_project_name_to_code_search(self, es_with_collector, fuzzy_search_user):
         """Projects with numeric names should not match on project codes."""
+        fuzzy_search_user.is_superuser = True
+        fuzzy_search_user.save()
         investment_project = InvestmentProjectFactory(
             cdms_project_code='DHP-00000048',
         )
@@ -1584,8 +1588,9 @@ class TestBasicSearch(APITestMixin):
         )
         es_with_collector.flush_and_refresh()
 
+        api_client = self.create_api_client(user=fuzzy_search_user)
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(
+        response = api_client.get(
             url,
             data={
                 'term': investment_project.project_code,


### PR DESCRIPTION
### Description of change

Fixes a test that was supposed to have the fuzzy search feature flag enabled by enabling the fuzzy search user feature flag.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
