### PR TITLE
Fix job timeout for queues

### DIFF
--- a/datahub/core/queues/job_scheduler.py
+++ b/datahub/core/queues/job_scheduler.py
@@ -18,7 +18,7 @@ def job_scheduler(
     retry_backoff=False,
     retry_intervals=0,
     cron=None,
-    timeout=180,
+    job_timeout=180,
 ):
     """Job scheduler for setting up Jobs that run tasks
 
@@ -29,7 +29,7 @@ def job_scheduler(
         max_retries (int, optional): Maximum number of retries before giving up.
             Defaults to 3 based on the RQ default.
         queue_name (string, optional): Name of a queue to schedule work with. Defaults to
-        SHORT_RUNNING_QUEUE.
+            SHORT_RUNNING_QUEUE.
         is_burst (bool, optional): If True, will use a burst worker queue strategy.
             If False, will use the default queue strategy running a fetch-fork-execute loop.
             Defaults to False unless this is a Test.
@@ -46,7 +46,7 @@ def job_scheduler(
             Defaults to 0.
         cron (str, optional): Add a schedule using the cron format, see https://crontab.cronhub.io/
             for generating a cron string
-        timeout (int, optional): Default timeout is 180 seconds
+        job_timeout (int, optional): Default timeout is 180 seconds
     """
     is_backoff_an_int = isinstance(retry_backoff, int) and retry_backoff > 1
     if retry_backoff is True or is_backoff_an_int:
@@ -80,7 +80,7 @@ def job_scheduler(
                     max=max_retries,
                     interval=retry_intervals,
                 ),
-                timeout=timeout,
+                job_timeout=job_timeout,
             )
         logger.info(f'Generated job id "{job.id}" with "{job.__dict__}"')
         return job

--- a/datahub/core/test/queues/test_job_scheduler.py
+++ b/datahub/core/test/queues/test_job_scheduler.py
@@ -66,7 +66,7 @@ def test_datahub_enque_is_configured_with_correct_default_number_of_retries_and_
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
-        timeout=180,
+        job_timeout=180,
     )
 
 
@@ -82,6 +82,7 @@ def test_datahub_enque_is_configured_with_retry_backoff_for_two_retries(
         queue_name='234',
         max_retries=2,
         retry_backoff=True,
+        job_timeout=600,
     )
 
     queue.work('234')
@@ -95,7 +96,7 @@ def test_datahub_enque_is_configured_with_retry_backoff_for_two_retries(
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
-        timeout=180,
+        job_timeout=600,
     )
 
 
@@ -125,7 +126,7 @@ def test_datahub_enque_is_configured_with_retry_backoff_as_number(
         args=('arg1', 'arg2'),
         kwargs={'test': True},
         retry=retry_arg,
-        timeout=180,
+        job_timeout=180,
     )
 
 

--- a/datahub/core/test/queues/test_scheduler.py
+++ b/datahub/core/test/queues/test_scheduler.py
@@ -140,3 +140,15 @@ def test_fork_queue_worker_is_called_with_work_arguments(
     fork_queue.work('one-running', with_scheduler=False)
     mock_worker.assert_called_with(('one-running',), connection=fork_queue._connection)
     assert call().work(with_scheduler=False) in mock_worker.mock_calls
+
+
+def test_job_timeout_is_generated_on_job(queue: DataHubScheduler):
+    job = queue.enqueue(
+        queue_name='123',
+        function=PickleableMock.queue_handler,
+        job_timeout=600,
+    )
+
+    queue.work('123')
+
+    assert job.timeout == 600

--- a/datahub/search/migrate.py
+++ b/datahub/search/migrate.py
@@ -76,7 +76,7 @@ def _schedule_resync(search_app):
         function_args=(search_app.name, search_app.search_model.get_target_mapping_hash()),
         max_retries=5,
         retry_intervals=60,
-        timeout=1800,
+        job_timeout=1800,
     )
     logger.info(
         f'Task {job.id} complete model migration is scheduled for {search_app.name}',
@@ -89,6 +89,6 @@ def _schedule_initial_sync(search_app):
         queue_name=LONG_RUNNING_QUEUE,
         function=sync_model,
         function_args=(search_app.name,),
-        timeout=600,
+        job_timeout=600,
     )
     logger.info(f'Scheduling with {job.id} for initial sync for the {search_app.name} search app')

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -27,7 +27,7 @@ def schedule_model_sync(search_app):
         queue_name=LONG_RUNNING_QUEUE,
         function=sync_model,
         function_args=(search_app.name,),
-        timeout=1800,
+        job_timeout=1800,
     )
     logger.info(
         f'Task {job.id} sync_model scheduled for {search_app.name}',


### PR DESCRIPTION
### Description of change

Job timeout default of 180 seconds was incorrectly named

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
