### PR TITLE
Add reminder summary endpoint

### DIFF
--- a/changelog/reminder/summary.feature.md
+++ b/changelog/reminder/summary.feature.md
@@ -1,0 +1,3 @@
+API now provides a summary of reminders for the current user:
+
+GET /v4/reminder/summary

--- a/datahub/reminder/urls.py
+++ b/datahub/reminder/urls.py
@@ -3,10 +3,10 @@ from django.urls import path
 from datahub.reminder.views import (
     NoRecentInvestmentInteractionReminderViewset,
     NoRecentInvestmentInteractionSubscriptionViewset,
+    reminder_summary_view,
     UpcomingEstimatedLandDateReminderViewset,
     UpcomingEstimatedLandDateSubscriptionViewset,
 )
-
 
 urlpatterns = [
     path(
@@ -37,5 +37,10 @@ urlpatterns = [
             'get': 'list',
         }),
         name='estimated-land-date-reminder',
+    ),
+    path(
+        'reminder/summary',
+        reminder_summary_view,
+        name='summary',
     ),
 ]

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -1,7 +1,11 @@
+from django.db import transaction
 from rest_framework import viewsets
+from rest_framework.decorators import api_view, permission_classes
 from rest_framework.mixins import ListModelMixin
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
+from datahub.investment.project.proposition.models import Proposition, PropositionStatus
 from datahub.reminder.models import (
     NoRecentInvestmentInteractionReminder,
     NoRecentInvestmentInteractionSubscription,
@@ -55,3 +59,26 @@ class NoRecentInvestmentInteractionReminderViewset(BaseReminderViewset):
 class UpcomingEstimatedLandDateReminderViewset(BaseReminderViewset):
     serializer_class = UpcomingEstimatedLandDateReminderSerializer
     model_class = UpcomingEstimatedLandDateReminder
+
+
+@transaction.non_atomic_requests
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def reminder_summary_view(request):
+    """Returns the reminder summary."""
+    estimated_land_date = UpcomingEstimatedLandDateReminder.objects.filter(
+        adviser=request.user,
+    ).count()
+    no_recent_interaction = NoRecentInvestmentInteractionReminder.objects.filter(
+        adviser=request.user,
+    ).count()
+    outstanding_propositions = Proposition.objects.filter(
+        adviser=request.user,
+        status=PropositionStatus.ONGOING,
+    ).count()
+
+    return Response({
+        'estimated_land_date': estimated_land_date,
+        'no_recent_investment_interaction': no_recent_interaction,
+        'outstanding_propositions': outstanding_propositions,
+    })


### PR DESCRIPTION
### Description of change

API now provides a summary of reminders for the current user:

GET /v4/reminder/summary

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
