### PR TITLE
fix: updated sso_user_id to sso_user_email_id

### DIFF
--- a/datahub/company/tasks/adviser.py
+++ b/datahub/company/tasks/adviser.py
@@ -121,7 +121,7 @@ def _automatic_adviser_deactivate(limit=1000, simulate=False):
         )),
         date_joined__lt=two_years_ago,
         is_active=True,
-        sso_user_id__isnull=True,
+        sso_email_user_id__isnull=True,
     )[:limit]
 
     for adviser in advisers_to_be_deactivated:

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -36,6 +36,7 @@ class AdviserFactory(factory.django.DjangoModelFactory):
     telephone_number = factory.Faker('phone_number')
     date_joined = now()
     sso_user_id = factory.LazyFunction(uuid.uuid4)
+    sso_email_user_id = email
 
     class Meta:
         model = 'company.Advisor'

--- a/datahub/company/test/tasks/test_adviser_task.py
+++ b/datahub/company/test/tasks/test_adviser_task.py
@@ -1,7 +1,6 @@
 import logging
 from datetime import date, datetime
 from unittest import mock
-from uuid import uuid4
 
 import pytest
 from dateutil.relativedelta import relativedelta
@@ -41,7 +40,7 @@ def deactivateable_adviser(**kwargs):
     in tests
     """
     return AdviserFactory(**{
-        'sso_user_id': None,
+        'sso_email_user_id': None,
         'date_joined': date.today() - relativedelta(years=2, days=1),
         'is_active': True,
         **kwargs,
@@ -181,17 +180,18 @@ class TestAdviserDeactivateTask:
                 assert adviser2.is_active is False
                 assert adviser3.is_active is True
 
-    def test_adviser_with_sso_id_does_not_dectivate(self):
+    def test_adviser_with_sso_email_id_does_not_deactivate(self):
         """
-        Test adviser with an SSO ID does not deactivate
+        Test adviser with an SSO user email ID does not deactivate if it has
+        logged in within the last 2 years
 
         The plan would be to have logic to properly deactivate these, but since
         we don't have this logic for now, we test that we don't deactivate these
         """
         with freeze_time('2017-02-21'):
             adviser1 = deactivateable_adviser()
-            adviser2 = deactivateable_adviser(sso_user_id=None)
-            adviser3 = deactivateable_adviser(sso_user_id=uuid4())
+            adviser2 = deactivateable_adviser(sso_email_user_id=None)
+            adviser3 = deactivateable_adviser(sso_email_user_id='foo@bar.com')
             assert adviser1.is_active is True
             assert adviser2.is_active is True
             assert adviser3.is_active is True


### PR DESCRIPTION
### Description of change

Previous logic for de-activating dummy adviser accounts filtered based on those with no sso_user_id. However, it should have been filtering based on sso_email_user_id, as some adviser accounts will not have an sso user id recorded.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
