### PR TITLE
Patch subscriptions

### DIFF
--- a/changelog/investment/patch_reminder_subscriptions.feature.md
+++ b/changelog/investment/patch_reminder_subscriptions.feature.md
@@ -1,0 +1,4 @@
+Reminder subscriptions can be updated with the PATCH method:
+
+PATCH /reminder/subscription/no-recent-investment-interaction
+PATCH /reminder/subscription/estimated-land-date

--- a/datahub/reminder/test/test_views.py
+++ b/datahub/reminder/test/test_views.py
@@ -53,6 +53,33 @@ class TestNoRecentInvestmentInteractionSubscriptionViewset(APITestMixin):
             'email_reminders_enabled': True,
         }
 
+    def test_patch_existing_subscription(self):
+        """Patching the subscription will update an existing subscription"""
+        NoRecentInvestmentInteractionSubscriptionFactory(
+            adviser=self.user,
+            reminder_days=[10, 20, 40],
+            email_reminders_enabled=True,
+        )
+        url = reverse(self.url_name)
+        data = {'reminder_days': [15, 30], 'email_reminders_enabled': False}
+        response = self.api_client.patch(url, data)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'reminder_days': [15, 30],
+            'email_reminders_enabled': False,
+        }
+
+    def test_patch_subscription_no_existing(self):
+        """Patching the subscription will create one if it didn't exist already"""
+        url = reverse(self.url_name)
+        data = {'reminder_days': [15]}
+        response = self.api_client.patch(url, data)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'reminder_days': [15],
+            'email_reminders_enabled': False,
+        }
+
 
 class TestUpcomingEstimatedLandDateSubscriptionViewset(APITestMixin):
     """
@@ -91,6 +118,33 @@ class TestUpcomingEstimatedLandDateSubscriptionViewset(APITestMixin):
         assert response.json() == {
             'reminder_days': [10, 20, 40],
             'email_reminders_enabled': True,
+        }
+
+    def test_patch_existing_subscription(self):
+        """Patching the subscription will update an existing subscription"""
+        UpcomingEstimatedLandDateSubscriptionFactory(
+            adviser=self.user,
+            reminder_days=[10, 20, 40],
+            email_reminders_enabled=True,
+        )
+        url = reverse(self.url_name)
+        data = {'reminder_days': [15, 30], 'email_reminders_enabled': False}
+        response = self.api_client.patch(url, data)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'reminder_days': [15, 30],
+            'email_reminders_enabled': False,
+        }
+
+    def test_patch_subscription_no_existing(self):
+        """Patching the subscription will create one if it didn't exist already"""
+        url = reverse(self.url_name)
+        data = {'reminder_days': [15]}
+        response = self.api_client.patch(url, data)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'reminder_days': [15],
+            'email_reminders_enabled': False,
         }
 
 

--- a/datahub/reminder/urls.py
+++ b/datahub/reminder/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
         'reminder/subscription/no-recent-investment-interaction',
         NoRecentInvestmentInteractionSubscriptionViewset.as_view({
             'get': 'retrieve',
+            'patch': 'partial_update',
         }),
         name='no-recent-investment-interaction-subscription',
     ),
@@ -20,6 +21,7 @@ urlpatterns = [
         'reminder/subscription/estimated-land-date',
         UpcomingEstimatedLandDateSubscriptionViewset.as_view({
             'get': 'retrieve',
+            'patch': 'partial_update',
         }),
         name='estimated-land-date-subscription',
     ),

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -1,7 +1,7 @@
 from django.db import transaction
 from rest_framework import viewsets
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.mixins import ListModelMixin
+from rest_framework.mixins import ListModelMixin, RetrieveModelMixin, UpdateModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -20,18 +20,21 @@ from datahub.reminder.serializers import (
 )
 
 
-class BaseSubscriptionViewset(viewsets.GenericViewSet):
+class BaseSubscriptionViewset(
+    viewsets.GenericViewSet,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+):
     permission_classes = ()
 
-    def retrieve(self, request, pk=None):
+    def get_object(self):
         """
-        Gets subscription settings for current user.
+        Gets subscription settings instance for current user.
 
         If settings have not been created yet, add them.
         """
-        obj, created = self.queryset.get_or_create(adviser=request.user)
-        serializer = self.serializer_class(obj)
-        return Response(serializer.data)
+        obj, created = self.queryset.get_or_create(adviser=self.request.user)
+        return obj
 
 
 class NoRecentInvestmentInteractionSubscriptionViewset(BaseSubscriptionViewset):


### PR DESCRIPTION
### Description of change

Provides a patch method to the reminder subscription endpoints

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
