### PR TITLE
Add clean growth investment business activity

### DIFF
--- a/changelog/investment/clean-growth-business-type.feature.md
+++ b/changelog/investment/clean-growth-business-type.feature.md
@@ -1,0 +1,1 @@
+A new investment business activity metadata type was added called 'Clean growth'.

--- a/datahub/metadata/migrations/0023_update_investment_business_activities.py
+++ b/datahub/metadata/migrations/0023_update_investment_business_activities.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_investment_business_activities(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0023_update_investment_business_activities.yaml'
+    )
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0022_update_trade_agreements'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_investment_business_activities, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0023_update_investment_business_activities.yaml
+++ b/datahub/metadata/migrations/0023_update_investment_business_activities.yaml
@@ -1,0 +1,3 @@
+- model: metadata.investmentbusinessactivity
+  pk: 3ad715e8-dd41-4250-a736-51ea3e8a125f
+  fields: {disabled_on: null, name: 'Clean growth'}


### PR DESCRIPTION
### Description of change

This PR adds a migration to bring in a new investment business activity to the corresponding metadata table called 'Clean growth'.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
