### PR TITLE
feature/CLS2-199-send-batch-requests-to-opensearch

### DIFF
--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -717,47 +717,28 @@ def append_datahub_details(family_tree_members: list):
                 break  # Stop once we've found the match
 
 
-def _batch_list(list, number_items):
-    """
-    Create a list of lists, with the maximum number of items in each list set to the number
-    provided in number_items
-
-    Args:
-        list (_type_): The list to create a batch of lists from
-        number_items (_type_): The maximum number of items
-
-    Returns:
-        A list of lists, with each inner list containing at most the number_items. The final inner
-        list may contain less then the number_items
-    """
-    list = iter(list)
-    return iter(lambda: tuple(islice(list, number_items)), ())
-
-
 def _load_datahub_details(family_tree_members_duns):
     """
     Load any known datahub details for the duns numbers provided
     """
-    results = []
-    for batch_of_duns_numbers in _batch_list(family_tree_members_duns, 100):
-        query = get_search_by_entities_query(
-            [SearchCompany],
-            term='',
-            filter_data={'duns_number': list(batch_of_duns_numbers)},
-            fields_to_include=(
-                'id',
-                'name',
-                'duns_number',
-                'uk_region',
-                'address',
-                'registered_address',
-                'sector',
-                'latest_interaction_date',
-                'archived',
-                'one_list_tier',
-                'number_of_employees',
-            ),
-        )
-        opensearch_results = execute_search_query(query)
-        results.extend(opensearch_results.hits)
-    return [x.to_dict() for x in results]
+
+    query = get_search_by_entities_query(
+        [SearchCompany],
+        term='',
+        filter_data={'duns_number': list(family_tree_members_duns)},
+        fields_to_include=(
+            'id',
+            'name',
+            'duns_number',
+            'uk_region',
+            'address',
+            'registered_address',
+            'sector',
+            'latest_interaction_date',
+            'archived',
+            'one_list_tier',
+            'number_of_employees',
+        ),
+    )
+    for hit in query.scan():
+        yield hit.to_dict()

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -672,9 +672,7 @@ def append_datahub_details(family_tree_members: list):
     Appended any known datahub details to the list of family tree members provided
     """
     family_tree_members_duns = [object['duns'] for object in family_tree_members]
-
-    family_tree_members_datahub_details = _load_datahub_details(family_tree_members_duns)
-
+    family_tree_members_datahub_details = load_datahub_details(family_tree_members_duns)
     empty_address = {
         'line_1': None,
         'line_2': None,
@@ -731,7 +729,7 @@ def _batch_list(list, number_items):
     return iter(lambda: tuple(islice(list, number_items)), ())
 
 
-def _load_datahub_details(family_tree_members_duns):
+def load_datahub_details(family_tree_members_duns):
     """
     Load any known datahub details for the duns numbers provided
     """

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -763,4 +763,4 @@ def load_datahub_details(family_tree_members_duns):
         opensearch_results = execute_search_query(query)
         results.extend(opensearch_results.hits)
 
-    return [x.to_dict() for x in results]
+    return [result.to_dict() for result in results]

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -2,7 +2,6 @@ import logging
 import uuid
 
 from datetime import timedelta
-from itertools import islice
 
 import numpy as np
 import pandas as pd
@@ -30,7 +29,6 @@ from datahub.dnb_api.constants import (
 from datahub.dnb_api.serializers import DNBCompanySerializer
 from datahub.metadata.models import AdministrativeArea, Country
 from datahub.search.company.models import Company as SearchCompany
-from datahub.search.execute_query import execute_search_query
 from datahub.search.query_builder import (
     get_search_by_entities_query,
 )
@@ -721,7 +719,6 @@ def _load_datahub_details(family_tree_members_duns):
     """
     Load any known datahub details for the duns numbers provided
     """
-
     query = get_search_by_entities_query(
         [SearchCompany],
         term='',

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -31,9 +31,10 @@ from datahub.dnb_api.serializers import DNBCompanySerializer
 from datahub.metadata.models import AdministrativeArea, Country
 from datahub.search.company.models import Company as SearchCompany
 from datahub.search.execute_query import execute_search_query
-from datahub.search.query_builder import get_search_by_entities_query, MAX_RESULTS
+from datahub.search.query_builder import get_search_by_entities_query
 
 logger = logging.getLogger(__name__)
+MAX_DUNS_NUMBERS_PER_REQUEST = 1024
 
 
 class DNBServiceBaseError(Exception):
@@ -737,11 +738,11 @@ def _load_datahub_details(family_tree_members_duns):
     # Because of the way the get_search_by_entities_query creates an opensearch query, which is
     # to convert every duns number into a separate match filter, we need to batch the opensearch
     # queries so only 1024 are sent at a time
-    MAX_DUNS_NUMBERS_PER_REQUEST = 1024
 
     results = []
     for batch_of_duns_numbers in _batch_list(
-        family_tree_members_duns, MAX_DUNS_NUMBERS_PER_REQUEST
+        family_tree_members_duns,
+        MAX_DUNS_NUMBERS_PER_REQUEST,
     ):
         query = get_search_by_entities_query(
             [SearchCompany],

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -721,16 +721,25 @@ def _load_datahub_details(family_tree_members_duns):
     Load any known datahub details for the duns numbers provided
     """
 
-    def batch_list(arr_range, arr_size):
-        arr_range = iter(arr_range)
-        return iter(lambda: tuple(islice(arr_range, arr_size)), ())
+    def batch_list(list, number_items):
+        """_summary_
+
+        Args:
+            list (_type_): The list to create a batch of lists from
+            number_items (_type_): The maximum number of items
+
+        Returns:
+            A list of lists, with each inner list containing at most the number_items. The final inner list may contain less then the number_items
+        """
+        list = iter(list)
+        return iter(lambda: tuple(islice(list, number_items)), ())
 
     results = []
     for batch_of_duns_numbers in batch_list(family_tree_members_duns, 100):
         opensearch_results = get_search_by_entities_query(
             [SearchCompany],
             term='',
-            filter_data={'duns_number': list(batch_of_duns_numbers)},
+            filter_data={'duns_number': batch_of_duns_numbers},
             fields_to_include=(
                 'id',
                 'name',


### PR DESCRIPTION
Because of the way the `get_search_by_entities_query` functions creates an opensearch query, which is to convert every duns number into a separate match filter, we need to batch the opensearch queries so only 1024 are sent at a time.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
