### PR TITLE
Update modified_on field for related objects on merge

### DIFF
--- a/changelog/company/update-modified-on-field-when-merging.bugfix.md
+++ b/changelog/company/update-modified-on-field-when-merging.bugfix.md
@@ -1,0 +1,1 @@
+When merging two companies, the modified_on field of the objects related to the source company (e.g. interactions or contacts) will now be updated when they are moved over to the target company.

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -74,7 +74,7 @@ def _default_object_updater(obj, field, target_company, source_company):
         return
 
     setattr(obj, field, target_company)
-    obj.save(update_fields=(field,))
+    obj.save(update_fields=(field, 'modified_on'))
 
 
 def _company_list_item_updater(list_item, field, target_company, source_company):

--- a/datahub/company/test/admin/merge/test_step_3.py
+++ b/datahub/company/test/admin/merge/test_step_3.py
@@ -232,11 +232,11 @@ class TestConfirmMergeViewPost(AdminTestMixin):
             obj.refresh_from_db()
 
         assert all(obj.company == target_company for obj in source_non_project_related_objects)
-        assert all(obj.modified_on == creation_time for obj in source_non_project_related_objects)
+        assert all(obj.modified_on == merge_time for obj in source_non_project_related_objects)
 
         for field, investment_projects in source_investment_projects_by_field.items():
             assert all(getattr(obj, field) == target_company for obj in investment_projects)
-            assert all(obj.modified_on == creation_time for obj in investment_projects)
+            assert all(obj.modified_on == merge_time for obj in investment_projects)
 
         source_company.refresh_from_db()
 

--- a/datahub/company/test/test_merge.py
+++ b/datahub/company/test/test_merge.py
@@ -423,7 +423,10 @@ class TestDuplicateCompanyMerger:
         assert all(getattr(investment_project, field) != target_company for field in other_fields)
         assert all(getattr(investment_project, field) != source_company for field in other_fields)
 
-        assert investment_project.modified_on == creation_time
+        # Only check that the modified field is updated if the investment project
+        # is linked to the source company
+        if fields:
+            assert investment_project.modified_on == merge_time
 
         source_company.refresh_from_db()
 

--- a/datahub/company/test/test_merge.py
+++ b/datahub/company/test/test_merge.py
@@ -343,7 +343,7 @@ class TestDuplicateCompanyMerger:
             obj.refresh_from_db()
 
         assert all(obj.company == target_company for obj in source_related_objects)
-        assert all(obj.modified_on == creation_time for obj in source_related_objects)
+        assert all(obj.modified_on == merge_time for obj in source_related_objects)
 
         source_company.refresh_from_db()
 


### PR DESCRIPTION
### Description of change

**Reason behind the change**
This PR addresses an issue reported by users in which when merging one company into another, activities related to the source company do not appear in the activity feed of the target company for around 2 days.

The cause of this is that data returned by our activity stream endpoints are ordered by the objects' `modified_on` fields ([pagination code here](https://github.com/uktrade/data-hub-api/blob/develop/datahub/activity_stream/pagination.py#L100)), however when two companies are merged together, the `modified_on` field of the objects related to the source company is not updated. This means that activity stream doesn't pick up that the company related to these objects has changed until the full ingest of Data Hub activities happens, which is every couple of days.

**What is the change**
This PR updates the `default_object_updater` method used to update all objects related to a source company when merging, so that the `modified_on` field of all related objects (e.g. interactions, contacts, investment projects) is updated when they move from one company record to another.

**NOTE**

**Source company**: a company being merged into another, which will become archived after the merge

**Target company**: the company which the source company is merged into, which will have all of the source company's activities linked to it after merge

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
