### PR TITLE
fix: update countries and territories with correct names and iso codes

### DIFF
--- a/datahub/metadata/migrations/0044_update_countries_and_iso_codes.py
+++ b/datahub/metadata/migrations/0044_update_countries_and_iso_codes.py
@@ -1,0 +1,21 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_countries(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0044_update_countries_and_iso_codes.yaml'
+    )
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0043_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_countries, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0044_update_countries_and_iso_codes.yaml
+++ b/datahub/metadata/migrations/0044_update_countries_and_iso_codes.yaml
@@ -1,0 +1,18 @@
+- model: metadata.country
+  pk: 1a50bdb8-5d95-e211-a939-e4115bead28a
+  fields:
+    disabled_on: null
+    name: Curaçao
+    iso_alpha2_code: CW
+- model: metadata.country
+  pk: 7c756b9a-5d95-e211-a939-e4115bead28a
+  fields:
+    disabled_on: null
+    name: Sint Maarten (Dutch part)
+    iso_alpha2_code: SX
+- model: metadata.country
+  pk: 36afd8d0-5d95-e211-a939-e4115bead28a
+  fields:
+    disabled_on: null
+    name: Western Sahara
+    iso_alpha2_code: EH


### PR DESCRIPTION
### Description of change

Currently, Data Hub's country metadata does not match up with DBT's reference countries, territories and regions dataset (https://data.trade.gov.uk/datasets/240d5034-6a83-451b-8307-5755672f881b#countries-territories-and-regions). This PR updates the names, iso codes and disabled_on status of 3 countries/ territories to match their state on the reference dataset.

- Renamed Netherlands Antilles to Curaçao, set its iso_alpha2_code to CW, set its disabled_on to NULL
- Renamed St Martin to Sint Maarten (Dutch part) with iso_alpha2_code to be SX
- Set Western Sahara's iso_alpha_2_code to be EH, and disabled_on to be NULL

These changes effect 9 companies, 7 of which are archived

Netherlands Antilles and Curaçao do not cover the same geographical area, and neither do St Martin and Sint Maarten (Dutch part). However:

- The 5 companies that are listed as being in Netherlands Antilles are all in Curaçao from looking at parts of their address.
- The 4 companies listed as being in St Martin are all in Philipsburg, which is on the Dutch part of the island.

There will be a follow up PR to add in all remaining missing countries and territories from DBT's reference dataset.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
