### PR TITLE
Add export_barrier_type field to interaction bulk upload.

### DIFF
--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -471,6 +471,10 @@ class ExportSubSegment(Enum):
 class ExportBarrierType(Enum):
     """Interaction export barrier type constant."""
 
+    capacity = Constant(
+        'Capacity', 'd0c8fe10-dd29-4e39-a422-80dd111199e7',
+    )
+
     finance = Constant(
         'Finance', '758c4132-a07b-4e4d-a43d-f2f630113023',
     )

--- a/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
@@ -48,6 +48,7 @@
         <th>{% trans 'Event' %}</th>
         <th>{% trans 'Subject' %}</th>
         <th>{% trans 'Notes' %}</th>
+        <th>{% trans 'Export barrier type' %}</th>
       </tr>
     </thead>
   {% for row in matched_rows %}
@@ -74,6 +75,10 @@
       <td>{{ row.event }}</td>
       <td>{{ row.subject }}</td>
       <td>{{ row.notes }}</td>
+      <td>{% for barrier_type in row.export_barrier_type %}
+        {% if not forloop.first %}<br>{%  endif %}
+        {{ barrier_type.name }}
+      {% endfor %}</td>
     </tr>
 
   {% endfor %}

--- a/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
@@ -38,7 +38,7 @@
     <tr>
       <td><code>{% trans 'service' %}</code></td>
       <td>{{ yes }}</td>
-      <td>{% trans 'The name of the service of the interaction e.g. <code>Account Management</code>' %}</td>
+      <td>{% trans 'The name of the service of the interaction e.g. <code>Account management</code>' %}</td>
     </tr>
     <tr>
       <td><code>{% trans 'service_answer' %}</code></td>
@@ -53,7 +53,7 @@
     <tr>
       <td><code>{% trans 'adviser_1' %}</code></td>
       <td>{{ yes }}</td>
-      <td>{% trans 'The full name of a DIT adviser' %}</td>
+      <td>{% trans 'The full name of a DBT adviser' %}</td>
     </tr>
     <tr>
       <td><code>{% trans 'team_1' %}</code></td>
@@ -89,6 +89,11 @@
       <td><code>{% trans 'notes' %}</code></td>
       <td>{{ no }}</td>
       <td>{% trans 'Notes about the interaction' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'export_barrier_type' %}</code></td>
+      <td>{{ no }}</td>
+      <td>{% trans 'For the export theme, if any assistance given in removing export barriers then specify Access, Capacity, Finance, Knowledge or a combination. For multiple, use quotes and commas like "Access,Capacity"' %}</td>
     </tr>
   </table>
 


### PR DESCRIPTION
### Description of change

This adds "Export barrier type" support for interaction bulk upload.

<img width="1086" alt="Screenshot 2023-06-16 at 13 04 12" src="https://github.com/uktrade/data-hub-api/assets/5889630/d819588e-257f-416c-86bd-527b2fab5e7e">

If the theme of interaction is export, then "Helped remove export barrier" becomes answered "Yes" if at least one export barrier type is provided. If export barrier type is empty, then helped remove export barrier becomes "No".

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
