### PR TITLE
Add werkzeug to Dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,4 +14,7 @@ updates:
   - dependency-name: pytest
     versions:
     - ">= 4.6.1.a, < 4.6.2"
+  - dependency-name: werkzeug
+    versions:
+    - "> 2.0.3"
   rebase-strategy: disabled

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,6 @@ updates:
     timezone: Europe/London
   open-pull-requests-limit: 10
   ignore:
-  - dependency-name: pip-tools
-    versions:
-    - ">= 5.a, < 6"
-  - dependency-name: pytest
-    versions:
-    - ">= 4.6.1.a, < 4.6.2"
   - dependency-name: werkzeug
     versions:
     - "> 2.0.3"


### PR DESCRIPTION
### Description of change

As `werkzeug` was rolled back in [this PR](https://github.com/uktrade/data-hub-api/pull/4115), we don't want Dependabot to try and update it again.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
