### PR TITLE
Fix company activity URL.

### DIFF
--- a/datahub/reminder/emails.py
+++ b/datahub/reminder/emails.py
@@ -20,7 +20,7 @@ def get_inner_template_content(notification_type):
 def get_company_item(company):
     """Get company item."""
     return {
-        'company_url': f'{company.get_absolute_url()}/details',
+        'company_url': f'{company.get_absolute_url()}/activity',
         'settings_url': settings.DATAHUB_FRONTEND_REMINDER_SETTINGS_URL,
         'company_name': company.name,
     }

--- a/datahub/reminder/test/test_emails.py
+++ b/datahub/reminder/test/test_emails.py
@@ -240,7 +240,7 @@ class TestEmailFunctions:
                 template_id,
                 {
                     'company_name': company.name,
-                    'company_url': f'{company.get_absolute_url()}/details',
+                    'company_url': f'{company.get_absolute_url()}/activity',
                     'last_interaction_date': last_interaction_date.strftime(DATE_FORMAT),
                     'last_interaction_created_by': interaction.created_by.name,
                     'last_interaction_type': interaction.get_kind_display(),
@@ -289,7 +289,7 @@ class TestEmailFunctions:
                 template_id,
                 {
                     'company_name': company.name,
-                    'company_url': f'{company.get_absolute_url()}/details',
+                    'company_url': f'{company.get_absolute_url()}/activity',
                     'last_interaction_date': last_interaction_date.strftime(DATE_FORMAT),
                     'settings_url': settings.DATAHUB_FRONTEND_REMINDER_SETTINGS_URL,
                     'time_period': timesince(


### PR DESCRIPTION
### Description of change

The current company URL in that is being sent to Notify is incorrect. It directs user to a page that used to exist and now redirects to `/activity`, but due to bug in the front end it is losing any URL parameters when doing it.

The fix should get Notify template to have correct company URL (`/activity` rather than `/details`) moving forward.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
