### PR TITLE
DET-113 Add fields to Interaction for Activity Stream

### DIFF
--- a/datahub/activity_stream/interaction/serializers.py
+++ b/datahub/activity_stream/interaction/serializers.py
@@ -62,13 +62,12 @@ class InteractionActivitySerializer(ActivitySerializer):
             'generator': self._get_generator(),
             'object': {
                 'id': interaction_id,
-                'type': ['dit:Event', f'dit:{self.KINDS_JSON[instance.kind]}'],
+                'type': ['dit:Event', f'dit:{self.KINDS_JSON[instance.kind]}', f'dit:{instance.theme}',],
                 'startTime': instance.date,
                 'dit:status': instance.status,
                 'dit:archived': instance.archived,
                 'dit:subject': instance.subject,
-                'dit:notes': instance.notes,
-                'dit:theme': instance.theme,
+                'dit:content': instance.notes,
                 'attributedTo': [
                     *self._get_companies(instance.companies),
                     *self._get_dit_participants(instance.dit_participants),

--- a/datahub/activity_stream/interaction/serializers.py
+++ b/datahub/activity_stream/interaction/serializers.py
@@ -67,6 +67,8 @@ class InteractionActivitySerializer(ActivitySerializer):
                 'dit:status': instance.status,
                 'dit:archived': instance.archived,
                 'dit:subject': instance.subject,
+                'dit:notes': instance.notes,
+                'dit:theme': instance.theme,
                 'attributedTo': [
                     *self._get_companies(instance.companies),
                     *self._get_dit_participants(instance.dit_participants),

--- a/datahub/activity_stream/interaction/serializers.py
+++ b/datahub/activity_stream/interaction/serializers.py
@@ -62,7 +62,11 @@ class InteractionActivitySerializer(ActivitySerializer):
             'generator': self._get_generator(),
             'object': {
                 'id': interaction_id,
-                'type': ['dit:Event', f'dit:{self.KINDS_JSON[instance.kind]}', f'dit:{instance.theme}',],
+                'type': [
+                    'dit:Event',
+                    f'dit:{self.KINDS_JSON[instance.kind]}',
+                    f'dit:{instance.theme}',
+                ],
                 'startTime': instance.date,
                 'dit:status': instance.status,
                 'dit:archived': instance.archived,

--- a/datahub/activity_stream/interaction/serializers.py
+++ b/datahub/activity_stream/interaction/serializers.py
@@ -65,13 +65,13 @@ class InteractionActivitySerializer(ActivitySerializer):
                 'type': [
                     'dit:Event',
                     f'dit:{self.KINDS_JSON[instance.kind]}',
-                    f'dit:{instance.theme}',
+                    f'dit:datahub:theme:{instance.theme}',
                 ],
+                'content': instance.notes,
                 'startTime': instance.date,
                 'dit:status': instance.status,
                 'dit:archived': instance.archived,
                 'dit:subject': instance.subject,
-                'dit:content': instance.notes,
                 'attributedTo': [
                     *self._get_companies(instance.companies),
                     *self._get_dit_participants(instance.dit_participants),

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -48,7 +48,11 @@ def test_interaction_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:Interaction', f'dit:datahub:theme:{interaction.theme}'],
+                    'type': [
+                        'dit:Event', 
+                        'dit:Interaction', 
+                        f'dit:datahub:theme:{interaction.theme}'
+                    ],
                     'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
@@ -130,7 +134,11 @@ def test_interaction_investment_project_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:Interaction', f'dit:datahub:theme:{interaction.theme}'],
+                    'type': [
+                        'dit:Event', 
+                        'dit:Interaction', 
+                        f'dit:datahub:theme:{interaction.theme}'
+                    ],
                     'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
@@ -219,7 +227,11 @@ def test_service_delivery_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:ServiceDelivery', f'dit:datahub:theme:{interaction.theme}'],
+                    'type': [
+                        'dit:Event', 
+                        'dit:ServiceDelivery', 
+                        f'dit:datahub:theme:{interaction.theme}'
+                    ],
                     'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
@@ -300,7 +312,11 @@ def test_service_delivery_event_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:ServiceDelivery', f'dit:datahub:theme:{interaction.theme}'],
+                    'type': [
+                        'dit:Event', 
+                        'dit:ServiceDelivery', 
+                        f'dit:datahub:theme:{interaction.theme}'
+                    ],
                     'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -48,14 +48,14 @@ def test_interaction_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:Interaction', f'dit:{interaction.theme}'],
+                    'type': ['dit:Event', 'dit:Interaction', f'dit:datahub:theme:{interaction.theme}'],
+                    'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
                     'dit:archived': interaction.archived,
                     'dit:communicationChannel': {'name': interaction.communication_channel.name},
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
-                    'dit:content': interaction.notes,
                     'attributedTo': [
                         *[
                             {
@@ -130,14 +130,14 @@ def test_interaction_investment_project_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:Interaction', f'dit:{interaction.theme}'],
+                    'type': ['dit:Event', 'dit:Interaction', f'dit:datahub:theme:{interaction.theme}'],
+                    'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
                     'dit:archived': interaction.archived,
                     'dit:communicationChannel': {'name': interaction.communication_channel.name},
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
-                    'dit:content': interaction.notes,
                     'attributedTo': [
                         *[
                             {
@@ -219,13 +219,13 @@ def test_service_delivery_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:ServiceDelivery', f'dit:{interaction.theme}'],
+                    'type': ['dit:Event', 'dit:ServiceDelivery', f'dit:datahub:theme:{interaction.theme}'],
+                    'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
                     'dit:archived': interaction.archived,
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
-                    'dit:content': interaction.notes,
                     'attributedTo': [
                         *[
                             {
@@ -300,13 +300,13 @@ def test_service_delivery_event_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:ServiceDelivery', f'dit:{interaction.theme}'],
+                    'type': ['dit:Event', 'dit:ServiceDelivery', f'dit:datahub:theme:{interaction.theme}'],
+                    'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
                     'dit:archived': interaction.archived,
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
-                    'dit:content': interaction.notes,
                     'attributedTo': [
                         *[
                             {

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -48,15 +48,14 @@ def test_interaction_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:Interaction'],
+                    'type': ['dit:Event', 'dit:Interaction', f'dit:{interaction.theme}'],
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
                     'dit:archived': interaction.archived,
                     'dit:communicationChannel': {'name': interaction.communication_channel.name},
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
-                    'dit:notes': interaction.notes,
-                    'dit:theme': interaction.theme,
+                    'dit:content': interaction.notes,
                     'attributedTo': [
                         *[
                             {
@@ -131,15 +130,14 @@ def test_interaction_investment_project_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:Interaction'],
+                    'type': ['dit:Event', 'dit:Interaction', f'dit:{interaction.theme}'],
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
                     'dit:archived': interaction.archived,
                     'dit:communicationChannel': {'name': interaction.communication_channel.name},
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
-                    'dit:notes': interaction.notes,
-                    'dit:theme': interaction.theme,
+                    'dit:content': interaction.notes,
                     'attributedTo': [
                         *[
                             {
@@ -221,14 +219,13 @@ def test_service_delivery_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:ServiceDelivery'],
+                    'type': ['dit:Event', 'dit:ServiceDelivery', f'dit:{interaction.theme}'],
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
                     'dit:archived': interaction.archived,
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
-                    'dit:notes': interaction.notes,
-                    'dit:theme': interaction.theme,
+                    'dit:content': interaction.notes,
                     'attributedTo': [
                         *[
                             {
@@ -303,14 +300,13 @@ def test_service_delivery_event_activity(api_client):
                 'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
-                    'type': ['dit:Event', 'dit:ServiceDelivery'],
+                    'type': ['dit:Event', 'dit:ServiceDelivery', f'dit:{interaction.theme}'],
                     'startTime': format_date_or_datetime(interaction.date),
                     'dit:status': interaction.status,
                     'dit:archived': interaction.archived,
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
-                    'dit:notes': interaction.notes,
-                    'dit:theme': interaction.theme,
+                    'dit:content': interaction.notes,
                     'attributedTo': [
                         *[
                             {

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -49,9 +49,9 @@ def test_interaction_activity(api_client):
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
                     'type': [
-                        'dit:Event', 
-                        'dit:Interaction', 
-                        f'dit:datahub:theme:{interaction.theme}'
+                        'dit:Event',
+                        'dit:Interaction',
+                        f'dit:datahub:theme:{interaction.theme}',
                     ],
                     'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
@@ -135,9 +135,9 @@ def test_interaction_investment_project_activity(api_client):
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
                     'type': [
-                        'dit:Event', 
-                        'dit:Interaction', 
-                        f'dit:datahub:theme:{interaction.theme}'
+                        'dit:Event',
+                        'dit:Interaction',
+                        f'dit:datahub:theme:{interaction.theme}',
                     ],
                     'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
@@ -228,9 +228,9 @@ def test_service_delivery_activity(api_client):
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
                     'type': [
-                        'dit:Event', 
-                        'dit:ServiceDelivery', 
-                        f'dit:datahub:theme:{interaction.theme}'
+                        'dit:Event',
+                        'dit:ServiceDelivery',
+                        f'dit:datahub:theme:{interaction.theme}',
                     ],
                     'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),
@@ -313,9 +313,9 @@ def test_service_delivery_event_activity(api_client):
                 'object': {
                     'id': f'dit:DataHubInteraction:{interaction.id}',
                     'type': [
-                        'dit:Event', 
-                        'dit:ServiceDelivery', 
-                        f'dit:datahub:theme:{interaction.theme}'
+                        'dit:Event',
+                        'dit:ServiceDelivery',
+                        f'dit:datahub:theme:{interaction.theme}',
                     ],
                     'content': interaction.notes,
                     'startTime': format_date_or_datetime(interaction.date),

--- a/datahub/activity_stream/interaction/test/test_views.py
+++ b/datahub/activity_stream/interaction/test/test_views.py
@@ -55,6 +55,8 @@ def test_interaction_activity(api_client):
                     'dit:communicationChannel': {'name': interaction.communication_channel.name},
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
+                    'dit:notes': interaction.notes,
+                    'dit:theme': interaction.theme,
                     'attributedTo': [
                         *[
                             {
@@ -136,6 +138,8 @@ def test_interaction_investment_project_activity(api_client):
                     'dit:communicationChannel': {'name': interaction.communication_channel.name},
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
+                    'dit:notes': interaction.notes,
+                    'dit:theme': interaction.theme,
                     'attributedTo': [
                         *[
                             {
@@ -223,6 +227,8 @@ def test_service_delivery_activity(api_client):
                     'dit:archived': interaction.archived,
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
+                    'dit:notes': interaction.notes,
+                    'dit:theme': interaction.theme,
                     'attributedTo': [
                         *[
                             {
@@ -303,6 +309,8 @@ def test_service_delivery_event_activity(api_client):
                     'dit:archived': interaction.archived,
                     'dit:subject': interaction.subject,
                     'dit:service': {'name': interaction.service.name},
+                    'dit:notes': interaction.notes,
+                    'dit:theme': interaction.theme,
                     'attributedTo': [
                         *[
                             {


### PR DESCRIPTION
### Description of change

We want to display data from Activity Stream on the Data Hub front end,
so that users have a more complete picture of the data.

We are missing a couple of fields on the Interaction model when it is
serialised for Activity Stream: `notes` and `theme`.

This commit adds them to the serializer.
 
![Screenshot 2022-04-20 at 12 49 26](https://user-images.githubusercontent.com/16647486/164224142-54f3c9c6-3607-4698-bca0-5a59466e273d.png)

To see via API request:
GET to `localhost:8000/v3/activity-stream/interaction` with Hawk authentication. The Hawk Auth ID will be `ACTIVITY_STREAM_ACCESS_KEY_ID` and the Hawk auth key will be `ACTIVITY_STREAM_SECRET_ACCESS_KEY` 

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
