### PR TITLE
Fix to connect local front end to local API

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ Dependencies:
     cp config/settings/sample.env config/settings/.env
     ```
 
-8.  Set `DOCKER_DEV=False` in `.env`
+8.  Set `DOCKER_DEV=False` and `LOCAL_DEV=True` in `.env`
 
 9. Make sure you have OpenSearch running locally. If you don't, you can run one in Docker:
 

--- a/datahub/core/hawk_receiver.py
+++ b/datahub/core/hawk_receiver.py
@@ -1,3 +1,4 @@
+import environ
 import logging
 from functools import partial
 
@@ -9,6 +10,8 @@ from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import BasePermission
 
+environ.Env.read_env(env_file='./.env')  # reads the .env file
+env = environ.Env()
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +130,8 @@ def _authorise(request):
         request.build_absolute_uri(),
         request.method,
         content=request.body,
-        content_type=request.content_type,
+        # Running on local dev replace content type plain/text with '' to avoid validation issues.
+        content_type=request.content_type if not env.bool('LOCAL_DEV', False) else '',
         seen_nonce=_seen_nonce,
     )
 

--- a/datahub/core/hawk_receiver.py
+++ b/datahub/core/hawk_receiver.py
@@ -1,9 +1,9 @@
-import environ
 import logging
 from functools import partial
 
 from django.conf import settings
 from django.core.cache import cache
+import environ
 from mohawk import Receiver
 from mohawk.exc import HawkFail
 from rest_framework.authentication import BaseAuthentication

--- a/datahub/core/hawk_receiver.py
+++ b/datahub/core/hawk_receiver.py
@@ -1,6 +1,7 @@
 import logging
-import environ
 from functools import partial
+
+import environ
 
 from django.conf import settings
 from django.core.cache import cache

--- a/datahub/core/hawk_receiver.py
+++ b/datahub/core/hawk_receiver.py
@@ -1,9 +1,9 @@
 import logging
+import environ
 from functools import partial
 
 from django.conf import settings
 from django.core.cache import cache
-import environ
 from mohawk import Receiver
 from mohawk.exc import HawkFail
 from rest_framework.authentication import BaseAuthentication

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       - node.name=node-001
       - discovery.type=single-node
       - bootstrap.memory_lock=true
+    ports:
+      - "9200:9200"
 
   redis:
     image: redis:6.2.6


### PR DESCRIPTION
Initial fix local development
Expose docker port 9200 locally for OpenSearch

### Description of change
### Before
Previously when trying to connect a local Data Hub front end to a locally run Data Hub API it would give an error. Now it should successfully connect.

### Test instructions
Set `LOCAL_DEV=True` in your API .env file.
Start API as normal.
Checkout the front end branch https://github.com/uktrade/data-hub-frontend/tree/firebreak/local-dev-fix and set API_ROOT=http://127.0.0.1:8000 in the front end .env.

You now can run the front end and connected to the native API.

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
