### PR TITLE
Fix inner template admin form.

### DIFF
--- a/datahub/investment/project/notification/admin.py
+++ b/datahub/investment/project/notification/admin.py
@@ -9,3 +9,9 @@ class NotificationInnerTemplateAdmin(BaseModelAdminMixin, admin.ModelAdmin):
     """Notification inner template Admin."""
 
     list_display = ('notification_type', )
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        """Ensure the content field retains newlines."""
+        if db_field.name == 'content':
+            kwargs['strip'] = False
+        return super().formfield_for_dbfield(db_field, request, **kwargs)

--- a/datahub/investment/project/notification/test/test_admin.py
+++ b/datahub/investment/project/notification/test/test_admin.py
@@ -1,0 +1,38 @@
+from django.urls import reverse
+from rest_framework import status
+
+from datahub.core.test_utils import AdminTestMixin
+from datahub.investment.project.notification.models import NotificationInnerTemplate
+
+
+class TestNotificaitonInnerTemplateAdmin(AdminTestMixin):
+    """Tests for notification inner template django admin."""
+
+    def test_admin_update_inner_template_retains_newline(self):
+        """Test updating inner template will retain a newline."""
+        notification_type = NotificationInnerTemplate.NotificationType.NOT_SET
+        template = NotificationInnerTemplate.objects.create(
+            content='test',
+            notification_type=notification_type,
+        )
+        app_label = template._meta.app_label
+        model_name = template._meta.model_name
+        url = reverse(
+            f'admin:{app_label}_{model_name}_change',
+            args=(template.pk,),
+        )
+        response = self.client.get(url, follow=True)
+        assert response.status_code == status.HTTP_200_OK
+
+        data = {
+            'id': template.id,
+            'content': f'{template.content}\r\n',
+            'notification_type': template.notification_type,
+            '_save': 'Save',
+        }
+
+        response = self.client.post(url, data, follow=True)
+        assert response.status_code == status.HTTP_200_OK
+
+        template.refresh_from_db()
+        assert template.content == 'test\r\n'


### PR DESCRIPTION
### Description of change

This PR ensures that when admin user edits the notification inner template, the newlines will be retained.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
