### PR TITLE
Fix sync_search command.

### DIFF
--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -20,18 +20,18 @@ def sync_all_models():
     Task that starts sub-tasks to sync all models to OpenSearch.
     """
     for search_app in get_search_apps():
-        schedule_model_sync(search_app)
+        schedule_model_sync((search_app.name,))
 
 
-def schedule_model_sync(search_app):
+def schedule_model_sync(search_app: tuple):
     job = job_scheduler(
         queue_name=LONG_RUNNING_QUEUE,
         function=sync_model,
-        function_args=(search_app.name,),
+        function_args=search_app,
         job_timeout=HALF_DAY_IN_SECONDS,
     )
     logger.info(
-        f'Task {job.id} sync_model scheduled for {search_app.name}',
+        f'Task {job.id} sync_model scheduled for {search_app[0]}',
     )
 
 

--- a/datahub/search/test/commands/test_sync_search.py
+++ b/datahub/search/test/commands/test_sync_search.py
@@ -34,6 +34,7 @@ def test_sync_one_model(sync_model_mock, search_model):
     management.call_command(sync_search.Command(), model=[search_model])
 
     assert sync_model_mock.call_count == 1
+    sync_model_mock.assert_called_with((search_model,))
 
 
 @mock.patch('datahub.search.management.commands.sync_search.schedule_model_sync')
@@ -48,6 +49,8 @@ def test_sync_all_models(sync_model_mock):
     management.call_command(sync_search.Command())
 
     assert sync_model_mock.call_count == len(get_search_apps())
+    expected_calls = [mock.call((app.name,)) for app in get_search_apps()]
+    assert expected_calls == sync_model_mock.call_args_list
 
 
 @mock.patch('datahub.search.management.commands.sync_search.schedule_model_sync')


### PR DESCRIPTION
### Description of change

This fixes broken `sync_search` command and updates tests to ensure `schedule_model_sync` is called with correct parameters. 

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
