### PR TITLE
Fix flaky get_company test.

### DIFF
--- a/datahub/company/test/test_company_exportcountry_views.py
+++ b/datahub/company/test/test_company_exportcountry_views.py
@@ -541,13 +541,13 @@ class TestCompaniesToCompanyExportCountryModel(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         response_data['export_countries'].sort(key=lambda item: item['country']['name'])
-        current_countries_request = status_wise_items.get(
+        current_countries_request = sorted(status_wise_items.get(
             CompanyExportCountry.Status.CURRENTLY_EXPORTING,
             [],
-        )
-        current_countries_response = [
+        ))
+        current_countries_response = sorted([
             c['id'] for c in response_data.get('export_to_countries', [])
-        ]
+        ])
 
         future_countries_request = sorted(status_wise_items.get(
             CompanyExportCountry.Status.FUTURE_INTEREST,


### PR DESCRIPTION
### Description of change

This fixes a flaky `test_get_company` test.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
