### PR TITLE
Ccit 335 investment status last project won

### DIFF
--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -82,7 +82,7 @@ class SearchOrderAPIView(SearchOrderAPIViewMixin, SearchAPIView):
         base_query.aggs.bucket(self.subtotal_cost_field, 'sum', field=self.subtotal_cost_field)
         return base_query
 
-    def enhance_response(self, results, response):
+    def enhance_response(self, results, response, validated_data):
         """Enhance response with total subtotal cost."""
         summary = {}
 

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -262,11 +262,11 @@ class SearchAPIView(APIView):
             'results': [x.to_dict() for x in results.hits],
         }
 
-        response = self.enhance_response(results, response)
+        response = self.enhance_response(results, response, validated_data)
 
         return Response(data=response)
 
-    def enhance_response(self, results, response):
+    def enhance_response(self, results, response, validated_data):
         """Placeholder for a method to enhance the response with custom data."""
         return response
 


### PR DESCRIPTION
### Description of change

Make validated_data available for enchanced_response on investment_project call.
Include last investment project stage won to summary.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

When calling http://localhost:3000/api-proxy/v3/search/investment_project with show_summary: true
{"limit":200,"investor_company":["0f5216e0-849f-11e6-ae22-56b6b6499611"],"show_summary":true}

it now returns the additional details:

![image](https://user-images.githubusercontent.com/699259/229838447-95d4fd5e-fe8c-434f-b949-d7524ac25365.png)

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
