### PR TITLE
Resolve timeout not getting the correct value

### DIFF
--- a/datahub/core/queues/job_scheduler.py
+++ b/datahub/core/queues/job_scheduler.py
@@ -74,13 +74,13 @@ def job_scheduler(
             job = scheduler.enqueue(
                 queue_name=queue_name,
                 function=function,
-                args=function_args,
-                kwargs=function_kwargs,
                 retry=Retry(
                     max=max_retries,
                     interval=retry_intervals,
                 ),
                 timeout=timeout,
+                args=function_args,
+                kwargs=function_kwargs,
             )
         logger.info(f'Generated job id "{job.id}" with "{job.__dict__}"')
         return job

--- a/datahub/core/queues/scheduler.py
+++ b/datahub/core/queues/scheduler.py
@@ -58,7 +58,7 @@ class DataHubScheduler:
             'burst-no-fork': BurstNoFork(self._connection),
         }[strategy]
 
-    def enqueue(self, queue_name: str, function, *args, **kwargs):
+    def enqueue(self, queue_name: str, function, retry, timeout: int, *args, **kwargs):
         queue = RqQueue(
             name=queue_name,
             is_async=self.is_async,
@@ -67,6 +67,8 @@ class DataHubScheduler:
         self._queues.append(queue)
         return queue.enqueue(
             function,
+            retry=retry,
+            timeout=timeout,
             *args,
             **kwargs,
         )

--- a/datahub/core/queues/scheduler.py
+++ b/datahub/core/queues/scheduler.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from types import FunctionType
 
 from django.conf import settings
 from redis import Redis
@@ -58,7 +59,15 @@ class DataHubScheduler:
             'burst-no-fork': BurstNoFork(self._connection),
         }[strategy]
 
-    def enqueue(self, queue_name: str, function, retry, timeout: int, *args, **kwargs):
+    def enqueue(
+        self,
+        queue_name: str,
+        function: FunctionType,
+        retry=None,
+        timeout=180,
+        *args,
+        **kwargs,
+    ):
         queue = RqQueue(
             name=queue_name,
             is_async=self.is_async,
@@ -67,10 +76,10 @@ class DataHubScheduler:
         self._queues.append(queue)
         return queue.enqueue(
             function,
-            retry=retry,
-            timeout=timeout,
             *args,
             **kwargs,
+            retry=retry,
+            job_timeout=timeout,
         )
 
     def cron(self, queue_name: str, cron: str, function, *args, **kwargs):

--- a/datahub/core/test/queues/test_job_scheduler.py
+++ b/datahub/core/test/queues/test_job_scheduler.py
@@ -1,5 +1,4 @@
-from pprint import pprint
-from unittest.mock import call, MagicMock, Mock
+from unittest.mock import call, MagicMock
 
 from datahub.core.queues.cron_constants import EVERY_MINUTE
 from datahub.core.queues.job_scheduler import job_scheduler, retry_backoff_intervals
@@ -59,13 +58,13 @@ def test_datahub_enque_is_configured_with_correct_default_number_of_retries_and_
 
     queue.work('234')
 
-    retry_mock.called_with(max=2, interval=[3,0])
+    retry_mock.called_with(max=2, interval=[3, 0])
     assert call().enqueue(
         PickleableMock.queue_handler,
-        retry='retrymock',
-        timeout=180,
         args=('arg1', 'arg2'),
         kwargs={'test': True},
+        retry='retrymock',
+        job_timeout=180,
     ) in rq_queue_mock.mock_calls
 
 
@@ -86,16 +85,16 @@ def test_datahub_enque_is_configured_with_retry_backoff_for_two_retries(
 
     queue.work('234')
 
-    retry_mock.called_with(max=2, interval=[1,4])
+    retry_mock.called_with(max=2, interval=[1, 4])
     assert rq_queue_mock.mock_calls[1] == call().enqueue(
         PickleableMock.queue_handler,
-        retry='retrymock',
-        timeout=180,
         args=('arg1', 'arg2'),
         kwargs={'test': True},
+        retry='retrymock',
+        job_timeout=180,
     )
 
-######
+
 def test_datahub_enque_is_configured_with_retry_backoff_as_number(
     monkeypatch,
     queue: DataHubScheduler,
@@ -110,17 +109,18 @@ def test_datahub_enque_is_configured_with_retry_backoff_as_number(
         queue_name='234',
         max_retries=3,
         retry_backoff=30,
+        timeout=100,
     )
 
     queue.work('234')
 
-    retry_mock.called_with(max=3, interval=[1,4])   
+    retry_mock.called_with(max=3, interval=[1, 4])
     assert rq_queue_mock.mock_calls[1] == call().enqueue(
         PickleableMock.queue_handler,
-        retry='retrymock',
-        timeout=180,
         args=('arg1', 'arg2'),
         kwargs={'test': True},
+        retry='retrymock',
+        job_timeout=100,
     )
 
 
@@ -162,7 +162,7 @@ def retry_setup(monkeypatch):
     retry_mock = MagicMock(return_value='retrymock')
     monkeypatch.setattr(
         'datahub.core.queues.job_scheduler.Retry',
-        retry_mock
+        retry_mock,
     )
-    
+
     return retry_mock


### PR DESCRIPTION
### Description of change

RQ timeout was not overriding the default timeout value

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
