### PR TITLE
Bump boto3 from 1.23.0 to 1.23.10

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -20,7 +20,7 @@ python-dateutil==2.8.2
 psycopg2==2.9.3
 psycogreen==1.0.2
 
-boto3==1.23.0
+boto3==1.23.10
 
 notifications-python-client==6.3.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,8 @@ aiosignal==1.2.0
     # via aiohttp
 amqp==5.0.9
     # via kombu
+appnope==0.1.3
+    # via ipython
 asgiref==3.5.0
     # via django
 astroid==2.11.5
@@ -30,9 +32,9 @@ backcall==0.2.0
     # via ipython
 billiard==3.6.4.0
     # via celery
-boto3==1.23.0
+boto3==1.23.10
     # via -r requirements.in
-botocore==1.26.0
+botocore==1.26.10
     # via
     #   boto3
     #   s3transfer
@@ -431,6 +433,10 @@ traitlets==5.1.1
     # via
     #   ipython
     #   matplotlib-inline
+typing-extensions==4.2.0
+    # via
+    #   astroid
+    #   pylint
 uritemplate==4.1.1
     # via -r requirements.in
 urllib3==1.26.8


### PR DESCRIPTION
### Description of change

**THIS PR SHOULDN'T BE MERGED** until investigation into why boto 1.23.7 caused the API jenkins deployment to fail. 
Initial failed build [here](https://jenkins.ci.uktrade.digital/view/Datahub/job/datahub-api/4061/).

Upgrade boto to 1.23.10.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
