### PR TITLE
Allow reminders to be deleted

### DIFF
--- a/changelog/reminder/delete-reminders.feature.md
+++ b/changelog/reminder/delete-reminders.feature.md
@@ -1,0 +1,4 @@
+Reminders can be deleted with the API
+
+DELETE /api/v4/reminder/estimated-land-date/<uuid>
+DELETE /api/v4/reminder/no-recent-investment-interaction/<uuid>

--- a/datahub/reminder/test/test_views.py
+++ b/datahub/reminder/test/test_views.py
@@ -6,6 +6,10 @@ from rest_framework.test import APIClient
 from datahub.core.test_utils import APITestMixin
 from datahub.investment.project.proposition.models import PropositionStatus
 from datahub.investment.project.proposition.test.factories import PropositionFactory
+from datahub.reminder.models import (
+    NoRecentInvestmentInteractionReminder,
+    UpcomingEstimatedLandDateReminder,
+)
 from datahub.reminder.test.factories import (
     NoRecentInvestmentInteractionReminderFactory,
     NoRecentInvestmentInteractionSubscriptionFactory,
@@ -155,6 +159,7 @@ class TestNoRecentInvestmentInteractionReminderViewset(APITestMixin):
     """
 
     url_name = 'api-v4:reminder:no-recent-investment-interaction-reminder'
+    detail_url_name = 'api-v4:reminder:no-recent-investment-interaction-reminder-detail'
 
     def create_reminders(self):
         """Creates some mock reminders"""
@@ -252,6 +257,20 @@ class TestNoRecentInvestmentInteractionReminderViewset(APITestMixin):
         assert results[0]['id'] == str(reminder_2.id)
         assert results[1]['id'] == str(reminder_1.id)
 
+    def test_delete(self):
+        """Deleting should remove the model instance"""
+        reminder_count = 3
+        reminder = NoRecentInvestmentInteractionReminderFactory.create_batch(
+            reminder_count,
+            adviser=self.user,
+        )[0]
+        url = reverse(self.detail_url_name, kwargs={'pk': str(reminder.id)})
+        response = self.api_client.delete(url)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert NoRecentInvestmentInteractionReminder.objects.filter(
+            adviser=self.user,
+        ).count() == reminder_count - 1
+
 
 @freeze_time('2022-05-05T17:00:00.000000Z')
 class TestUpcomingEstimatedLandDateReminderViewset(APITestMixin):
@@ -260,6 +279,7 @@ class TestUpcomingEstimatedLandDateReminderViewset(APITestMixin):
     """
 
     url_name = 'api-v4:reminder:estimated-land-date-reminder'
+    detail_url_name = 'api-v4:reminder:estimated-land-date-reminder-detail'
 
     def create_reminders(self):
         """Creates some mock reminders"""
@@ -356,6 +376,20 @@ class TestUpcomingEstimatedLandDateReminderViewset(APITestMixin):
         results = data.get('results', [])
         assert results[0]['id'] == str(reminder_2.id)
         assert results[1]['id'] == str(reminder_1.id)
+
+    def test_delete(self):
+        """Deleting should remove the model instance"""
+        reminder_count = 3
+        reminder = UpcomingEstimatedLandDateReminderFactory.create_batch(
+            reminder_count,
+            adviser=self.user,
+        )[0]
+        url = reverse(self.detail_url_name, kwargs={'pk': str(reminder.id)})
+        response = self.api_client.delete(url)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert UpcomingEstimatedLandDateReminder.objects.filter(
+            adviser=self.user,
+        ).count() == reminder_count - 1
 
 
 class TestGetReminderSummaryView(APITestMixin):

--- a/datahub/reminder/urls.py
+++ b/datahub/reminder/urls.py
@@ -34,11 +34,25 @@ urlpatterns = [
         name='no-recent-investment-interaction-reminder',
     ),
     path(
+        'reminder/no-recent-investment-interaction/<uuid:pk>',
+        NoRecentInvestmentInteractionReminderViewset.as_view({
+            'delete': 'destroy',
+        }),
+        name='no-recent-investment-interaction-reminder-detail',
+    ),
+    path(
         'reminder/estimated-land-date',
         UpcomingEstimatedLandDateReminderViewset.as_view({
             'get': 'list',
         }),
         name='estimated-land-date-reminder',
+    ),
+    path(
+        'reminder/estimated-land-date/<uuid:pk>',
+        UpcomingEstimatedLandDateReminderViewset.as_view({
+            'delete': 'destroy',
+        }),
+        name='estimated-land-date-reminder-detail',
     ),
     path(
         'reminder/summary',

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -2,7 +2,12 @@ from django.db import transaction
 from rest_framework import viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.filters import OrderingFilter
-from rest_framework.mixins import ListModelMixin, RetrieveModelMixin, UpdateModelMixin
+from rest_framework.mixins import (
+    DestroyModelMixin,
+    ListModelMixin,
+    RetrieveModelMixin,
+    UpdateModelMixin,
+)
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
@@ -48,7 +53,7 @@ class UpcomingEstimatedLandDateSubscriptionViewset(BaseSubscriptionViewset):
     queryset = UpcomingEstimatedLandDateSubscription.objects.all()
 
 
-class BaseReminderViewset(viewsets.GenericViewSet, ListModelMixin):
+class BaseReminderViewset(viewsets.GenericViewSet, ListModelMixin, DestroyModelMixin):
     permission_classes = ()
     filter_backends = (OrderingFilter,)
     ordering_fields = ('created_on',)


### PR DESCRIPTION
### Description of change

Reminders can now be deleted via the API

DELETE /api/v4/reminder/estimated-land-date/<uuid>
DELETE /api/v4/reminder/no-recent-investment-interaction/<uuid>

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
