### PR TITLE
Add company export pipeline filters

### DIFF
--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -634,3 +634,17 @@ class CompanyExportViewSet(SoftDeleteCoreViewSet):
     permission_classes = [
         IsAuthenticated,
     ]
+    filter_backends = (
+        DjangoFilterBackend,
+        OrderingFilter,
+    )
+    filterset_fields = [
+        'created_on',
+        'destination_country',
+        'export_potential',
+        'sector',
+        'status',
+        'team_members',
+    ]
+    ordering_fields = ('created_on',)
+    ordering = ('-created_on')


### PR DESCRIPTION
### Description of change
Adds the following filters to the export pipeline:
* `created_on`
* `destination_country`
* `export_potential`
* `sector`
* `status`
* `team_members` (owner)

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
