### PR TITLE
Fix opensearch docker

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -6,9 +6,9 @@ DJANGO_SECRET_KEY=changeme
 DJANGO_SETTINGS_MODULE=config.settings.local
 COV_TOKEN=${COV_TOKEN}
 ES_INDEX_PREFIX=test_index
-ES5_URL=http://es:9200
+ES5_URL=http://opensearch:9200
 # This has been readded to allow tests utilizing elasticsearch to be unskipped
-OPENSEARCH_URL=http://es:9200
+OPENSEARCH_URL=http://opensearch:9200
 REDIS_BASE_URL=redis://redis:6379
 AWS_DEFAULT_REGION=eu-west-2
 AWS_ACCESS_KEY_ID=foo
@@ -50,7 +50,7 @@ DJANGO_SUPERUSER_SSO_EMAIL_USER_ID=test@gov.uk
 # The superuser should have an SSO email user ID set for this to work.
 SUPERUSER_ACCESS_TOKEN=ditStaffToken
 
-# Settings for Elasticsearch APM. 
+# Settings for Elasticsearch APM.
 ES_APM_ENABLED=False
 # ES_APM_SERVICE_NAME=datahub
 # ES_APM_SECRET_TOKEN=

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -8,7 +8,7 @@ es_amp=""
 if [ "$ES_APM_ENABLED" = 'True' ] ; then
    es_amp="-wait tcp://es-apm:8200"
 fi
-dockerize -wait  tcp://postgres:5432 -wait tcp://es:9200  -wait tcp://redis:6379 $es_amp
+dockerize -wait  tcp://postgres:5432 -wait tcp:/opensearch:9200  -wait tcp://redis:6379 $es_amp
 
 python /app/manage.py migrate
 python /app/manage.py migrate_es


### PR DESCRIPTION
### Description of change

Fixes uat setup script to use opensearch instead of es and removes old uses of es_apm which is no longer used.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
