### PR TITLE
feature/CLS2-199-index-additional-company-data

### DIFF
--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -13,29 +13,35 @@ class CompanySearchApp(SearchApp):
     search_model = Company
     view_permissions = (f'company.{CompanyPermission.view_company}',)
     export_permission = f'company.{CompanyPermission.export_company}'
-    queryset = DBCompany.objects.select_related(
-        'archived_by',
-        'business_type',
-        'employee_range',
-        'export_experience_category',
-        'headquarter_type',
-        'one_list_account_owner',
-        'global_headquarters__one_list_account_owner',
-        'global_headquarters',
-        'address_country',
-        'registered_address_country',
-        'sector',
-        'sector__parent',
-        'sector__parent__parent',
-        'turnover_range',
-        'uk_region',
-        'address_area',
-        'registered_address_area',
-    ).prefetch_related(
-        'export_countries__country',
-    ).annotate(
-        latest_interaction_date=get_aggregate_subquery(
-            DBCompany,
-            Max('interactions__date'),
-        ),
+    queryset = (
+        DBCompany.objects.select_related(
+            'archived_by',
+            'business_type',
+            'employee_range',
+            'export_experience_category',
+            'headquarter_type',
+            'one_list_account_owner',
+            'global_headquarters__one_list_account_owner',
+            'global_headquarters',
+            'address_country',
+            'registered_address_country',
+            'sector',
+            'sector__parent',
+            'sector__parent__parent',
+            'turnover_range',
+            'uk_region',
+            'address_area',
+            'registered_address_area',
+            'global_headquarters__one_list_tier',
+            'one_list_tier',
+        )
+        .prefetch_related(
+            'export_countries__country',
+        )
+        .annotate(
+            latest_interaction_date=get_aggregate_subquery(
+                DBCompany,
+                Max('interactions__date'),
+            ),
+        )
     )

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -32,7 +32,6 @@ class CompanySearchApp(SearchApp):
             'uk_region',
             'address_area',
             'registered_address_area',
-            'global_headquarters__one_list_tier',
             'one_list_tier',
         )
         .prefetch_related(

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -62,6 +62,7 @@ class Company(BaseSearchModel):
     latest_interaction_date = Date()
     export_segment = Text()
     export_sub_segment = Text()
+    one_list_tier = fields.id_name_field()
 
     COMPUTED_MAPPINGS = {
         'address': partial(dict_utils.address_dict, prefix='address'),
@@ -71,17 +72,20 @@ class Company(BaseSearchModel):
             dict_utils.contact_or_adviser_dict,
         ),
         'export_to_countries': lambda obj: [
-            dict_utils.id_name_dict(o.country) for o in obj.export_countries.all()
+            dict_utils.id_name_dict(o.country)
+            for o in obj.export_countries.all()
             if o.status == CompanyExportCountry.Status.CURRENTLY_EXPORTING
         ],
         'future_interest_countries': lambda obj: [
-            dict_utils.id_name_dict(o.country) for o in obj.export_countries.all()
+            dict_utils.id_name_dict(o.country)
+            for o in obj.export_countries.all()
             if o.status == CompanyExportCountry.Status.FUTURE_INTEREST
         ],
         'latest_interaction_date': lambda obj: obj.latest_interaction_date,
         'uk_address_postcode': lambda obj: obj.address_postcode if obj.uk_based else '',
-        'uk_registered_address_postcode':
-            lambda obj: obj.registered_address_postcode if obj.uk_based else '',
+        'uk_registered_address_postcode': lambda obj: obj.registered_address_postcode
+        if obj.uk_based
+        else '',
         'export_segment': lambda obj: obj.export_segment,
         'export_sub_segment': lambda obj: obj.export_sub_segment,
     }
@@ -94,10 +98,10 @@ class Company(BaseSearchModel):
         'global_headquarters': dict_utils.id_name_dict,
         'headquarter_type': dict_utils.id_name_dict,
         'sector': dict_utils.sector_dict,
-
         'turnover_range': dict_utils.id_name_dict,
         'uk_based': bool,
         'uk_region': dict_utils.id_name_dict,
+        'one_list_tier': dict_utils.id_name_dict,
     }
 
     SEARCH_FIELDS = (

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -34,6 +34,7 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
     area = SingleOrListField(child=StringUUIDField(), required=False)
     export_segment = SingleOrListField(required=False)
     export_sub_segment = SingleOrListField(required=False)
+    one_list_tier = SingleOrListField(child=StringUUIDField(), required=False)
 
     SORT_BY_FIELDS = (
         'modified_on',

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -40,12 +40,10 @@ class TestCompanySearchModel:
             'reference_code',
             'sector',
             'latest_interaction_date',
-
             'address',
             'registered_address',
-
             'one_list_group_global_account_manager',
-
+            'one_list_tier',
             'trading_names',
             'turnover_range',
             'uk_based',

--- a/datahub/search/company/test/test_opensearch.py
+++ b/datahub/search/company/test/test_opensearch.py
@@ -394,6 +394,16 @@ def test_mapping(opensearch):
             },
             'website': {'type': 'text'},
             'latest_interaction_date': {'type': 'date'},
+            'one_list_tier': {
+                'properties': {
+                    'id': {'type': 'keyword'},
+                    'name': {
+                        'normalizer': 'lowercase_asciifolding_normalizer',
+                        'type': 'keyword',
+                    },
+                },
+                'type': 'object',
+            },
         },
     }
 
@@ -529,7 +539,7 @@ def test_get_basic_search_query():
 @pytest.mark.django_db
 def test_limited_get_search_by_entity_query():
     """Tests search by entity."""
-    expected_query = {
+    expected_limited_get_search_by_entity_query = {
         'query': {
             'bool': {
                 'must': [
@@ -543,7 +553,8 @@ def test_limited_get_search_by_entity_query():
                                             'boost': 2,
                                         },
                                     },
-                                }, {
+                                },
+                                {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
@@ -598,8 +609,7 @@ def test_limited_get_search_by_entity_query():
                                             {
                                                 'match': {
                                                     'address.country.id': {
-                                                        'query':
-                                                            '80756b9a-5d95-e211-a939-e4115bead28a',
+                                                        'query': '80756b9a-5d95-e211-a939-e4115bead28a',  # noqa: E501
                                                         'operator': 'and',
                                                     },
                                                 },
@@ -607,7 +617,8 @@ def test_limited_get_search_by_entity_query():
                                         ],
                                         'minimum_should_match': 1,
                                     },
-                                }, {
+                                },
+                                {
                                     'range': {
                                         'archived': {
                                             'lte': '2017-06-13T09:44:31.062870',
@@ -648,7 +659,7 @@ def test_limited_get_search_by_entity_query():
         limit=5,
     )
 
-    assert query.to_dict() == expected_query
+    assert query.to_dict() == expected_limited_get_search_by_entity_query
 
 
 @pytest.mark.django_db
@@ -703,4 +714,5 @@ def test_indexed_doc(opensearch):
         'latest_interaction_date',
         'export_sub_segment',
         'export_segment',
+        'one_list_tier',
     }

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -57,6 +57,7 @@ class SearchCompanyAPIViewMixin:
         'uk_postcode',
         'export_segment',
         'export_sub_segment',
+        'one_list_tier',
     )
 
     REMAP_FIELDS = {
@@ -65,6 +66,7 @@ class SearchCompanyAPIViewMixin:
         'export_to_countries': 'export_to_countries.id',
         'future_interest_countries': 'future_interest_countries.id',
         'one_list_group_global_account_manager': 'one_list_group_global_account_manager.id',
+        'one_list_tier': 'one_list_tier.id',
     }
 
     COMPOSITE_FILTERS = {
@@ -224,15 +226,17 @@ class SearchCompanyExportAPIView(SearchCompanyAPIViewMixin, SearchExportAPIView)
             'address_country__name': 'Country',
         }
 
-        field_titles.update({
-            'address_area__name': 'Area',
-            'uk_region__name': 'UK region',
-            'export_to_countries_list': 'Countries exported to',
-            'future_interest_countries_list': 'Countries of interest',
-            'archived': 'Archived',
-            'created_on': 'Date created',
-            'number_of_employees_value': 'Number of employees',
-            'turnover_value': 'Annual turnover',
-            'upper_headquarter_type_name': 'Headquarter type',
-        })
+        field_titles.update(
+            {
+                'address_area__name': 'Area',
+                'uk_region__name': 'UK region',
+                'export_to_countries_list': 'Countries exported to',
+                'future_interest_countries_list': 'Countries of interest',
+                'archived': 'Archived',
+                'created_on': 'Date created',
+                'number_of_employees_value': 'Number of employees',
+                'turnover_value': 'Annual turnover',
+                'upper_headquarter_type_name': 'Headquarter type',
+            },
+        )
         return field_titles


### PR DESCRIPTION
### Description of change

Include the one list tier of a company in the opensearch indexed data

Example indexed entry with new field:
![image](https://github.com/uktrade/data-hub-api/assets/102232401/030a0b22-612f-42f4-9acd-afd1b1e6f96a)


### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
