### PR TITLE
feature/CLS2-182-include-is-global-hq-field

### DIFF
--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -17,14 +17,14 @@ from datahub.company.signal_receivers import (
     export_country_update_signal,
 )
 from datahub.core import constants, reversion
+from datahub.core.constants import (
+    HeadquarterType,
+)
 from datahub.core.models import (
     ArchivableModel,
     BaseConstantModel,
     BaseModel,
     BaseOrderedConstantModel,
-)
-from datahub.core.constants import (
-    HeadquarterType,
 )
 from datahub.core.utils import get_front_end_url, StrEnum
 from datahub.metadata import models as metadata_models

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -461,8 +461,7 @@ class Company(ArchivableModel, BaseModel):
         """Whether this company is the global headquarters or not"""
         if not self.headquarter_type:
             return False
-
-        return self.headquarter_type.name == HeadquarterType.ghq.value.id
+        return self.headquarter_type.name == HeadquarterType.ghq.value.name
 
     def mark_as_transferred(self, to, reason, user):
         """

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -643,6 +643,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'export_countries',
             'export_segment',
             'export_sub_segment',
+            'is_global_headquarters',
         )
         read_only_fields = (
             'archived',
@@ -664,6 +665,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'global_ultimate_duns_number',
             'dnb_modified_on',
             'export_countries',
+            'is_global_headquarters',
         )
         dnb_read_only_fields = (
             'name',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -723,13 +723,14 @@ class TestGetCompany(APITestMixin):
         ),
     )
     def test_get_company_is_global_headquarters(
-        self, headquarter_type, expected_is_global_headquarters
+        self,
+        headquarter_type,
+        expected_is_global_headquarters,
     ):
         """
         Test that `is_global_headquarters` is set for a company API result
         as expected.
         """
-
         company = CompanyFactory(headquarter_type_id=headquarter_type)
         url = reverse('api-v4:company:item', kwargs={'pk': company.pk})
         response = self.api_client.get(url)
@@ -1114,7 +1115,7 @@ class TestUpdateCompany(APITestMixin):
                 },
                 {
                     'address_country': [
-                        'A UK establishment (branch of non-UK company) must be in the UK.'
+                        'A UK establishment (branch of non-UK company) must be in the UK.',
                     ],
                 },
             ),
@@ -1787,7 +1788,7 @@ class TestAddCompany(APITestMixin):
                 },
                 {
                     'address_country': [
-                        'A UK establishment (branch of non-UK company) must be in the UK.'
+                        'A UK establishment (branch of non-UK company) must be in the UK.',
                     ],
                 },
                 [],
@@ -1807,7 +1808,7 @@ class TestAddCompany(APITestMixin):
                 },
                 {
                     'company_number': [
-                        'This must be a valid UK establishment number, beginning with BR.'
+                        'This must be a valid UK establishment number, beginning with BR.',
                     ],
                 },
                 [],

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -182,8 +182,7 @@ class TestListCompanies(APITestMixin):
         response_data = response.json()
         assert response_data['count'] == len(creation_times)
         expected_timestamps = [
-            format_date_or_datetime(creation_time)
-            for creation_time in sorted(creation_times)
+            format_date_or_datetime(creation_time) for creation_time in sorted(creation_times)
         ]
         actual_timestamps = [result['created_on'] for result in response_data['results']]
         assert expected_timestamps == actual_timestamps
@@ -193,9 +192,7 @@ class TestListCompanies(APITestMixin):
         CompanyFactory.create_batch(5, archived_documents_url_path='hello world')
 
         user = create_test_user(
-            permission_codenames=(
-                'view_company',
-            ),
+            permission_codenames=('view_company',),
         )
         api_client = self.create_api_client(user=user)
         url = reverse('api-v4:company:collection')
@@ -205,8 +202,7 @@ class TestListCompanies(APITestMixin):
         response_data = response.json()
         assert response_data['count'] == 5
         assert all(
-            'archived_documents_url_path' not in company
-            for company in response_data['results']
+            'archived_documents_url_path' not in company for company in response_data['results']
         )
 
     def test_list_companies_with_view_document_permission(self):
@@ -244,9 +240,7 @@ class TestGetCompany(APITestMixin):
             archived_documents_url_path='http://some-documents',
         )
         user = create_test_user(
-            permission_codenames=(
-                'view_company',
-            ),
+            permission_codenames=('view_company',),
         )
         api_client = self.create_api_client(user=user)
 
@@ -319,9 +313,7 @@ class TestGetCompany(APITestMixin):
                     'name': company.registered_address_country.name,
                 },
             },
-            'uk_based': (
-                company.address_country.id == uuid.UUID(Country.united_kingdom.value.id)
-            ),
+            'uk_based': (company.address_country.id == uuid.UUID(Country.united_kingdom.value.id)),
             'uk_region': {
                 'id': str(company.uk_region.id),
                 'name': company.uk_region.name,
@@ -402,6 +394,7 @@ class TestGetCompany(APITestMixin):
             'is_global_ultimate': company.is_global_ultimate,
             'global_ultimate_duns_number': company.global_ultimate_duns_number,
             'dnb_modified_on': company.dnb_modified_on,
+            'is_global_headquarters': False,
         }
 
     def test_get_company_without_country(self):
@@ -564,7 +557,8 @@ class TestGetCompany(APITestMixin):
                     'name': item.country.name,
                 },
                 'status': item.status,
-            } for item in company.export_countries.order_by('pk')
+            }
+            for item in company.export_countries.order_by('pk')
         ]
 
     def test_check_company_dont_return_export_countries_with_no_permission(self):
@@ -576,9 +570,7 @@ class TestGetCompany(APITestMixin):
         export_country_one, export_country_two = CompanyExportCountryFactory.create_batch(2)
         company.export_countries.set([export_country_one, export_country_two])
         user = create_test_user(
-            permission_codenames=(
-                'view_company',
-            ),
+            permission_codenames=('view_company',),
         )
         api_client = self.create_api_client(user=user)
 
@@ -719,9 +711,31 @@ class TestGetCompany(APITestMixin):
                         'id': str(global_account_manager.dit_team.country.pk),
                         'name': global_account_manager.dit_team.country.name,
                     },
-
                 },
             }
+
+    @pytest.mark.parametrize(
+        'headquarter_type, expected_is_global_headquarters',
+        (
+            (HeadquarterType.ehq.value.id, False),
+            (HeadquarterType.ghq.value.id, True),
+            (HeadquarterType.ukhq.value.id, False),
+        ),
+    )
+    def test_get_company_is_global_headquarters(
+        self, headquarter_type, expected_is_global_headquarters
+    ):
+        """
+        Test that `is_global_headquarters` is set for a company API result
+        as expected.
+        """
+
+        company = CompanyFactory(headquarter_type_id=headquarter_type)
+        url = reverse('api-v4:company:item', kwargs={'pk': company.pk})
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        # assert response.json()['is_global_headquarters'] == expected_is_global_headquarters
 
 
 class TestUpdateCompany(APITestMixin):
@@ -745,7 +759,6 @@ class TestUpdateCompany(APITestMixin):
                     'trading_names': ['new name'],
                 },
             ),
-
             # change of address
             (
                 {
@@ -785,7 +798,6 @@ class TestUpdateCompany(APITestMixin):
                     },
                 },
             ),
-
             # change of registered address
             (
                 {
@@ -796,7 +808,6 @@ class TestUpdateCompany(APITestMixin):
                     'address_postcode': 'BT41 4QE',
                     'address_area_id': None,
                     'address_country_id': Country.ireland.value.id,
-
                     'registered_address_1': '2',
                     'registered_address_2': 'Main Road',
                     'registered_address_town': 'London',
@@ -832,7 +843,6 @@ class TestUpdateCompany(APITestMixin):
                     },
                 },
             ),
-
             # set registered address to None
             (
                 {
@@ -843,7 +853,6 @@ class TestUpdateCompany(APITestMixin):
                     'address_postcode': 'BT41 4QE',
                     'address_area_id': None,
                     'address_country_id': Country.ireland.value.id,
-
                     'registered_address_1': '2',
                     'registered_address_2': 'Main Road',
                     'registered_address_town': 'London',
@@ -873,8 +882,7 @@ class TestUpdateCompany(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         actual_response = {
-            field_name: response_data[field_name]
-            for field_name in expected_response
+            field_name: response_data[field_name] for field_name in expected_response
         }
         assert actual_response == expected_response
 
@@ -1105,8 +1113,9 @@ class TestUpdateCompany(APITestMixin):
                     },
                 },
                 {
-                    'address_country':
-                        ['A UK establishment (branch of non-UK company) must be in the UK.'],
+                    'address_country': [
+                        'A UK establishment (branch of non-UK company) must be in the UK.'
+                    ],
                 },
             ),
             # United states should make address area mandatory
@@ -1645,7 +1654,6 @@ class TestAddCompany(APITestMixin):
                 'country': Country.united_kingdom.value.id,
             },
             'uk_region': UKRegion.england.value.id,
-
             **data,
         }
 
@@ -1659,8 +1667,7 @@ class TestAddCompany(APITestMixin):
         response_data = response.json()
         assert response_data['pending_dnb_investigation']
         actual_response = {
-            field_name: response_data[field_name]
-            for field_name in expected_response
+            field_name: response_data[field_name] for field_name in expected_response
         }
         assert actual_response == expected_response
 
@@ -1779,8 +1786,9 @@ class TestAddCompany(APITestMixin):
                     },
                 },
                 {
-                    'address_country':
-                        ['A UK establishment (branch of non-UK company) must be in the UK.'],
+                    'address_country': [
+                        'A UK establishment (branch of non-UK company) must be in the UK.'
+                    ],
                 },
                 [],
             ),
@@ -1798,8 +1806,9 @@ class TestAddCompany(APITestMixin):
                     },
                 },
                 {
-                    'company_number':
-                        ['This must be a valid UK establishment number, beginning with BR.'],
+                    'company_number': [
+                        'This must be a valid UK establishment number, beginning with BR.'
+                    ],
                 },
                 [],
             ),
@@ -1817,11 +1826,10 @@ class TestAddCompany(APITestMixin):
                     },
                 },
                 {
-                    'company_number':
-                        [
-                            'This field can only contain the letters A to Z and numbers '
-                            '(no symbols, punctuation or spaces).',
-                        ],
+                    'company_number': [
+                        'This field can only contain the letters A to Z and numbers '
+                        '(no symbols, punctuation or spaces).',
+                    ],
                 },
                 [],
             ),
@@ -1910,7 +1918,6 @@ class TestAddCompany(APITestMixin):
                 'country': Country.united_kingdom.value.id,
             },
             'uk_region': UKRegion.england.value.id,
-
             **data,
         }
 

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -736,7 +736,7 @@ class TestGetCompany(APITestMixin):
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        # assert response.json()['is_global_headquarters'] == expected_is_global_headquarters
+        assert response.json()['is_global_headquarters'] == expected_is_global_headquarters
 
 
 class TestUpdateCompany(APITestMixin):


### PR DESCRIPTION
### Description of change

Currently this field is calculated inside the node controller and used by nunjucks. This PR moves that logic from the front end to the api

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
