### PR TITLE
feature/CLS2-215-cache-dnb-data

### DIFF
--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -642,7 +642,7 @@ class TestDNBHierarchyData:
     """
 
     VALID_DUNS_NUMBER = '123456789'
-    FAMILY_TREE_CACHE_KEY = f'family_tree_${VALID_DUNS_NUMBER}'
+    FAMILY_TREE_CACHE_KEY = f'family_tree_{VALID_DUNS_NUMBER}'
 
     @override_settings(DNB_SERVICE_BASE_URL=None)
     def test_dnb_hierarchy_improperly_configured_url_error(self):

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -641,7 +641,7 @@ class TestDNBHierarchyData:
     Tests for DNB Hierarchy function.
     """
 
-    VALID_DUNS_NUMBER = "123456789"
+    VALID_DUNS_NUMBER = '123456789'
     FAMILY_TREE_CACHE_KEY = f'family_tree_${VALID_DUNS_NUMBER}'
 
     @override_settings(DNB_SERVICE_BASE_URL=None)
@@ -671,7 +671,8 @@ class TestDNBHierarchyData:
 
     @pytest.mark.usefixtures('local_memory_cache')
     def test_when_called_multiple_times_only_first_call_makes_an_api_call_to_dnb(
-        self, requests_mock
+        self,
+        requests_mock,
     ):
         """
         Test that after a successful call to the dnb api, all subsequent calls to the
@@ -694,7 +695,7 @@ class TestDNBHierarchyData:
         """
         Test when a value is stored in the cache the dnb api is not called
         """
-        cache.set(self.FAMILY_TREE_CACHE_KEY, "cached")
+        cache.set(self.FAMILY_TREE_CACHE_KEY, 'cached')
 
         matcher = requests_mock.post(
             DNB_HIERARCHY_SEARCH_URL,
@@ -703,22 +704,22 @@ class TestDNBHierarchyData:
         )
 
         result = get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
-        assert result == "cached"
+        assert result == 'cached'
 
         get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
         get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
 
         assert not matcher.called
 
+    @pytest.mark.usefixtures('local_memory_cache')
     def test_when_dnb_api_error_response_is_not_cached(self, requests_mock):
         """
         Test when the dnb api doesn't return a success http status code the value is not cached
         """
-
         requests_mock.post(
             DNB_HIERARCHY_SEARCH_URL,
             status_code=500,
-            content=b'{}',
+            content=b'{"family_tree_members":[]}',
         )
         get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
         assert cache.get(self.FAMILY_TREE_CACHE_KEY) is None

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -552,7 +552,6 @@ def get_company_hierarchy_data(duns_number):
     cache_value = cache.get(cache_key)
 
     if cache_value:
-        print("USING CACHED VALUE")
         return cache_value
     api_client = _get_api_client()
 
@@ -563,13 +562,14 @@ def get_company_hierarchy_data(duns_number):
         timeout=3.0,
     )
 
+    response_data = response.json()
+
     # only cache successful dnb calls
     if response.status_code == status.HTTP_200_OK:
-        print("SAVE VALUE IN CACHE")
         one_day_timeout = int(timedelta(days=1).total_seconds())
-        cache.set(cache_key, response.json(), one_day_timeout)
+        cache.set(cache_key, response_data, one_day_timeout)
 
-    return response.json()
+    return response_data
 
 
 def is_valid_uuid(value):

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -1,11 +1,14 @@
 import logging
 import uuid
 
+from datetime import timedelta
+
 import numpy as np
 import pandas as pd
 
+
 import reversion
-from datetime import timedelta
+
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -5,11 +5,14 @@ import numpy as np
 import pandas as pd
 
 import reversion
+from datetime import timedelta
 from django.conf import settings
+from django.core.cache import cache
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.timezone import now
 from requests.exceptions import ConnectionError, Timeout
 from rest_framework import serializers, status
+
 from reversion.models import Version
 
 from datahub.core import statsd
@@ -538,14 +541,20 @@ def _get_api_client(request=None):
     )
 
 
-def get_company_hierarchy_data(duns_number, request=None):
+def get_company_hierarchy_data(duns_number):
     """
     Get company hierarchy data
     """
     if not settings.DNB_SERVICE_BASE_URL:
         raise ImproperlyConfigured('The setting DNB_SERVICE_BASE_URL has not been set')
 
-    api_client = _get_api_client(request)
+    cache_key = f'family_tree_${duns_number}'
+    cache_value = cache.get(cache_key)
+
+    if cache_value:
+        print("USING CACHED VALUE")
+        return cache_value
+    api_client = _get_api_client()
 
     response = api_client.request(
         'POST',
@@ -553,6 +562,12 @@ def get_company_hierarchy_data(duns_number, request=None):
         json={'duns_number': duns_number},
         timeout=3.0,
     )
+
+    # only cache successful dnb calls
+    if response.status_code == status.HTTP_200_OK:
+        print("SAVE VALUE IN CACHE")
+        one_day_timeout = int(timedelta(days=1).total_seconds())
+        cache.set(cache_key, response.json(), one_day_timeout)
 
     return response.json()
 

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -551,7 +551,7 @@ def get_company_hierarchy_data(duns_number):
     if not settings.DNB_SERVICE_BASE_URL:
         raise ImproperlyConfigured('The setting DNB_SERVICE_BASE_URL has not been set')
 
-    cache_key = f'family_tree_${duns_number}'
+    cache_key = f'family_tree_{duns_number}'
     cache_value = cache.get(cache_key)
 
     if cache_value:


### PR DESCRIPTION
The dnb family tree data does not change very often, and we are charged for each call we make to it. This change caches that data for 1 day in redis

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
