### PR TITLE
Add company number to search

### DIFF
--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -37,6 +37,7 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
     one_list_tier = SingleOrListField(child=StringUUIDField(), required=False)
     duns_number = SingleOrListField(child=serializers.CharField(), required=False)
     number_of_employees = serializers.IntegerField(required=False)
+    company_number = SingleOrListField(child=serializers.CharField(), required=False)
 
     SORT_BY_FIELDS = (
         'modified_on',

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -59,6 +59,7 @@ class SearchCompanyAPIViewMixin:
         'export_sub_segment',
         'one_list_tier',
         'duns_number',
+        'company_number',
     )
 
     REMAP_FIELDS = {


### PR DESCRIPTION
### Description of change

Allow searching of a company by its company number (AKA the Companies House number) when using the company search API endpoint. This is needed for an upcoming piece of React work.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
