### PR TITLE
TET-332 add default timeout to queue

### DIFF
--- a/datahub/core/queues/job_scheduler.py
+++ b/datahub/core/queues/job_scheduler.py
@@ -74,13 +74,13 @@ def job_scheduler(
             job = scheduler.enqueue(
                 queue_name=queue_name,
                 function=function,
+                timeout=timeout,
                 args=function_args,
                 kwargs=function_kwargs,
                 retry=Retry(
                     max=max_retries,
                     interval=retry_intervals,
                 ),
-                timeout=timeout,
             )
         logger.info(f'Generated job id "{job.id}" with "{job.__dict__}"')
         return job

--- a/datahub/core/queues/scheduler.py
+++ b/datahub/core/queues/scheduler.py
@@ -58,8 +58,9 @@ class DataHubScheduler:
             'burst-no-fork': BurstNoFork(self._connection),
         }[strategy]
 
-    def enqueue(self, queue_name: str, function, *args, **kwargs):
+    def enqueue(self, queue_name: str, function, timeout: int, *args, **kwargs):
         queue = RqQueue(
+            default_timeout=timeout,
             name=queue_name,
             is_async=self.is_async,
             connection=self._connection,

--- a/datahub/core/test/queues/test_job_scheduler.py
+++ b/datahub/core/test/queues/test_job_scheduler.py
@@ -63,10 +63,10 @@ def test_datahub_enque_is_configured_with_correct_default_number_of_retries_and_
     datahub_queue_mock.assert_called_with(
         queue_name='234',
         function=PickleableMock.queue_handler,
+        timeout=180,
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
-        timeout=180,
     )
 
 
@@ -92,10 +92,10 @@ def test_datahub_enque_is_configured_with_retry_backoff_for_two_retries(
     datahub_queue_mock.assert_called_with(
         queue_name='234',
         function=PickleableMock.queue_handler,
+        timeout=180,
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
-        timeout=180,
     )
 
 
@@ -122,10 +122,10 @@ def test_datahub_enque_is_configured_with_retry_backoff_as_number(
     datahub_queue_mock.assert_called_with(
         queue_name='234',
         function=PickleableMock.queue_handler,
+        timeout=180,
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
-        timeout=180,
     )
 
 


### PR DESCRIPTION
### Description of change

We are still seeing timeout errors for 180 seconds - trying to override any default here

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
