### PR TITLE
bugfix/RR-905-advisor-reminders

### DIFF
--- a/datahub/reminder/tasks.py
+++ b/datahub/reminder/tasks.py
@@ -597,14 +597,13 @@ def generate_new_export_interaction_reminders_for_subscription(subscription, cur
         threshold = current_date - relativedelta(days=reminder_day)
 
         for company in _get_managed_companies(subscription.adviser).iterator():
-            qs = (
-                Interaction.objects.filter(
-                    companies__in=[company],
-                    created_on__date=threshold,
-                )
-                .exclude(created_by=subscription.adviser)
-                .exclude(modified_by=subscription.adviser)
+            qs = Interaction.objects.filter(
+                companies__in=[company],
+                created_on__date=threshold,
+            ).exclude(
+                Q(created_by=subscription.adviser) | Q(modified_by=subscription.adviser),
             )
+            print(qs.query)
             has_interactions = qs.exists()
 
             if has_interactions:

--- a/datahub/reminder/tasks.py
+++ b/datahub/reminder/tasks.py
@@ -597,10 +597,14 @@ def generate_new_export_interaction_reminders_for_subscription(subscription, cur
         threshold = current_date - relativedelta(days=reminder_day)
 
         for company in _get_managed_companies(subscription.adviser).iterator():
-            qs = Interaction.objects.filter(
-                companies__in=[company],
-                created_on__date=threshold,
-            ).exclude(created_by=subscription.adviser)
+            qs = (
+                Interaction.objects.filter(
+                    companies__in=[company],
+                    created_on__date=threshold,
+                )
+                .exclude(created_by=subscription.adviser)
+                .exclude(modified_by=subscription.adviser)
+            )
             has_interactions = qs.exists()
 
             if has_interactions:

--- a/datahub/reminder/tasks.py
+++ b/datahub/reminder/tasks.py
@@ -603,7 +603,6 @@ def generate_new_export_interaction_reminders_for_subscription(subscription, cur
             ).exclude(
                 Q(created_by=subscription.adviser) | Q(modified_by=subscription.adviser),
             )
-            print(qs.query)
             has_interactions = qs.exists()
 
             if has_interactions:

--- a/datahub/reminder/test/test_tasks.py
+++ b/datahub/reminder/test/test_tasks.py
@@ -1861,7 +1861,7 @@ class TestGenerateNewExportInteractionReminderTask:
             current_date=self.current_date,
         )
 
-    def test_only_send_reminder_when_advisor_did_not_create_the_interaction(
+    def test_dont_send_reminder_when_advisor_did_not_create_the_interaction(
         self,
         new_export_interaction_reminders_user_feature_flag,
         mock_create_new_export_interaction_reminder,
@@ -1968,6 +1968,58 @@ class TestGenerateNewExportInteractionReminderTask:
                 ),
             ],
         )
+
+    def test_dont_send_reminder_when_advisor_modifed_the_interaction(
+        self,
+        new_export_interaction_reminders_user_feature_flag,
+        mock_create_new_export_interaction_reminder,
+    ):
+        """
+        New Export Interaction reminders should not be sent to the advisor who modified the
+        interaction
+        """
+        creator_advisor = AdviserFactory()
+        creator_advisor.features.set(
+            [
+                new_export_interaction_reminders_user_feature_flag,
+            ],
+        )
+
+        modifier_advisor = AdviserFactory()
+        modifier_advisor.features.set(
+            [
+                new_export_interaction_reminders_user_feature_flag,
+            ],
+        )
+
+        subscription = NewExportInteractionSubscriptionFactory(
+            adviser=modifier_advisor,
+            reminder_days=[15],
+            email_reminders_enabled=True,
+        )
+
+        company = CompanyFactory(
+            one_list_account_owner=modifier_advisor,
+            one_list_tier_id=OneListTierID.tier_d_international_trade_advisers.value,
+        )
+
+        interaction_date = self.current_date - relativedelta(days=15)
+        with freeze_time(interaction_date):
+            interaction = CompanyInteractionFactory(
+                company=company,
+                created_by=creator_advisor,
+            )
+
+        interaction.notes = 'Test modification'
+        interaction.modified_by = modifier_advisor
+        interaction.save()
+
+        generate_new_export_interaction_reminders_for_subscription(
+            subscription=subscription,
+            current_date=self.current_date,
+        )
+
+        assert mock_create_new_export_interaction_reminder.call_count == 0
 
     @pytest.mark.parametrize('day_offset', (0, 1))
     def test_dont_send_reminder_if_no_new_interactions(

--- a/datahub/reminder/test/test_tasks.py
+++ b/datahub/reminder/test/test_tasks.py
@@ -1969,7 +1969,7 @@ class TestGenerateNewExportInteractionReminderTask:
             ],
         )
 
-    def test_dont_send_reminder_when_advisor_modifed_the_interaction(
+    def test_dont_send_reminder_when_advisor_modified_the_interaction(
         self,
         new_export_interaction_reminders_user_feature_flag,
         mock_create_new_export_interaction_reminder,


### PR DESCRIPTION
### Description of change

When an advisor has modified an interaction, they should not receive a notification about that change. 
Currently we only exclude the advisor who created that interaction from receiving notifications, but this should be extended to advisors who modify an interaction

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
