### PR TITLE
Fetaure/add specific investment program

### DIFF
--- a/changelog/investment/add-specific-investment-programme.feature.md
+++ b/changelog/investment/add-specific-investment-programme.feature.md
@@ -1,0 +1,1 @@
+Its now possible to view Enquiry Response Unit support in Specific investment programme

--- a/datahub/investment/project/migrations/0006_update_specific_programmes.py
+++ b/datahub/investment/project/migrations/0006_update_specific_programmes.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def update_specific_programmes(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps, PurePath(__file__).parent / "0006_update_specific_programmes.yaml"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("investment", "0005_update_specific_programmes"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_specific_programmes, migrations.RunPython.noop),
+    ]

--- a/datahub/investment/project/migrations/0006_update_specific_programmes.yaml
+++ b/datahub/investment/project/migrations/0006_update_specific_programmes.yaml
@@ -1,3 +1,3 @@
 - model: investment.specificprogramme
   pk: e986629a-f07c-11ec-8ea0-0242ac120002
-  fields: { disabled_on: null, name: "Enquiry Response Unit support" }
+  fields: { disabled_on: null, name: "Enquiry Response Unit Support" }

--- a/datahub/investment/project/migrations/0006_update_specific_programmes.yaml
+++ b/datahub/investment/project/migrations/0006_update_specific_programmes.yaml
@@ -1,0 +1,3 @@
+- model: investment.specificprogramme
+  pk: e986629a-f07c-11ec-8ea0-0242ac120002
+  fields: { disabled_on: null, name: "Enquiry Response Unit support" }


### PR DESCRIPTION
### Description of change

Add Enquiry response Unit in specific investment programme

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
