### PR TITLE
Cancel existing cron jobs before starting cron scheduling service

### DIFF
--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -12,11 +12,13 @@ from django.conf import settings
 from datahub.core.queues.constants import EVERY_ONE_AM, EVERY_TEN_MINUTES
 from datahub.core.queues.health_check import queue_health_check
 from datahub.core.queues.job_scheduler import job_scheduler
+from datahub.core.queues.scheduler import DataHubScheduler
 from datahub.search.tasks import sync_all_models
 logger = getLogger(__name__)
 
 
 def schedule_jobs():
+    cancel_existing_cron_jobs()
     logger.info('Scheduling jobs that run on a cron')
     job_scheduler(
         function=queue_health_check,
@@ -28,6 +30,12 @@ def schedule_jobs():
             function=sync_all_models,
             cron=EVERY_ONE_AM,
         )
+
+
+def cancel_existing_cron_jobs():
+    logger.info('Cancel any existing rq scheduled cron jobs')
+    with DataHubScheduler() as scheduler:
+        scheduler.cancel_cron_jobs()
 
 
 def create_rqscheduler_command():

--- a/datahub/core/test/queues/test_job_scheduler.py
+++ b/datahub/core/test/queues/test_job_scheduler.py
@@ -141,7 +141,7 @@ def test_retry_backoff_returns_zero_when_turned_off():
 
 
 def test_job_scheduler_creates_cron_jobs(queue: DataHubScheduler):
-    existing_job_count = len(list(queue.get_scheduled_jobs()))
+    existing_job_count = len(list(queue.scheduled_jobs()))
     actual_job = job_scheduler(
         function=PickleableMock.queue_handler,
         function_args=('arg1', 'arg2'),
@@ -150,8 +150,8 @@ def test_job_scheduler_creates_cron_jobs(queue: DataHubScheduler):
         cron=EVERY_MINUTE,
     )
 
-    assert actual_job in queue.get_scheduled_jobs()
-    assert len(list(queue.get_scheduled_jobs())) == existing_job_count + 1
+    assert actual_job in queue.scheduled_jobs()
+    assert len(list(queue.scheduled_jobs())) == existing_job_count + 1
     assert actual_job.meta['cron_string'] == EVERY_MINUTE
 
 


### PR DESCRIPTION
### Description of change

Scheduled cron jobs seem to be running even after cron settings altered

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
