### PR TITLE
Add id to event data fields

### DIFF
--- a/datahub/activity_stream/event/serializers.py
+++ b/datahub/activity_stream/event/serializers.py
@@ -49,10 +49,16 @@ class EventActivitySerializer(ActivitySerializer):
                 'dit:address_town': instance.address_town,
                 'dit:address_county': instance.address_county,
                 'dit:address_postcode': instance.address_postcode,
-                'dit:address_country': {'name': instance.address_country.name},
+                'dit:address_country': {
+                    'name': instance.address_country.name,
+                    'id': instance.address_country.id,
+                },
                 'dit:disabledOn': instance.disabled_on,
                 'dit:archivedDocumentsUrlPath': instance.archived_documents_url_path,
-                'dit:eventType': {'name': instance.event_type.name},
+                'dit:eventType': {
+                    'name': instance.event_type.name,
+                    'id': instance.event_type.id,
+                },
                 'dit:hasRelatedTradeAgreements': instance.has_related_trade_agreements,
                 'dit:relatedProgrammes': [
                     *self._get_related_programmes(instance.related_programmes),
@@ -71,10 +77,12 @@ class EventActivitySerializer(ActivitySerializer):
         if instance.uk_region is not None:
             event['object']['dit:ukRegion'] = {
                 'name': instance.uk_region.name,
+                'id': instance.uk_region.id,
             }
         if instance.organiser is not None:
             event['object']['dit:organiser'] = {
                 'name': instance.organiser.name,
+                'id': instance.organiser.id,
             }
         if instance.lead_team is not None:
             event['object']['dit:leadTeam'] = {

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -37,10 +37,14 @@ def test_event_activity(api_client):
                     'generator': {'name': 'dit:dataHub', 'type': 'Application'},
                     'object': {
                         'id': f'dit:DataHubEvent:{event.id}',
-                        'type': ['dit:dataHub:Event',
-                                 ],
+                        'type': [
+                            'dit:dataHub:Event',
+                        ],
                         'name': event.name,
-                        'dit:eventType': {'name': event.event_type.name},
+                        'dit:eventType': {
+                            'name': event.event_type.name,
+                            'id': event.event_type.id,
+                        },
                         'content': event.notes,
                         'startTime': format_date_or_datetime(event.start_date),
                         'endTime': format_date_or_datetime(event.end_date),
@@ -52,13 +56,22 @@ def test_event_activity(api_client):
                         'dit:address_town': event.address_town,
                         'dit:address_county': event.address_county,
                         'dit:address_postcode': event.address_postcode,
-                        'dit:address_country': {'name': event.address_country.name},
+                        'dit:address_country': {
+                            'name': event.address_country.name,
+                            'id': event.address_country.id,
+                        },
                         'dit:leadTeam': {'name': event.lead_team.name},
-                        'dit:organiser': {'name': event.organiser.name},
+                        'dit:organiser': {
+                            'name': event.organiser.name,
+                            'id': event.organiser.id,
+                        },
                         'dit:disabledOn': event.disabled_on,
                         'dit:service': {'name': event.service.name},
                         'dit:archivedDocumentsUrlPath': event.archived_documents_url_path,
-                        'dit:ukRegion': {'name': event.uk_region.name},
+                        'dit:ukRegion': {
+                            'name': event.uk_region.name,
+                            'id': event.uk_region.id,
+                        },
                         'dit:teams': [
                             *[
                                 {

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -43,7 +43,7 @@ def test_event_activity(api_client):
                         'name': event.name,
                         'dit:eventType': {
                             'name': event.event_type.name,
-                            'id': event.event_type.pk,
+                            'id': str(event.event_type.id),
                         },
                         'content': event.notes,
                         'startTime': format_date_or_datetime(event.start_date),
@@ -58,19 +58,19 @@ def test_event_activity(api_client):
                         'dit:address_postcode': event.address_postcode,
                         'dit:address_country': {
                             'name': event.address_country.name,
-                            'id': event.address_country.pk,
+                            'id': str(event.address_country.id),
                         },
                         'dit:leadTeam': {'name': event.lead_team.name},
                         'dit:organiser': {
                             'name': event.organiser.name,
-                            'id': event.organiser.pk,
+                            'id': str(event.organiser.id),
                         },
                         'dit:disabledOn': event.disabled_on,
                         'dit:service': {'name': event.service.name},
                         'dit:archivedDocumentsUrlPath': event.archived_documents_url_path,
                         'dit:ukRegion': {
                             'name': event.uk_region.name,
-                            'id': event.uk_region.pk,
+                            'id': str(event.uk_region.id),
                         },
                         'dit:teams': [
                             *[

--- a/datahub/activity_stream/event/test/test_event_views.py
+++ b/datahub/activity_stream/event/test/test_event_views.py
@@ -43,7 +43,7 @@ def test_event_activity(api_client):
                         'name': event.name,
                         'dit:eventType': {
                             'name': event.event_type.name,
-                            'id': event.event_type.id,
+                            'id': event.event_type.pk,
                         },
                         'content': event.notes,
                         'startTime': format_date_or_datetime(event.start_date),
@@ -58,19 +58,19 @@ def test_event_activity(api_client):
                         'dit:address_postcode': event.address_postcode,
                         'dit:address_country': {
                             'name': event.address_country.name,
-                            'id': event.address_country.id,
+                            'id': event.address_country.pk,
                         },
                         'dit:leadTeam': {'name': event.lead_team.name},
                         'dit:organiser': {
                             'name': event.organiser.name,
-                            'id': event.organiser.id,
+                            'id': event.organiser.pk,
                         },
                         'dit:disabledOn': event.disabled_on,
                         'dit:service': {'name': event.service.name},
                         'dit:archivedDocumentsUrlPath': event.archived_documents_url_path,
                         'dit:ukRegion': {
                             'name': event.uk_region.name,
-                            'id': event.uk_region.id,
+                            'id': event.uk_region.pk,
                         },
                         'dit:teams': [
                             *[


### PR DESCRIPTION
### Description of change
Adding id field to the following fields for data hub event data in activity stream:

- `dit:address_country`
- `dit:ukRegion`
- `dit:eventType`
- `dit:organiser`

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
