### PR TITLE
fix: using last login to determine active advisers

### DIFF
--- a/datahub/company/models/adviser.py
+++ b/datahub/company/models/adviser.py
@@ -48,7 +48,7 @@ class AdviserManager(BaseUserManager):
         return self._create_user(email, password, **extra_fields)
 
 
-@reversion.register_base_model(extra_exclude=('last_login',))
+@reversion.register_base_model()
 class Advisor(AbstractBaseUser, PermissionsMixin):
     """Adviser model.
 

--- a/datahub/company/tasks/adviser.py
+++ b/datahub/company/tasks/adviser.py
@@ -25,7 +25,9 @@ logger = logging.getLogger(__name__)
 
 def _automatic_adviser_deactivate(limit=1000, simulate=False):
     two_years_ago = date.today() - relativedelta(years=2)
+    six_months_ago = date.today() - relativedelta(months=6)
     advisers_to_be_deactivated = Advisor.objects.filter(
+        Q(last_login__lt=six_months_ago) | Q(last_login__isnull=True),
         ~Exists(Interaction.objects.filter(
             (
                 Q(date__gte=two_years_ago)


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
