### PR TITLE
Fix notifications update criteria and template variable

### DIFF
--- a/datahub/investment/project/notification/emails.py
+++ b/datahub/investment/project/notification/emails.py
@@ -79,8 +79,7 @@ def get_project_item(project):
     """Get project item."""
     return {
         'project_details_url': f'{project.get_absolute_url()}/details',
-        'project_subscription_url': f'{project.get_absolute_url()}/notifications/'
-                                    'estimated-land-date',
+        'settings_url': settings.DATAHUB_FRONTEND_REMINDER_SETTINGS_URL,
         'investor_company_name': project.investor_company.name,
         'project_name': project.name,
         'project_code': project.project_code,

--- a/datahub/investment/project/notification/test/test_emails.py
+++ b/datahub/investment/project/notification/test/test_emails.py
@@ -76,8 +76,7 @@ class TestEmailFunctions:
                 template_id,
                 {
                     'project_details_url': f'{project.get_absolute_url()}/details',
-                    'project_subscription_url': f'{project.get_absolute_url()}/notifications/'
-                                                'estimated-land-date',
+                    'settings_url': settings.DATAHUB_FRONTEND_REMINDER_SETTINGS_URL,
                     'investor_company_name': project.investor_company.name,
                     'project_name': project.name,
                     'project_code': project.project_code,
@@ -153,8 +152,7 @@ class TestEmailFunctions:
                 template_id,
                 {
                     'project_details_url': f'{project.get_absolute_url()}/details',
-                    'project_subscription_url': f'{project.get_absolute_url()}/notifications/'
-                                                'estimated-land-date',
+                    'settings_url': settings.DATAHUB_FRONTEND_REMINDER_SETTINGS_URL,
                     'investor_company_name': project.investor_company.name,
                     'project_name': project.name,
                     'project_code': project.project_code,

--- a/datahub/reminder/tasks.py
+++ b/datahub/reminder/tasks.py
@@ -53,7 +53,9 @@ def generate_estimated_land_date_reminders():
             )
             return
         current_date = now().date()
-        for subscription in UpcomingEstimatedLandDateSubscription.objects.all().iterator():
+        for subscription in UpcomingEstimatedLandDateSubscription.objects.select_related(
+            'adviser',
+        ).filter(adviser__is_active=True).iterator():
             generate_estimated_land_date_reminders_for_subscription(
                 subscription=subscription,
                 current_date=current_date,
@@ -131,7 +133,9 @@ def generate_no_recent_interaction_reminders():
             )
             return
         current_date = now().date()
-        for subscription in NoRecentInvestmentInteractionSubscription.objects.all().iterator():
+        for subscription in NoRecentInvestmentInteractionSubscription.objects.select_related(
+            'adviser',
+        ).filter(adviser__is_active=True).iterator():
             generate_no_recent_interaction_reminders_for_subscription(
                 subscription=subscription,
                 current_date=current_date,


### PR DESCRIPTION
### Description of change

This ensures that reminders are not generated for inactive users.

It no longer passes a link to individual notification settings to Notify template - as we are in the process of removing individual subscriptions.

Fixes some flaky tests.

### Checklist

* [ ] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [ ] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
