### PR TITLE
RR-848-archive-dont-delete-export-items 

### DIFF
--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -332,8 +332,8 @@ class TestDeleteExport(APITestMixin):
 
     def test_delete_success(self):
         """
-        Test a DELETE request with a known export id provides a success response, and a second
-        request with the same id returns a not found error
+        Test a DELETE request with a known export id provides a success response, and
+        request with the same id returns the item archived
         """
         export = ExportFactory()
         url = reverse('api-v4:export:item', kwargs={'pk': export.id})
@@ -341,5 +341,5 @@ class TestDeleteExport(APITestMixin):
         response = self.api_client.delete(url)
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
-        response = self.api_client.delete(url)
-        assert response.status_code == status.HTTP_404_NOT_FOUND
+        response = self.api_client.get(url)
+        assert response.json()['archived']

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -66,10 +66,10 @@ from datahub.core.hawk_receiver import (
     HawkResponseSigningMixin,
     HawkScopePermission,
 )
-from datahub.core.mixins import ArchivableViewSetMixin, SoftDeleteViaArchiveMixin
+from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.permissions import HasPermissions
 from datahub.core.schemas import StubSchema
-from datahub.core.viewsets import CoreViewSet
+from datahub.core.viewsets import CoreViewSet, SoftDeleteCoreViewSet
 from datahub.investment.project.queryset import get_slim_investment_project_queryset
 
 
@@ -621,14 +621,7 @@ class ExportWinsForCompanyView(APIView):
         return JsonResponse(export_wins_results.json())
 
 
-class CompanyExportViewSet(
-    mixins.CreateModelMixin,
-    mixins.RetrieveModelMixin,
-    mixins.UpdateModelMixin,
-    SoftDeleteViaArchiveMixin,
-    mixins.ListModelMixin,
-    GenericViewSet,
-):
+class CompanyExportViewSet(SoftDeleteCoreViewSet):
     """View for company exports"""
 
     queryset = CompanyExport.objects.select_related(

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -66,7 +66,7 @@ from datahub.core.hawk_receiver import (
     HawkResponseSigningMixin,
     HawkScopePermission,
 )
-from datahub.core.mixins import ArchivableViewSetMixin
+from datahub.core.mixins import ArchivableViewSetMixin, SoftDeleteViaArchiveMixin
 from datahub.core.permissions import HasPermissions
 from datahub.core.schemas import StubSchema
 from datahub.core.viewsets import CoreViewSet
@@ -621,7 +621,14 @@ class ExportWinsForCompanyView(APIView):
         return JsonResponse(export_wins_results.json())
 
 
-class CompanyExportViewSet(CoreViewSet):
+class CompanyExportViewSet(
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    mixins.UpdateModelMixin,
+    SoftDeleteViaArchiveMixin,
+    mixins.ListModelMixin,
+    GenericViewSet,
+):
     """View for company exports"""
 
     queryset = CompanyExport.objects.select_related(

--- a/datahub/core/mixins.py
+++ b/datahub/core/mixins.py
@@ -2,8 +2,10 @@
 from django.conf import settings
 from rest_framework import mixins
 from rest_framework import serializers
+from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.response import Response
+
 
 from datahub.core.models import ArchivableModel
 from datahub.core.schemas import StubSchema
@@ -81,9 +83,5 @@ class SoftDeleteViaArchiveMixin(mixins.DestroyModelMixin):
                 request._user,
                 reason='Archived instead of deleting when DELETE request received',
             )
+            return Response(status=status.HTTP_204_NO_CONTENT)
         return super().destroy(request, *args, **kwargs)
-
-    def perform_destroy(self, instance):
-        """Override to stop the export being deleted if the instance is an archivable model"""
-        if not issubclass(type(instance), ArchivableModel):
-            instance.save()

--- a/datahub/core/mixins.py
+++ b/datahub/core/mixins.py
@@ -1,9 +1,11 @@
 """General mixins."""
 from django.conf import settings
+from rest_framework import mixins
 from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from datahub.core.models import ArchivableModel
 from datahub.core.schemas import StubSchema
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -66,3 +68,22 @@ class ArchivableViewSetMixin:
 
         obj_serializer = self.get_serializer_class()(obj)
         return Response(data=obj_serializer.data)
+
+
+class SoftDeleteViaArchiveMixin(mixins.DestroyModelMixin):
+    """To be used with models that should be archived instead of deleted"""
+
+    def destroy(self, request, *args, **kwargs):
+        """Archive instead of deleting."""
+        instance = self.get_object()
+        if issubclass(type(instance), ArchivableModel):
+            instance.archive(
+                request._user,
+                reason='Archived instead of deleting when DELETE request received',
+            )
+        return super().destroy(request, *args, **kwargs)
+
+    def perform_destroy(self, instance):
+        """Override to stop the export being deleted if the instance is an archivable model"""
+        if not issubclass(type(instance), ArchivableModel):
+            instance.save()

--- a/datahub/core/test/test_mixins.py
+++ b/datahub/core/test/test_mixins.py
@@ -1,0 +1,52 @@
+from rest_framework import serializers, status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from datahub.core.test.support.models import EmptyModel
+from datahub.core.test_utils import APITestMixin
+from datahub.core.viewsets import SoftDeleteCoreViewSet
+
+factory = APIRequestFactory()
+AUTH_USER_MODEL = 'company.Advisor'
+
+
+class TestEmptyModelSerializer(serializers.ModelSerializer):
+    """DRF Serializer to use with the EmptyModel."""
+
+    class Meta:
+        model = EmptyModel
+        depth = 1
+        fields = '__all__'
+
+
+class TestEmptyModelSoftDeleteCoreViewSet(SoftDeleteCoreViewSet):
+    lookup_field = 'id'
+    permission_classes = []
+    queryset = EmptyModel.objects.all()
+    serializer_class = TestEmptyModelSerializer
+
+
+class TestSoftDeleteViaArchiveMixin(APITestMixin):
+    def test_destroy_with_non_archivable_model_deletes_object(self):
+
+        empty_model = EmptyModel.objects.create()
+        id = empty_model.id
+
+        my_view = TestEmptyModelSoftDeleteCoreViewSet.as_view(
+            {
+                'delete': 'destroy',
+                'get': 'retrieve',
+            },
+        )
+
+        delete_request = factory.delete(f'/{id}/')
+        force_authenticate(delete_request, self.user)
+
+        delete_response = my_view(delete_request, id=id)
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+
+        get_request = factory.get(f'/{id}/')
+        force_authenticate(get_request, self.user)
+
+        get_response = my_view(get_request, id=id)
+
+        assert get_response.status_code == status.HTTP_404_NOT_FOUND

--- a/datahub/core/viewsets.py
+++ b/datahub/core/viewsets.py
@@ -1,8 +1,12 @@
 from copy import copy
 
 from django.core.exceptions import FieldDoesNotExist
+
+
 from rest_framework import mixins
 from rest_framework.viewsets import GenericViewSet
+
+from datahub.core.mixins import SoftDeleteViaArchiveMixin
 
 
 def has_fields(model, *fields):
@@ -17,11 +21,10 @@ def has_fields(model, *fields):
     return True
 
 
-class CoreViewSet(
+class BaseViewSet(
     mixins.CreateModelMixin,
     mixins.RetrieveModelMixin,
     mixins.UpdateModelMixin,
-    mixins.DestroyModelMixin,
     mixins.ListModelMixin,
     GenericViewSet,
 ):
@@ -85,3 +88,17 @@ class CoreViewSet(
                 additional_data['created_by'] = self.request.user
 
         return additional_data
+
+
+class CoreViewSet(
+    BaseViewSet,
+    mixins.DestroyModelMixin,
+):
+    """Base class for view sets that need to delete via destroy."""
+
+
+class SoftDeleteCoreViewSet(
+    BaseViewSet,
+    SoftDeleteViaArchiveMixin,
+):
+    """Base class for view sets that need to delete using archive as a soft delete"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,16 @@
 version: "2"
 
 services:
+  mock-sso:
+    image: gcr.io/sre-docker-registry/github.com/uktrade/mock-sso:latest
+    ports:
+      - 8080:8080
+    environment:
+      MOCK_SSO_SCOPE: data-hub:internal-api
+      MOCK_SSO_TOKEN: 123
+      MOCK_SSO_EMAIL_USER_ID: test@gov.uk
+      MOCK_SSO_USERNAME: test@gov.uk
+
   api:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,6 @@
 version: "2"
 
 services:
-  mock-sso:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/mock-sso:latest
-    ports:
-      - 8080:8080
-    environment:
-      MOCK_SSO_SCOPE: data-hub:internal-api
-      MOCK_SSO_TOKEN: 123
-      MOCK_SSO_EMAIL_USER_ID: test@gov.uk
-      MOCK_SSO_USERNAME: test@gov.uk
 
   api:
     build:


### PR DESCRIPTION
### Description of change

- Add a new mixin that extends the `mixins.DestroyModelMixin`, to perform a soft delete via archiving instead of a full delete from the DB. This is needed for the export pipeline items

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
