### PR TITLE
Add `updated` to Events in Activity Stream

### DIFF
--- a/changelog/event/activity-stream.api.md
+++ b/changelog/event/activity-stream.api.md
@@ -1,0 +1,1 @@
+Events serialized for Activity Stream now have the field `object.updated` to show when they were last modified.

--- a/datahub/activity_stream/event/serializers.py
+++ b/datahub/activity_stream/event/serializers.py
@@ -42,6 +42,7 @@ class EventActivitySerializer(ActivitySerializer):
                 'content': instance.notes,
                 'startTime': instance.start_date,
                 'endTime': instance.end_date,
+                'updated': instance.modified_on,
                 'url': instance.get_absolute_url(),
                 'dit:address_1': instance.address_1,
                 'dit:address_2': instance.address_2,

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -45,6 +45,7 @@ def test_event_activity(api_client):
                         'startTime': format_date_or_datetime(event.start_date),
                         'endTime': format_date_or_datetime(event.end_date),
                         'url': event.get_absolute_url(),
+                        'updated': format_date_or_datetime(event.modified_on),
                         'dit:locationType': {'name': event.location_type.name},
                         'dit:address_1': event.address_1,
                         'dit:address_2': event.address_2,


### PR DESCRIPTION
### Description of change

We want to sort by recently updated for Data Hub Events (and Aventri
Events) from Activity Stream.
This commit adds the field to the serializer for Data Hub Events.

The field is part of the Activity Stream standard so we thought best to
use a common field
https://www.w3.org/TR/activitystreams-vocabulary/#dfn-updated

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
