### PR TITLE
Fix failing task when adviser has no projects.

### DIFF
--- a/datahub/reminder/tasks.py
+++ b/datahub/reminder/tasks.py
@@ -178,7 +178,7 @@ def generate_estimated_land_date_reminders_for_subscription(subscription, curren
         estimated_land_date__in=eld_filter,
     ).order_by('pk')
 
-    if _has_existing_estimated_land_date_reminder(
+    if not projects.exists() or _has_existing_estimated_land_date_reminder(
         projects[0],
         subscription.adviser,
         current_date,

--- a/datahub/reminder/test/test_tasks.py
+++ b/datahub/reminder/test/test_tasks.py
@@ -581,6 +581,26 @@ class TestGenerateEstimatedLandDateReminderTask:
             for project in [active_ongoing_project, active_delayed_project]
         ], any_order=True)
 
+    def test_wont_send_notifications_if_no_projects(
+        self,
+        adviser,
+        mock_create_estimated_land_date_reminder,
+    ):
+        """
+        A reminder should not be sent if adviser has no projects.
+        """
+        days = 30
+        subscription = UpcomingEstimatedLandDateSubscriptionFactory(
+            adviser=adviser,
+            reminder_days=[days],
+            email_reminders_enabled=True,
+        )
+        generate_estimated_land_date_reminders_for_subscription(
+            subscription=subscription,
+            current_date=self.current_date,
+        )
+        mock_create_estimated_land_date_reminder.assert_not_called()
+
     def test_no_user_feature_flag(
         self,
         mock_create_estimated_land_date_reminder,


### PR DESCRIPTION
### Description of change

This fixes a bug where the estimated land date notification task would fail if user with a subscription had not projects.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
