### PR TITLE
Change Estimated Land Date notification criteria.

### DIFF
--- a/changelog/investment/change-notification-sending-criteria.internal.md
+++ b/changelog/investment/change-notification-sending-criteria.internal.md
@@ -1,0 +1,1 @@
+Notifications for Estimated Land Date are now being sent only for active ongoing and delayed investment projects.

--- a/datahub/investment/project/notification/tasks.py
+++ b/datahub/investment/project/notification/tasks.py
@@ -12,6 +12,7 @@ from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.investment.project import (
     INVESTMENT_ESTIMATED_LAND_DATE_NOTIFICATION_FEATURE_FLAG_NAME,
 )
+from datahub.investment.project.models import InvestmentProject
 from datahub.investment.project.notification.emails import send_estimated_land_date_reminder
 from datahub.investment.project.notification.models import InvestmentNotificationSubscription
 
@@ -47,11 +48,11 @@ def get_subscriptions_for_estimated_land_date(notification_type: str):
         investment_project__estimated_land_date__year=future_estimated_land_date.year,
         investment_project__estimated_land_date__month=future_estimated_land_date.month,
         investment_project__estimated_land_date__day=future_estimated_land_date.day,
-    ).exclude(
-        investment_project__stage_id__in=(
-            InvestmentProjectStage.verify_win.value.id,
-            InvestmentProjectStage.won.value.id,
-        ),
+        investment_project__status__in=[
+            InvestmentProject.Status.ONGOING,
+            InvestmentProject.Status.DELAYED,
+        ],
+        investment_project__stage_id=InvestmentProjectStage.active.value.id,
     )
     return subscriptions
 


### PR DESCRIPTION
### Description of change

Notifications for Estimated Land Date are now being sent only for active and ongoing investment projects.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
