### PR TITLE
RR-715: Update reminder summary endpoint

### DIFF
--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -135,16 +135,32 @@ def reminder_summary_view(request):
     estimated_land_date = UpcomingEstimatedLandDateReminder.objects.filter(
         adviser=request.user,
     ).count()
-    no_recent_interaction = NoRecentInvestmentInteractionReminder.objects.filter(
+    no_recent_investment_interaction = NoRecentInvestmentInteractionReminder.objects.filter(
         adviser=request.user,
     ).count()
     outstanding_propositions = Proposition.objects.filter(
         adviser=request.user,
         status=PropositionStatus.ONGOING,
     ).count()
+    no_recent_export_interaction = NoRecentExportInteractionReminder.objects.filter(
+        adviser=request.user,
+    ).count()
+
+    total_count = sum([
+        estimated_land_date,
+        no_recent_investment_interaction,
+        outstanding_propositions,
+        no_recent_export_interaction,
+    ])
 
     return Response({
-        'estimated_land_date': estimated_land_date,
-        'no_recent_investment_interaction': no_recent_interaction,
-        'outstanding_propositions': outstanding_propositions,
+        'count': total_count,
+        'investment': {
+            'estimated_land_date': estimated_land_date,
+            'no_recent_interaction': no_recent_investment_interaction,
+            'outstanding_propositions': outstanding_propositions,
+        },
+        'export': {
+            'no_recent_interaction': no_recent_export_interaction,
+        },
     })


### PR DESCRIPTION
### Description of change
Reformats the data provided by `/v4/reminder/summary` and adds a total count option. As we add more kinds of reminders, the summary JSON is becoming unwieldy. This PR updates it to this structure:

```
{
  "count": 4
  "investment": {
    "estimated_land_date": 1,
    "no_recent_interaction": 0,
    "outstanding_propositions": 1
  },
  "export": {
    "no_recent_interaction": 2
  }
}
```

I will be working with the @paulgain to make sure this breaking change is released in a way that doesn't cause disruption to the FE service.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
