### PR TITLE
fix: archive companies with duns number as long as they have no active subsidiaries

### DIFF
--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -420,6 +420,18 @@ class Company(ArchivableModel, BaseModel):
             return False
         return self.duns_number == self.global_ultimate_duns_number
 
+    @property
+    def descendants(self):
+        """
+        All direct and indirect subsidiaries of this company.
+        """
+        to_do = list(self.subsidiaries.all())
+        yield from to_do
+        while to_do:
+            for subsidiary in to_do.pop().subsidiaries.all():
+                to_do.append(subsidiary)
+                yield subsidiary
+
     def mark_as_transferred(self, to, reason, user):
         """
         Marks a company record as having been transferred to another company record.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -421,16 +421,13 @@ class Company(ArchivableModel, BaseModel):
         return self.duns_number == self.global_ultimate_duns_number
 
     @property
-    def descendants(self):
+    def related_companies(self):
         """
-        All direct and indirect subsidiaries of this company.
+        All companies that share the same global ultimate duns number
         """
-        to_do = list(self.subsidiaries.all())
-        yield from to_do
-        while to_do:
-            for subsidiary in to_do.pop().subsidiaries.all():
-                to_do.append(subsidiary)
-                yield subsidiary
+        return Company.objects.filter(
+            global_ultimate_duns_number=self.global_ultimate_duns_number,
+        ).exclude(global_ultimate_duns_number='').exclude(global_ultimate_duns_number=None)
 
     def mark_as_transferred(self, to, reason, user):
         """

--- a/datahub/company/tasks/company.py
+++ b/datahub/company/tasks/company.py
@@ -49,8 +49,8 @@ def _automatic_company_archive(limit, simulate):
         company
         for company in candidate_companies_to_be_archived
         if not any(
-            not (descendant.archived or descendant in candidate_companies_to_be_archived)
-            for descendant in company.descendants
+            not (related_company.archived or related_company in candidate_companies_to_be_archived)
+            for related_company in company.related_companies
         )
     ][:limit]
 


### PR DESCRIPTION
### Description of change

As per https://data-services-help.trade.gov.uk/data-hub/updates/announcements/data-hub-data-retention-approach/, all companies (so including those that have a duns number and so part of a "tree" of companies) should be archived as long as they don't have any active subsidiaries or subsidiaries that match the other conditions for archiving.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
