### PR TITLE
Filter the list of exports by applying multiple 'export potential' query params 

### DIFF
--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -497,17 +497,15 @@ class TestExportFilters(APITestMixin):
         )
 
         url = reverse('api-v4:export:collection')
-        response = self.api_client.get(
-            url,
-            {
-                'export_potential': CompanyExport.ExportPotential.LOW,
-            },
-        )
+        query = '?export_potential=medium&export_potential=low'
+        response = self.api_client.get(url + query)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
-        assert response_data['count'] == 1
-        assert response_data['results'][0]['export_potential'] == CompanyExport.ExportPotential.LOW
+        assert response_data['count'] == 2
+        results = response_data['results']
+        assert results[0]['export_potential'] == CompanyExport.ExportPotential.LOW
+        assert results[1]['export_potential'] == CompanyExport.ExportPotential.MEDIUM
 
     def test_filtered_by_export_sector(self):
         """List of exports filtered by sector."""

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -630,8 +630,17 @@ class ExportWinsForCompanyView(APIView):
 class CompanyExportEstimatedWinDateFilterSet(FilterSet):
     """CompanyExport estimated win date filter."""
 
-    estimated_win_date = DateFromToRangeFilter(field_name='estimated_win_date')
-    status = MultipleChoiceFilter(field_name='status', choices=CompanyExport.ExportStatus.choices)
+    estimated_win_date = DateFromToRangeFilter(
+        field_name='estimated_win_date',
+    )
+    status = MultipleChoiceFilter(
+        field_name='status',
+        choices=CompanyExport.ExportStatus.choices,
+    )
+    export_potential = MultipleChoiceFilter(
+        field_name='export_potential',
+        choices=CompanyExport.ExportPotential.choices,
+    )
 
     class Meta:
         model = CompanyExport


### PR DESCRIPTION
### Description of change
The client can now filter the list of exports by applying multiple query params to the API call to fetch all exports that match the query.

For example, if the client wants a list of exports where the export potential is `high` or `medium`:
`/v4/export?export_potential=high&export_potential=medium`

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
