### PR TITLE
Fix: handle requests for the reminder subscription summary where none exist

### DIFF
--- a/datahub/reminder/test/test_views.py
+++ b/datahub/reminder/test/test_views.py
@@ -313,6 +313,24 @@ class TestGetReminderSubscriptionSummaryView(APITestMixin):
             },
         }
 
+    def test_no_subscriptions(self):
+        """Should return base summary cases."""
+        url = reverse(self.url_name)
+        response = self.api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data == {
+            'estimated_land_date': {
+                'email_reminders_enabled': False, 'reminder_days': [],
+            },
+            'no_recent_investment_interaction': {
+                'email_reminders_enabled': False, 'reminder_days': [],
+            },
+            'no_recent_export_interaction': {
+                'email_reminders_enabled': False, 'reminder_days': [],
+            },
+        }
+
 
 @freeze_time('2022-05-05T17:00:00.000000Z')
 class TestNoRecentInvestmentInteractionReminderViewset(APITestMixin):

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -66,14 +66,26 @@ class UpcomingEstimatedLandDateSubscriptionViewset(BaseSubscriptionViewset):
 @permission_classes([IsAuthenticated])
 def reminder_subscription_summary_view(request):
     """Returns the reminder subscription summary."""
+
+    def get_object(queryset):
+        """
+        Gets subscription settings instance for current user.
+
+        If settings have not been created yet, add them.
+        """
+        obj, created = queryset.get_or_create(
+            adviser=request.user,
+        )
+        return obj
+
     estimated_land_date = UpcomingEstimatedLandDateSubscriptionSerializer(
-        UpcomingEstimatedLandDateSubscription.objects.get(adviser=request.user),
+        get_object(UpcomingEstimatedLandDateSubscription.objects.all()),
     ).data
     no_recent_investment_interaction = NoRecentInvestmentInteractionSubscriptionSerializer(
-        NoRecentInvestmentInteractionSubscription.objects.get(adviser=request.user),
+        get_object(NoRecentInvestmentInteractionSubscription.objects.all()),
     ).data
     no_recent_export_interaction = NoRecentExportInteractionSubscriptionSerializer(
-        NoRecentExportInteractionSubscription.objects.get(adviser=request.user),
+        get_object(NoRecentExportInteractionSubscription.objects.all()),
     ).data
 
     return Response({


### PR DESCRIPTION
### Description of change
Handles requests to `/v4/reminder/subscription/summary` in cases where the user does not have one or more subscription set up, by creating versions with the default case. 

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
