### PR TITLE
Fix interaction companies in bulk upload

### DIFF
--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -269,6 +269,7 @@ class InteractionCSVRowForm(forms.Form):
         serializer_data = self.cleaned_data_as_serializer_dict()
 
         contacts = serializer_data.pop('contacts')
+        companies = serializer_data.pop('companies')
         dit_participants = serializer_data.pop('dit_participants')
         # Remove `is_event` if it's present as it's a computed field and isn't saved
         # on the model
@@ -283,6 +284,7 @@ class InteractionCSVRowForm(forms.Form):
         interaction.save()
 
         interaction.contacts.add(*contacts)
+        interaction.companies.add(*companies)
 
         for dit_participant in dit_participants:
             InteractionDITParticipant(
@@ -425,6 +427,7 @@ class InteractionCSVRowForm(forms.Form):
             'contacts': [data['contact']],
             'communication_channel': data.get('communication_channel'),
             'company': data['contact'].company,
+            'companies': [data['contact'].company],
             'date': datetime.combine(data['date'], time(), tzinfo=utc),
             'dit_participants': dit_participants,
             'event': data.get('event_id'),

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -1171,6 +1171,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
             'contacts': [contact],
             'communication_channel': communication_channel,
             'company': contact.company,
+            'companies': [contact.company],
             'date': datetime(2018, 1, 1, tzinfo=utc),
             'dit_participants': [
                 {
@@ -1215,6 +1216,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
             'contacts': [contact],
             'communication_channel': None,
             'company': contact.company,
+            'companies': [contact.company],
             'date': datetime(2018, 1, 1, tzinfo=utc),
             'dit_participants': [
                 {
@@ -1276,6 +1278,8 @@ class TestInteractionCSVRowFormSaving:
         assert interaction.created_by == user
         assert interaction.modified_by == user
         assert interaction.source == source
+        assert interaction.company == contact.company
+        assert [company.id for company in interaction.companies.all()] == [contact.company_id]
 
         assert list(interaction.contacts.all()) == [contact]
         assert interaction.dit_participants.count() == 1
@@ -1324,6 +1328,8 @@ class TestInteractionCSVRowFormSaving:
         assert interaction.created_by == user
         assert interaction.modified_by == user
         assert interaction.source == source
+        assert interaction.company == contact.company
+        assert [company.id for company in interaction.companies.all()] == [contact.company_id]
 
         assert list(interaction.contacts.all()) == [contact]
         assert interaction.dit_participants.count() == 2


### PR DESCRIPTION
### Description of change

The interaction bulk upload form does not currently set interaction companies and only the legacy company field. This causes problems as front end expects companies value to be present in some cases. This for instance prevents interactions uploaded through form from being edited etc.

This update ensures that both company and companies fields are set.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
