### PR TITLE
Modify interaction serializer to make has_related_trade_agreement field not mandatory

### DIFF
--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -609,7 +609,7 @@ class InteractionSerializer(BaseInteractionSerializer):
 class InteractionSerializerV4(BaseInteractionSerializer):
     """Interaction Serializer for V4 Endpoint"""
 
-    has_related_trade_agreements = serializers.BooleanField(required=True)
+    has_related_trade_agreements = serializers.BooleanField(required=False)
     related_trade_agreements = NestedRelatedField(
         'metadata.TradeAgreement', many=True, required=True, allow_empty=True,
     )
@@ -736,7 +736,16 @@ class InteractionSerializerV4(BaseInteractionSerializer):
                 ValidationRule(
                     'required',
                     OperatorRule('related_trade_agreements', bool),
-                    when=OperatorRule('has_related_trade_agreements', bool),
+                    when=AndRule(
+                        OperatorRule('has_related_trade_agreements', bool),
+                        InRule(
+                            'theme',
+                            [Interaction.Theme.EXPORT,
+                             Interaction.Theme.TRADE_AGREEMENT,
+                             Interaction.Theme.OTHER,
+                             ],
+                        ),
+                    ),
                 ),
                 ValidationRule(
                     'invalid_when_no_related_trade_agreement',

--- a/datahub/interaction/test/views/test_interaction_v4.py
+++ b/datahub/interaction/test/views/test_interaction_v4.py
@@ -638,7 +638,6 @@ class TestAddInteraction(APITestMixin):
                     'subject': ['This field is required.'],
                     'company': ['This field is required.'],
                     'was_policy_feedback_provided': ['This field is required.'],
-                    'has_related_trade_agreements': ['This field is required.'],
                     'related_trade_agreements': ['This field is required.'],
                 },
             ),
@@ -789,6 +788,36 @@ class TestAddInteraction(APITestMixin):
                     'contacts': [
                         lambda: ContactFactory(
                             company=Company.objects.get(name='Martian Island'),
+                        ),
+                    ],
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
+                    'service': Service.inbound_referral.value.id,
+                    'communication_channel': partial(
+                        random_obj_for_model,
+                        CommunicationChannel,
+                    ),
+                    'was_policy_feedback_provided': False,
+                    'has_related_trade_agreements': True,
+                    'related_trade_agreements': [],
+                },
+                {
+                    'related_trade_agreements': ['This field is required.'],
+                },
+            ),
+            # related trade agreements field cannot be blank
+            # when has_related_trade_agreements is true for Export, Trade Agreement and Other theme
+            (
+                {
+                    'kind': Interaction.Kind.INTERACTION,
+                    'theme': Interaction.Theme.TRADE_AGREEMENT,
+                    'date': date.today().isoformat(),
+                    'subject': 'whatever',
+                    'company': lambda: CompanyFactory(name='Martian Explore Ltd'),
+                    'contacts': [
+                        lambda: ContactFactory(
+                            company=Company.objects.get(name='Martian Explore Ltd'),
                         ),
                     ],
                     'dit_participants': [
@@ -1520,6 +1549,38 @@ class TestAddInteraction(APITestMixin):
                     ),
                     'was_policy_feedback_provided': False,
                     'has_related_trade_agreements': False,
+                    'related_trade_agreements': [],
+                    'were_countries_discussed': True,
+                },
+                {
+                    'were_countries_discussed': [
+                        "This value can't be selected for investment interactions.",
+                    ],
+                },
+            ),
+            # were_countries_discussed can't be true for investment theme
+            # with non-required has_related_trade_agreements field
+            (
+                {
+                    'theme': Interaction.Theme.INVESTMENT,
+                    'kind': Interaction.Kind.INTERACTION,
+                    'date': date.today().isoformat(),
+                    'subject': 'whatever',
+                    'company': lambda: CompanyFactory(name='Martian Explore Ltd'),
+                    'contacts': [
+                        lambda: ContactFactory(
+                            company=Company.objects.get(name='Martian Explore Ltd'),
+                        ),
+                    ],
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
+                    'service': Service.inbound_referral.value.id,
+                    'communication_channel': partial(
+                        random_obj_for_model,
+                        CommunicationChannel,
+                    ),
+                    'was_policy_feedback_provided': False,
                     'related_trade_agreements': [],
                     'were_countries_discussed': True,
                 },


### PR DESCRIPTION
### Description of change
The aim of this PR is to remove the question and so reduce the time it takes users to create Investment-type interactions. (note: this applies to both “standard” Investment type interactions, and those created from an investment project)

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [X] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [X] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
