### PR TITLE
Add validation to reminder days field

### DIFF
--- a/datahub/reminder/serializers.py
+++ b/datahub/reminder/serializers.py
@@ -1,3 +1,5 @@
+import collections
+
 from rest_framework import serializers
 
 from datahub.investment.project.models import InvestmentProject
@@ -11,6 +13,16 @@ from datahub.reminder.models import (
 
 class NoRecentInvestmentInteractionSubscriptionSerializer(serializers.ModelSerializer):
     """Serializer for No Recent Investment Interaction Subscription."""
+
+    def validate_reminder_days(self, reminder_days):
+        duplicate_days = [
+            day for day, count in collections.Counter(reminder_days).items() if count > 1
+        ]
+        if len(duplicate_days) > 0:
+            raise serializers.ValidationError(
+                f'Duplicate reminder days are not allowed {duplicate_days}',
+            )
+        return reminder_days
 
     class Meta:
         model = NoRecentInvestmentInteractionSubscription

--- a/datahub/reminder/test/test_views.py
+++ b/datahub/reminder/test/test_views.py
@@ -73,15 +73,42 @@ class TestNoRecentInvestmentInteractionSubscriptionViewset(APITestMixin):
             'email_reminders_enabled': False,
         }
 
+    def test_400_patch_existing_subscription_duplicate_days(self):
+        """Patching the subscription will update an existing subscription"""
+        NoRecentInvestmentInteractionSubscriptionFactory(
+            adviser=self.user,
+            reminder_days=[10, 20, 40],
+            email_reminders_enabled=True,
+        )
+        url = reverse(self.url_name)
+        data = {'reminder_days': [15, 15], 'email_reminders_enabled': False}
+        response = self.api_client.patch(url, data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'reminder_days': ['Duplicate reminder days are not allowed [15]'],
+        }
+
     def test_patch_subscription_no_existing(self):
         """Patching the subscription will create one if it didn't exist already"""
         url = reverse(self.url_name)
         data = {'reminder_days': [15]}
         response = self.api_client.patch(url, data)
+
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
             'reminder_days': [15],
             'email_reminders_enabled': False,
+        }
+
+    def test_400_patch_subscription_no_existing_duplicate_days(self):
+        """Patching the subscription will create one if it didn't exist already"""
+        url = reverse(self.url_name)
+        data = {'reminder_days': [10, 10, 15]}
+        response = self.api_client.patch(url, data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'reminder_days': ['Duplicate reminder days are not allowed [10]'],
         }
 
 


### PR DESCRIPTION
### Description of change

Add validation to reminder_days field to ensure duplicates are not allowed when attempting to add a reminder.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
