### PR TITLE
Improve visualisation of user feature flags

### DIFF
--- a/datahub/feature_flag/models.py
+++ b/datahub/feature_flag/models.py
@@ -64,4 +64,5 @@ class UserFeatureFlagGroup(BaseModel):
 
     def __str__(self):
         """Human readable representation."""
-        return f'{self.code} ({"active" if self.is_active else "inactive"})'
+        features = ', '.join([str(feature) for feature in self.features.all().order_by('code')])
+        return f'{self.code} ({"active" if self.is_active else "inactive"}): {features}'


### PR DESCRIPTION
### Description of change

This PR should help an administrator see what user feature flags are assigned to a user feature flag group in the Adviser view, so that it helps ensuring that correct user feature flags are selected.

<img width="1041" alt="Screenshot 2022-11-04 at 09 19 15" src="https://user-images.githubusercontent.com/5889630/199939536-26374556-9fd2-47ff-bf86-cdd7637d1d12.png">


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
