### PR TITLE
Allow users to sort by the `modified_on` field of the `/v3/search/investment_project` endpoint

### DIFF
--- a/changelog/investment_search_sort_by_modified_on.feature.md
+++ b/changelog/investment_search_sort_by_modified_on.feature.md
@@ -1,0 +1,1 @@
+The `modified_on` field has been added to the `SORT_BY_FIELDS` tuple.

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -54,4 +54,5 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
         'estimated_land_date',
         'name',
         'stage.name',
+        'modified_on',
     )


### PR DESCRIPTION
### Description of change

Allow users to sort by the `modified_on` field of the `/v3/search/investment_project` endpoint
### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
