### PR TITLE
Added None checks to catch possible empty relational data for the eve…

### DIFF
--- a/datahub/activity_stream/event/serializers.py
+++ b/datahub/activity_stream/event/serializers.py
@@ -32,7 +32,6 @@ class EventActivitySerializer(ActivitySerializer):
                 'dit:address_postcode': instance.address_postcode,
                 'dit:address_country': {'name': instance.address_country.name},
                 'dit:disabledOn': instance.disabled_on,
-                'dit:service': {'name': instance.service.name},
                 'dit:archivedDocumentsUrlPath': instance.archived_documents_url_path,
                 'dit:eventType': {'name': instance.event_type.name},
             },
@@ -53,6 +52,10 @@ class EventActivitySerializer(ActivitySerializer):
         if instance.location_type is not None:
             event['object']['dit:locationType'] = {
                 'name': instance.location_type.name,
+            }
+        if instance.service is not None:
+            event['object']['dit:service'] = {
+                'name': instance.service.name,
             }
 
         return event

--- a/datahub/activity_stream/event/serializers.py
+++ b/datahub/activity_stream/event/serializers.py
@@ -30,9 +30,11 @@ class EventActivitySerializer(ActivitySerializer):
                 'dit:address_town': instance.address_town,
                 'dit:address_county': instance.address_county,
                 'dit:address_postcode': instance.address_postcode,
+                'dit:address_country': {'name': instance.address_country.name},
                 'dit:disabledOn': instance.disabled_on,
                 'dit:service': {'name': instance.service.name},
                 'dit:archivedDocumentsUrlPath': instance.archived_documents_url_path,
+                'dit:eventType': {'name': instance.event_type.name},
             },
 
         }
@@ -48,17 +50,9 @@ class EventActivitySerializer(ActivitySerializer):
             event['object']['dit:leadTeam'] = {
                 'name': instance.lead_team.name,
             }
-        if instance.address_country is not None:
-            event['object']['dit:address_country'] = {
-                'name': instance.address_country.name,
-            }
         if instance.location_type is not None:
             event['object']['dit:locationType'] = {
                 'name': instance.location_type.name,
-            }
-        if instance.event_type is not None:
-            event['object']['dit:eventType'] = {
-                'name': instance.event_type.name,
             }
 
         return event

--- a/datahub/activity_stream/event/serializers.py
+++ b/datahub/activity_stream/event/serializers.py
@@ -21,20 +21,15 @@ class EventActivitySerializer(ActivitySerializer):
                     'dit:dataHub:Event',
                 ],
                 'name': instance.name,
-                'dit:eventType': {'name': instance.event_type.name},
                 'content': instance.notes,
                 'startTime': instance.start_date,
                 'endTime': instance.end_date,
                 'url': instance.get_absolute_url(),
-                'dit:locationType': {'name': instance.location_type.name},
                 'dit:address_1': instance.address_1,
                 'dit:address_2': instance.address_2,
                 'dit:address_town': instance.address_town,
                 'dit:address_county': instance.address_county,
                 'dit:address_postcode': instance.address_postcode,
-                'dit:address_country': {'name': instance.address_country.name},
-                'dit:leadTeam': {'name': instance.lead_team.name},
-                'dit:organiser': {'name': instance.organiser.name},
                 'dit:disabledOn': instance.disabled_on,
                 'dit:service': {'name': instance.service.name},
                 'dit:archivedDocumentsUrlPath': instance.archived_documents_url_path,
@@ -44,6 +39,26 @@ class EventActivitySerializer(ActivitySerializer):
         if instance.uk_region is not None:
             event['object']['dit:ukRegion'] = {
                 'name': instance.uk_region.name,
+            }
+        if instance.organiser is not None:
+            event['object']['dit:organiser'] = {
+                'name': instance.organiser.name,
+            }
+        if instance.lead_team is not None:
+            event['object']['dit:leadTeam'] = {
+                'name': instance.lead_team.name,
+            }
+        if instance.address_country is not None:
+            event['object']['dit:address_country'] = {
+                'name': instance.address_country.name,
+            }
+        if instance.location_type is not None:
+            event['object']['dit:locationType'] = {
+                'name': instance.location_type.name,
+            }
+        if instance.event_type is not None:
+            event['object']['dit:eventType'] = {
+                'name': instance.event_type.name,
             }
 
         return event

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -62,3 +62,55 @@ def test_event_activity(api_client):
                 },
             ],
         }
+
+
+@pytest.mark.django_db
+def test_null_event_region(api_client):
+    """
+    Test that we can handle event region  being None
+    """
+    with freeze_time() as frozen_datetime:
+        EventFactory(uk_region_id=None)
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:events'))
+
+        assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_null_event_organiser(api_client):
+    """
+    Test that we can handle event Organiser  being None
+    """
+    with freeze_time() as frozen_datetime:
+        EventFactory(organiser=None)
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:events'))
+
+        assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_null_event_lead_team(api_client):
+    """
+    Test that we can handle event Lead Team being None
+    """
+    with freeze_time() as frozen_datetime:
+        EventFactory(lead_team_id=None)
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:events'))
+
+        assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_null_event_location_type(api_client):
+    """
+    Test that we can handle event location Type  being None
+    """
+    with freeze_time() as frozen_datetime:
+        EventFactory(location_type_id=None)
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:events'))
+
+        assert response.status_code == status.HTTP_200_OK

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -114,3 +114,16 @@ def test_null_event_location_type(api_client):
         response = hawk.get(api_client, get_url('api-v3:activity-stream:events'))
 
         assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_null_event_service(api_client):
+    """
+    Test that we can handle event service being None
+    """
+    with freeze_time() as frozen_datetime:
+        EventFactory(service_id=None)
+        frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
+        response = hawk.get(api_client, get_url('api-v3:activity-stream:events'))
+
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
…nts information

### Previously merged wasn't working on Develop due to "None" type error

Have added additional checks to ensure that attributes that are None type are not attempted to be read.


### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  
  
* [x] Has this branch been rebased on top of the current `develop` branch?


* [x] Is the CircleCI build passing?

