### PR TITLE
Removed minimum value for turnover

### DIFF
--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -196,7 +196,6 @@ class Company(ArchivableModel, BaseModel):
         null=True,
         blank=True,
         help_text='In USD. Only used when duns_number is set.',
-        validators=[MinValueValidator(0)],
     )
     is_turnover_estimated = models.BooleanField(
         null=True,

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -7,7 +7,6 @@ from django.core.validators import (
     integer_validator,
     MaxLengthValidator,
     MinLengthValidator,
-    MinValueValidator,
 )
 from django.db import models, transaction
 from django.utils.timezone import now

--- a/datahub/dataset/company/test/test_views.py
+++ b/datahub/dataset/company/test/test_views.py
@@ -176,6 +176,30 @@ class TestCompaniesDatasetViewSet(BaseDatasetViewTest):
         expected_result = get_expected_data_from_company(company)
         assert result == expected_result
 
+    @pytest.mark.parametrize(
+        'company_factory', (
+            CompanyWithAreaFactory,
+            ArchivedCompanyFactory,
+        ),
+    )
+    def test_turnover_negative(self, data_flow_api_client, company_factory):
+        """Test that endpoint returns with expected data for a null turnover value"""
+        company = company_factory()
+        company.created_by = None
+        company.created_on = None
+        company.turnover = -1000
+        company.save()
+
+        response = data_flow_api_client.get(self.view_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_results = response.json()['results']
+
+        assert len(response_results) == 1
+        result = response_results[0]
+        expected_result = get_expected_data_from_company(company)
+        assert result == expected_result
+
     def test_success_subsidiary(self, data_flow_api_client):
         """Test that for a company and it's subsidiary two companies are returned"""
         company = SubsidiaryFactory()


### PR DESCRIPTION
### Description of change

We get D&B synchronisation errors when a company D&B are sending has a negative turnover. Therefore this change is to remove the minimum value

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
