### PR TITLE
Merge all instances from inactive to active adviser

### DIFF
--- a/datahub/dbmaintenance/management/commands/merge_adviser.py
+++ b/datahub/dbmaintenance/management/commands/merge_adviser.py
@@ -8,7 +8,7 @@ from datahub.event.models import Event
 from datahub.interaction.models import InteractionDITParticipant
 from datahub.investment.investor_profile.models import LargeCapitalInvestorProfile
 from datahub.investment.opportunity.models import LargeCapitalOpportunity
-from datahub.investment.project.proposition.models import PropositionDocumentPermission
+from datahub.investment.project.proposition.models import Proposition
 from datahub.user.company_list.models import CompanyList, PipelineItem
 from datahub.user_event_log.models import UserEvent
 
@@ -30,7 +30,7 @@ class Command(BaseCommand):
             active_advisor = Advisor.objects.get(id=active_advisor_id, is_active=True)
         except Advisor.DoesNotExist as e:
             self.stderr.write(self.style.ERROR(str(e)))
-            return
+            raise
 
         # Dictionary of models and their respective fields that refer to Advisor
         model_fields_dict = {
@@ -40,7 +40,7 @@ class Command(BaseCommand):
             Event: ['organiser'],
             LargeCapitalInvestorProfile: ['required_checks_conducted_by'],
             LargeCapitalOpportunity: ['required_checks_conducted_by'],
-            PropositionDocumentPermission: ['adviser'],
+            Proposition: ['adviser'],
             CompanyList: ['adviser'],
             PipelineItem: ['adviser'],
             UserEvent: ['adviser'],

--- a/datahub/dbmaintenance/management/commands/merge_adviser.py
+++ b/datahub/dbmaintenance/management/commands/merge_adviser.py
@@ -1,0 +1,65 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from datahub.company.models import Advisor
+from datahub.company.models import OneListCoreTeamMember
+from datahub.company_referral.models import CompanyReferral
+from datahub.event.models import Event
+from datahub.interaction.models import InteractionDITParticipant
+from datahub.investment.investor_profile.models import LargeCapitalInvestorProfile
+from datahub.investment.opportunity.models import LargeCapitalOpportunity
+from datahub.investment.project.proposition.models import PropositionDocumentPermission
+from datahub.user.company_list.models import CompanyList, PipelineItem
+from datahub.user_event_log.models import UserEvent
+
+
+class Command(BaseCommand):
+    help = 'Merges inactive advisor with active in all models, then deletes the inactive advisor'
+
+    def add_arguments(self, parser):
+        parser.add_argument('inactive_advisor_id', type=str, help='UUID of the inactive advisor')
+        parser.add_argument('active_advisor_id', type=str, help='UUID of the active advisor')
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        inactive_advisor_id = options['inactive_advisor_id']
+        active_advisor_id = options['active_advisor_id']
+
+        try:
+            inactive_advisor = Advisor.objects.get(id=inactive_advisor_id, is_active=False)
+            active_advisor = Advisor.objects.get(id=active_advisor_id, is_active=True)
+        except Advisor.DoesNotExist as e:
+            self.stderr.write(self.style.ERROR(str(e)))
+            return
+
+        # Dictionary of models and their respective fields that refer to Advisor
+        model_fields_dict = {
+            InteractionDITParticipant: ['adviser'],
+            OneListCoreTeamMember: ['adviser'],
+            CompanyReferral: ['recipient', 'completed_by'],
+            Event: ['organiser'],
+            LargeCapitalInvestorProfile: ['required_checks_conducted_by'],
+            LargeCapitalOpportunity: ['required_checks_conducted_by'],
+            PropositionDocumentPermission: ['adviser'],
+            CompanyList: ['adviser'],
+            PipelineItem: ['adviser'],
+            UserEvent: ['adviser'],
+        }
+
+        for model, fields in model_fields_dict.items():
+            for field in fields:
+                instances_to_update = model.objects.filter(**{field: inactive_advisor})
+                self.stdout.write(self.style.SUCCESS(
+                    f'{instances_to_update.count()} instances of {model.__name__} will be updated'  # noqa
+                ))
+                instances_to_update.update(**{field: active_advisor})
+                self.stdout.write(self.style.SUCCESS(
+                    f'Successfully merged {model.__name__} instances from adviser {inactive_advisor_id} into {active_advisor_id}'  # noqa
+                ))
+
+        # Once all instances have been updated, delete the inactive advisor
+        inactive_advisor.delete()
+
+        self.stdout.write(self.style.SUCCESS(
+            f'Successfully deleted inactive advisor {inactive_advisor_id}'  # noqa
+        ))

--- a/datahub/dbmaintenance/management/commands/tests/test_merge_adviser.py
+++ b/datahub/dbmaintenance/management/commands/tests/test_merge_adviser.py
@@ -1,0 +1,39 @@
+import pytest
+
+from django.core.management import call_command
+
+from datahub.company.models import Advisor
+from datahub.company.test.factories import AdviserFactory
+from datahub.core.test_utils import APITestMixin
+
+
+class TestAdviser(APITestMixin):
+    def test_invalid_advisor_id(self):
+        """Test with non-existent advisor id."""
+        active_advisor = AdviserFactory(is_active=True)
+        with pytest.raises(Advisor.DoesNotExist):
+            call_command(
+                'merge_adviser',
+                '12345678-1234-5678-1234-567812345678',
+                str(active_advisor.id),
+            )
+
+    def test_invalid_active_advisor_id(self):
+        """Test with non-existent advisor id."""
+        inactive_advisor = AdviserFactory(is_active=False)
+        with pytest.raises(Advisor.DoesNotExist):
+            call_command(
+                'merge_adviser',
+                str(inactive_advisor.id),
+                '12345678-1234-5678-1234-567812345678',
+            )
+
+    def test_merge_adviser_output(self, capfd):
+        """Test the stdout and stderr of the command."""
+        active_advisor = AdviserFactory(is_active=True)
+        inactive_advisor = AdviserFactory(is_active=False)
+        call_command('merge_adviser', str(inactive_advisor.id), str(active_advisor.id))
+
+        out, err = capfd.readouterr()
+        assert 'Successfully deleted inactive advisor' in out
+        assert err == ''


### PR DESCRIPTION
### Description of change

The script will perform 2 critical operations:

1. Swap all adviser model reference from the inactive to the active adviser
2. Once completed it will hard delete the adviser object

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
