### PR TITLE
Add One List Team Advisers to CompaniesDatasetView

### DIFF
--- a/changelog/company/cds-294-adviser-core-team.api.md
+++ b/changelog/company/cds-294-adviser-core-team.api.md
@@ -1,0 +1,1 @@
+Add `one_list_core_team_advisers` field to GET responses for `/v4/dataset/companies-dataset` which represents an array of the Advisers on core team. 

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -278,6 +278,15 @@ def get_attr_or_none(obj, attr):
 
 
 def get_attr_or_default(obj, attr, default=None):
+    """
+    Gets an attribute of an object, or returns a default value if the attribute does not exist.
+
+    Dotted paths to attributes can be provided to specify nested attributes.
+
+    Usage example:
+        # Returns company.contact.name or [None] if contact is None
+        get_attr_or_default(company, 'contact.name', [None])
+    """
     try:
         return attrgetter(attr)(obj)
     except AttributeError:

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -277,6 +277,13 @@ def get_attr_or_none(obj, attr):
         return None
 
 
+def get_attr_or_default(obj, attr, default=None):
+    try:
+        return attrgetter(attr)(obj)
+    except AttributeError:
+        return default
+
+
 class MockQuerySet:
     """Mock version of QuerySet that represents a fixed set of items."""
 

--- a/datahub/dataset/company/test/test_views.py
+++ b/datahub/dataset/company/test/test_views.py
@@ -7,10 +7,10 @@ from datahub.company.test.factories import (
     ArchivedCompanyFactory,
     CompanyFactory,
     CompanyWithAreaFactory,
-    SubsidiaryFactory,
     OneListCoreTeamMemberFactory,
+    SubsidiaryFactory,
 )
-from datahub.core.test_utils import format_date_or_datetime, get_attr_or_none, get_attr_or_default
+from datahub.core.test_utils import format_date_or_datetime, get_attr_or_default, get_attr_or_none
 from datahub.dataset.core.test import BaseDatasetViewTest
 from datahub.metadata.utils import convert_usd_to_gbp
 
@@ -62,7 +62,11 @@ def get_expected_data_from_company(company):
         'name': company.name,
         'number_of_employees': company.number_of_employees,
         'one_list_tier__name': get_attr_or_none(company, 'one_list_tier.name'),
-        'one_list_core_team_advisers': get_attr_or_default(company, 'one_list_core_team_advisers', [None]),
+        'one_list_core_team_advisers': get_attr_or_default(
+            company,
+            'one_list_core_team_advisers',
+            [None],
+        ),
         'one_list_account_owner_id': company.one_list_account_owner_id,
         'reference_code': company.reference_code,
         'registered_address_1': company.registered_address_1,
@@ -131,11 +135,15 @@ class TestCompaniesDatasetViewSet(BaseDatasetViewTest):
         ),
     )
     def test_core_team_member(self, data_flow_api_client, company_factory):
+        """Test that endpoint returns with advisers on the core team"""
         company = company_factory()
         company.created_by = None
         company.created_on = None
         company.one_list_core_team_advisers = [
-            str(o.adviser.id) for o in OneListCoreTeamMemberFactory.create_batch(3, company=company)
+            str(o.adviser.id) for o in OneListCoreTeamMemberFactory.create_batch(
+                3,
+                company=company,
+            )
         ]
         company.save()
         response = data_flow_api_client.get(self.view_url)

--- a/datahub/dataset/company/test/test_views.py
+++ b/datahub/dataset/company/test/test_views.py
@@ -137,8 +137,6 @@ class TestCompaniesDatasetViewSet(BaseDatasetViewTest):
     def test_core_team_member(self, data_flow_api_client, company_factory):
         """Test that endpoint returns with advisers on the core team"""
         company = company_factory()
-        company.created_by = None
-        company.created_on = None
         company.one_list_core_team_advisers = [
             str(o.adviser.id) for o in OneListCoreTeamMemberFactory.create_batch(
                 3,

--- a/datahub/dataset/company/test/test_views.py
+++ b/datahub/dataset/company/test/test_views.py
@@ -8,8 +8,9 @@ from datahub.company.test.factories import (
     CompanyFactory,
     CompanyWithAreaFactory,
     SubsidiaryFactory,
+    OneListCoreTeamMemberFactory,
 )
-from datahub.core.test_utils import format_date_or_datetime, get_attr_or_none
+from datahub.core.test_utils import format_date_or_datetime, get_attr_or_none, get_attr_or_default
 from datahub.dataset.core.test import BaseDatasetViewTest
 from datahub.metadata.utils import convert_usd_to_gbp
 
@@ -61,6 +62,7 @@ def get_expected_data_from_company(company):
         'name': company.name,
         'number_of_employees': company.number_of_employees,
         'one_list_tier__name': get_attr_or_none(company, 'one_list_tier.name'),
+        'one_list_core_team_advisers': get_attr_or_default(company, 'one_list_core_team_advisers', [None]),
         'one_list_account_owner_id': company.one_list_account_owner_id,
         'reference_code': company.reference_code,
         'registered_address_1': company.registered_address_1,
@@ -113,6 +115,28 @@ class TestCompaniesDatasetViewSet(BaseDatasetViewTest):
         company = company_factory()
         company.created_by = None
         company.created_on = None
+        company.save()
+        response = data_flow_api_client.get(self.view_url)
+        assert response.status_code == status.HTTP_200_OK
+        response_results = response.json()['results']
+        assert len(response_results) == 1
+        result = response_results[0]
+        expected_result = get_expected_data_from_company(company)
+        assert result == expected_result
+
+    @pytest.mark.parametrize(
+        'company_factory', (
+            CompanyWithAreaFactory,
+            ArchivedCompanyFactory,
+        ),
+    )
+    def test_core_team_member(self, data_flow_api_client, company_factory):
+        company = company_factory()
+        company.created_by = None
+        company.created_on = None
+        company.one_list_core_team_advisers = [
+            str(o.adviser.id) for o in OneListCoreTeamMemberFactory.create_batch(3, company=company)
+        ]
         company.save()
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK

--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -2,6 +2,7 @@ from datahub.company.models import Company
 from datahub.dataset.core.views import BaseDatasetView
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.metadata.utils import convert_usd_to_gbp
+from django.contrib.postgres.aggregates import ArrayAgg
 
 
 class CompaniesDatasetView(BaseDatasetView):
@@ -16,6 +17,7 @@ class CompaniesDatasetView(BaseDatasetView):
         """Returns list of Company records"""
         return Company.objects.annotate(
             sector_name=get_sector_name_subquery('sector'),
+            one_list_core_team_advisers=ArrayAgg('one_list_core_team_members__adviser_id'),
         ).values(
             'address_1',
             'address_2',
@@ -45,7 +47,7 @@ class CompaniesDatasetView(BaseDatasetView):
             'number_of_employees',
             'one_list_account_owner_id',
             'one_list_tier__name',
-            'one_list_core_team_members__adviser',
+            'one_list_core_team_advisers',
             'reference_code',
             'registered_address_1',
             'registered_address_2',

--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -1,8 +1,9 @@
+from django.contrib.postgres.aggregates import ArrayAgg
+
 from datahub.company.models import Company
 from datahub.dataset.core.views import BaseDatasetView
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.metadata.utils import convert_usd_to_gbp
-from django.contrib.postgres.aggregates import ArrayAgg
 
 
 class CompaniesDatasetView(BaseDatasetView):

--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -45,6 +45,7 @@ class CompaniesDatasetView(BaseDatasetView):
             'number_of_employees',
             'one_list_account_owner_id',
             'one_list_tier__name',
+            'one_list_core_team_members__adviser',
             'reference_code',
             'registered_address_1',
             'registered_address_2',


### PR DESCRIPTION
### Description of change

This PR adds `one_list_core_team_members__adviser_id` to the GET API view for syncing with data-flow. Following this PR, changes need to be made to the data-flow repo in order to be able to query this field in Data Workspace, however this PR can still be merged before those changes are made. 

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
