### PR TITLE
Extend long running timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,6 @@ start-frontend-api-dnb:
 stop-frontend-api-dnb:
 	$(MAKE) -C ../dnb-service stop-dnb-for-data-hub-api
 	$(MAKE) -C ../data-hub-frontend stop-dev
+
+migrate_search:
+	docker-compose run api python manage.py migrate_search

--- a/datahub/core/queues/job_scheduler.py
+++ b/datahub/core/queues/job_scheduler.py
@@ -18,6 +18,7 @@ def job_scheduler(
     retry_backoff=False,
     retry_intervals=0,
     cron=None,
+    timeout=180,
 ):
     """Job scheduler for setting up Jobs that run tasks
 
@@ -45,6 +46,7 @@ def job_scheduler(
             Defaults to 0.
         cron (str, optional): Add a schedule using the cron format, see https://crontab.cronhub.io/
             for generating a cron string
+        timeout (int, optional): Default timeout is 180 seconds
     """
     is_backoff_an_int = isinstance(retry_backoff, int) and retry_backoff > 1
     if retry_backoff is True or is_backoff_an_int:
@@ -78,6 +80,7 @@ def job_scheduler(
                     max=max_retries,
                     interval=retry_intervals,
                 ),
+                timeout=timeout,
             )
         logger.info(f'Generated job id "{job.id}" with "{job.__dict__}"')
         return job

--- a/datahub/core/test/queues/test_job_scheduler.py
+++ b/datahub/core/test/queues/test_job_scheduler.py
@@ -66,6 +66,7 @@ def test_datahub_enque_is_configured_with_correct_default_number_of_retries_and_
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
+        timeout=180,
     )
 
 
@@ -94,6 +95,7 @@ def test_datahub_enque_is_configured_with_retry_backoff_for_two_retries(
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
+        timeout=180,
     )
 
 
@@ -123,6 +125,7 @@ def test_datahub_enque_is_configured_with_retry_backoff_as_number(
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
+        timeout=180,
     )
 
 

--- a/datahub/search/migrate.py
+++ b/datahub/search/migrate.py
@@ -76,6 +76,7 @@ def _schedule_resync(search_app):
         function_args=(search_app.name, search_app.search_model.get_target_mapping_hash()),
         max_retries=5,
         retry_intervals=60,
+        timeout=1800,
     )
     logger.info(
         f'Task {job.id} complete model migration is scheduled for {search_app.name}',
@@ -88,5 +89,6 @@ def _schedule_initial_sync(search_app):
         queue_name=LONG_RUNNING_QUEUE,
         function=sync_model,
         function_args=(search_app.name,),
+        timeout=600,
     )
     logger.info(f'Scheduling with {job.id} for initial sync for the {search_app.name} search app')

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -27,6 +27,7 @@ def schedule_model_sync(search_app):
         queue_name=LONG_RUNNING_QUEUE,
         function=sync_model,
         function_args=(search_app.name,),
+        timeout=1800,
     )
     logger.info(
         f'Task {job.id} sync_model scheduled for {search_app.name}',


### PR DESCRIPTION
### Description of change

long-running-workers timeout as jobs take over 3 minutes. Setting the time limit at 30 minutes to see if this resolves this problem.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
