### PR TITLE
Add newsfragments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 ## Internal changes
 
-- It's now possble to deploy only production pips to a production environment, reducing the size of release.
+- It's now possible to deploy only production pips to a production environment, reducing the size of release.
 
 
 # Data Hub API 40.8.0 (2022-06-20)
@@ -86,7 +86,7 @@
 - **Events** - It is now possible to get a list of events in activity-stream [format.](https://www.w3.org/TR/activitystreams-core/)
 
       The URL for this is:    `/v3/activity-stream/event`
-- **Interactions** Its now possible to view Free Trade Agreement: Switzerland and UK-Lebanon Association Agreement
+- **Interactions** It's now possible to view Free Trade Agreement: Switzerland and UK-Lebanon Association Agreement
 - **Investment** Estimated land date reminders are only generated for active ongoing and active delayed projects
 - **Investment** Reminder subscriptions can be updated with the PATCH method:
 

--- a/changelog/reminder/active-users.feature.md
+++ b/changelog/reminder/active-users.feature.md
@@ -1,0 +1,1 @@
+Reminders are now only generated for active users.

--- a/changelog/reminder/notify-template.bugfix.md
+++ b/changelog/reminder/notify-template.bugfix.md
@@ -1,0 +1,1 @@
+Notify template no longer links to deprecated individual notification settings.


### PR DESCRIPTION
### Description of change

Adds missing newsfragments and fixes some tpos.

### Checklist

* [x] If this is a releasable change, has a news fragment been added?

  <details>
  <summary>Explanation</summary>
  
  A news fragment is required for any releasable change (i.e. code that runs in or affects production) so that a corresponding changelog entry is added when releasing.
  
  Check [changelog/README.md](https://github.com/uktrade/data-hub-api/blob/master/changelog/README.md) for instructions.
  
  </details>
  
* [x] Has this branch been rebased on top of the current `develop` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/develop/docs/CONTRIBUTING.md) for more guidelines.
