### PR TITLE
Fix flaky test

### DIFF
--- a/datahub/company/test/test_export_views.py
+++ b/datahub/company/test/test_export_views.py
@@ -1,6 +1,8 @@
 import datetime
 import uuid
 
+from operator import attrgetter, itemgetter
+
 import pytest
 
 from dateutil.parser import parse
@@ -836,8 +838,12 @@ class TestExportOwnerList(APITestMixin):
 
         response = self.api_client.get(url)
         response_data = response.json()
+        response_data.sort(key=itemgetter('id'))
+
+        owners = [self.user, other_owner]
+        owners.sort(key=attrgetter('id'))
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response_data) == 2
-        assert response_data[0]['id'] == str(other_owner.id)
-        assert response_data[1]['id'] == str(self.user.id)
+        assert response_data[0]['id'] == str(owners[0].id)
+        assert response_data[1]['id'] == str(owners[1].id)


### PR DESCRIPTION
### Description of change
Fixes a flaky test that depended on an array of owners (AKA advisers) being in a certain order. This fix simply sorts both arrays (`response_data` and `owner`) on owner id before comparing the ids for equality.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
