### PR TITLE
New endpoint for a list of export owners

### DIFF
--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -803,3 +803,41 @@ class TestExportSortBy(APITestMixin):
         response_data = response.json()
         assert response_data['count'] == 3
         assert [result['title'] for result in response_data['results']] == results
+
+
+class TestExportOwnerList(APITestMixin):
+    """Test a list of export owners"""
+
+    def test_a_list_of_owners(self):
+        other_owner = AdviserFactory()
+        other_team_member = AdviserFactory()
+
+        ExportFactory(
+            owner=self.user,
+            team_members=[other_team_member],
+        )
+
+        ExportFactory(
+            owner=other_owner,
+            team_members=[self.user],
+        )
+
+        ExportFactory(
+            owner=other_owner,
+            team_members=[other_team_member],
+        )
+
+        ExportFactory(
+            owner=self.user,
+            team_members=[],
+        )
+
+        url = reverse('api-v4:export:owner')
+
+        response = self.api_client.get(url)
+        response_data = response.json()
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response_data) == 2
+        assert response_data[0]['id'] == str(other_owner.id)
+        assert response_data[1]['id'] == str(self.user.id)

--- a/datahub/company/urls/export.py
+++ b/datahub/company/urls/export.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
-from datahub.company.views import CompanyExportViewSet
+from datahub.company.views import (
+    CompanyExportViewSet,
+    owner_list,
+)
 
 export_v4_collection = CompanyExportViewSet.as_view(
     {
@@ -26,5 +29,10 @@ urls_v4 = [
         'export/<uuid:pk>',
         export_v4_item,
         name='item',
+    ),
+    path(
+        'export/owner',
+        owner_list,
+        name='owner',
     ),
 ]


### PR DESCRIPTION
### Description of change
Added a new endpoint `/v4/export/owner` that responds with a list export owners (AKA advisers). The list includes users that own an export, if the user is a team member of an export then the owner of that export is also included in the list of owners. An owner should only appear once in the list - no duplicates.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
