### PR TITLE
Remove un-used policy area and issue type including test specs

### DIFF
--- a/datahub/company_referral/test/test_complete_view.py
+++ b/datahub/company_referral/test/test_complete_view.py
@@ -257,9 +257,8 @@ class TestCompleteCompanyReferral(APITestMixin):
             'service_delivery_status': None,
             'grant_amount_offered': None,
             'net_company_receipt': None,
-            'policy_areas': [],
             'policy_feedback_notes': '',
-            'policy_issue_types': [],
+            # 'policy_issue_types': [],
             'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),

--- a/datahub/company_referral/test/test_complete_view.py
+++ b/datahub/company_referral/test/test_complete_view.py
@@ -258,7 +258,6 @@ class TestCompleteCompanyReferral(APITestMixin):
             'grant_amount_offered': None,
             'net_company_receipt': None,
             'policy_feedback_notes': '',
-            # 'policy_issue_types': [],
             'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),

--- a/datahub/interaction/queryset.py
+++ b/datahub/interaction/queryset.py
@@ -29,7 +29,6 @@ def get_base_interaction_queryset():
         'company_referral__recipient__dit_team',
     ).prefetch_related(
         Prefetch('contacts', queryset=Contact.objects.order_by('pk')),
-        # 'policy_issue_types',
         Prefetch(
             'dit_participants',
             queryset=(

--- a/datahub/interaction/queryset.py
+++ b/datahub/interaction/queryset.py
@@ -29,8 +29,7 @@ def get_base_interaction_queryset():
         'company_referral__recipient__dit_team',
     ).prefetch_related(
         Prefetch('contacts', queryset=Contact.objects.order_by('pk')),
-        'policy_areas',
-        'policy_issue_types',
+        # 'policy_issue_types',
         Prefetch(
             'dit_participants',
             queryset=(

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -34,7 +34,6 @@ from datahub.interaction.models import (
     Interaction,
     InteractionDITParticipant,
     InteractionExportCountry,
-    PolicyIssueType,
     ServiceDeliveryStatus,
 )
 from datahub.interaction.permissions import HasAssociatedInvestmentProjectValidator
@@ -203,12 +202,6 @@ class BaseInteractionSerializer(serializers.ModelSerializer):
     service_delivery_status = NestedRelatedField(
         ServiceDeliveryStatus, required=False, allow_null=True,
     )
-    # policy_issue_types = NestedRelatedField(
-    #     PolicyIssueType,
-    #     allow_empty=True,
-    #     many=True,
-    #     required=False,
-    # )
     export_barrier_types = NestedRelatedField(
         ExportBarrierType,
         allow_empty=True,
@@ -469,7 +462,6 @@ class InteractionSerializer(BaseInteractionSerializer):
             'notes',
             'archived_documents_url_path',
             'policy_feedback_notes',
-            # 'policy_issue_types',
             'was_policy_feedback_provided',
             'were_countries_discussed',
             'export_countries',
@@ -533,13 +525,11 @@ class InteractionSerializer(BaseInteractionSerializer):
                 ),
                 ValidationRule(
                     'invalid_when_no_policy_feedback',
-                    # OperatorRule('policy_issue_types', not_),
                     OperatorRule('policy_feedback_notes', not_),
                     when=OperatorRule('was_policy_feedback_provided', not_),
                 ),
                 ValidationRule(
                     'required',
-                    # OperatorRule('policy_issue_types', bool),
                     OperatorRule('policy_feedback_notes', is_not_blank),
                     when=OperatorRule('was_policy_feedback_provided', bool),
                 ),
@@ -668,7 +658,6 @@ class InteractionSerializerV4(BaseInteractionSerializer):
             'notes',
             'archived_documents_url_path',
             'policy_feedback_notes',
-            # 'policy_issue_types',
             'helped_remove_export_barrier',
             'export_barrier_types',
             'export_barrier_notes',
@@ -736,13 +725,11 @@ class InteractionSerializerV4(BaseInteractionSerializer):
                 ),
                 ValidationRule(
                     'invalid_when_no_policy_feedback',
-                    # OperatorRule('policy_issue_types', not_),
                     OperatorRule('policy_feedback_notes', not_),
                     when=OperatorRule('was_policy_feedback_provided', not_),
                 ),
                 ValidationRule(
                     'required',
-                    # OperatorRule('policy_issue_types', bool),
                     OperatorRule('policy_feedback_notes', is_not_blank),
                     when=OperatorRule('was_policy_feedback_provided', bool),
                 ),

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -34,7 +34,6 @@ from datahub.interaction.models import (
     Interaction,
     InteractionDITParticipant,
     InteractionExportCountry,
-    PolicyArea,
     PolicyIssueType,
     ServiceDeliveryStatus,
 )
@@ -204,13 +203,12 @@ class BaseInteractionSerializer(serializers.ModelSerializer):
     service_delivery_status = NestedRelatedField(
         ServiceDeliveryStatus, required=False, allow_null=True,
     )
-    policy_areas = NestedRelatedField(PolicyArea, many=True, required=False, allow_empty=True)
-    policy_issue_types = NestedRelatedField(
-        PolicyIssueType,
-        allow_empty=True,
-        many=True,
-        required=False,
-    )
+    # policy_issue_types = NestedRelatedField(
+    #     PolicyIssueType,
+    #     allow_empty=True,
+    #     many=True,
+    #     required=False,
+    # )
     export_barrier_types = NestedRelatedField(
         ExportBarrierType,
         allow_empty=True,
@@ -470,9 +468,8 @@ class InteractionSerializer(BaseInteractionSerializer):
             'theme',
             'notes',
             'archived_documents_url_path',
-            'policy_areas',
             'policy_feedback_notes',
-            'policy_issue_types',
+            # 'policy_issue_types',
             'was_policy_feedback_provided',
             'were_countries_discussed',
             'export_countries',
@@ -536,15 +533,13 @@ class InteractionSerializer(BaseInteractionSerializer):
                 ),
                 ValidationRule(
                     'invalid_when_no_policy_feedback',
-                    OperatorRule('policy_issue_types', not_),
-                    OperatorRule('policy_areas', not_),
+                    # OperatorRule('policy_issue_types', not_),
                     OperatorRule('policy_feedback_notes', not_),
                     when=OperatorRule('was_policy_feedback_provided', not_),
                 ),
                 ValidationRule(
                     'required',
-                    OperatorRule('policy_areas', bool),
-                    OperatorRule('policy_issue_types', bool),
+                    # OperatorRule('policy_issue_types', bool),
                     OperatorRule('policy_feedback_notes', is_not_blank),
                     when=OperatorRule('was_policy_feedback_provided', bool),
                 ),
@@ -672,9 +667,8 @@ class InteractionSerializerV4(BaseInteractionSerializer):
             'theme',
             'notes',
             'archived_documents_url_path',
-            'policy_areas',
             'policy_feedback_notes',
-            'policy_issue_types',
+            # 'policy_issue_types',
             'helped_remove_export_barrier',
             'export_barrier_types',
             'export_barrier_notes',
@@ -742,15 +736,13 @@ class InteractionSerializerV4(BaseInteractionSerializer):
                 ),
                 ValidationRule(
                     'invalid_when_no_policy_feedback',
-                    OperatorRule('policy_issue_types', not_),
-                    OperatorRule('policy_areas', not_),
+                    # OperatorRule('policy_issue_types', not_),
                     OperatorRule('policy_feedback_notes', not_),
                     when=OperatorRule('was_policy_feedback_provided', not_),
                 ),
                 ValidationRule(
                     'required',
-                    OperatorRule('policy_areas', bool),
-                    OperatorRule('policy_issue_types', bool),
+                    # OperatorRule('policy_issue_types', bool),
                     OperatorRule('policy_feedback_notes', is_not_blank),
                     when=OperatorRule('was_policy_feedback_provided', bool),
                 ),

--- a/datahub/interaction/test/views/test_interaction_v4.py
+++ b/datahub/interaction/test/views/test_interaction_v4.py
@@ -29,7 +29,6 @@ from datahub.interaction.models import (
     CommunicationChannel,
     Interaction,
     InteractionPermission,
-    PolicyArea,
     PolicyIssueType,
     ServiceDeliveryStatus,
 )
@@ -92,11 +91,8 @@ class TestAddInteraction(APITestMixin):
             # company interaction with policy feedback
             {
                 'was_policy_feedback_provided': True,
-                'policy_areas': [
-                    partial(random_obj_for_model, PolicyArea),
-                ],
                 'policy_feedback_notes': 'Policy feedback notes',
-                'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
+                # 'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
             },
         ),
     )
@@ -143,9 +139,8 @@ class TestAddInteraction(APITestMixin):
             'service_delivery_status': None,
             'grant_amount_offered': None,
             'net_company_receipt': None,
-            'policy_areas': request_data.get('policy_areas', []),
             'policy_feedback_notes': request_data.get('policy_feedback_notes', ''),
-            'policy_issue_types': request_data.get('policy_issue_types', []),
+            # 'policy_issue_types': request_data.get('policy_issue_types', []),
             'was_policy_feedback_provided': request_data.get(
                 'was_policy_feedback_provided', False,
             ),
@@ -263,11 +258,8 @@ class TestAddInteraction(APITestMixin):
             # company interaction with policy feedback
             {
                 'was_policy_feedback_provided': True,
-                'policy_areas': [
-                    partial(random_obj_for_model, PolicyArea),
-                ],
                 'policy_feedback_notes': 'Policy feedback notes',
-                'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
+                # 'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
             },
         ),
     )
@@ -398,9 +390,8 @@ class TestAddInteraction(APITestMixin):
             'service_delivery_status': None,
             'grant_amount_offered': None,
             'net_company_receipt': None,
-            'policy_areas': request_data.get('policy_areas', []),
             'policy_feedback_notes': request_data.get('policy_feedback_notes', ''),
-            'policy_issue_types': request_data.get('policy_issue_types', []),
+            # 'policy_issue_types': request_data.get('policy_issue_types', []),
             'was_policy_feedback_provided': request_data.get(
                 'was_policy_feedback_provided', False,
             ),
@@ -732,9 +723,8 @@ class TestAddInteraction(APITestMixin):
                     'related_trade_agreements': [],
                 },
                 {
-                    'policy_areas': ['This field is required.'],
                     'policy_feedback_notes': ['This field is required.'],
-                    'policy_issue_types': ['This field is required.'],
+                    # 'policy_issue_types': ['This field is required.'],
                 },
             ),
             # policy feedback fields cannot be blank when policy feedback provided
@@ -758,16 +748,14 @@ class TestAddInteraction(APITestMixin):
                         CommunicationChannel,
                     ),
                     'was_policy_feedback_provided': True,
-                    'policy_areas': [],
                     'policy_feedback_notes': '',
-                    'policy_issue_types': [],
+                    # 'policy_issue_types': [],
                     'has_related_trade_agreements': False,
                     'related_trade_agreements': [],
                 },
                 {
-                    'policy_areas': ['This field is required.'],
                     'policy_feedback_notes': ['This field is required.'],
-                    'policy_issue_types': ['This field is required.'],
+                    # 'policy_issue_types': ['This field is required.'],
                 },
             ),
             # at least one trade agreements field required when there are related trade agreements
@@ -1301,11 +1289,10 @@ class TestAddInteraction(APITestMixin):
                         random_obj_for_model,
                         ServiceDeliveryStatus,
                     ),
-                    'policy_areas': [partial(random_obj_for_model, PolicyArea)],
                     'policy_feedback_notes': 'Policy feedback notes.',
-                    'policy_issue_types': [
-                        partial(random_obj_for_model, PolicyIssueType),
-                    ],
+                    # 'policy_issue_types': [
+                    #     partial(random_obj_for_model, PolicyIssueType),
+                    # ],
                     'related_trade_agreements': [TradeAgreement.uk_japan.value.id],
                 },
                 {
@@ -1314,15 +1301,12 @@ class TestAddInteraction(APITestMixin):
                     'service_delivery_status': [
                         'This field is only valid for service deliveries.',
                     ],
-                    'policy_areas': [
-                        'This field is only valid when policy feedback has been provided.',
-                    ],
                     'policy_feedback_notes': [
                         'This field is only valid when policy feedback has been provided.',
                     ],
-                    'policy_issue_types': [
-                        'This field is only valid when policy feedback has been provided.',
-                    ],
+                    # 'policy_issue_types': [
+                    #     'This field is only valid when policy feedback has been provided.',
+                    # ],
                     'related_trade_agreements': [
                         'This field is only valid when there are related trade agreements.',
                     ],
@@ -1909,21 +1893,14 @@ class TestGetInteraction(APITestMixin):
             'service_delivery_status': None,
             'grant_amount_offered': None,
             'net_company_receipt': None,
-            'policy_areas': [
-                {
-                    'id': str(policy_area.pk),
-                    'name': policy_area.name,
-                }
-                for policy_area in interaction.policy_areas.all()
-            ],
             'policy_feedback_notes': interaction.policy_feedback_notes,
-            'policy_issue_types': [
-                {
-                    'id': str(policy_issue_type.pk),
-                    'name': policy_issue_type.name,
-                }
-                for policy_issue_type in interaction.policy_issue_types.all()
-            ],
+            # 'policy_issue_types': [
+            #     {
+            #         'id': str(policy_issue_type.pk),
+            #         'name': policy_issue_type.name,
+            #     }
+            #     for policy_issue_type in interaction.policy_issue_types.all()
+            # ],
             'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),
@@ -2056,9 +2033,8 @@ class TestGetInteraction(APITestMixin):
             'service_delivery_status': None,
             'grant_amount_offered': None,
             'net_company_receipt': None,
-            'policy_areas': [],
             'policy_feedback_notes': '',
-            'policy_issue_types': [],
+            # 'policy_issue_types': [],
             'was_policy_feedback_provided': False,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),

--- a/datahub/interaction/test/views/test_interaction_v4.py
+++ b/datahub/interaction/test/views/test_interaction_v4.py
@@ -29,7 +29,6 @@ from datahub.interaction.models import (
     CommunicationChannel,
     Interaction,
     InteractionPermission,
-    PolicyIssueType,
     ServiceDeliveryStatus,
 )
 from datahub.interaction.test.factories import (
@@ -92,7 +91,6 @@ class TestAddInteraction(APITestMixin):
             {
                 'was_policy_feedback_provided': True,
                 'policy_feedback_notes': 'Policy feedback notes',
-                # 'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
             },
         ),
     )
@@ -140,7 +138,6 @@ class TestAddInteraction(APITestMixin):
             'grant_amount_offered': None,
             'net_company_receipt': None,
             'policy_feedback_notes': request_data.get('policy_feedback_notes', ''),
-            # 'policy_issue_types': request_data.get('policy_issue_types', []),
             'was_policy_feedback_provided': request_data.get(
                 'was_policy_feedback_provided', False,
             ),
@@ -259,7 +256,6 @@ class TestAddInteraction(APITestMixin):
             {
                 'was_policy_feedback_provided': True,
                 'policy_feedback_notes': 'Policy feedback notes',
-                # 'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
             },
         ),
     )
@@ -391,7 +387,6 @@ class TestAddInteraction(APITestMixin):
             'grant_amount_offered': None,
             'net_company_receipt': None,
             'policy_feedback_notes': request_data.get('policy_feedback_notes', ''),
-            # 'policy_issue_types': request_data.get('policy_issue_types', []),
             'was_policy_feedback_provided': request_data.get(
                 'was_policy_feedback_provided', False,
             ),
@@ -724,7 +719,6 @@ class TestAddInteraction(APITestMixin):
                 },
                 {
                     'policy_feedback_notes': ['This field is required.'],
-                    # 'policy_issue_types': ['This field is required.'],
                 },
             ),
             # policy feedback fields cannot be blank when policy feedback provided
@@ -749,13 +743,11 @@ class TestAddInteraction(APITestMixin):
                     ),
                     'was_policy_feedback_provided': True,
                     'policy_feedback_notes': '',
-                    # 'policy_issue_types': [],
                     'has_related_trade_agreements': False,
                     'related_trade_agreements': [],
                 },
                 {
                     'policy_feedback_notes': ['This field is required.'],
-                    # 'policy_issue_types': ['This field is required.'],
                 },
             ),
             # at least one trade agreements field required when there are related trade agreements
@@ -1290,9 +1282,6 @@ class TestAddInteraction(APITestMixin):
                         ServiceDeliveryStatus,
                     ),
                     'policy_feedback_notes': 'Policy feedback notes.',
-                    # 'policy_issue_types': [
-                    #     partial(random_obj_for_model, PolicyIssueType),
-                    # ],
                     'related_trade_agreements': [TradeAgreement.uk_japan.value.id],
                 },
                 {
@@ -1304,9 +1293,6 @@ class TestAddInteraction(APITestMixin):
                     'policy_feedback_notes': [
                         'This field is only valid when policy feedback has been provided.',
                     ],
-                    # 'policy_issue_types': [
-                    #     'This field is only valid when policy feedback has been provided.',
-                    # ],
                     'related_trade_agreements': [
                         'This field is only valid when there are related trade agreements.',
                     ],
@@ -1894,13 +1880,6 @@ class TestGetInteraction(APITestMixin):
             'grant_amount_offered': None,
             'net_company_receipt': None,
             'policy_feedback_notes': interaction.policy_feedback_notes,
-            # 'policy_issue_types': [
-            #     {
-            #         'id': str(policy_issue_type.pk),
-            #         'name': policy_issue_type.name,
-            #     }
-            #     for policy_issue_type in interaction.policy_issue_types.all()
-            # ],
             'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),
@@ -2034,7 +2013,6 @@ class TestGetInteraction(APITestMixin):
             'grant_amount_offered': None,
             'net_company_receipt': None,
             'policy_feedback_notes': '',
-            # 'policy_issue_types': [],
             'was_policy_feedback_provided': False,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -14,7 +14,6 @@ from datahub.event.test.factories import EventFactory
 from datahub.interaction.models import (
     CommunicationChannel,
     Interaction,
-    PolicyIssueType,
     ServiceDeliveryStatus,
 )
 from datahub.interaction.test.factories import (
@@ -65,7 +64,6 @@ class TestAddServiceDelivery(APITestMixin):
                 'is_event': False,
                 'was_policy_feedback_provided': True,
                 'policy_feedback_notes': 'Policy feedback notes',
-                # 'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
             },
             # Interaction with a status
             {
@@ -110,8 +108,6 @@ class TestAddServiceDelivery(APITestMixin):
             'net_company_receipt': request_data.get('net_company_receipt'),
             'communication_channel': None,
             'policy_feedback_notes': request_data.get('policy_feedback_notes', ''),
-            # 'policy_issue_types':
-            #     request_data.get('policy_issue_types', []),
             'was_policy_feedback_provided':
                 request_data.get('was_policy_feedback_provided', False),
             'subject': 'whatever',
@@ -239,7 +235,6 @@ class TestAddServiceDelivery(APITestMixin):
                 },
                 {
                     'policy_feedback_notes': ['This field is required.'],
-                    # 'policy_issue_types': ['This field is required.'],
                 },
             ),
 
@@ -264,11 +259,9 @@ class TestAddServiceDelivery(APITestMixin):
 
                     'was_policy_feedback_provided': True,
                     'policy_feedback_notes': '',
-                    # 'policy_issue_types': [],
                 },
                 {
                     'policy_feedback_notes': ['This field is required.'],
-                    # 'policy_issue_types': ['This field is required.'],
                 },
             ),
 
@@ -297,7 +290,6 @@ class TestAddServiceDelivery(APITestMixin):
                     # fields not allowed
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'policy_feedback_notes': 'Policy feedback notes.',
-                    # 'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
                     'investment_project': InvestmentProjectFactory,
                 },
                 {
@@ -305,9 +297,6 @@ class TestAddServiceDelivery(APITestMixin):
                     'policy_feedback_notes': [
                         'This field is only valid when policy feedback has been provided.',
                     ],
-                    # 'policy_issue_types': [
-                    #     'This field is only valid when policy feedback has been provided.',
-                    # ],
                     'investment_project': ['This field is only valid for interactions.'],
                 },
             ),

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -13,7 +13,7 @@ from datahub.core.test_utils import APITestMixin, random_obj_for_model
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.models import (
     CommunicationChannel,
-    Interaction, PolicyArea,
+    Interaction,
     PolicyIssueType,
     ServiceDeliveryStatus,
 )
@@ -64,11 +64,8 @@ class TestAddServiceDelivery(APITestMixin):
             {
                 'is_event': False,
                 'was_policy_feedback_provided': True,
-                'policy_areas': [
-                    partial(random_obj_for_model, PolicyArea),
-                ],
                 'policy_feedback_notes': 'Policy feedback notes',
-                'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
+                # 'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
             },
             # Interaction with a status
             {
@@ -112,10 +109,9 @@ class TestAddServiceDelivery(APITestMixin):
             'grant_amount_offered': request_data.get('grant_amount_offered'),
             'net_company_receipt': request_data.get('net_company_receipt'),
             'communication_channel': None,
-            'policy_areas': request_data.get('policy_areas', []),
             'policy_feedback_notes': request_data.get('policy_feedback_notes', ''),
-            'policy_issue_types':
-                request_data.get('policy_issue_types', []),
+            # 'policy_issue_types':
+            #     request_data.get('policy_issue_types', []),
             'was_policy_feedback_provided':
                 request_data.get('was_policy_feedback_provided', False),
             'subject': 'whatever',
@@ -242,9 +238,8 @@ class TestAddServiceDelivery(APITestMixin):
                     'was_policy_feedback_provided': True,
                 },
                 {
-                    'policy_areas': ['This field is required.'],
                     'policy_feedback_notes': ['This field is required.'],
-                    'policy_issue_types': ['This field is required.'],
+                    # 'policy_issue_types': ['This field is required.'],
                 },
             ),
 
@@ -268,14 +263,12 @@ class TestAddServiceDelivery(APITestMixin):
                     ),
 
                     'was_policy_feedback_provided': True,
-                    'policy_areas': [],
                     'policy_feedback_notes': '',
-                    'policy_issue_types': [],
+                    # 'policy_issue_types': [],
                 },
                 {
-                    'policy_areas': ['This field is required.'],
                     'policy_feedback_notes': ['This field is required.'],
-                    'policy_issue_types': ['This field is required.'],
+                    # 'policy_issue_types': ['This field is required.'],
                 },
             ),
 
@@ -303,22 +296,18 @@ class TestAddServiceDelivery(APITestMixin):
 
                     # fields not allowed
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
-                    'policy_areas': [partial(random_obj_for_model, PolicyArea)],
                     'policy_feedback_notes': 'Policy feedback notes.',
-                    'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
+                    # 'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
                     'investment_project': InvestmentProjectFactory,
                 },
                 {
                     'communication_channel': ['This field is not valid for service deliveries.'],
-                    'policy_areas': [
-                        'This field is only valid when policy feedback has been provided.',
-                    ],
                     'policy_feedback_notes': [
                         'This field is only valid when policy feedback has been provided.',
                     ],
-                    'policy_issue_types': [
-                        'This field is only valid when policy feedback has been provided.',
-                    ],
+                    # 'policy_issue_types': [
+                    #     'This field is only valid when policy feedback has been provided.',
+                    # ],
                     'investment_project': ['This field is only valid for interactions.'],
                 },
             ),


### PR DESCRIPTION
### Description of change
When adding Business Intelligence to an interaction, there are two compulsory questions around policy (issue type and area). The Business Intelligence team do not trust this data - users' answers not reliable.

The purpose of this ticket is to remove those questions - Policy issue types area and Policy areas implementation at Datahub-API.
<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [X] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [X] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
