### PR TITLE
bugfix/exclude-soft-deleted-export-form-items

### DIFF
--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -469,6 +469,36 @@ class TestExportFilters(APITestMixin):
         assert response_data['count'] == 1
         assert response_data['results'][0]['team_members'][0]['id'] == str(team_member_1.id)
 
+    def test_filtered_by_archived(self):
+        """List of exports filtered by archive value"""
+        archived = ExportFactory(archived=True)
+        not_archived = ExportFactory(archived=False)
+
+        url = reverse('api-v4:export:collection')
+        archived_response = self.api_client.get(
+            url,
+            {
+                'archived': True,
+            },
+        )
+        assert archived_response.status_code == status.HTTP_200_OK
+        response_data = archived_response.json()
+
+        assert response_data['count'] == 1
+        assert response_data['results'][0]['id'] == str(archived.id)
+
+        not_archived_response = self.api_client.get(
+            url,
+            {
+                'archived': False,
+            },
+        )
+        assert not_archived_response.status_code == status.HTTP_200_OK
+        response_data = not_archived_response.json()
+
+        assert response_data['count'] == 1
+        assert response_data['results'][0]['id'] == str(not_archived.id)
+
 
 class TestExportSortBy(APITestMixin):
     """Test the sorting on the GET export endpoint"""

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -644,11 +644,11 @@ class CompanyExportViewSet(SoftDeleteCoreViewSet):
         'sector',
         'status',
         'team_members',
+        'archived',
     ]
     ordering_fields = (
         'created_on',
         'title',
-
     )
     ordering = (
         '-created_on',


### PR DESCRIPTION
### Description of change

Added a filter to allow excluding of archived export items

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
