### PR TITLE
Use no-notification feature group for notifications opt out.

### DIFF
--- a/datahub/reminder/__init__.py
+++ b/datahub/reminder/__init__.py
@@ -16,3 +16,4 @@ INVESTMENT_ESTIMATED_LAND_DATE_EMAIL_STATUS_FEATURE_FLAG_NAME = \
     'investment-estimated-land-date-email-status'
 INVESTMENT_NOTIFICATIONS_FEATURE_GROUP_NAME = 'investment-notifications'
 EXPORT_NOTIFICATIONS_FEATURE_GROUP_NAME = 'export-notifications'
+NO_NOTIFICATIONS_FEATURE_GROUP_NAME = 'no-notifications'


### PR DESCRIPTION
### Description of change

When user has `no-notifications` group assigned, they will not be included in notifications migration.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
