### PR TITLE
bugfix/CLS2-199-append-missed-opensearch-field

### DIFF
--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -2515,7 +2515,7 @@ class TestCompanyHierarchyView(APITestMixin):
                 'duns_number': ultimate_company_dnb['duns'],
                 'id': ultimate_company_dh.id,
                 'name': ultimate_company_dh.name,
-                'numberOfEmployees': None,
+                'number_of_employees': ultimate_company_dh.number_of_employees,
                 'address': {
                     'country': {
                         'id': str(ultimate_company_dh.address_country.id),
@@ -2546,6 +2546,7 @@ class TestCompanyHierarchyView(APITestMixin):
                     'id': str(ultimate_company_dh.uk_region.id),
                     'name': ultimate_company_dh.uk_region.name,
                 },
+                'one_list_tier': None,
                 'archived': False,
                 'latest_interaction_date': None,
                 'hierarchy': 1,
@@ -2569,6 +2570,7 @@ class TestCompanyHierarchyView(APITestMixin):
             'duns': '987654321',
             'primaryName': faker.company(),
             'corporateLinkage': {'hierarchyLevel': 1},
+            'numberOfEmployees': [{'value': 400}],
         }
         tree_member_level_2 = {
             'duns': '123456789',
@@ -2598,6 +2600,7 @@ class TestCompanyHierarchyView(APITestMixin):
             id='8e2e9b35-3415-4b9b-b9ff-f97446ac8942',
             duns_number=ultimate_tree_member_level_1['duns'],
             archived=True,
+            number_of_employees=5000,
         )
 
         opensearch_with_signals.indices.refresh()
@@ -2608,7 +2611,7 @@ class TestCompanyHierarchyView(APITestMixin):
             'ultimate_global_company': {
                 'duns_number': ultimate_tree_member_level_1['duns'],
                 'name': ultimate_company_dh.name,
-                'numberOfEmployees': None,
+                'number_of_employees': 400,
                 'id': ultimate_company_dh.id,
                 'address': {
                     'country': {
@@ -2640,6 +2643,7 @@ class TestCompanyHierarchyView(APITestMixin):
                     'id': str(ultimate_company_dh.uk_region.id),
                     'name': ultimate_company_dh.uk_region.name,
                 },
+                'one_list_tier': None,
                 'archived': True,
                 'latest_interaction_date': None,
                 'hierarchy': 1,
@@ -2648,11 +2652,14 @@ class TestCompanyHierarchyView(APITestMixin):
                         'duns_number': tree_member_level_2['duns'],
                         'id': None,
                         'name': tree_member_level_2['primaryName'],
-                        'numberOfEmployees': tree_member_level_2['numberOfEmployees'][0]['value'],
+                        'number_of_employees': tree_member_level_2['numberOfEmployees'][0][
+                            'value'
+                        ],
                         'address': None,
                         'registered_address': None,
                         'sector': None,
                         'uk_region': None,
+                        'one_list_tier': None,
                         'archived': False,
                         'latest_interaction_date': None,
                         'hierarchy': 2,
@@ -2661,11 +2668,12 @@ class TestCompanyHierarchyView(APITestMixin):
                                 'duns_number': tree_member_level_3['duns'],
                                 'id': None,
                                 'name': tree_member_level_3['primaryName'],
-                                'numberOfEmployees': None,
+                                'number_of_employees': None,
                                 'address': None,
                                 'registered_address': None,
                                 'sector': None,
                                 'uk_region': None,
+                                'one_list_tier': None,
                                 'archived': False,
                                 'latest_interaction_date': None,
                                 'hierarchy': 3,

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -13,7 +13,7 @@ from requests.exceptions import ConnectionError, Timeout
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.company.models import Company, CompanyPermission
+from datahub.company.models import Company, CompanyPermission, OneListTier
 from datahub.company.test.factories import CompanyFactory
 from datahub.core import constants
 from datahub.core.serializers import AddressSerializer
@@ -2504,6 +2504,7 @@ class TestCompanyHierarchyView(APITestMixin):
             duns_number=ultimate_company_dnb['duns'],
             id='8e2e9b35-3415-4b9b-b9ff-f97446ac8942',
             name=ultimate_company_dnb['primaryName'],
+            one_list_tier=OneListTier.objects.first(),
         )
         opensearch_with_signals.indices.refresh()
 
@@ -2546,7 +2547,10 @@ class TestCompanyHierarchyView(APITestMixin):
                     'id': str(ultimate_company_dh.uk_region.id),
                     'name': ultimate_company_dh.uk_region.name,
                 },
-                'one_list_tier': None,
+                'one_list_tier': {
+                    'id': str(ultimate_company_dh.one_list_tier.id),
+                    'name': ultimate_company_dh.one_list_tier.name,
+                },
                 'archived': False,
                 'latest_interaction_date': None,
                 'hierarchy': 1,

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -628,6 +628,9 @@ def create_company_hierarchy_dataframe(family_tree_members: list):
     _merge_columns_into_single_column(normalized_df, 'sector', ['sector.id', 'sector.name'])
     _merge_columns_into_single_column(normalized_df, 'ukRegion', ['ukRegion.id', 'ukRegion.name'])
     _merge_columns_into_single_column(
+        normalized_df, 'oneListTier', ['oneListTier.id', 'oneListTier.name']
+    )
+    _merge_columns_into_single_column(
         normalized_df,
         'address',
         [
@@ -693,7 +696,7 @@ def append_datahub_details(family_tree_members: list):
         if isinstance(number_of_employees, list):
             family_member['numberOfEmployees'] = number_of_employees[0].get('value')
         for datahub_detail in family_tree_members_datahub_details:
-            if duns_number_to_find == datahub_detail['duns_number']:
+            if duns_number_to_find == datahub_detail.get('duns_number'):
                 family_member['primaryName'] = datahub_detail.get('name')
                 family_member['companyId'] = datahub_detail.get('id')
                 family_member['ukRegion'] = datahub_detail.get('uk_region')
@@ -704,6 +707,9 @@ def append_datahub_details(family_tree_members: list):
                     'latest_interaction_date',
                 )
                 family_member['archived'] = datahub_detail.get('archived')
+                family_member['oneListTier'] = datahub_detail.get('one_list_tier')
+                if not number_of_employees:
+                    family_member['numberOfEmployees'] = datahub_detail.get('number_of_employees')
                 break  # Stop once we've found the match
 
 
@@ -715,6 +721,19 @@ def _load_datahub_details(family_tree_members_duns):
         [SearchCompany],
         term='',
         filter_data={'duns_number': family_tree_members_duns},
+        fields_to_include=(
+            'id',
+            'name',
+            'duns_number',
+            'uk_region',
+            'address',
+            'registered_address',
+            'sector',
+            'latest_interaction_date',
+            'archived',
+            'one_list_tier',
+            'number_of_employees',
+        ),
     ).execute()
 
     return [x.to_dict() for x in opensearch_results.hits]

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -628,7 +628,9 @@ def create_company_hierarchy_dataframe(family_tree_members: list):
     _merge_columns_into_single_column(normalized_df, 'sector', ['sector.id', 'sector.name'])
     _merge_columns_into_single_column(normalized_df, 'ukRegion', ['ukRegion.id', 'ukRegion.name'])
     _merge_columns_into_single_column(
-        normalized_df, 'oneListTier', ['oneListTier.id', 'oneListTier.name']
+        normalized_df,
+        'oneListTier',
+        ['oneListTier.id', 'oneListTier.name'],
     )
     _merge_columns_into_single_column(
         normalized_df,

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -693,7 +693,7 @@ def append_datahub_details(family_tree_members: list):
         family_member['sector'] = empty_id_name
         family_member['latestInteractionDate'] = None
         family_member['archived'] = False
-        family_member['oneListTier'] = None
+        family_member['oneListTier'] = empty_id_name
         number_of_employees = family_member.get('numberOfEmployees')
         if isinstance(number_of_employees, list):
             family_member['numberOfEmployees'] = number_of_employees[0].get('value')

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -440,7 +440,8 @@ class DNBCompanyHierarchyView(APIView):
                 'sector': 'sector',
                 'latestInteractionDate': 'latest_interaction_date',
                 'archived': 'archived',
-                'numberOfEmployees': 'numberOfEmployees',
+                'numberOfEmployees': 'number_of_employees',
+                'oneListTier': 'one_list_tier',
             },
         )
 


### PR DESCRIPTION
### Description of change

- Add the missing one list tier field to the response
- Rename the incorrectly named `numberOfEmployees` to `number_of_employees`

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
