### PR TITLE
Remove archived companies from global search

### DIFF
--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -306,7 +306,7 @@ def _build_fuzzy_term_query(term, fields=None):
         ),
     ]
 
-    return Bool(should=should_query)
+    return Bool(should=should_query, must_not=Match(archived=True))
 
 
 def _build_exists_query(field, value):

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -270,6 +270,13 @@ def test_build_term_query(term, expected):
                             },
                         },
                     ],
+                    'must_not': [
+                        {
+                            'match': {
+                                'archived': True,
+                            },
+                        },
+                    ],
                 },
             },
         ),
@@ -311,6 +318,13 @@ def test_build_fuzzy_term_query_no_fields():
                         'type': 'cross_fields',
                         'operator': 'and',
                         'boost': 4,
+                    },
+                },
+            ],
+            'must_not': [
+                {
+                    'match': {
+                        'archived': True,
                     },
                 },
             ],


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

To stop archived results from being returned in the global search.

Before:
![Screenshot 2023-01-12 at 15 44 39](https://user-images.githubusercontent.com/72826129/212315588-127c80b3-ecc8-444b-bc86-4aee11742d8e.png)

After:
![Screenshot 2023-01-13 at 10 04 43](https://user-images.githubusercontent.com/72826129/212315582-00fdd9b1-2e89-4102-b41f-e258d2656a68.png)


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
