### PR TITLE
Add a task to send investment project estimated land date notifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `ENABLE_ADMIN_ADD_ACCESS_TOKEN_VIEW` | No | Whether to enable the add access token page for superusers in the admin site (default=True). |
 | `ENABLE_DAILY_OPENSEARCH_SYNC` | No | Whether to enable the daily OpenSearch sync (default=False). |
 | `ENABLE_EMAIL_INGESTION` | No | True or False.  Whether or not to activate the celery beat task for ingesting emails |
+  `ENABLE_INVESTMENT_NOTIFICATION` | No | True or False. Whether or not to activate the celery beat task for sending investment notifications |
 | `ENABLE_MAILBOX_PROCESSING` | No | True or False.  Whether or not to activate the celery beat task for mailbox processing |
 | `ENABLE_SLACK_MESSAGING` | No | If present and truthy, enable the transmission of messages to Slack. Necessitates the specification of the other env vars `SLACK_API_TOKEN` and `SLACK_MESSAGE_CHANNEL` |
 | `ENABLE_SPI_REPORT_GENERATION` | No | Whether to enable daily SPI report (default=False). |
@@ -440,6 +441,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `INVESTMENT_DOCUMENT_BUCKET` | No | S3 bucket for investment project documents storage. |
 | `INVESTMENT_NOTIFICATION_ADMIN_EMAIL`  | Yes | |
 | `INVESTMENT_NOTIFICATION_API_KEY`  | Yes | |
+  `INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID` | Yes | An ID of Notify Template for Estimated Land Date notifications |
 | `MAILBOX_AWS_ACCESS_KEY_ID` | No | Same use as AWS_ACCESS_KEY_ID, but for mailbox. |
 | `MAILBOX_AWS_SECRET_ACCESS_KEY` | No | Same use as AWS_SECRET_ACCESS_KEY, but for mailbox. |
 | `MAILBOX_AWS_REGION` | No | Same use as AWS_DEFAULT_REGION, but for mailbox. |

--- a/changelog/investment/investment-notification-task.feature.md
+++ b/changelog/investment/investment-notification-task.feature.md
@@ -1,0 +1,1 @@
+An investment estimated land date notification sending task has been added. It runs every morning and sends notification to project managers about estimated land date due in 30 or 60 days if they have notification subscription enabled.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -476,6 +476,12 @@ if REDIS_BASE_URL:
             'schedule': 30.0,  # Every 30 seconds
         }
 
+    if env.bool('ENABLE_INVESTMENT_NOTIFICATION', False):
+        CELERY_BEAT_SCHEDULE['send_estimated_land_date_task'] = {
+            'task': 'datahub.investment.project.notification.tasks.send_estimated_land_date_task',
+            'schedule': crontab(minute=0, hour=8),
+        }
+
     CELERY_WORKER_LOG_FORMAT = (
         "[%(asctime)s: %(levelname)s/%(processName)s] [%(name)s] %(message)s"
     )
@@ -526,6 +532,10 @@ OMIS_PUBLIC_ORDER_URL = f'{OMIS_PUBLIC_BASE_URL}/{{public_token}}'
 
 INVESTMENT_NOTIFICATION_ADMIN_EMAIL = env('INVESTMENT_NOTIFICATION_ADMIN_EMAIL', default='')
 INVESTMENT_NOTIFICATION_API_KEY = env('INVESTMENT_NOTIFICATION_API_KEY', default='')
+INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID = env(
+    'INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID',
+    default='',
+)
 
 # GOV.UK PAY
 GOVUK_PAY_URL = env('GOVUK_PAY_URL', default='')

--- a/datahub/investment/project/__init__.py
+++ b/datahub/investment/project/__init__.py
@@ -1,3 +1,6 @@
 """Functionality related to investment projects."""
 
 default_app_config = 'datahub.investment.project.apps.InvestmentConfig'
+
+INVESTMENT_ESTIMATED_LAND_DATE_NOTIFICATION_FEATURE_FLAG_NAME = \
+    'investment-estimated-land-date-notification'

--- a/datahub/investment/project/notification/tasks.py
+++ b/datahub/investment/project/notification/tasks.py
@@ -1,0 +1,127 @@
+from logging import getLogger
+
+from celery import shared_task
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.core.cache import cache
+from django.db.models import F
+from django.utils.timezone import now
+from django_pglocks import advisory_lock
+
+from datahub.core import statsd
+from datahub.feature_flag.utils import is_feature_flag_active
+from datahub.investment.project import (
+    INVESTMENT_ESTIMATED_LAND_DATE_NOTIFICATION_FEATURE_FLAG_NAME,
+)
+from datahub.investment.project.notification.models import InvestmentNotificationSubscription
+from datahub.notification.constants import NotifyServiceName
+from datahub.notification.notify import notify_adviser_by_email
+
+logger = getLogger(__name__)
+
+estimated_land_date_notification = InvestmentNotificationSubscription.EstimatedLandDateNotification
+TASK_TOKEN_TIMEOUT = 24 * 3600
+
+
+def send_investment_notification(project, adviser, notification_type):
+    """
+    Sends investment notification by email.
+    """
+    statsd.incr(f'send_investment_notification.{notification_type}')
+
+    notify_adviser_by_email(
+        adviser,
+        settings.INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID,
+        {
+            'project_details_url': f'{project.get_absolute_url()}/details',
+            'project_subscription_url': f'{project.get_absolute_url()}/notifications/'
+                                        'estimated-land-date',
+            'investor_company_name': project.investor_company.name,
+            'project_name': project.name,
+            'project_code': project.project_code,
+            # '%-d %B %Y' formats date to 1 January 2022
+            'estimated_land_date': project.estimated_land_date.strftime('%-d %B %Y'),
+        },
+        NotifyServiceName.investment,
+    )
+
+
+def get_subscriptions_for_estimated_land_date(notification_type: str):
+    """
+    Gets subscriptions for estimated land date.
+
+    The notification type is defined as either '30' or '60' days.
+
+    The subscriptions are only returned for advisers who are project managers.
+    """
+    days = int(notification_type)
+    future_estimated_land_date = now() + relativedelta(days=days)
+
+    subscriptions = InvestmentNotificationSubscription.objects.select_related(
+        'investment_project',
+        'adviser',
+    ).filter(
+        # the estimated land date subscriptions are only valid for project managers
+        adviser_id=F('investment_project__project_manager_id'),
+        estimated_land_date__contains=[notification_type],
+        investment_project__estimated_land_date__year=future_estimated_land_date.year,
+        investment_project__estimated_land_date__month=future_estimated_land_date.month,
+        investment_project__estimated_land_date__day=future_estimated_land_date.day,
+    )
+    return subscriptions
+
+
+@shared_task(
+    autoretry_for=(Exception,),
+    queue='long-running',
+    max_retries=5,
+    retry_backoff=30,
+)
+def send_estimated_land_date_task():
+    """
+    The task runs every day for each notification type. It collects the active subscriptions
+    and sends a notification if investment project's estimated land date is in 30 or 60 days
+    and project manager has active subscription for given days.
+
+    For each notification a token is set with 24h expiration time, in an event when the task
+    gets restarted so that the notifications won't be sent multiple times.
+    """
+    if not is_feature_flag_active(INVESTMENT_ESTIMATED_LAND_DATE_NOTIFICATION_FEATURE_FLAG_NAME):
+        logger.info(
+            f'Feature flag "{INVESTMENT_ESTIMATED_LAND_DATE_NOTIFICATION_FEATURE_FLAG_NAME}"'
+            'is not active, '
+            'exiting.',
+        )
+        return
+
+    with advisory_lock('send_estimated_land_date_notifications', wait=False) as acquired:
+        if not acquired:
+            logger.info(
+                'Notifications for estimated land dates are already being processed by '
+                'another worker.',
+            )
+            return
+
+        notification_types = estimated_land_date_notification.values
+
+        for notification_type in notification_types:
+            subscriptions = get_subscriptions_for_estimated_land_date(notification_type)
+
+            for subscription in subscriptions.iterator():
+                token = _get_token_name(
+                    subscription.investment_project,
+                    subscription.adviser,
+                    notification_type,
+                )
+                if not cache.get(token):
+                    cache.set(token, True, TASK_TOKEN_TIMEOUT)
+                    send_investment_notification(
+                        subscription.investment_project,
+                        subscription.adviser,
+                        notification_type,
+                    )
+
+
+def _get_token_name(project, adviser, notification_type):
+    token = f'notification:{project.id}-{adviser.id}-{notification_type}'
+    return token

--- a/datahub/investment/project/notification/test/test_tasks.py
+++ b/datahub/investment/project/notification/test/test_tasks.py
@@ -1,0 +1,235 @@
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.test.utils import override_settings
+from django.utils.timezone import now
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.investment.project import (
+    INVESTMENT_ESTIMATED_LAND_DATE_NOTIFICATION_FEATURE_FLAG_NAME,
+)
+from datahub.investment.project.notification.models import InvestmentNotificationSubscription
+from datahub.investment.project.notification.tasks import (
+    get_subscriptions_for_estimated_land_date,
+    send_estimated_land_date_task,
+)
+from datahub.investment.project.notification.test.factories import (
+    InvestmentNotificationSubscriptionFactory,
+)
+from datahub.investment.project.test.factories import (
+    InvestmentProjectFactory,
+)
+from datahub.notification.constants import NotifyServiceName
+
+pytestmark = pytest.mark.django_db
+
+estimated_land_date_notification = InvestmentNotificationSubscription.EstimatedLandDateNotification
+
+
+@pytest.fixture
+def mock_notify_adviser_by_email(monkeypatch):
+    """
+    Mocks the notify_adviser_by_email function.
+    """
+    mock_notify_adviser_by_email = mock.Mock()
+    monkeypatch.setattr(
+        'datahub.investment.project.notification.tasks.notify_adviser_by_email',
+        mock_notify_adviser_by_email,
+    )
+    return mock_notify_adviser_by_email
+
+
+@pytest.fixture
+def mock_statsd(monkeypatch):
+    """
+    Returns a mock statsd client instance.
+    """
+    mock_statsd = mock.Mock()
+    monkeypatch.setattr(
+        'datahub.investment.project.notification.tasks.statsd',
+        mock_statsd,
+    )
+    return mock_statsd
+
+
+@pytest.fixture()
+def investment_estimated_land_date_notification_feature_flag():
+    """
+    Creates the investment estimated land date notification feature flag.
+    """
+    yield FeatureFlagFactory(code=INVESTMENT_ESTIMATED_LAND_DATE_NOTIFICATION_FEATURE_FLAG_NAME)
+
+
+@pytest.mark.usefixtures('local_memory_cache')
+class TestInvestmentNotificationSubscriptionTasks:
+    """Test investment notification subscription tasks."""
+
+    @pytest.mark.parametrize(
+        'notification_type',
+        (
+            (
+                estimated_land_date_notification.ESTIMATED_LAND_DATE_30.value
+            ),
+            (
+                estimated_land_date_notification.ESTIMATED_LAND_DATE_60.value
+            ),
+        ),
+    )
+    def test_get_subscriptions_for_estimated_land_date(self, notification_type):
+        """Tests that query returns correct subscriptions."""
+        adviser = AdviserFactory()
+        future_estimated_land_date = now() + relativedelta(days=int(notification_type))
+        project = InvestmentProjectFactory(
+            project_manager=adviser,
+            estimated_land_date=future_estimated_land_date,
+        )
+        InvestmentProjectFactory(
+            project_manager=adviser,
+            estimated_land_date=future_estimated_land_date - relativedelta(days=1),
+        )
+        InvestmentProjectFactory(
+            project_manager=adviser,
+            estimated_land_date=future_estimated_land_date + relativedelta(days=1),
+        )
+        InvestmentNotificationSubscriptionFactory(
+            investment_project=project,
+            adviser=adviser,
+            estimated_land_date=[notification_type],
+        )
+        InvestmentNotificationSubscriptionFactory.create_batch(2, adviser=adviser)
+
+        subscriptions = get_subscriptions_for_estimated_land_date(notification_type)
+        assert subscriptions.count() == 1
+        assert subscriptions[0].adviser == adviser
+        assert subscriptions[0].investment_project == project
+        assert notification_type in subscriptions[0].estimated_land_date
+
+    @pytest.mark.parametrize(
+        'notification_type',
+        (
+            (
+                estimated_land_date_notification.ESTIMATED_LAND_DATE_30.value
+            ),
+            (
+                estimated_land_date_notification.ESTIMATED_LAND_DATE_60.value
+            ),
+        ),
+    )
+    def test_sends_investment_notification_with_feature_flag(
+        self,
+        notification_type,
+        investment_estimated_land_date_notification_feature_flag,
+        mock_notify_adviser_by_email,
+        mock_statsd,
+    ):
+        """
+        Test that a notification will be sent for each notification type.
+        """
+        adviser = AdviserFactory()
+        future_estimated_land_date = now() + relativedelta(days=int(notification_type))
+        project = InvestmentProjectFactory(
+            project_manager=adviser,
+            estimated_land_date=future_estimated_land_date,
+        )
+        InvestmentProjectFactory(
+            project_manager=adviser,
+            estimated_land_date=future_estimated_land_date - relativedelta(days=1),
+        )
+        InvestmentProjectFactory(
+            project_manager=adviser,
+            estimated_land_date=future_estimated_land_date + relativedelta(days=1),
+        )
+        InvestmentNotificationSubscriptionFactory(
+            investment_project=project,
+            adviser=adviser,
+            estimated_land_date=[notification_type],
+        )
+
+        template_id = str(uuid4())
+        with override_settings(
+            INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID=template_id,
+        ):
+            send_estimated_land_date_task()
+
+            mock_notify_adviser_by_email.assert_called_once_with(
+                adviser,
+                template_id,
+                {
+                    'project_details_url': f'{project.get_absolute_url()}/details',
+                    'project_subscription_url': f'{project.get_absolute_url()}/notifications/'
+                                                'estimated-land-date',
+                    'investor_company_name': project.investor_company.name,
+                    'project_name': project.name,
+                    'project_code': project.project_code,
+                    'estimated_land_date': project.estimated_land_date.strftime('%-d %B %Y'),
+                },
+                NotifyServiceName.investment,
+            )
+            mock_statsd.incr.assert_called_once_with(
+                f'send_investment_notification.{notification_type}',
+            )
+
+    def test_doesnt_send_investment_notification_without_feature_flag(
+        self,
+        mock_notify_adviser_by_email,
+    ):
+        """
+        Tests that notifications are not sent if the feature flag is not enabled.
+        """
+        notification_type = estimated_land_date_notification.ESTIMATED_LAND_DATE_30.value
+        adviser = AdviserFactory()
+        future_estimated_land_date = now() + relativedelta(days=int(notification_type))
+        project = InvestmentProjectFactory(
+            project_manager=adviser,
+            estimated_land_date=future_estimated_land_date,
+        )
+        InvestmentNotificationSubscriptionFactory(
+            investment_project=project,
+            adviser=adviser,
+            estimated_land_date=[notification_type],
+        )
+
+        template_id = str(uuid4())
+        with override_settings(
+            INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID=template_id,
+        ):
+            send_estimated_land_date_task()
+
+            mock_notify_adviser_by_email.assert_not_called()
+
+    def test_does_not_send_multiple_notifications(
+        self,
+        investment_estimated_land_date_notification_feature_flag,
+        mock_notify_adviser_by_email,
+    ):
+        """
+        Test that the send_estimate_land_date_task will not send multiple notifications if
+        called multiple times.
+        """
+        notification_type = estimated_land_date_notification.ESTIMATED_LAND_DATE_30.value
+        adviser = AdviserFactory()
+        future_estimated_land_date = now() + relativedelta(days=int(notification_type))
+        project = InvestmentProjectFactory(
+            project_manager=adviser,
+            estimated_land_date=future_estimated_land_date,
+        )
+        InvestmentNotificationSubscriptionFactory(
+            investment_project=project,
+            adviser=adviser,
+            estimated_land_date=[notification_type],
+        )
+
+        template_id = str(uuid4())
+        with override_settings(
+            INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID=template_id,
+        ):
+            send_estimated_land_date_task()
+            send_estimated_land_date_task()
+            send_estimated_land_date_task()
+            send_estimated_land_date_task()
+            send_estimated_land_date_task()
+
+            mock_notify_adviser_by_email.assert_called_once()


### PR DESCRIPTION
### Description of change

An investment estimated land date notification sending task has been added. It runs every morning and sends notification to project managers about estimated land date due in 30 or 60 days if they have notification subscription enabled.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
