### PR TITLE
Generate no recent investment interaction reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ Data Hub API can run on any Heroku-style platform. Configuration is performed vi
 | `INVESTMENT_NOTIFICATION_API_KEY` | Yes | |
 | `INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID` | Yes | An ID of Notify Template for Estimated Land Date notifications |
 | `INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_SUMMARY_TEMPLATE_ID` | Yes | An ID of Notify Template for Estimated Land Date summary notifications |
+| `INVESTMENT_NOTIFICATION_NO_RECENT_INTERACTION_TEMPLATE_ID` | Yes | An ID of Notify Template for No Recent Investment Interaction notifications |
 | `MAILBOX_AWS_ACCESS_KEY_ID` | No | Same use as AWS_ACCESS_KEY_ID, but for mailbox. |
 | `MAILBOX_AWS_SECRET_ACCESS_KEY` | No | Same use as AWS_SECRET_ACCESS_KEY, but for mailbox. |
 | `MAILBOX_AWS_REGION` | No | Same use as AWS_DEFAULT_REGION, but for mailbox. |

--- a/changelog/reminder/generate-nri-reminders.feature.md
+++ b/changelog/reminder/generate-nri-reminders.feature.md
@@ -1,0 +1,1 @@
+No recent investment interaction reminders are now automatically created according to each adviser's subscriptions.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -483,6 +483,12 @@ if REDIS_BASE_URL:
             'schedule': crontab(minute=30, hour=8, day_of_month=1),
         }
 
+    if env.bool('ENABLE_NO_RECENT_INTERACTION_REMINDERS', False):
+        CELERY_BEAT_SCHEDULE['generate_no_recent_interaction_reminders'] = {
+            'task': 'datahub.reminder.tasks.generate_no_recent_interaction_reminders',
+            'schedule': crontab(minute=00, hour=8),
+        }
+
     CELERY_WORKER_LOG_FORMAT = (
         "[%(asctime)s: %(levelname)s/%(processName)s] [%(name)s] %(message)s"
     )

--- a/datahub/investment/project/notification/test/test_emails.py
+++ b/datahub/investment/project/notification/test/test_emails.py
@@ -1,0 +1,172 @@
+from unittest import mock
+from uuid import uuid4
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.test.utils import override_settings
+from django.utils.timesince import timesince
+from django.utils.timezone import now
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.investment.project.notification.emails import (
+    get_projects_summary_list,
+    send_estimated_land_date_reminder,
+    send_estimated_land_date_summary,
+    send_no_recent_interaction_reminder,
+)
+from datahub.investment.project.test.factories import (
+    InvestmentProjectFactory,
+)
+from datahub.notification.constants import NotifyServiceName
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mock_notify_adviser_by_email(monkeypatch):
+    """
+    Mocks the notify_adviser_by_email function.
+    """
+    mock_notify_adviser_by_email = mock.Mock()
+    monkeypatch.setattr(
+        'datahub.investment.project.notification.emails.notify_adviser_by_email',
+        mock_notify_adviser_by_email,
+    )
+    return mock_notify_adviser_by_email
+
+
+@pytest.fixture
+def mock_statsd(monkeypatch):
+    """
+    Returns a mock statsd client instance.
+    """
+    mock_statsd = mock.Mock()
+    monkeypatch.setattr(
+        'datahub.investment.project.notification.emails.statsd',
+        mock_statsd,
+    )
+    return mock_statsd
+
+
+class TestEmailFunctions:
+    """Test email notification sending functions."""
+
+    def test_sends_estimated_land_date_notification(
+        self,
+        mock_notify_adviser_by_email,
+        mock_statsd,
+    ):
+        """Test it sends an estimated land date notification."""
+        adviser = AdviserFactory()
+        project = InvestmentProjectFactory()
+
+        template_id = str(uuid4())
+        with override_settings(
+            INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_TEMPLATE_ID=template_id,
+        ):
+            send_estimated_land_date_reminder(
+                project=project,
+                adviser=adviser,
+                days_left=30,
+            )
+
+            mock_notify_adviser_by_email.assert_called_once_with(
+                adviser,
+                template_id,
+                {
+                    'project_details_url': f'{project.get_absolute_url()}/details',
+                    'project_subscription_url': f'{project.get_absolute_url()}/notifications/'
+                                                'estimated-land-date',
+                    'investor_company_name': project.investor_company.name,
+                    'project_name': project.name,
+                    'project_code': project.project_code,
+                    'project_status': project.status.capitalize(),
+                    'project_stage': project.stage.name,
+                    'estimated_land_date': project.estimated_land_date.strftime('%-d %B %Y'),
+                },
+                NotifyServiceName.investment,
+            )
+            mock_statsd.incr.assert_called_once_with('send_investment_notification.30')
+
+    def test_sends_estimated_land_date_summary_notification(
+        self,
+        mock_notify_adviser_by_email,
+        mock_statsd,
+    ):
+        """Test it sends an estimated land date summary notification."""
+        adviser = AdviserFactory()
+        projects = InvestmentProjectFactory.create_batch(2)
+
+        notifications = get_projects_summary_list(projects)
+
+        current_date = now().date()
+
+        template_id = str(uuid4())
+        with override_settings(
+            INVESTMENT_NOTIFICATION_ESTIMATED_LAND_DATE_SUMMARY_TEMPLATE_ID=template_id,
+        ):
+            send_estimated_land_date_summary(
+                projects=projects,
+                adviser=adviser,
+                current_date=current_date,
+            )
+
+            mock_notify_adviser_by_email.assert_called_once_with(
+                adviser,
+                template_id,
+                {
+                    'month': current_date.strftime('%B'),
+                    'reminders_number': len(notifications),
+                    'summary': ''.join(notifications),
+                    'settings_url': settings.DATAHUB_FRONTEND_REMINDER_SETTINGS_URL,
+                },
+                NotifyServiceName.investment,
+            )
+            mock_statsd.incr.assert_called_once_with('send_estimated_land_date_summary')
+
+    def test_sends_no_recent_interaction_notification(
+        self,
+        mock_notify_adviser_by_email,
+        mock_statsd,
+    ):
+        """Test it sends a no recent interaction notification."""
+        adviser = AdviserFactory()
+        project = InvestmentProjectFactory()
+
+        current_date = now().date()
+        last_interaction_date = current_date - relativedelta(days=5)
+
+        template_id = str(uuid4())
+        with override_settings(
+            INVESTMENT_NOTIFICATION_NO_RECENT_INTERACTION_TEMPLATE_ID=template_id,
+        ):
+            send_no_recent_interaction_reminder(
+                project=project,
+                adviser=adviser,
+                reminder_days=5,
+                current_date=current_date,
+            )
+
+            mock_notify_adviser_by_email.assert_called_once_with(
+                adviser,
+                template_id,
+                {
+                    'project_details_url': f'{project.get_absolute_url()}/details',
+                    'project_subscription_url': f'{project.get_absolute_url()}/notifications/'
+                                                'estimated-land-date',
+                    'investor_company_name': project.investor_company.name,
+                    'project_name': project.name,
+                    'project_code': project.project_code,
+                    'project_status': project.status.capitalize(),
+                    'project_stage': project.stage.name,
+                    'estimated_land_date': project.estimated_land_date.strftime('%-d %B %Y'),
+                    'time_period': timesince(
+                        last_interaction_date,
+                        now=current_date,
+                    ).split(',')[0],
+                    'last_interaction_date': last_interaction_date.strftime('%-d %B %Y'),
+                },
+                NotifyServiceName.investment,
+            )
+            mock_statsd.incr.assert_called_once_with('send_no_recent_interaction_notification.5')

--- a/datahub/reminder/__init__.py
+++ b/datahub/reminder/__init__.py
@@ -1,1 +1,2 @@
+NO_RECENT_INTERACTION_REMINDERS_FEATURE_FLAG_NAME = 'no-recent-interaction-reminders'
 ESTIMATED_LAND_DATE_REMINDERS_FEATURE_FLAG_NAME = 'estimated-land-date-reminders'

--- a/datahub/reminder/tasks.py
+++ b/datahub/reminder/tasks.py
@@ -1,23 +1,34 @@
 from logging import getLogger
 
 from celery import shared_task
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Count, Q
+from django.utils.timesince import timesince
 from django.utils.timezone import now
 from django_pglocks import advisory_lock
 
 from datahub.core.constants import InvestmentProjectStage
+from datahub.interaction.models import Interaction
 from datahub.investment.project.models import InvestmentProject
 from datahub.investment.project.notification.emails import (
     send_estimated_land_date_reminder,
     send_estimated_land_date_summary,
+    send_no_recent_interaction_reminder,
 )
-from datahub.reminder import ESTIMATED_LAND_DATE_REMINDERS_FEATURE_FLAG_NAME
+from datahub.reminder import (
+    ESTIMATED_LAND_DATE_REMINDERS_FEATURE_FLAG_NAME,
+    NO_RECENT_INTERACTION_REMINDERS_FEATURE_FLAG_NAME,
+)
 from datahub.reminder.models import (
+    NoRecentInvestmentInteractionReminder,
+    NoRecentInvestmentInteractionSubscription,
     UpcomingEstimatedLandDateReminder,
     UpcomingEstimatedLandDateSubscription,
 )
-from datahub.reminder.utils import reminder_days_to_date_filter
+from datahub.reminder.utils import (
+    reminder_days_to_estimated_land_date_filter,
+)
 
 NOTIFICATION_SUMMARY_THRESHOLD = settings.NOTIFICATION_SUMMARY_THRESHOLD
 
@@ -70,7 +81,10 @@ def generate_estimated_land_date_reminders_for_subscription(subscription, curren
         return
 
     first_day_of_the_month = now().date().replace(day=1)
-    eld_filter = reminder_days_to_date_filter(first_day_of_the_month, subscription.reminder_days)
+    eld_filter = reminder_days_to_estimated_land_date_filter(
+        first_day_of_the_month,
+        subscription.reminder_days,
+    )
 
     projects = InvestmentProject.objects.filter(
         Q(project_manager=subscription.adviser)
@@ -96,7 +110,7 @@ def generate_estimated_land_date_reminders_for_subscription(subscription, curren
     for project in projects:
         day_diff = (project.estimated_land_date - current_date).days
         days_left = 30 if day_diff < 32 else 60
-        create_reminder(
+        create_estimated_land_date_reminder(
             project=project,
             adviser=subscription.adviser,
             days_left=days_left,
@@ -106,7 +120,83 @@ def generate_estimated_land_date_reminders_for_subscription(subscription, curren
         )
 
 
-def create_reminder(project, adviser, days_left, send_email, current_date):
+@shared_task(
+    autoretry_for=(Exception,),
+    queue='long-running',
+    max_retries=5,
+    retry_backoff=30,
+)
+def generate_no_recent_interaction_reminders():
+    """
+    Generates No Recent Interaction Reminders according to each adviser's Subscriptions
+    """
+    with advisory_lock('generate_no_recent_interaction_reminders', wait=False) as acquired:
+        if not acquired:
+            logger.info(
+                'Reminders for no recent interactions are already being '
+                'processed by another worker.',
+            )
+            return
+        current_date = now().date()
+        for subscription in NoRecentInvestmentInteractionSubscription.objects.all().iterator():
+            generate_no_recent_interaction_reminders_for_subscription(
+                subscription=subscription,
+                current_date=current_date,
+            )
+
+
+@shared_task(
+    autoretry_for=(Exception,),
+    queue='long-running',
+    max_retries=5,
+    retry_backoff=30,
+)
+def generate_no_recent_interaction_reminders_for_subscription(subscription, current_date):
+    """
+    Generates the no recent interaction reminders for a given subscription.
+    """
+    user_features = subscription.adviser.features.filter(
+        is_active=True,
+    ).values_list('code', flat=True)
+    if NO_RECENT_INTERACTION_REMINDERS_FEATURE_FLAG_NAME not in user_features:
+        logger.info(
+            f'Feature flag "{NO_RECENT_INTERACTION_REMINDERS_FEATURE_FLAG_NAME}"'
+            'is not active for this user, exiting.',
+        )
+        return
+
+    for reminder_day in subscription.reminder_days:
+        threshold = current_date - relativedelta(days=reminder_day)
+        projects = Interaction.objects.filter(
+            Q(investment_project__project_manager=subscription.adviser)
+            | Q(investment_project__project_assurance_adviser=subscription.adviser)
+            | Q(investment_project__client_relationship_manager=subscription.adviser)
+            | Q(investment_project__referral_source_adviser=subscription.adviser),
+            created_on__date__gte=threshold,
+            investment_project__status__in=[
+                InvestmentProject.Status.ONGOING,
+                InvestmentProject.Status.DELAYED,
+            ],
+            investment_project__stage_id=InvestmentProjectStage.active.value.id,
+        ).values('investment_project_id').annotate(total=Count('investment_project_id'))
+
+        for project_data in projects:
+            # if total is greater than 1, it means there are more recent interactions, so
+            # we should skip
+            if project_data['total'] > 1:
+                continue
+
+            project = InvestmentProject.objects.get(id=project_data['investment_project_id'])
+            create_no_recent_interaction_reminder(
+                project=project,
+                adviser=subscription.adviser,
+                reminder_days=reminder_day,
+                send_email=subscription.email_reminders_enabled,
+                current_date=current_date,
+            )
+
+
+def create_estimated_land_date_reminder(project, adviser, days_left, send_email, current_date):
     """
     Creates a reminder and sends an email if required.
 
@@ -133,4 +223,43 @@ def create_reminder(project, adviser, days_left, send_email, current_date):
             project=project,
             adviser=adviser,
             days_left=days_left,
+        )
+
+
+def create_no_recent_interaction_reminder(
+    project,
+    adviser,
+    reminder_days,
+    send_email,
+    current_date,
+):
+    """
+    Creates a no recent interaction reminder and sends an email if required.
+
+    If a reminder has already been sent on the same day, then do nothing.
+    """
+    last_interaction_date = current_date - relativedelta(days=reminder_days)
+    days_text = timesince(last_interaction_date, now=current_date).split(',')[0]
+    has_existing = NoRecentInvestmentInteractionReminder.objects.filter(
+        adviser=adviser,
+        event=f'No recent interaction with {project.name} in {days_text}',
+        project=project,
+        created_on__date=current_date,
+    ).exists()
+
+    if has_existing:
+        return
+
+    NoRecentInvestmentInteractionReminder.objects.create(
+        adviser=adviser,
+        event=f'No recent interaction with {project.name} in {days_text}',
+        project=project,
+    )
+
+    if send_email:
+        send_no_recent_interaction_reminder(
+            project=project,
+            adviser=adviser,
+            reminder_days=reminder_days,
+            current_date=current_date,
         )

--- a/datahub/reminder/utils.py
+++ b/datahub/reminder/utils.py
@@ -7,5 +7,5 @@ REMINDER_DAYS_MAPPING = {
 }
 
 
-def reminder_days_to_date_filter(current_date, reminder_days):
+def reminder_days_to_estimated_land_date_filter(current_date, reminder_days):
     return [REMINDER_DAYS_MAPPING[days_left](current_date) for days_left in reminder_days]


### PR DESCRIPTION
### Description of change

No recent investment interaction reminders are now automatically created according to each adviser's subscriptions.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
