### PR TITLE
Enabled whitenoise on all environments

### DIFF
--- a/changelog/enabled-whitenoise.internal.md
+++ b/changelog/enabled-whitenoise.internal.md
@@ -1,0 +1,1 @@
+whitenoise support enabled on all our environments

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -304,7 +304,7 @@ SWAGGER_UI_JS = {
 
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
-
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 APPEND_SLASH = False
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,3 +1,1 @@
 from config.settings.common_logging import *
-
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -72,6 +72,7 @@ CELERY_TASK_ALWAYS_EAGER = True
 # Stop WhiteNoise emitting warnings when running tests without running collectstatic first
 WHITENOISE_AUTOREFRESH = True
 WHITENOISE_USE_FINDERS = True
+STATICFILES_STORAGE = None
 
 PAAS_IP_WHITELIST = ['1.2.3.4']
 

--- a/web.sh
+++ b/web.sh
@@ -13,4 +13,5 @@ if [ -z "$SKIP_ES_MAPPING_MIGRATIONS" ] && [ "${CF_INSTANCE_INDEX:-0}" == "0" ];
   ./manage.py migrate_es
 fi
 
+python manage.py collectstatic
 python app.py


### PR DESCRIPTION
### Description of change

We need whitenoise enabled on all our environments now so that static files can be served by WSGIserver we recently replaced gunicorn with. We also collect static files explicitly on startup and not relying on cloudfoundry's python buildpack.