### PR TITLE
feature/RR-881-exclude-advisor-who-created-interaction-from-email

### DIFF
--- a/datahub/reminder/tasks.py
+++ b/datahub/reminder/tasks.py
@@ -599,7 +599,7 @@ def generate_new_export_interaction_reminders_for_subscription(subscription, cur
             qs = Interaction.objects.filter(
                 companies__in=[company],
                 created_on__date=threshold,
-            )
+            ).exclude(created_by=subscription.adviser)
             has_interactions = qs.exists()
 
             if has_interactions:

--- a/datahub/reminder/test/test_tasks.py
+++ b/datahub/reminder/test/test_tasks.py
@@ -1868,7 +1868,7 @@ class TestGenerateNewExportInteractionReminderTask:
     ):
         """
         New Export Interaction reminders should not be sent to the advisor who created the
-        interaction, they should only go to adviosrs when they did not create the interaction
+        interaction, they should only go to an advisor when they did not create the interaction
         """
 
         def _export_interaction_advisor(day):
@@ -1894,8 +1894,9 @@ class TestGenerateNewExportInteractionReminderTask:
         day = 15
         interaction_date = self.current_date - relativedelta(days=day)
 
-        # setup 3 users - 1 with only interactions they created, 1 with a mix and 1 with only
-        # interactions they didnt create
+        # setup 3 advisors, along with a company and subscription - 1 advisor with only company
+        # interactions they created, 1 with a mix of company interactions they created and created
+        # by another advisor, and 1 with only company interactions created by another advisor
         (
             only_own_interactions_advisor,
             only_own_interactions_company,

--- a/datahub/reminder/test/test_tasks.py
+++ b/datahub/reminder/test/test_tasks.py
@@ -1861,49 +1861,111 @@ class TestGenerateNewExportInteractionReminderTask:
             current_date=self.current_date,
         )
 
-    def test_dont_send_reminder_when_the_advisor_created_the_interaction(
+    def test_only_send_reminder_when_advisor_did_not_create_the_interaction(
         self,
-        adviser,
+        new_export_interaction_reminders_user_feature_flag,
         mock_create_new_export_interaction_reminder,
     ):
         """
         New Export Interaction reminders should not be sent to the advisor who created the
-        interaction.
+        interaction, they should only go to adviosrs when they did not create the interaction
         """
-        day = 15
-        subscription = NewExportInteractionSubscriptionFactory(
-            adviser=adviser,
-            reminder_days=[day],
-            email_reminders_enabled=True,
-        )
-        company = CompanyFactory(
-            one_list_account_owner=adviser,
-            one_list_tier_id=OneListTierID.tier_d_international_trade_advisers.value,
-        )
 
+        def _export_interaction_advisor(day):
+            advisor = AdviserFactory()
+            advisor.features.set(
+                [
+                    new_export_interaction_reminders_user_feature_flag,
+                ],
+            )
+
+            subscription = NewExportInteractionSubscriptionFactory(
+                adviser=advisor,
+                reminder_days=[day],
+                email_reminders_enabled=True,
+            )
+            company = CompanyFactory(
+                one_list_account_owner=advisor,
+                one_list_tier_id=OneListTierID.tier_d_international_trade_advisers.value,
+            )
+
+            return advisor, company, subscription
+
+        day = 15
         interaction_date = self.current_date - relativedelta(days=day)
 
+        # setup 3 users - 1 with only interactions they created, 1 with a mix and 1 with only
+        # interactions they didnt create
+        (
+            only_own_interactions_advisor,
+            only_own_interactions_company,
+            only_own_interactions_subscription,
+        ) = _export_interaction_advisor(day)
         with freeze_time(interaction_date):
-            CompanyInteractionFactory(
-                company=company,
-                created_by=adviser,
+            CompanyInteractionFactory.create_batch(
+                3,
+                company=only_own_interactions_company,
+                created_by=only_own_interactions_advisor,
             )
-            included_interaction = CompanyInteractionFactory(
-                company=company,
+
+        (
+            own_and_other_interations_advisor,
+            own_and_other_interations_company,
+            own_and_other_interations_subscription,
+        ) = _export_interaction_advisor(day)
+        with freeze_time(interaction_date):
+            CompanyInteractionFactory.create_batch(
+                3,
+                company=own_and_other_interations_company,
+                created_by=own_and_other_interations_advisor,
+            )
+            own_and_other_interations_expected_interaction = CompanyInteractionFactory(
+                company=own_and_other_interations_company,
+            )
+
+        (
+            only_other_interactions_advisor,
+            only_other_interactions_company,
+            only_other_interactions_subscription,
+        ) = _export_interaction_advisor(day)
+        with freeze_time(interaction_date):
+            only_other_interactions_expected_interaction = CompanyInteractionFactory(
+                company=only_other_interactions_company,
             )
 
         generate_new_export_interaction_reminders_for_subscription(
-            subscription=subscription,
+            subscription=only_own_interactions_subscription,
+            current_date=self.current_date,
+        )
+        generate_new_export_interaction_reminders_for_subscription(
+            subscription=own_and_other_interations_subscription,
+            current_date=self.current_date,
+        )
+        generate_new_export_interaction_reminders_for_subscription(
+            subscription=only_other_interactions_subscription,
             current_date=self.current_date,
         )
 
-        mock_create_new_export_interaction_reminder.assert_called_with(
-            company=company,
-            adviser=adviser,
-            interaction=included_interaction,
-            reminder_days=day,
-            send_email=True,
-            current_date=self.current_date,
+        assert mock_create_new_export_interaction_reminder.call_count == 2
+        mock_create_new_export_interaction_reminder.assert_has_calls(
+            [
+                mock.call(
+                    company=own_and_other_interations_company,
+                    adviser=own_and_other_interations_advisor,
+                    interaction=own_and_other_interations_expected_interaction,
+                    reminder_days=day,
+                    send_email=True,
+                    current_date=self.current_date,
+                ),
+                mock.call(
+                    company=only_other_interactions_company,
+                    adviser=only_other_interactions_advisor,
+                    interaction=only_other_interactions_expected_interaction,
+                    reminder_days=day,
+                    send_email=True,
+                    current_date=self.current_date,
+                ),
+            ],
         )
 
     @pytest.mark.parametrize('day_offset', (0, 1))


### PR DESCRIPTION
### Description of change
- Exclude any interactions created by the advisor in the list of reminders
<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
