### PR TITLE
Add dependabot quarterly maintenance

### DIFF
--- a/docs/Dependabot.md
+++ b/docs/Dependabot.md
@@ -11,5 +11,6 @@ This is the process we have identified for dealing with Dependabot PRs that save
 7. Rebase the dependency branch against `main` to remove all the merge commits, then push the changes and open a PR.
 8. If you are satisfied that everything is in order and all the tests have passed, request reviews as normal.
 9. Once merged, deploy to production as soon as possible.
+10. Removed orphan closed PR dependencies every first working day in quarter of the year for those older than 90 days.
 
 If the OpenSearch version has been updated, the version used by [the e2e tests](https://github.com/uktrade/data-hub-frontend/blob/main/docker-compose.e2e.backend.yml#L58) needs to be updated to match.


### PR DESCRIPTION
## Description of change

As part of our Datahub maintenance(including related microservices) in order to improve the availability of the service. I’m setting every quarter starting next month April 2023 to removed orphan closed PR dependencies that merged into main for older than 90days.


## Screenshots
![dependabotOrphan](https://user-images.githubusercontent.com/28296624/228498510-8b354afe-146f-42e7-b5fd-114822fee92c.png)



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
