### PR TITLE
Chore/tet 191 remove celery from documents tasks

### DIFF
--- a/datahub/documents/models.py
+++ b/datahub/documents/models.py
@@ -6,7 +6,7 @@ from django.db import models, transaction
 from django.utils.timezone import now
 
 from datahub.core.models import ArchivableModel, BaseModel
-from datahub.documents.tasks import virus_scan_document
+from datahub.documents.tasks import schedule_virus_scan_document
 from datahub.documents.utils import sign_s3_url
 
 logger = getLogger(__name__)
@@ -80,7 +80,7 @@ class Document(BaseModel, ArchivableModel):
         if not self.scan_initiated_on:
             self.mark_scan_scheduled()
 
-            virus_scan_document.apply_async(args=(str(self.pk),))
+            schedule_virus_scan_document(str(self.pk))
 
         return self.status
 

--- a/datahub/documents/tasks.py
+++ b/datahub/documents/tasks.py
@@ -14,9 +14,12 @@ logger = getLogger(__name__)
 def schedule_delete_document(document_pk):
     job = job_scheduler(
         function=delete_document,
-        function_args=(document_pk),
+        function_args=(document_pk,),
     )
+    import pprint
+    pprint.pprint(f'Task {job.id} schedule_delete_document')
     logger.info(f'Task {job.id} schedule_delete_document')
+    return job
 
 
 @transaction.atomic

--- a/datahub/documents/tasks.py
+++ b/datahub/documents/tasks.py
@@ -15,8 +15,6 @@ def schedule_delete_document(document_pk):
         function=delete_document,
         function_args=(document_pk,),
     )
-    import pprint
-    pprint.pprint(f'Task {job.id} schedule_delete_document')
     logger.info(f'Task {job.id} schedule_delete_document')
     return job
 
@@ -38,8 +36,6 @@ def schedule_virus_scan_document(document_pk: str):
         function=virus_scan_document,
         function_args=(document_pk,),
     )
-    import pprint
-    pprint.pprint(f'Task {job.id} schedule_virus_scan_document')
     logger.info(f'Task {job.id} schedule_virus_scan_document')
     return job
 

--- a/datahub/documents/tasks.py
+++ b/datahub/documents/tasks.py
@@ -4,13 +4,21 @@ from celery import shared_task
 from django.db import transaction
 from django_pglocks import advisory_lock
 
+from datahub.core.queues.job_scheduler import job_scheduler
 from datahub.documents.av_scan import perform_virus_scan
 from datahub.documents.utils import get_document_by_pk, perform_delete_document
 
 logger = getLogger(__name__)
 
 
-@shared_task
+def schedule_delete_document(document_pk):
+    job = job_scheduler(
+        function=delete_document,
+        function_args=(document_pk),
+    )
+    logger.info(f'Task {job.id} schedule_delete_document')
+
+
 @transaction.atomic
 def delete_document(document_pk):
     """Handle document delete."""

--- a/datahub/documents/tasks.py
+++ b/datahub/documents/tasks.py
@@ -1,6 +1,5 @@
 from logging import getLogger
 
-from celery import shared_task
 from django.db import transaction
 from django_pglocks import advisory_lock
 
@@ -34,7 +33,17 @@ def delete_document(document_pk):
         raise
 
 
-@shared_task
+def schedule_virus_scan_document(document_pk: str):
+    job = job_scheduler(
+        function=virus_scan_document,
+        function_args=(document_pk,),
+    )
+    import pprint
+    pprint.pprint(f'Task {job.id} schedule_virus_scan_document')
+    logger.info(f'Task {job.id} schedule_virus_scan_document')
+    return job
+
+
 def virus_scan_document(document_pk: str):
     """Virus scans an uploaded document.
 

--- a/datahub/documents/test/test_av_scan.py
+++ b/datahub/documents/test/test_av_scan.py
@@ -36,7 +36,7 @@ def test_virus_scan_document_clean(get_signed_url_mock, requests_mock):
         },
     )
 
-    virus_scan_document.apply(args=(str(document.id), )).get()
+    virus_scan_document(str(document.id))
     document.refresh_from_db()
     assert document.av_clean is True
 
@@ -63,7 +63,7 @@ def test_virus_scan_document_infected(get_signed_url_mock, requests_mock):
         },
     )
 
-    virus_scan_document.apply(args=(str(document.id), )).get()
+    virus_scan_document(str(document.id))
     document.refresh_from_db()
     assert document.av_clean is False
 
@@ -97,7 +97,7 @@ def test_virus_scan_document_bad_response_body(get_signed_url_mock, requests_moc
         VirusScanException,
         match=error_message,
     ):
-        virus_scan_document.apply(args=(str(document.id), )).get()
+        virus_scan_document(str(document.id))
 
     document.refresh_from_db()
     assert document.av_clean is None
@@ -119,7 +119,7 @@ def test_virus_scan_document_file_not_found(get_signed_url_mock, requests_mock):
         match=rf'Unable to download the document with ID {document.pk} '
               rf'for scanning \(status_code\=404\).',
     ):
-        virus_scan_document.apply(args=(str(document.id), )).get()
+        virus_scan_document(str(document.id))
     document.refresh_from_db()
     assert document.av_clean is None
 
@@ -143,7 +143,7 @@ def test_virus_scan_document_bad_response_status(get_signed_url_mock, requests_m
     )
 
     with pytest.raises(HTTPError) as excinfo:
-        virus_scan_document.apply(args=(str(document.id), )).get()
+        virus_scan_document(str(document.id))
     document.refresh_from_db()
     assert document.av_clean is None
     assert str(excinfo.value) == '400 Client Error: None for url: http://av-service/'

--- a/datahub/documents/test/test_tasks.py
+++ b/datahub/documents/test/test_tasks.py
@@ -32,7 +32,7 @@ def test_delete_document(s3_stubber):
         },
     )
 
-    result = delete_document.apply(args=(document.pk, )).get()
+    result = delete_document(document.pk)
     assert result is None
 
     with pytest.raises(MyEntityDocument.DoesNotExist):
@@ -63,7 +63,7 @@ def test_delete_document_s3_failure(s3_stubber):
     )
 
     with pytest.raises(Exception):
-        delete_document.apply(args=(document.pk, )).get()
+        delete_document(document.pk).get()
 
     qs = MyEntityDocument.objects.include_objects_deletion_pending()
     assert qs.filter(pk=entity_document.pk).exists() is True

--- a/datahub/documents/test/test_views.py
+++ b/datahub/documents/test/test_views.py
@@ -152,7 +152,7 @@ class TestDocumentViews(APITestMixin):
         response_data = response.json()
         assert response_data['status'] == 'virus_scanning_scheduled'
         mock_schedule_virus_scan_document.assert_called_once_with(
-            str(entity_document.document.pk)
+            str(entity_document.document.pk),
         )
 
     def mock_document_upload(self):

--- a/datahub/documents/test/test_views.py
+++ b/datahub/documents/test/test_views.py
@@ -1,5 +1,5 @@
 """Tests for generic document views."""
-
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -128,13 +128,23 @@ class TestDocumentViews(APITestMixin):
         monkeypatch,
         test_urls,
     ):
+        """Tests that a virus scan of the document is called."""
         mock_schedule_virus_scan_document = Mock()
         monkeypatch.setattr(
             'datahub.documents.models.schedule_virus_scan_document',
             mock_schedule_virus_scan_document,
         )
 
-        """Tests that a virus scan of the document is scheduled."""
+        response, entity_document = self.mock_document_item()
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['status'] == 'virus_scanning_scheduled'
+        mock_schedule_virus_scan_document.assert_called_once_with(
+            str(entity_document.document.pk),
+        )
+
+    def mock_document_item(self):
         entity_document = MyEntityDocument.objects.create(
             original_filename='test.txt',
             my_field='cats use whiskers to navigate in the dark',
@@ -148,12 +158,20 @@ class TestDocumentViews(APITestMixin):
         )
 
         response = self.api_client.post(url)
+        return response, entity_document
+
+    def test_schedule_virus_scan_document(
+        self,
+        caplog,
+        monkeypatch,
+        test_urls,
+    ):
+        """Tests that a virus scan of the document is scheduled."""
+        caplog.set_level(logging.INFO)
+        response, entity_document = self.mock_document_item()
+
         assert response.status_code == status.HTTP_200_OK
-        response_data = response.json()
-        assert response_data['status'] == 'virus_scanning_scheduled'
-        mock_schedule_virus_scan_document.assert_called_once_with(
-            str(entity_document.document.pk),
-        )
+        assert any("schedule_virus_scan_document" in message for message in caplog.messages)
 
     def mock_document_upload(self):
         entity_document = MyEntityDocument.objects.create(
@@ -166,11 +184,15 @@ class TestDocumentViews(APITestMixin):
 
         return response, entity_document
 
-    def test_document_delete(self, monkeypatch, test_urls):
+    def test_document_delete(self, caplog, monkeypatch, test_urls):
         """Tests document deletion."""
+        caplog.set_level(logging.INFO, "datahub.documents.tasks")
+
         response, entity_document = self.mock_document_upload()
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        assert any("schedule_delete_document" in message for message in caplog.messages)
 
         with pytest.raises(Document.DoesNotExist):
             entity_document.document.refresh_from_db()

--- a/datahub/documents/test/test_views.py
+++ b/datahub/documents/test/test_views.py
@@ -150,8 +150,10 @@ class TestDocumentViews(APITestMixin):
             args=(str(entity_document.document.pk),),
         )
 
-    @patch('datahub.documents.tasks.delete_document.apply_async')
-    def test_document_delete(self, delete_document, test_urls):
+    # Refactor whole test not to mock apply_async and use real method
+    # @patch('datahub.documents.tasks.delete_document.apply_async')
+    def test_document_delete(self, test_urls):
+        # Call schedule_delete_document(...)
         """Tests document deletion."""
         entity_document = MyEntityDocument.objects.create(
             original_filename='test.txt',
@@ -159,14 +161,14 @@ class TestDocumentViews(APITestMixin):
         )
         entity_document.document.uploaded_on = now()
 
-        document_pk = entity_document.document.pk
+        # document_pk = entity_document.document.pk
 
         url = reverse('test-document-item', kwargs={'entity_document_pk': entity_document.pk})
 
         response = self.api_client.delete(url)
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
-        delete_document.assert_called_once_with(args=(document_pk,))
+        # delete_document.assert_called_once_with(args=(document_pk,))
 
         entity_document.document.refresh_from_db()
         assert entity_document.document.status == UploadStatus.DELETION_PENDING

--- a/datahub/documents/test/test_views.py
+++ b/datahub/documents/test/test_views.py
@@ -171,7 +171,7 @@ class TestDocumentViews(APITestMixin):
         response, entity_document = self.mock_document_item()
 
         assert response.status_code == status.HTTP_200_OK
-        assert any("schedule_virus_scan_document" in message for message in caplog.messages)
+        assert any('schedule_virus_scan_document' in message for message in caplog.messages)
 
     def mock_document_upload(self):
         entity_document = MyEntityDocument.objects.create(
@@ -186,13 +186,13 @@ class TestDocumentViews(APITestMixin):
 
     def test_document_delete(self, caplog, monkeypatch, test_urls):
         """Tests document deletion."""
-        caplog.set_level(logging.INFO, "datahub.documents.tasks")
+        caplog.set_level(logging.INFO, 'datahub.documents.tasks')
 
         response, entity_document = self.mock_document_upload()
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
-        assert any("schedule_delete_document" in message for message in caplog.messages)
+        assert any('schedule_delete_document' in message for message in caplog.messages)
 
         with pytest.raises(Document.DoesNotExist):
             entity_document.document.refresh_from_db()

--- a/datahub/documents/views.py
+++ b/datahub/documents/views.py
@@ -47,7 +47,7 @@ class BaseEntityDocumentModelViewSet(CoreViewSet):
 
     def perform_destroy(self, instance):
         """
-        Marks document with pending_delete status and schedules Celery task that
+        Marks document with pending_delete status and schedules an RQ job that
         performs deletion of corresponding s3 file, document and entity_document.
 
         Deletion of document will cascade to entity document.

--- a/datahub/documents/views.py
+++ b/datahub/documents/views.py
@@ -5,7 +5,7 @@ from rest_framework.decorators import action
 from datahub.core.schemas import StubSchema
 from datahub.core.viewsets import CoreViewSet
 from datahub.documents.exceptions import TemporarilyUnavailableException
-from datahub.documents.tasks import delete_document
+from datahub.documents.tasks import schedule_delete_document
 
 
 class BaseEntityDocumentModelViewSet(CoreViewSet):
@@ -54,4 +54,4 @@ class BaseEntityDocumentModelViewSet(CoreViewSet):
         """
         instance.document.mark_deletion_pending()
 
-        delete_document.apply_async(args=(instance.document.pk,))
+        schedule_delete_document(instance.document.pk)

--- a/datahub/investment/project/evidence/test/test_views.py
+++ b/datahub/investment/project/evidence/test/test_views.py
@@ -1,6 +1,6 @@
 import datetime
 from operator import attrgetter, itemgetter
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
@@ -528,8 +528,6 @@ class TestEvidenceDocumentViews(APITestMixin):
         Checks that a virus scan of the document was scheduled. Virus scanning is
         tested separately in the documents app.
         """
-
-        """Tests schedule of document deletion."""
         mock_schedule_virus_scan_document = Mock()
         monkeypatch.setattr(
             'datahub.documents.models.schedule_virus_scan_document',
@@ -590,7 +588,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
         mock_schedule_virus_scan_document.assert_called_once_with(
-            str(entity_document.document.pk)
+            str(entity_document.document.pk),
         )
 
     @pytest.mark.parametrize('permissions,associated,allowed', DELETE_PERMISSIONS)

--- a/datahub/investment/project/evidence/test/test_views.py
+++ b/datahub/investment/project/evidence/test/test_views.py
@@ -532,7 +532,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         """Tests schedule of document deletion."""
         mock_schedule_virus_scan_document = Mock()
         monkeypatch.setattr(
-            'datahub.documents.tasks.schedule_virus_scan_document',
+            'datahub.documents.models.schedule_virus_scan_document',
             mock_schedule_virus_scan_document,
         )
 

--- a/datahub/investment/project/proposition/test/test_views.py
+++ b/datahub/investment/project/proposition/test/test_views.py
@@ -1976,7 +1976,7 @@ class TestPropositionDocumentViews(APITestMixin):
         """
         mock_schedule_virus_scan_document = Mock()
         monkeypatch.setattr(
-            'datahub.documents.tasks.schedule_virus_scan_document',
+            'datahub.documents.models.schedule_virus_scan_document',
             mock_schedule_virus_scan_document,
         )
 
@@ -2032,7 +2032,7 @@ class TestPropositionDocumentViews(APITestMixin):
         """
         mock_schedule_virus_scan_document = Mock()
         monkeypatch.setattr(
-            'datahub.documents.tasks.schedule_virus_scan_document',
+            'datahub.documents.models.schedule_virus_scan_document',
             mock_schedule_virus_scan_document,
         )
 
@@ -2084,7 +2084,7 @@ class TestPropositionDocumentViews(APITestMixin):
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
         mock_schedule_virus_scan_document.assert_called_once_with(
-            args=(str(entity_document.document.pk), ),
+            str(entity_document.document.pk)
         )
 
     def test_restricted_user_cannot_schedule_virus_scan_for_non_associated_document(self):

--- a/datahub/investment/project/proposition/test/test_views.py
+++ b/datahub/investment/project/proposition/test/test_views.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 import factory
 import pytest
@@ -1964,10 +1964,9 @@ class TestPropositionDocumentViews(APITestMixin):
         assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
-    @patch('datahub.documents.tasks.virus_scan_document.apply_async')
     def test_document_upload_schedule_virus_scan(
         self,
-        virus_scan_document_apply_async,
+        monkeypatch,
         permissions,
     ):
         """Tests scheduling virus scan after upload completion.
@@ -1975,6 +1974,12 @@ class TestPropositionDocumentViews(APITestMixin):
         Checks that a virus scan of the document was scheduled. Virus scanning is
         tested separately in the documents app.
         """
+        mock_schedule_virus_scan_document = Mock()
+        monkeypatch.setattr(
+            'datahub.documents.tasks.schedule_virus_scan_document',
+            mock_schedule_virus_scan_document,
+        )
+
         user = create_test_user(permission_codenames=permissions)
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
@@ -2014,18 +2019,23 @@ class TestPropositionDocumentViews(APITestMixin):
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
-        virus_scan_document_apply_async.assert_called_once_with(
-            args=(str(entity_document.document.pk), ),
+        mock_schedule_virus_scan_document.assert_called_once_with(
+            str(entity_document.document.pk)
         )
 
-    @patch('datahub.documents.tasks.virus_scan_document.apply_async')
     def test_restricted_user_can_schedule_virus_scan_for_associated_document(
         self,
-        virus_scan_document_apply_async,
+        monkeypatch,
     ):
         """
         Test that restricted user can schedule a virus scan for associated document.
         """
+        mock_schedule_virus_scan_document = Mock()
+        monkeypatch.setattr(
+            'datahub.documents.tasks.schedule_virus_scan_document',
+            mock_schedule_virus_scan_document,
+        )
+
         user = create_test_user(
             permission_codenames=(PropositionDocumentPermission.change_associated,),
             dit_team=TeamFactory(),
@@ -2073,7 +2083,7 @@ class TestPropositionDocumentViews(APITestMixin):
             'created_on': format_date_or_datetime(entity_document.created_on),
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
-        virus_scan_document_apply_async.assert_called_once_with(
+        mock_schedule_virus_scan_document.assert_called_once_with(
             args=(str(entity_document.document.pk), ),
         )
 
@@ -2116,9 +2126,14 @@ class TestPropositionDocumentViews(APITestMixin):
         assert entity_document.document.status == UploadStatus.NOT_VIRUS_SCANNED
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_DELETE_PERMISSIONS)
-    @patch('datahub.documents.tasks.delete_document.apply_async')
-    def test_document_delete(self, delete_document, permissions):
+    def test_document_delete(self, monkeypatch, permissions):
         """Tests document deletion."""
+        mock_schedule_delete_document = Mock()
+        monkeypatch.setattr(
+            'datahub.documents.views.schedule_delete_document',
+            mock_schedule_delete_document,
+        )
+
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk, original_filename='test.txt',
@@ -2143,11 +2158,16 @@ class TestPropositionDocumentViews(APITestMixin):
         response = api_client.delete(url)
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        delete_document.assert_called_once_with(args=(document_pk, ))
+        mock_schedule_delete_document.assert_called_once_with(document_pk)
 
-    @patch('datahub.documents.tasks.delete_document.apply_async')
-    def test_restricted_user_can_delete_associated_document(self, delete_document):
+    def test_restricted_user_can_delete_associated_document(self, monkeypatch):
         """Test that restricted user can delete associated document."""
+        mock_schedule_delete_document = Mock()
+        monkeypatch.setattr(
+            'datahub.documents.views.schedule_delete_document',
+            mock_schedule_delete_document,
+        )
+
         user = create_test_user(
             permission_codenames=(PropositionDocumentPermission.delete_associated,),
             dit_team=TeamFactory(),
@@ -2181,11 +2201,17 @@ class TestPropositionDocumentViews(APITestMixin):
         api_client = self.create_api_client(user=user)
         response = api_client.delete(url)
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        delete_document.assert_called_once_with(args=(document_pk, ))
+        mock_schedule_delete_document.assert_called_once_with(document_pk)
 
-    @patch('datahub.documents.tasks.delete_document.apply_async')
-    def test_restricted_user_cannot_delete_non_associated_document(self, delete_document):
+    def test_restricted_user_cannot_delete_non_associated_document(self, monkeypatch):
         """Test that restricted user cannot delete non associated document."""
+
+        mock_schedule_delete_document = Mock()
+        monkeypatch.setattr(
+            'datahub.documents.views.schedule_delete_document',
+            mock_schedule_delete_document,
+        )
+
         user = create_test_user(
             permission_codenames=(PropositionDocumentPermission.delete_associated,),
             dit_team=TeamFactory(),
@@ -2224,11 +2250,16 @@ class TestPropositionDocumentViews(APITestMixin):
 
         entity_document.document.refresh_from_db()
         assert entity_document.document.status == UploadStatus.VIRUS_SCANNED
-        assert delete_document.called is False
+        assert mock_schedule_delete_document.called is False
 
-    @patch('datahub.documents.tasks.delete_document.apply_async')
-    def test_document_delete_without_permission(self, delete_document):
+    def test_document_delete_without_permission(self, monkeypatch):
         """Tests user can't delete document without permissions."""
+        mock_schedule_delete_document = Mock()
+        monkeypatch.setattr(
+            'datahub.documents.views.schedule_delete_document',
+            mock_schedule_delete_document,
+        )
+
         user = create_test_user(
             permission_codenames=(),
             dit_team=TeamFactory(),
@@ -2251,12 +2282,17 @@ class TestPropositionDocumentViews(APITestMixin):
         api_client = self.create_api_client(user=user)
         response = api_client.delete(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
-        assert delete_document.called is False
+        assert mock_schedule_delete_document.called is False
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_DELETE_PERMISSIONS)
-    @patch('datahub.documents.tasks.delete_document.apply_async')
-    def test_document_delete_creates_user_event_log(self, delete_document, permissions):
+    def test_document_delete_creates_user_event_log(self, monkeypatch, permissions):
         """Tests document deletion creates user event log."""
+        mock_schedule_delete_document = Mock()
+        monkeypatch.setattr(
+            'datahub.documents.views.schedule_delete_document',
+            mock_schedule_delete_document,
+        )
+
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk, original_filename='test.txt',
@@ -2296,7 +2332,7 @@ class TestPropositionDocumentViews(APITestMixin):
             response = api_client.delete(url)
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
-        delete_document.assert_called_once_with(args=(document_pk, ))
+        mock_schedule_delete_document.assert_called_once_with(document_pk)
 
         assert UserEvent.objects.count() == 1
 

--- a/datahub/investment/project/proposition/test/test_views.py
+++ b/datahub/investment/project/proposition/test/test_views.py
@@ -1,6 +1,6 @@
 import datetime
 import uuid
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import factory
 import pytest
@@ -2020,7 +2020,7 @@ class TestPropositionDocumentViews(APITestMixin):
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
         mock_schedule_virus_scan_document.assert_called_once_with(
-            str(entity_document.document.pk)
+            str(entity_document.document.pk),
         )
 
     def test_restricted_user_can_schedule_virus_scan_for_associated_document(
@@ -2084,7 +2084,7 @@ class TestPropositionDocumentViews(APITestMixin):
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
         mock_schedule_virus_scan_document.assert_called_once_with(
-            str(entity_document.document.pk)
+            str(entity_document.document.pk),
         )
 
     def test_restricted_user_cannot_schedule_virus_scan_for_non_associated_document(self):
@@ -2205,7 +2205,6 @@ class TestPropositionDocumentViews(APITestMixin):
 
     def test_restricted_user_cannot_delete_non_associated_document(self, monkeypatch):
         """Test that restricted user cannot delete non associated document."""
-
         mock_schedule_delete_document = Mock()
         monkeypatch.setattr(
             'datahub.documents.views.schedule_delete_document',


### PR DESCRIPTION
### Description of change

Remove Celery from documents tasks and replace with RQ.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
