### PR TITLE
Add other standard type service interaction metadata

### DIFF
--- a/datahub/metadata/migrations/0052_update_services.py
+++ b/datahub/metadata/migrations/0052_update_services.py
@@ -1,0 +1,33 @@
+from pathlib import PurePath
+
+import mptt
+from django.db import migrations
+
+import datahub
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0052_update_services.yaml'
+    )
+
+def rebuild_tree(apps, schema_editor):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0051_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0052_update_services.yaml
+++ b/datahub/metadata/migrations/0052_update_services.yaml
@@ -1,0 +1,12 @@
+- model: metadata.service
+  pk: b7f74b3b-a3ff-4534-ba7e-dacce2f3204a
+  fields:
+    disabled_on:
+    order: 674.0
+    segment: Global Talent Network
+    parent: 552f4ba8-b993-498f-a640-c1b9a888f83e
+    contexts: ["other_interaction", "trade_agreement_interaction"]
+    lft: 6
+    rght: 7
+    tree_id: 3
+    level: 1


### PR DESCRIPTION
### Description of change
Create a new sub-service under A specific service, for standard Other-type interactions called Global Talent Network.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [X] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [X] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
