### PR TITLE
Sort reminders by created date

### DIFF
--- a/changelog/reminder/sort-reminders.feature.md
+++ b/changelog/reminder/sort-reminders.feature.md
@@ -1,0 +1,4 @@
+Reminders can now be sorted by created_on with the sort by parameter:
+
+?sortby=created_on
+?sortby=-created_on

--- a/datahub/reminder/serializers.py
+++ b/datahub/reminder/serializers.py
@@ -44,7 +44,7 @@ class UpcomingEstimatedLandDateReminderSerializer(serializers.ModelSerializer):
 
 
 class NoRecentInvestmentInteractionReminderSerializer(serializers.ModelSerializer):
-    """Serializer for Upcoming Estimated Land Date Reminder."""
+    """Serializer for No Recent Investment Interaction Reminder."""
 
     project = NestedInvestmentProjectSerializer(many=False, read_only=True)
 

--- a/datahub/reminder/test/test_views.py
+++ b/datahub/reminder/test/test_views.py
@@ -156,6 +156,18 @@ class TestNoRecentInvestmentInteractionReminderViewset(APITestMixin):
 
     url_name = 'api-v4:reminder:no-recent-investment-interaction-reminder'
 
+    def create_reminders(self):
+        """Creates some mock reminders"""
+        with freeze_time('2022-05-05T18:00:00.000000Z'):
+            reminder_1 = NoRecentInvestmentInteractionReminderFactory(
+                adviser=self.user,
+            )
+        with freeze_time('2022-05-05T19:00:00.000000Z'):
+            reminder_2 = NoRecentInvestmentInteractionReminderFactory(
+                adviser=self.user,
+            )
+        return [reminder_1, reminder_2]
+
     def test_not_authed(self):
         """Should return Unauthorised"""
         url = reverse(self.url_name)
@@ -204,6 +216,42 @@ class TestNoRecentInvestmentInteractionReminderViewset(APITestMixin):
         data = response.json()
         assert data.get('count') == reminder_count
 
+    def test_default_sort_by(self):
+        """Default sort should be in reverse date order"""
+        reminder_1, reminder_2 = self.create_reminders()
+        url = reverse(self.url_name)
+        response = self.api_client.get(f'{url}?offset=0&limit=2')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data.get('count') == 2
+        results = data.get('results', [])
+        assert results[0]['id'] == str(reminder_2.id)
+        assert results[1]['id'] == str(reminder_1.id)
+
+    def test_sort_by_created(self):
+        """Should sort in date order"""
+        reminder_1, reminder_2 = self.create_reminders()
+        url = reverse(self.url_name)
+        response = self.api_client.get(f'{url}?offset=0&limit=2&sortby=created_on')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data.get('count') == 2
+        results = data.get('results', [])
+        assert results[0]['id'] == str(reminder_1.id)
+        assert results[1]['id'] == str(reminder_2.id)
+
+    def test_sort_by_created_descending(self):
+        """Should sort in reverse date order"""
+        reminder_1, reminder_2 = self.create_reminders()
+        url = reverse(self.url_name)
+        response = self.api_client.get(f'{url}?offset=0&limit=2&sortby=-created_on')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data.get('count') == 2
+        results = data.get('results', [])
+        assert results[0]['id'] == str(reminder_2.id)
+        assert results[1]['id'] == str(reminder_1.id)
+
 
 @freeze_time('2022-05-05T17:00:00.000000Z')
 class TestUpcomingEstimatedLandDateReminderViewset(APITestMixin):
@@ -212,6 +260,18 @@ class TestUpcomingEstimatedLandDateReminderViewset(APITestMixin):
     """
 
     url_name = 'api-v4:reminder:estimated-land-date-reminder'
+
+    def create_reminders(self):
+        """Creates some mock reminders"""
+        with freeze_time('2022-05-05T18:00:00.000000Z'):
+            reminder_1 = UpcomingEstimatedLandDateReminderFactory(
+                adviser=self.user,
+            )
+        with freeze_time('2022-05-05T19:00:00.000000Z'):
+            reminder_2 = UpcomingEstimatedLandDateReminderFactory(
+                adviser=self.user,
+            )
+        return [reminder_1, reminder_2]
 
     def test_not_authed(self):
         """Should return Unauthorised"""
@@ -260,6 +320,42 @@ class TestUpcomingEstimatedLandDateReminderViewset(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert data.get('count') == reminder_count
+
+    def test_default_sort_by(self):
+        """Default sort should be in reverse date order"""
+        reminder_1, reminder_2 = self.create_reminders()
+        url = reverse(self.url_name)
+        response = self.api_client.get(f'{url}?offset=0&limit=2')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data.get('count') == 2
+        results = data.get('results', [])
+        assert results[0]['id'] == str(reminder_2.id)
+        assert results[1]['id'] == str(reminder_1.id)
+
+    def test_sort_by_created(self):
+        """Should sort in date order"""
+        reminder_1, reminder_2 = self.create_reminders()
+        url = reverse(self.url_name)
+        response = self.api_client.get(f'{url}?offset=0&limit=2&sortby=created_on')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data.get('count') == 2
+        results = data.get('results', [])
+        assert results[0]['id'] == str(reminder_1.id)
+        assert results[1]['id'] == str(reminder_2.id)
+
+    def test_sort_by_created_descending(self):
+        """Should sort in reverse date order"""
+        reminder_1, reminder_2 = self.create_reminders()
+        url = reverse(self.url_name)
+        response = self.api_client.get(f'{url}?offset=0&limit=2&sortby=-created_on')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data.get('count') == 2
+        results = data.get('results', [])
+        assert results[0]['id'] == str(reminder_2.id)
+        assert results[1]['id'] == str(reminder_1.id)
 
 
 class TestGetReminderSummaryView(APITestMixin):

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from rest_framework import viewsets
 from rest_framework.decorators import api_view, permission_classes
+from rest_framework.filters import OrderingFilter
 from rest_framework.mixins import ListModelMixin, RetrieveModelMixin, UpdateModelMixin
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -49,6 +50,9 @@ class UpcomingEstimatedLandDateSubscriptionViewset(BaseSubscriptionViewset):
 
 class BaseReminderViewset(viewsets.GenericViewSet, ListModelMixin):
     permission_classes = ()
+    filter_backends = (OrderingFilter,)
+    ordering_fields = ('created_on',)
+    ordering = ('-created_on',)
 
     def get_queryset(self):
         return self.model_class.objects.filter(adviser=self.request.user)


### PR DESCRIPTION
### Description of change

Sort reminders by created date (reverse order by deault)

?sortby=created_on

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
