### PR TITLE
Management command for rolling back company merge

### DIFF
--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -12,6 +12,7 @@ from datahub.cleanup.management.commands import delete_orphaned_versions
 from datahub.company.test.factories import (
     AdviserFactory,
     CompanyExportCountryFactory,
+    CompanyExportCountryHistoryFactory,
     CompanyFactory,
     ContactFactory,
     ExportFactory,
@@ -34,7 +35,10 @@ from datahub.investment.project.test.factories import (
 )
 from datahub.metadata.test.factories import SectorFactory
 from datahub.omis.order.test.factories import OrderFactory
-from datahub.user.company_list.test.factories import PipelineItemFactory
+from datahub.user.company_list.test.factories import (
+    CompanyListItemFactory,
+    PipelineItemFactory,
+)
 
 
 MAPPINGS = {
@@ -42,7 +46,9 @@ MAPPINGS = {
     'company.Company': CompanyFactory,
     'company.CompanyExport': ExportFactory,
     'company.CompanyExportCountry': CompanyExportCountryFactory,
+    'company.CompanyExportCountryHistory': CompanyExportCountryHistoryFactory,
     'company.Contact': ContactFactory,
+    'company_list.CompanyListItem': CompanyListItemFactory,
     'company_list.PipelineItem': PipelineItemFactory,
     'company_referral.CompanyReferral': CompanyReferralFactory,
     'event.Event': EventFactory,

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -13,6 +13,7 @@ from datahub.company.models import (
 from datahub.company_referral.models import CompanyReferral
 from datahub.core.exceptions import DataHubError
 from datahub.core.model_helpers import get_related_fields, get_self_referential_relations
+from datahub.dnb_api.utils import _get_rollback_version
 from datahub.interaction.models import Interaction
 from datahub.investment.project.models import InvestmentProject
 from datahub.omis.order.models import Order
@@ -196,6 +197,14 @@ def merge_companies(source_company: Company, target_company: Company, user):
         )
 
         return results
+
+
+def rollback_merge_companies(former_source_company: Company):
+    """
+    Rolls back a company merge of what was the "source_company" passed to merge_companies
+    """
+    rollback_version = _get_rollback_version(former_source_company, 'Company merged')
+    rollback_version.revision.revert()
 
 
 def get_planned_changes(company: Company):

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -737,6 +737,7 @@ class CompanyExportCountry(BaseModel):
         return f'{self.company} {self.country} {self.status}'
 
 
+@reversion.register_base_model()
 class CompanyExportCountryHistory(models.Model):
     """
     Historical log of `CompanyExportCountry` model.

--- a/datahub/company/test/test_merge.py
+++ b/datahub/company/test/test_merge.py
@@ -2,10 +2,12 @@ from datetime import datetime
 from unittest.mock import patch
 
 import pytest
+import reversion
 from django.utils.timezone import utc
 from freezegun import freeze_time
 
 from datahub.company.merge import (
+    ALLOWED_RELATIONS_FOR_MERGING,
     get_planned_changes,
     INVESTMENT_PROJECT_COMPANY_FIELDS,
     merge_companies,
@@ -605,6 +607,11 @@ class TestDuplicateCompanyMerger:
         user = AdviserFactory()
         with pytest.raises(MergeNotAllowedError):
             merge_companies(source_company, target_company, user)
+
+    def test_related_fields_are_versioned(self):
+        for relation in ALLOWED_RELATIONS_FOR_MERGING:
+            assert reversion.is_registered(relation.model), \
+                f'{relation.model} is not registered with reversion'
 
 
 def _company_factory(

--- a/datahub/dbmaintenance/management/commands/rollback_company_merge.py
+++ b/datahub/dbmaintenance/management/commands/rollback_company_merge.py
@@ -1,0 +1,26 @@
+from datahub.company.merge import rollback_merge_companies
+from datahub.company.models import Company
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+
+
+class Command(CSVBaseCommand):
+    """
+    Command to rollback company merges.
+    """
+
+    help = """
+    Rollback company merges.  This consumes a one-column CSV file from S3 which is a
+    list of company IDs to rollback. The command will go through each company, and
+    its related models, and reinstate them to how they were before the merge.
+    """
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        pk = parse_uuid(row['id'])
+        former_source_company = Company.objects.get(pk=pk)
+
+        if simulate:
+            return
+
+        rollback_merge_companies(former_source_company)

--- a/datahub/dbmaintenance/test/commands/test_rollback_company_merge.py
+++ b/datahub/dbmaintenance/test/commands/test_rollback_company_merge.py
@@ -1,0 +1,104 @@
+from io import BytesIO
+
+import pytest
+import reversion
+from django.core.management import call_command
+
+from datahub.company.merge import merge_companies
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.test_utils import create_test_user
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, formatted_dnb_company):
+    """
+    Test that the command successfully rolls back the specified records.
+    """
+    with reversion.create_revision():
+        company_1 = CompanyFactory(duns_number='123456789')
+        company_2 = CompanyFactory(duns_number='223456789')
+        company_3 = CompanyFactory(transferred_to=None)
+        company_4 = CompanyFactory(transferred_to=None)
+
+    user = create_test_user()
+    merge_companies(company_3, company_1, user)
+    merge_companies(company_4, company_2, user)
+
+    company_3.refresh_from_db()
+    company_4.refresh_from_db()
+    assert company_3.transferred_to == company_1
+    assert company_4.transferred_to == company_2
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f'id\n{company_3.id}\n{company_4.id}'
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command(
+        'rollback_company_merge',
+        bucket,
+        object_key,
+    )
+
+    company_3.refresh_from_db()
+    company_4.refresh_from_db()
+    assert company_3.transferred_to is None
+    assert company_4.transferred_to is None
+
+
+def test_simulate(s3_stubber):
+    """
+    Test that the command simulates rollbacks if --simulate is passed in.
+    """
+    with reversion.create_revision():
+        company_1 = CompanyFactory(duns_number='123456789')
+        company_2 = CompanyFactory(duns_number='223456789')
+        company_3 = CompanyFactory(transferred_to=None)
+        company_4 = CompanyFactory(transferred_to=None)
+
+    user = create_test_user()
+    merge_companies(company_3, company_1, user)
+    merge_companies(company_4, company_2, user)
+
+    company_3.refresh_from_db()
+    company_4.refresh_from_db()
+    assert company_3.transferred_to == company_1
+    assert company_4.transferred_to == company_2
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f'id\n{company_3.id}\n{company_4.id}'
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command(
+        'rollback_company_merge',
+        bucket,
+        object_key,
+        simulate=True,
+    )
+
+    company_3.refresh_from_db()
+    company_4.refresh_from_db()
+    assert company_3.transferred_to == company_1
+    assert company_4.transferred_to == company_2

--- a/datahub/user/company_list/models.py
+++ b/datahub/user/company_list/models.py
@@ -38,6 +38,7 @@ class CompanyListItemPermissionCode(StrEnum):
     delete_company_list_item = 'delete_companylistitem'
 
 
+@reversion.register_base_model()
 class CompanyListItem(BaseModel):
     """
     An item on a user's personal list of companies.


### PR DESCRIPTION
### Description of change

This is part of work DEET is doing updating companies based on recommendations from DnB. The current plan is to bulk merge companies, but a way of rolling this back is needed - and without that, we won't merge. Hence we're making this change before adding the ability to bulk merge companies.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
