### PR TITLE
Mark interaction questions to be optional

### DIFF
--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -769,17 +769,6 @@ class InteractionSerializerV4(BaseInteractionSerializer):
                 ),
                 ValidationRule(
                     'required',
-                    OperatorRule('were_countries_discussed', is_not_blank),
-                    when=AndRule(
-                        IsObjectBeingCreated(),
-                        InRule(
-                            'theme',
-                            [Interaction.Theme.EXPORT, Interaction.Theme.OTHER],
-                        ),
-                    ),
-                ),
-                ValidationRule(
-                    'required',
                     OperatorRule('export_countries', is_not_blank),
                     when=AndRule(
                         OperatorRule('were_countries_discussed', bool),

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -609,7 +609,6 @@ class InteractionSerializer(BaseInteractionSerializer):
 class InteractionSerializerV4(BaseInteractionSerializer):
     """Interaction Serializer for V4 Endpoint"""
 
-    has_related_trade_agreements = serializers.BooleanField(required=False)
     related_trade_agreements = NestedRelatedField(
         'metadata.TradeAgreement', many=True, required=True, allow_empty=True,
     )

--- a/datahub/interaction/test/views/test_interaction_v4.py
+++ b/datahub/interaction/test/views/test_interaction_v4.py
@@ -836,7 +836,8 @@ class TestAddInteraction(APITestMixin):
                     'related_trade_agreements': ['This field is required.'],
                 },
             ),
-            # were_countries_discussed can't be null for export interactions
+            # export_countries cannot be blank when
+            # were_countries_discussed is True for Export theme
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
@@ -853,124 +854,26 @@ class TestAddInteraction(APITestMixin):
                         {'adviser': AdviserFactory},
                     ],
                     'service': Service.inbound_referral.value.id,
-                    'was_policy_feedback_provided': False,
                     'communication_channel': partial(
                         random_obj_for_model,
                         CommunicationChannel,
                     ),
-                    'were_countries_discussed': None,
+                    'was_policy_feedback_provided': False,
+                    'were_countries_discussed': True,
+                    'export_countries': None,
                     'has_related_trade_agreements': False,
                     'related_trade_agreements': [],
                 },
                 {
-                    'were_countries_discussed': ['This field is required.'],
+                    'export_countries': ['This field may not be null.'],
                 },
             ),
-            # were_countries_discussed can't be null for other interactions
+            # export_countries cannot be blank when
+            # were_countries_discussed is True for Other theme
             (
                 {
                     'kind': Interaction.Kind.INTERACTION,
                     'theme': Interaction.Theme.OTHER,
-                    'date': date.today().isoformat(),
-                    'subject': 'whatever',
-                    'company': lambda: CompanyFactory(name='Martian Island'),
-                    'contacts': [
-                        lambda: ContactFactory(
-                            company=Company.objects.get(name='Martian Island'),
-                        ),
-                    ],
-                    'dit_participants': [
-                        {'adviser': AdviserFactory},
-                    ],
-                    'service': Service.inbound_referral.value.id,
-                    'communication_channel': partial(
-                        random_obj_for_model,
-                        CommunicationChannel,
-                    ),
-                    'was_policy_feedback_provided': False,
-                    'were_countries_discussed': None,
-                    'has_related_trade_agreements': False,
-                    'related_trade_agreements': [],
-                },
-                {
-                    'were_countries_discussed': ['This field is required.'],
-                },
-            ),
-            # were_countries_discussed can't be missing for export/other interactions
-            (
-                {
-                    'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.Theme.EXPORT,
-                    'date': date.today().isoformat(),
-                    'subject': 'whatever',
-                    'company': lambda: CompanyFactory(name='Martian Island'),
-                    'contacts': [
-                        lambda: ContactFactory(
-                            company=Company.objects.get(name='Martian Island'),
-                        ),
-                    ],
-                    'dit_participants': [
-                        {'adviser': AdviserFactory},
-                    ],
-                    'service': Service.inbound_referral.value.id,
-                    'communication_channel': partial(
-                        random_obj_for_model,
-                        CommunicationChannel,
-                    ),
-                    'was_policy_feedback_provided': False,
-                    'has_related_trade_agreements': False,
-                    'related_trade_agreements': [],
-                },
-                {
-                    'were_countries_discussed': ['This field is required.'],
-                },
-            ),
-            # were_countries_discussed can't be missing when sending export_countries
-            (
-                {
-                    'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.Theme.EXPORT,
-                    'date': date.today().isoformat(),
-                    'subject': 'whatever',
-                    'company': lambda: CompanyFactory(name='Martian Island'),
-                    'contacts': [
-                        lambda: ContactFactory(
-                            company=Company.objects.get(name='Martian Island'),
-                        ),
-                    ],
-                    'dit_participants': [
-                        {'adviser': AdviserFactory},
-                    ],
-                    'service': Service.inbound_referral.value.id,
-                    'communication_channel': partial(
-                        random_obj_for_model,
-                        CommunicationChannel,
-                    ),
-                    'was_policy_feedback_provided': False,
-                    'were_countries_discussed': None,
-                    'export_countries': [
-                        {
-                            'country': {
-                                'id': Country.canada.value.id,
-                            },
-                            'status': CompanyExportCountry.Status.CURRENTLY_EXPORTING,
-                        },
-                    ],
-                    'has_related_trade_agreements': False,
-                    'related_trade_agreements': [],
-                },
-                {
-                    'were_countries_discussed': ['This field is required.'],
-                    'export_countries': [
-                        'This field is only valid when countries were discussed.',
-                    ],
-                },
-            ),
-            # export_countries cannot be blank when were_countries_discussed is True
-            (
-                {
-                    'kind': Interaction.Kind.INTERACTION,
-                    'theme': Interaction.Theme.EXPORT,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': lambda: CompanyFactory(name='Martian Island'),

--- a/datahub/interaction/test/views/test_interaction_v4.py
+++ b/datahub/interaction/test/views/test_interaction_v4.py
@@ -1356,7 +1356,6 @@ class TestAddInteraction(APITestMixin):
                     'dit_participants': ['This field may not be null.'],
                     'was_policy_feedback_provided': ['This field may not be null.'],
                     'policy_feedback_notes': ['This field may not be null.'],
-                    'has_related_trade_agreements': ['This field may not be null.'],
                     'related_trade_agreements': ['This field may not be null.'],
                 },
             ),


### PR DESCRIPTION
### Description of change


The aim of this ticket is to mark some of the questions as optional(frontend) so that users don’t have to click no every single time. These questions are:
Related named trade agreement?
Countries discussed (only displays for Export-type interactions)?

The implementations also being covered a data field validation at the backend.



### Checklist

* [X] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
