### PR TITLE
Update OpenSearch docker instructions when running the API natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Dependencies:
 9. Make sure you have OpenSearch running locally. If you don't, you can run one in Docker:
 
     ```shell
-    docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" opensearchproject/opensearch:1.2.4
+    docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" -e "plugins.security.disabled=true" opensearchproject/opensearch:1.2.4
     ```
 
 10. Make sure you have redis running locally and that the REDIS_BASE_URL in your `.env` is up-to-date.


### PR DESCRIPTION
### Description of change
When bringing up OpenSearch locally using this command (as per the docs):

`docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" opensearchproject/opensearch:1.2.4`

Then running a test you get this error:
```
(data-hub-api-python-3.10) ~/Dev/data-hub-api$ pytest -s ./datahub/company/test/test_export_views.py
ImportError while loading conftest '/Users/paulgain/Dev/data-hub-api/conftest.py'.
conftest.py:10: in <module>
    from opensearchpy.helpers.test import get_test_client
../../.virtualenvs/data-hub-api-python-3.10/lib/python3.10/site-packages/opensearchpy/helpers/test.py:113: in <module>
    OPENSEARCH_VERSION = opensearch_version(client)
../../.virtualenvs/data-hub-api-python-3.10/lib/python3.10/site-packages/opensearchpy/helpers/test.py:103: in opensearch_version
    return _get_version(client.info()["version"]["number"])
../../.virtualenvs/data-hub-api-python-3.10/lib/python3.10/site-packages/opensearchpy/client/utils.py:178: in _wrapped
    return func(*args, params=params, headers=headers, **kwargs)
../../.virtualenvs/data-hub-api-python-3.10/lib/python3.10/site-packages/opensearchpy/client/__init__.py:251: in info
    return self.transport.perform_request(
../../.virtualenvs/data-hub-api-python-3.10/lib/python3.10/site-packages/opensearchpy/transport.py:407: in perform_request
    raise e
../../.virtualenvs/data-hub-api-python-3.10/lib/python3.10/site-packages/opensearchpy/transport.py:370: in perform_request
    status, headers_response, data = connection.perform_request(
../../.virtualenvs/data-hub-api-python-3.10/lib/python3.10/site-packages/opensearchpy/connection/http_urllib3.py:255: in perform_request
    raise ConnectionError("N/A", str(e), e)
E   opensearchpy.exceptions.ConnectionError: ConnectionError(('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))) caused by: ProtocolError(('Connection aborted.', RemoteDisconnected('Remote end closed connection without response')))
```

In the logs you have:
```
[2023-04-26T12:11:09,607][ERROR][o.o.s.s.h.n.SecuritySSLNettyHttpServerTransport] [2e67b6a74a11] Exception during establishing a SSL connection: io.netty.handler.ssl.NotSslRecordException: not an SSL/TLS record: 
```

By adding another parameter to `docker run` namely: `-e "plugins.security.disabled=true"` this fixes the issue by disabling the security plugin allowing the tests to run.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
