### PR TITLE
Add ids to reminder endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ pyrightconfig.json
 
 # Ctags
 tags
+
+# IDE
+.vscode/

--- a/changelog/reminder/add-reminder-ids-to-api.feature.md
+++ b/changelog/reminder/add-reminder-ids-to-api.feature.md
@@ -1,0 +1,1 @@
+Ids have now been added to the estimated land date and no recent interaction reminder endpoints.

--- a/datahub/reminder/serializers.py
+++ b/datahub/reminder/serializers.py
@@ -40,7 +40,7 @@ class UpcomingEstimatedLandDateReminderSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = UpcomingEstimatedLandDateReminder
-        fields = ('created_on', 'event', 'project')
+        fields = ('id', 'created_on', 'event', 'project')
 
 
 class NoRecentInvestmentInteractionReminderSerializer(serializers.ModelSerializer):
@@ -50,4 +50,4 @@ class NoRecentInvestmentInteractionReminderSerializer(serializers.ModelSerialize
 
     class Meta:
         model = NoRecentInvestmentInteractionReminder
-        fields = ('created_on', 'event', 'project')
+        fields = ('id', 'created_on', 'event', 'project')

--- a/datahub/reminder/test/test_views.py
+++ b/datahub/reminder/test/test_views.py
@@ -126,6 +126,7 @@ class TestNoRecentInvestmentInteractionReminderViewset(APITestMixin):
         results = data.get('results', [])
         assert len(results) == 2
         assert results[0] == {
+            'id': str(reminders[0].id),
             'created_on': '2022-05-05T17:00:00Z',
             'event': reminders[0].event,
             'project': {
@@ -182,6 +183,7 @@ class TestUpcomingEstimatedLandDateReminderViewset(APITestMixin):
         results = data.get('results', [])
         assert len(results) == 2
         assert results[0] == {
+            'id': str(reminders[0].id),
             'created_on': '2022-05-05T17:00:00Z',
             'event': reminders[0].event,
             'project': {


### PR DESCRIPTION
### Description of change

Adds ids to the two reminder endpoints

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
