### PR TITLE
Rollback werkzeug so that runserver_plus works

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -58,7 +58,7 @@ factory-boy==3.2.1
 freezegun==1.2.1
 requests-mock==1.9.3
 django-debug-toolbar==3.4.0
-werkzeug==2.1.2  # Required by runserver_plus - useful for local dev
+werkzeug==2.0.3  # Required by runserver_plus - useful for local dev
 pip-tools==6.6.0
 piprot==0.9.11
 semantic_version==2.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,6 @@ aiosignal==1.2.0
     # via aiohttp
 amqp==5.0.9
     # via kombu
-appnope==0.1.3
-    # via ipython
 asgiref==3.5.0
     # via django
 astroid==2.11.3
@@ -457,7 +455,7 @@ watchdog[watchmedo]==2.1.7
     # via -r requirements.in
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==2.1.2
+werkzeug==2.0.3
     # via -r requirements.in
 wheel==0.37.1
     # via pip-tools


### PR DESCRIPTION
### Description of change

Werkzeug deprecated 'werkzeug.server.shutdown' in version 2.1, but django extensions runserver_plus still tries to use it - see https://github.com/django-extensions/django-extensions/issues/1715. To fix this, I have rolled back werkzeug to 2.0.3

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
