### PR TITLE
Chore/ccit 14 remove celery apply async from search tasks

### DIFF
--- a/datahub/search/test/test_migrate.py
+++ b/datahub/search/test/test_migrate.py
@@ -125,7 +125,11 @@ def test_migrate_app_with_app_needing_migration(monkeypatch, mock_opensearch_cli
     ]
 
 
-def test_migrate_app_with_app_not_needing_migration(monkeypatch, mock_opensearch_client):
+def test_migrate_app_with_app_not_needing_migration(
+    async_queue,
+    monkeypatch,
+    mock_opensearch_client,
+):
     """Test that migrate_app() migrates an app needing migration."""
     migrate_model_task_mock = Mock()
     monkeypatch.setattr('datahub.search.migrate.complete_model_migration', migrate_model_task_mock)
@@ -144,7 +148,7 @@ def test_migrate_app_with_app_not_needing_migration(monkeypatch, mock_opensearch
 
     mock_app.search_model.create_index.assert_not_called()
     mock_client.indices.update_aliases.assert_not_called()
-    migrate_model_task_mock.apply_async.assert_not_called()
+    migrate_model_task_mock.assert_not_called()
 
 
 def test_migrate_app_with_app_in_inconsistent_state(monkeypatch, mock_opensearch_client):
@@ -182,7 +186,7 @@ def test_migrate_app_with_app_in_inconsistent_state(monkeypatch, mock_opensearch
     ]
 
 
-def test_migrate_app_with_app_in_invalid_state(monkeypatch, mock_opensearch_client):
+def test_migrate_app_with_app_in_invalid_state(async_queue, monkeypatch, mock_opensearch_client):
     """
     Test that migrate_app() raises an exception for apps in an invalid state.
 
@@ -206,4 +210,4 @@ def test_migrate_app_with_app_in_invalid_state(monkeypatch, mock_opensearch_clie
     with pytest.raises(DataHubError):
         migrate_app(mock_app)
 
-    migrate_model_task_mock.apply_async.assert_not_called()
+    migrate_model_task_mock.assert_not_called()

--- a/docs/Using RQ and RQScheduler.md
+++ b/docs/Using RQ and RQScheduler.md
@@ -51,7 +51,7 @@ Note: Cannot be used if time_delta is defined.
 Note: Cannot be used if cron is defined.
 
 ## Writing tests
-When running tests jobs are scheduled but not executed (as the workers do not automatically run during tests). If you want to run a test that automatically runs the scheduled jobs include the fixture `apply_async`.
+When running tests jobs are scheduled but not executed (as the workers do not automatically run during tests). If you want to run a test that automatically runs the scheduled jobs include the fixture `async_queue`.
 
     def test_stores_notification_id(
         self,
@@ -59,7 +59,7 @@ When running tests jobs are scheduled but not executed (as the workers do not au
     ):
          # Code under test that calls job_scheduler will be executed. 
 
-Additional examples in datahub/reminder/test/test_task.py/TestGeneratenoRecentInteractionReminderTask/test_stores_notification_id or various occurences of apply_async in datahub/core/test/.queues/test_scheduler.py.
+Additional examples in datahub/reminder/test/test_task.py/TestGeneratenoRecentInteractionReminderTask/test_stores_notification_id or various occurences of async_queue in datahub/core/test/.queues/test_scheduler.py.
 
 ## Monitoring RQ locally
 


### PR DESCRIPTION
### Description of change

Remove apply_async from search task tests.
Fix test documentation

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
