### PR TITLE
Remove deprecated code to stop `RemovedInDjango4xWarning`s

### DIFF
--- a/datahub/admin_report/__init__.py
+++ b/datahub/admin_report/__init__.py
@@ -1,3 +1,1 @@
 """Functionality for downloading CSV reports from the admin site."""
-
-default_app_config = 'datahub.admin_report.apps.AdminReportConfig'

--- a/datahub/company/__init__.py
+++ b/datahub/company/__init__.py
@@ -1,3 +1,1 @@
 """Functionality relating to companies, company contacts and advisers (users)."""
-
-default_app_config = 'datahub.company.apps.CompanyConfig'

--- a/datahub/company/signal_receivers.py
+++ b/datahub/company/signal_receivers.py
@@ -1,4 +1,4 @@
 from django.dispatch import Signal
 
-export_country_update_signal = Signal(providing_args=['instance', 'created', 'by'])
-export_country_delete_signal = Signal(providing_args=['instance', 'by'])
+export_country_update_signal = Signal()
+export_country_delete_signal = Signal()

--- a/datahub/company_referral/__init__.py
+++ b/datahub/company_referral/__init__.py
@@ -1,3 +1,1 @@
 """Functionality for referring companies between users."""
-
-default_app_config = 'datahub.company_referral.apps.CompanyReferralConfig'

--- a/datahub/core/__init__.py
+++ b/datahub/core/__init__.py
@@ -1,3 +1,1 @@
 """Various shared utilities used by other apps."""
-
-default_app_config = 'datahub.core.apps.CoreConfig'

--- a/datahub/email_ingestion/__init__.py
+++ b/datahub/email_ingestion/__init__.py
@@ -7,5 +7,4 @@ calendar invitations.
 
 from datahub.email_ingestion.mailbox import MailboxHandler
 
-default_app_config = 'datahub.email_ingestion.apps.EmailIngestionConfig'
 mailbox_handler = MailboxHandler()

--- a/datahub/feature_flag/__init__.py
+++ b/datahub/feature_flag/__init__.py
@@ -10,5 +10,3 @@ so the front end can check that status of each flag.
 
 They're also sometimes checked in the back end, but this is less common.
 """
-
-default_app_config = 'datahub.feature_flag.apps.FeatureFlagConfig'

--- a/datahub/investment/investor_profile/__init__.py
+++ b/datahub/investment/investor_profile/__init__.py
@@ -1,3 +1,1 @@
 """Functionality related to investor profiles for companies."""
-
-default_app_config = 'datahub.investment.investor_profile.apps.InvestorProfileConfig'

--- a/datahub/investment/opportunity/__init__.py
+++ b/datahub/investment/opportunity/__init__.py
@@ -1,3 +1,1 @@
 """Functionality related to large capital opportunities."""
-
-default_app_config = 'datahub.investment.opportunity.apps.OpportunityConfig'

--- a/datahub/investment/project/__init__.py
+++ b/datahub/investment/project/__init__.py
@@ -1,6 +1,4 @@
 """Functionality related to investment projects."""
 
-default_app_config = 'datahub.investment.project.apps.InvestmentConfig'
-
 INVESTMENT_ESTIMATED_LAND_DATE_NOTIFICATION_FEATURE_FLAG_NAME = \
     'investment-estimated-land-date-notification'

--- a/datahub/investment/project/evidence/__init__.py
+++ b/datahub/investment/project/evidence/__init__.py
@@ -1,3 +1,1 @@
 """Functionality related to evidence document uploads for investment projects."""
-
-default_app_config = 'datahub.investment.project.evidence.apps.InvestmentEvidenceConfig'

--- a/datahub/investment/project/proposition/__init__.py
+++ b/datahub/investment/project/proposition/__init__.py
@@ -3,5 +3,3 @@ Functionality related to investment project propositions.
 
 Propositions are always associated with an existing investment project.
 """
-
-default_app_config = 'datahub.investment.project.proposition.apps.InvestmentPropositionConfig'

--- a/datahub/investment/project/report/__init__.py
+++ b/datahub/investment/project/report/__init__.py
@@ -1,3 +1,1 @@
 """Functionality related to investment project service performance indicator (SPI) reports."""
-
-default_app_config = 'datahub.investment.project.report.apps.InvestmentReportConfig'

--- a/datahub/metadata/__init__.py
+++ b/datahub/metadata/__init__.py
@@ -18,6 +18,3 @@ from django.utils.module_loading import autodiscover_modules
 def autodiscover():
     """Loads the `metadata` module in each individual apps."""
     autodiscover_modules('metadata')
-
-
-default_app_config = 'datahub.metadata.apps.MetadataConfig'

--- a/datahub/omis/core/__init__.py
+++ b/datahub/omis/core/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'datahub.omis.core.apps.CoreConfig'

--- a/datahub/omis/invoice/__init__.py
+++ b/datahub/omis/invoice/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'datahub.omis.invoice.apps.InvoiceConfig'

--- a/datahub/omis/market/__init__.py
+++ b/datahub/omis/market/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'datahub.omis.market.apps.MarketConfig'

--- a/datahub/omis/notification/__init__.py
+++ b/datahub/omis/notification/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'datahub.omis.notification.apps.NotificationConfig'

--- a/datahub/omis/order/__init__.py
+++ b/datahub/omis/order/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'datahub.omis.order.apps.OrderConfig'

--- a/datahub/omis/order/signals.py
+++ b/datahub/omis/order/signals.py
@@ -1,10 +1,9 @@
-import django.dispatch
+from django.dispatch import Signal
 
+order_paid = Signal()
+order_completed = Signal()
+order_cancelled = Signal()
 
-order_paid = django.dispatch.Signal(providing_args=['order'])
-order_completed = django.dispatch.Signal(providing_args=['order'])
-order_cancelled = django.dispatch.Signal(providing_args=['order'])
-
-quote_generated = django.dispatch.Signal(providing_args=['order'])
-quote_accepted = django.dispatch.Signal(providing_args=['order'])
-quote_cancelled = django.dispatch.Signal(providing_args=['order', 'by'])
+quote_generated = Signal()
+quote_accepted = Signal()
+quote_cancelled = Signal()

--- a/datahub/omis/payment/__init__.py
+++ b/datahub/omis/payment/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'datahub.omis.payment.apps.PaymentConfig'

--- a/datahub/omis/quote/__init__.py
+++ b/datahub/omis/quote/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'datahub.omis.quote.apps.QuoteConfig'

--- a/datahub/omis/region/__init__.py
+++ b/datahub/omis/region/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = 'datahub.omis.region.apps.RegionConfig'

--- a/datahub/user/company_list/__init__.py
+++ b/datahub/user/company_list/__init__.py
@@ -1,3 +1,1 @@
 """Functionality related to personal company lists and pipelines."""
-
-default_app_config = 'datahub.user.company_list.apps.CompanyListConfig'

--- a/datahub/user_event_log/__init__.py
+++ b/datahub/user_event_log/__init__.py
@@ -1,3 +1,1 @@
 """Functionality used to log notable user activity or actions in the database."""
-
-default_app_config = 'datahub.user_event_log.apps.UserEventLogConfig'


### PR DESCRIPTION
### Description of change

I noticed there were lots of warnings when running the tests (locally and on CI) around deprecated code that seemed quite trivial - it made me take 0.01 seconds longer to read test output so I've had a go at fixing some of them. There are still many warnings on CI left 😅 . Links to docs in commit messages.

### Feedback

The docs say that the `providing_args` argument for Signal are purely for documentation - do we need a comment/docs to replace them? I'm not sure what they are useful for.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
