### PR TITLE
bugfix/RR-948-include-team-in-owner-response

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -1193,7 +1193,7 @@ class CompanyExportSerializer(serializers.ModelSerializer):
     """Company Export serializer"""
 
     company = NestedRelatedField(Company)
-    owner = NestedRelatedField(Advisor)
+    owner = NestedAdviserWithTeamField()
     team_members = NestedRelatedField(
         Advisor,
         many=True,

--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -176,6 +176,12 @@ class TestGetExport(APITestMixin):
             'owner': {
                 'id': str(export.owner.id),
                 'name': export.owner.name,
+                'first_name': export.owner.first_name,
+                'last_name': export.owner.last_name,
+                'dit_team': {
+                    'id': str(export.owner.dit_team.id),
+                    'name': export.owner.dit_team.name,
+                },
             },
             'sector': {
                 'id': str(export.sector.id),
@@ -399,6 +405,12 @@ class TestPatchExport(APITestMixin):
                 'owner': {
                     'id': str(export.owner.id),
                     'name': export.owner.name,
+                    'first_name': export.owner.first_name,
+                    'last_name': export.owner.last_name,
+                    'dit_team': {
+                        'id': str(export.owner.dit_team.id),
+                        'name': export.owner.dit_team.name,
+                    },
                 },
                 'sector': {
                     'id': str(export.sector.id),


### PR DESCRIPTION
### Description of change

Include the owners team in the export api responses

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
