### PR TITLE
bugfix/RR-957-export-item-returned-multiple-times

### DIFF
--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -661,7 +661,7 @@ class CompanyExportViewSet(SoftDeleteCoreViewSet):
             return (
                 super()
                 .get_queryset()
-                .filter(Q(owner=self.request.user) | Q(team_members=self.request.user))
+                .exclude(~Q(owner=self.request.user), ~Q(team_members=self.request.user))
             )
 
         return super().get_queryset()


### PR DESCRIPTION
### Description of change

- Fixed a bug where duplicate export items were being returned when an export item had team members.
- Used the django excludes command in place of filter, and added additional tests for checking duplicates not returned

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
