### PR TITLE
Add event type for Meet The Buyer

### DIFF
--- a/changelog/event/event_type_.feature.md
+++ b/changelog/event/event_type_.feature.md
@@ -1,0 +1,1 @@
+It's now possible to add event types for "Meet The Buyer".

--- a/datahub/event/migrations/0021_update_event_types.py
+++ b/datahub/event/migrations/0021_update_event_types.py
@@ -1,0 +1,20 @@
+from pathlib import PurePath
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def update_event_types(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps, PurePath(__file__).parent / "0021_update_event_types.yaml"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('event', '0020_update_event_programmes'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_event_types, migrations.RunPython.noop),
+    ]

--- a/datahub/event/migrations/0021_update_event_types.yaml
+++ b/datahub/event/migrations/0021_update_event_types.yaml
@@ -1,0 +1,3 @@
+- model: event.eventtype
+  pk: 5a38826c-90c3-4f42-8353-26b188a4c970
+  fields: { disabled_on: null, name: 'Meet The Buyer' }


### PR DESCRIPTION
### Description of change

New event type for _Meet The Buyer_

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
