### PR TITLE
Update redis to 6.2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ job_defaults: &job_defaults
         POSTGRES_DB: datahub
         POSTGRES_PASSWORD: datahub
 
-    - image: circleci/redis:3.2-alpine
+    - image: cimg/redis:6.2.6
   steps:
     - checkout
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Dependencies:
 
 - Python 3.10.x
 - PostgreSQL 12
-- redis 3.2
+- redis 6.x
 - OpenSearch 1.x
 
 1.  Clone the repository:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
       - bootstrap.memory_lock=true
 
   redis:
-    image: redis:3.2
+    image: redis:6.2.6
     restart: always
     ports:
       - '6379:6379'


### PR DESCRIPTION
### Description of change

Update redis to 6.x.

I won't merge this PR until all environments are running with 6.2.6

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
