### PR TITLE
fix: allow setting of null duns number

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_company_duns_number.py
+++ b/datahub/dbmaintenance/management/commands/update_company_duns_number.py
@@ -17,7 +17,7 @@ class Command(CSVBaseCommand):
         """Process one single row."""
         pk = parse_uuid(row['id'])
         company = Company.objects.get(pk=pk)
-        duns_number = parse_limited_string(row['duns_number'])
+        duns_number = parse_limited_string(row['duns_number'], blank_value=None)
 
         if company.duns_number == duns_number:
             return

--- a/datahub/dbmaintenance/test/commands/test_update_company_duns_number.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_duns_number.py
@@ -60,7 +60,7 @@ def test_run(s3_stubber, caplog):
     assert [company.duns_number for company in companies] == [
         '012345',
         '456',
-        '',
+        None,
         '087891',
         '087892',
     ]

--- a/datahub/dbmaintenance/utils.py
+++ b/datahub/dbmaintenance/utils.py
@@ -44,9 +44,9 @@ def parse_choice(value, choices, blank_value=''):
     return _parse_value(value, ChoiceField(choices=choices), blank_value=blank_value)
 
 
-def parse_limited_string(value, max_length=settings.CHAR_FIELD_MAX_LENGTH):
+def parse_limited_string(value, max_length=settings.CHAR_FIELD_MAX_LENGTH, blank_value=''):
     """Parses/validates a string."""
-    return _parse_value(value, CharField(max_length=max_length), blank_value='')
+    return _parse_value(value, CharField(max_length=max_length), blank_value=blank_value)
 
 
 def _parse_value(value, field, blank_value=None):


### PR DESCRIPTION
### Description of change

As part of dnb data cleanse using dnb's recommendations, we need the ability to rollback changes which means setting duns number to null rather than empty string. The empty string is not sufficient because there can be at most 1 company with an empty string duns number because of the unique constraint on that column.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
