### PR TITLE
Fix scheduling and flaky tests

### DIFF
--- a/datahub/reminder/test/test_views.py
+++ b/datahub/reminder/test/test_views.py
@@ -196,6 +196,7 @@ class TestNoRecentInvestmentInteractionReminderViewset(APITestMixin):
         assert 'previous' in data
         results = data.get('results', [])
         assert len(results) == 2
+        reminders = sorted(reminders, key=lambda x: x.pk)
         assert results[0] == {
             'id': str(reminders[0].id),
             'created_on': '2022-05-05T17:00:00Z',
@@ -316,6 +317,7 @@ class TestUpcomingEstimatedLandDateReminderViewset(APITestMixin):
         assert 'previous' in data
         results = data.get('results', [])
         assert len(results) == 2
+        reminders = sorted(reminders, key=lambda x: x.pk)
         assert results[0] == {
             'id': str(reminders[0].id),
             'created_on': '2022-05-05T17:00:00Z',

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -57,7 +57,7 @@ class BaseReminderViewset(viewsets.GenericViewSet, ListModelMixin, DestroyModelM
     permission_classes = ()
     filter_backends = (OrderingFilter,)
     ordering_fields = ('created_on',)
-    ordering = ('-created_on',)
+    ordering = ('-created_on', 'pk')
 
     def get_queryset(self):
         return self.model_class.objects.filter(adviser=self.request.user)


### PR DESCRIPTION
### Description of change

This fixes the no recent interaction reminders where a reminder wouldn't be sent if there was no interactions at all for a given investment project and X days have passed since its creation.

This also fixes a bug where reminder would be sent if there was no interaction on a given date, but there was a more recent interaction.

Two flaky tests were also fixed.

I didn't add a newsfragment, because previous PR has not been released yet.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
