### PR TITLE
Add created_by field to Investment Project serializer.

### DIFF
--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -10,7 +10,7 @@ from rest_framework import serializers
 
 import datahub.metadata.models as meta_models
 from datahub.company.models import Company, Contact
-from datahub.company.serializers import NestedAdviserField
+from datahub.company.serializers import NestedAdviserField, NestedAdviserWithEmailAndTeamField
 from datahub.core.constants import InvestmentProjectStage
 from datahub.core.serializers import NestedRelatedField, PermittedFieldsModelSerializer
 from datahub.core.validate_utils import DataCombiner
@@ -85,6 +85,7 @@ CORE_FIELDS = (
     'archived_on',
     'archived_reason',
     'archived_by',
+    'created_by',
     'created_on',
     'modified_on',
     'comments',
@@ -344,6 +345,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         allow_null=False, allow_empty=False,
     )
     archived_by = NestedAdviserField(read_only=True)
+    created_by = NestedAdviserWithEmailAndTeamField(read_only=True)
 
     project_manager_request_status = NestedRelatedField(
         ProjectManagerRequestStatus, required=False, allow_null=True,

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -130,6 +130,7 @@ class TestListView(APITestMixin):
             'archived_reason',
             'archived_by',
             'archived_documents_url_path',
+            'created_by',
             'created_on',
             'modified_on',
             'fdi_value',
@@ -680,6 +681,15 @@ class TestRetrieveView(APITestMixin):
         )
         assert sorted(contact['id'] for contact in response_data[
             'client_contacts']) == expected_client_contact_ids
+        assert response_data['created_by'] == {
+            'contact_email': project.created_by.contact_email,
+            'dit_team': {
+                'id': str(project.created_by.dit_team.id),
+                'name': project.created_by.dit_team.name,
+            },
+            'id': str(project.created_by.id),
+            'name': project.created_by.name,
+        }
 
     def test_get_project_no_investor_and_crm(self):
         """


### PR DESCRIPTION
### Description of change

This adds `created_by` field to the Investment Project serialiser. This is required so that we can display the team that has created the investment project in the Frontend.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
