### PR TITLE
Add new policy area for interactions

### DIFF
--- a/datahub/interaction/migrations/0079_add_new_policy_areas.py
+++ b/datahub/interaction/migrations/0079_add_new_policy_areas.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+from datahub.core.migration_utils import load_yaml_data_in_migration
+from pathlib import PurePath
+
+def load_new_policy_areas(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0079_add_new_policy_areas.yaml',
+    )
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('interaction', '0078_update_policy_areas'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=load_new_policy_areas,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/datahub/interaction/migrations/0079_add_new_policy_areas.yaml
+++ b/datahub/interaction/migrations/0079_add_new_policy_areas.yaml
@@ -1,0 +1,3 @@
+- model: interaction.policyarea
+  pk: ac27ee57-7290-4e15-82f3-6400b6e2b6fe
+  fields: {disabled_on: null, name: 'Free Trade Agreements: Switzerland', order: 2410.0}


### PR DESCRIPTION
### Description of change

Add `Free Trade Agreements: Switzerland` policy area to interactions.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
