### PR TITLE
Set the GREAT Investors - Capital Investment to be disabled

### DIFF
--- a/datahub/investment/project/fixtures/specific_programmes.yaml
+++ b/datahub/investment/project/fixtures/specific_programmes.yaml
@@ -18,7 +18,7 @@
   fields: {disabled_on: null, name: "Regeneration - Capital Investment"}
 - model: investment.specificprogramme
   pk: 26881936-6823-4ad7-a6e0-41fb9f714dab
-  fields: {disabled_on: null, name: "GREAT Investors - Capital Investment"}
+  fields: {disabled_on: '2022-12-19T11:25:03Z', name: "GREAT Investors - Capital Investment"}
 - model: investment.specificprogramme
   pk: ca8bd4cd-0c6b-4afd-b010-d5b38376c0fc
   fields: {disabled_on: null, name: "HQ-UK"}

--- a/docs/How to deactivate fixture data.md
+++ b/docs/How to deactivate fixture data.md
@@ -1,0 +1,21 @@
+# How to deactivate fixture data
+
+## Overview
+
+A lot of the data we use inside the API is hardcoded inside of .yaml files within each Django app. An example entry is shown here from the `specific_programmes.yaml` file
+
+```
+- model: investment.specificprogramme
+  pk: 26881936-6823-4ad7-a6e0-41fb9f714dab
+  fields: {disabled_on: null, name: "GREAT Investors - Capital Investment"}
+```
+
+If a request to remove this entry from being returned via the API was received, to avoid any breaking changes the entry should not be deleted. Instead, the `disabled_on` property should be set to the date the change is being made. This will allow any existing DB records to continue to work as the reference to the primary key still exists, but the value will be removed from any API GET requests for this data.
+
+The resulting entry in the .yaml would look like this
+
+```
+- model: investment.specificprogramme
+  pk: 26881936-6823-4ad7-a6e0-41fb9f714dab
+  fields: {disabled_on: '2022-12-19T11:25:03Z', name: "GREAT Investors - Capital Investment"}
+```


### PR DESCRIPTION
### Description of change

Deactivate  ‘GREAT Investors -- Capital Investment' in the Specific investment programme field when creating (or editing) an investment. The value will remain there for existing investments, but creating new investments will not allow selecting that as an option

## Before
![image](https://user-images.githubusercontent.com/102232401/208420490-46ab7528-392a-4282-8dfa-f11942d327db.png)


## After
![image](https://user-images.githubusercontent.com/102232401/208420342-d5937ab7-93ca-4cff-a055-9d6d88bc81a5.png)


<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
