### PR TITLE
Add stage and status to notification template

### DIFF
--- a/changelog/investment/stage-and-status-notification.feature.md
+++ b/changelog/investment/stage-and-status-notification.feature.md
@@ -1,0 +1,1 @@
+The `project_stage` and `project_status` variables have been added to Estimated Land Date notification template.

--- a/datahub/investment/project/notification/tasks.py
+++ b/datahub/investment/project/notification/tasks.py
@@ -40,6 +40,8 @@ def send_investment_notification(project, adviser, notification_type):
             'investor_company_name': project.investor_company.name,
             'project_name': project.name,
             'project_code': project.project_code,
+            'project_status': project.status.capitalize(),
+            'project_stage': project.stage.name,
             # '%-d %B %Y' formats date to 1 January 2022
             'estimated_land_date': project.estimated_land_date.strftime('%-d %B %Y'),
         },

--- a/datahub/investment/project/notification/test/test_tasks.py
+++ b/datahub/investment/project/notification/test/test_tasks.py
@@ -212,6 +212,8 @@ class TestInvestmentNotificationSubscriptionTasks:
                     'investor_company_name': project.investor_company.name,
                     'project_name': project.name,
                     'project_code': project.project_code,
+                    'project_status': project.status.capitalize(),
+                    'project_stage': project.stage.name,
                     'estimated_land_date': project.estimated_land_date.strftime('%-d %B %Y'),
                 },
                 NotifyServiceName.investment,


### PR DESCRIPTION
### Description of change

The `project_stage` and `project_status` variables have been added to Estimated Land Date notification template.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
