### PR TITLE
Bugfix/rr 945 users can see all exports

### DIFF
--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -238,7 +238,11 @@ class TestListExport(APITestMixin):
         ),
     )
     def test_list_request_user_is_owner_user_is_a_team_member_with_pagination_success(
-        self, batch_size, offset, limit, expected_count
+        self,
+        batch_size,
+        offset,
+        limit,
+        expected_count,
     ):
         """
         Test a request with pagination criteria returns expected export results

--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -469,6 +469,36 @@ class TestExportFilters(APITestMixin):
         assert response_data['count'] == 1
         assert response_data['results'][0]['team_members'][0]['id'] == str(team_member_1.id)
 
+    def test_filtered_by_archived(self):
+        """List of exports filtered by archive value"""
+        archived = ExportFactory(archived=True)
+        not_archived = ExportFactory(archived=False)
+
+        url = reverse('api-v4:export:collection')
+        archived_response = self.api_client.get(
+            url,
+            {
+                'archived': True,
+            },
+        )
+        assert archived_response.status_code == status.HTTP_200_OK
+        response_data = archived_response.json()
+
+        assert response_data['count'] == 1
+        assert response_data['results'][0]['id'] == str(archived.id)
+
+        not_archived_response = self.api_client.get(
+            url,
+            {
+                'archived': False,
+            },
+        )
+        assert not_archived_response.status_code == status.HTTP_200_OK
+        response_data = not_archived_response.json()
+
+        assert response_data['count'] == 1
+        assert response_data['results'][0]['id'] == str(not_archived.id)
+
 
 class TestExportSortBy(APITestMixin):
     """Test the sorting on the GET export endpoint"""

--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -214,7 +214,13 @@ class TestListExport(APITestMixin):
         self,
     ):
         """Test a GET with an unknown export id returns a not found error"""
-        export = ExportFactory(owner=AdviserFactory(), team_members=[self.user])
+        export = ExportFactory(
+            owner=AdviserFactory(),
+            team_members=[
+                self.user,
+                AdviserFactory(),
+            ],
+        )
         self._assert_export_list_success(export)
 
     def test_list_export_request_user_is_owner_user_not_a_team_member_returns_success_with_results(

--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -193,16 +193,41 @@ class TestGetExport(APITestMixin):
 class TestListExport(APITestMixin):
     """Test the LIST export endpoint"""
 
-    def test_list_without_pagination_success(self):
-        """
-        Test a request without any pagination criteria returns all stored exports in the response
-        """
-        ExportFactory.create_batch(20)
+    def _assert_export_list_success(self, export):
         url = reverse('api-v4:export:collection')
-        response = self.api_client.get(url)
 
+        response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()['count'] == 20
+        assert response.json()['count'] == 1
+        assert response.json()['results'][0]['id'] == str(export.id)
+
+    def test_list_export_request_user_not_owner_user_not_team_member_returns_empty_results(self):
+        """Test a GET with an unknown export id returns a not found error"""
+        ExportFactory(owner=AdviserFactory(), team_members=[AdviserFactory()])
+        url = reverse('api-v4:export:collection')
+
+        response = self.api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['count'] == 0
+
+    def test_list_export_request_user_not_owner_user_is_a_team_member_returns_success_with_results(
+        self,
+    ):
+        """Test a GET with an unknown export id returns a not found error"""
+        export = ExportFactory(owner=AdviserFactory(), team_members=[self.user])
+        self._assert_export_list_success(export)
+
+    def test_list_export_request_user_is_owner_user_not_a_team_member_returns_success_with_results(
+        self,
+    ):
+        """Test a GET with an unknown export id returns a not found error"""
+        export = ExportFactory(owner=self.user, team_members=[AdviserFactory()])
+        self._assert_export_list_success(export)
+
+    def test_get_export_request_user_is_owner_user_is_a_team_member_returns_success(self):
+        """Test a GET with an unknown export id returns a not found error"""
+        export = ExportFactory(owner=self.user, team_members=[self.user])
+        self._assert_export_list_success(export)
 
     @pytest.mark.parametrize(
         'batch_size,offset,limit,expected_count',
@@ -212,11 +237,13 @@ class TestListExport(APITestMixin):
             (2, 2, 1, 0),
         ),
     )
-    def test_list_with_pagination_success(self, batch_size, offset, limit, expected_count):
+    def test_list_request_user_is_owner_user_is_a_team_member_with_pagination_success(
+        self, batch_size, offset, limit, expected_count
+    ):
         """
         Test a request with pagination criteria returns expected export results
         """
-        ExportFactory.create_batch(batch_size)
+        ExportFactory.create_batch(batch_size, owner=self.user, team_members=[self.user])
 
         url = reverse('api-v4:export:collection')
         response = self.api_client.get(
@@ -349,9 +376,18 @@ class TestExportFilters(APITestMixin):
 
     def test_filtered_by_status(self):
         """List of exports filtered by status."""
-        ExportFactory(status=CompanyExport.ExportStatus.ACTIVE)
-        ExportFactory(status=CompanyExport.ExportStatus.INACTIVE)
-        ExportFactory(status=CompanyExport.ExportStatus.WON)
+        ExportFactory(
+            status=CompanyExport.ExportStatus.ACTIVE,
+            owner=self.user,
+        )
+        ExportFactory(
+            status=CompanyExport.ExportStatus.INACTIVE,
+            owner=self.user,
+        )
+        ExportFactory(
+            status=CompanyExport.ExportStatus.WON,
+            owner=self.user,
+        )
 
         url = reverse('api-v4:export:collection')
         response = self.api_client.get(
@@ -368,9 +404,18 @@ class TestExportFilters(APITestMixin):
 
     def test_filtered_by_export_potential(self):
         """List of exports filtered by export potential."""
-        ExportFactory(export_potential=CompanyExport.ExportPotential.HIGH)
-        ExportFactory(export_potential=CompanyExport.ExportPotential.MEDIUM)
-        ExportFactory(export_potential=CompanyExport.ExportPotential.LOW)
+        ExportFactory(
+            export_potential=CompanyExport.ExportPotential.HIGH,
+            owner=self.user,
+        )
+        ExportFactory(
+            export_potential=CompanyExport.ExportPotential.MEDIUM,
+            owner=self.user,
+        )
+        ExportFactory(
+            export_potential=CompanyExport.ExportPotential.LOW,
+            owner=self.user,
+        )
 
         url = reverse('api-v4:export:collection')
         response = self.api_client.get(
@@ -391,9 +436,18 @@ class TestExportFilters(APITestMixin):
         sector2 = SectorFactory()
         sector3 = SectorFactory()
 
-        ExportFactory(sector=sector1)
-        ExportFactory(sector=sector2)
-        ExportFactory(sector=sector3)
+        ExportFactory(
+            sector=sector1,
+            owner=self.user,
+        )
+        ExportFactory(
+            sector=sector2,
+            owner=self.user,
+        )
+        ExportFactory(
+            sector=sector3,
+            owner=self.user,
+        )
 
         url = reverse('api-v4:export:collection')
         response = self.api_client.get(
@@ -414,9 +468,18 @@ class TestExportFilters(APITestMixin):
         country2 = CountryFactory()
         country3 = CountryFactory()
 
-        ExportFactory(destination_country=country1)
-        ExportFactory(destination_country=country2)
-        ExportFactory(destination_country=country3)
+        ExportFactory(
+            destination_country=country1,
+            owner=self.user,
+        )
+        ExportFactory(
+            destination_country=country2,
+            owner=self.user,
+        )
+        ExportFactory(
+            destination_country=country3,
+            owner=self.user,
+        )
 
         url = reverse('api-v4:export:collection')
         response = self.api_client.get(
@@ -441,18 +504,21 @@ class TestExportFilters(APITestMixin):
             team_members=[
                 team_member_1,
             ],
+            owner=self.user,
         )
 
         ExportFactory(
             team_members=[
                 team_member_2,
             ],
+            owner=self.user,
         )
 
         ExportFactory(
             team_members=[
                 team_member_3,
             ],
+            owner=self.user,
         )
 
         url = reverse('api-v4:export:collection')
@@ -471,8 +537,14 @@ class TestExportFilters(APITestMixin):
 
     def test_filtered_by_archived(self):
         """List of exports filtered by archive value"""
-        archived = ExportFactory(archived=True)
-        not_archived = ExportFactory(archived=False)
+        archived = ExportFactory(
+            archived=True,
+            owner=self.user,
+        )
+        not_archived = ExportFactory(
+            archived=False,
+            owner=self.user,
+        )
 
         url = reverse('api-v4:export:collection')
         archived_response = self.api_client.get(
@@ -526,9 +598,18 @@ class TestExportSortBy(APITestMixin):
     )
     def test_sort_by_export_title(self, data, results):
         """Test sort by title (ascending)"""
-        ExportFactory(title='Title C')
-        ExportFactory(title='Title A')
-        ExportFactory(title='Title B')
+        ExportFactory(
+            title='Title C',
+            owner=self.user,
+        )
+        ExportFactory(
+            title='Title A',
+            owner=self.user,
+        )
+        ExportFactory(
+            title='Title B',
+            owner=self.user,
+        )
 
         url = reverse('api-v4:export:collection')
         response = self.api_client.get(url, data)

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -654,3 +654,15 @@ class CompanyExportViewSet(SoftDeleteCoreViewSet):
         '-created_on',
         'title',
     )
+
+    def get_queryset(self):
+        """Filter the queryset to the authenticated user"""
+
+        if self.action == 'list':
+            return (
+                super()
+                .get_queryset()
+                .filter(Q(owner=self.request.user) | Q(team_members=self.request.user))
+            )
+
+        return super().get_queryset()

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -644,11 +644,11 @@ class CompanyExportViewSet(SoftDeleteCoreViewSet):
         'sector',
         'status',
         'team_members',
+        'archived',
     ]
     ordering_fields = (
         'created_on',
         'title',
-
     )
     ordering = (
         '-created_on',

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -657,7 +657,6 @@ class CompanyExportViewSet(SoftDeleteCoreViewSet):
 
     def get_queryset(self):
         """Filter the queryset to the authenticated user"""
-
         if self.action == 'list':
             return (
                 super()


### PR DESCRIPTION
### Description of change

Filter the list endpoint to only include exports the logged in user is either an owner or team member of

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
