### PR TITLE
Feature/det 194 add many to many fields to event activity stream

### DIFF
--- a/datahub/activity_stream/event/serializers.py
+++ b/datahub/activity_stream/event/serializers.py
@@ -52,11 +52,11 @@ class EventActivitySerializer(ActivitySerializer):
                 'dit:disabledOn': instance.disabled_on,
                 'dit:archivedDocumentsUrlPath': instance.archived_documents_url_path,
                 'dit:eventType': {'name': instance.event_type.name},
-                'did:hasRelatedTradeAgreements': instance.has_related_trade_agreements,
+                'dit:hasRelatedTradeAgreements': instance.has_related_trade_agreements,
                 'dit:relatedProgrammes': [
                     *self._get_related_programmes(instance.related_programmes),
                 ],
-                'dit:Teams': [
+                'dit:teams': [
                     *self._get_teams(instance.teams),
                 ],
             },

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -144,3 +144,12 @@ def test_trade_agreements_only_shown_if_they_exist(api_client):
 
     assert response.status_code == status.HTTP_200_OK
     assert 'dit:relatedTradeAgreements' in response.json()['orderedItems'][0]['object']
+
+
+@pytest.mark.django_db
+def test_trade_agreements_do_not_show_if_they_do_not_exist(api_client):
+    EventFactory(has_related_trade_agreements=False)
+    response = _get_response(api_client)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert 'dit:relatedTradeAgreements' not in response.json()['orderedItems'][0]['object']

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -72,7 +72,7 @@ def test_event_activity(api_client):
                             *[
                                 {
                                     'id': f'dit:DataHubEventProgramme:{programme.pk}',
-                                    'name': programme.name
+                                    'name': programme.name,
                                 }
                                 for programme in event.related_programmes.order_by('pk')
                             ],

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -58,6 +58,37 @@ def test_event_activity(api_client):
                         'dit:service': {'name': event.service.name},
                         'dit:archivedDocumentsUrlPath': event.archived_documents_url_path,
                         'dit:ukRegion': {'name': event.uk_region.name},
+                        'dit:teams': [
+                            *[
+                                {
+                                    'id': f'dit:DataHubTeam:{team.pk}',
+                                    'type': ['Group', 'dit:Team'],
+                                    'name': team.name,
+                                }
+                                for team in event.teams.order_by('pk')
+                            ],
+                        ],
+                        'dit:relatedProgrammes': [
+                            *[
+                                {
+                                    'id': f'dit:DataHubEventProgramme:{programme.pk}',
+                                    'name': programme.name
+                                }
+                                for programme in event.related_programmes.order_by('pk')
+                            ],
+                        ],
+                        'dit:hasRelatedTradeAgreements': event.has_related_trade_agreements,
+                        'dit:relatedTradeAgreements':
+                        [
+                            *[
+                                {
+                                    'id': f'dit:DataHubTradeAgreement:{trade_agreement.pk}',
+                                    'name': trade_agreement.name,
+                                }
+                                for trade_agreement in
+                                event.related_trade_agreements.order_by('pk')
+                            ],
+                        ],
                     },
                 },
             ],

--- a/datahub/activity_stream/serializers.py
+++ b/datahub/activity_stream/serializers.py
@@ -89,3 +89,15 @@ class ActivitySerializer(serializers.Serializer):
             'name': 'dit:dataHub',
             'type': 'Application',
         }
+
+    def _get_trade_agreement(self, trade_agreement):
+        return {
+            'id': f'dit:DataHubTradeAgreement:{trade_agreement.pk}',
+            'name': trade_agreement.name,
+        }
+
+    def _get_trade_agreements(self, trade_agreements):
+        return [
+            self._get_trade_agreement(trade_agreement)
+            for trade_agreement in trade_agreements.order_by('pk')
+        ]

--- a/datahub/event/queryset.py
+++ b/datahub/event/queryset.py
@@ -1,3 +1,5 @@
+from django.db.models import Prefetch
+
 from datahub.event.models import Event
 
 
@@ -15,4 +17,10 @@ def get_base_event_queryset():
         'organiser',
         'lead_team',
         'service',
+    ).prefetch_related(
+        Prefetch(
+            'related_programmes',
+            'related_trade_agreements',
+            'teams',
+        ),
     )


### PR DESCRIPTION
### Description of change

<!--
Adds many to many fields:

- related_programmes,
- related_trade_agreements,
- teams

To the event serializer/query to make them available on Activity Stream for events 
-->

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?


