### PR TITLE
Add 'owner' filter to the export pipeline list

### DIFF
--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -603,6 +603,33 @@ class TestExportFilters(APITestMixin):
         assert response_data['count'] == 1
         assert response_data['results'][0]['team_members'][0]['id'] == str(team_member_1.id)
 
+    def test_filtered_by_other_owner(self):
+        """List of exports filtered by other owner"""
+        other_owner = AdviserFactory()
+
+        ExportFactory(
+            owner=self.user,
+        )
+
+        ExportFactory(
+            owner=other_owner,
+            team_members=[self.user],
+        )
+
+        url = reverse('api-v4:export:collection')
+        response = self.api_client.get(
+            url,
+            {
+                'owner': other_owner.id,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+
+        assert response_data['count'] == 1
+        assert response_data['results'][0]['owner']['id'] == str(other_owner.id)
+
     def test_filtered_by_archived(self):
         """List of exports filtered by archive value"""
         archived = ExportFactory(

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -639,12 +639,13 @@ class CompanyExportViewSet(SoftDeleteCoreViewSet):
         OrderingFilter,
     )
     filterset_fields = [
+        'archived',
         'destination_country',
         'export_potential',
+        'owner',
         'sector',
         'status',
         'team_members',
-        'archived',
     ]
     ordering_fields = (
         'created_on',


### PR DESCRIPTION
### Description of change
Add the owner filter to the export pipeline allowing authenticated users to filter on owners they are team members of.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
