### PR TITLE
Cls2 216 api endpoint to return related company ids

### DIFF
--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -889,15 +889,16 @@ class TestCompanyHierarchyDataframe:
 
         assert mocked_search_entity.call_count == 4
 
+
 class TestRelatedCompanyDataframe:
     def test_multiple_companies_both_directly_and_indirectly_related(
         self,
         opensearch_with_signals,
     ):
         """
-        Test when a dataframe is created using multiple companies where the parent relationship is bot
-        directly linked and indirectly linked value, the datatable is created with the correct column
-        value for each company
+        Test when a dataframe is created using multiple companies where the parent
+        relationship is both directly linked and indirectly linked value, the datatable
+        is created with the correct column value for each company
         """
         faker = Faker()
 

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -949,6 +949,7 @@ class TestRelatedCompanyDataframe:
         ]
 
         opensearch_with_signals.indices.refresh()
+
         df = create_related_company_dataframe(tree_members)
 
         assert df['duns'][0] == ultimate_company_dnb['duns']
@@ -961,3 +962,27 @@ class TestRelatedCompanyDataframe:
         assert df['corporateLinkage.parent.duns'][2] == parent_company_dnb['duns']
         assert df['corporateLinkage.parent.duns'][3] == parent_company_dnb['duns']
         assert df['corporateLinkage.parent.duns'][4] == ultimate_company_dnb['duns']
+
+    def test_none_returned_from_empty_tree_members(
+        self,
+        opensearch_with_signals,
+    ):
+        """
+        Test when a dataframe is created using multiple companies where the parent
+        relationship is both directly linked and indirectly linked value, the datatable
+        is created with the correct column value for each company
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '113456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        tree_members = [ultimate_company_dnb]
+
+        opensearch_with_signals.indices.refresh()
+        df = create_related_company_dataframe(tree_members)
+
+        assert df['corporateLinkage.parent.duns'][0] is None

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -2964,6 +2964,897 @@ class TestCompanyHierarchyView(APITestMixin, TestHierarchyAPITestMixin):
         ]
 
 
+class TestRelatedCompanyView(APITestMixin):
+    """
+    DNB Company Hierarchy Search view test case.
+    """
+
+    def test_company_id_is_valid(self):
+        api_client = self.create_api_client()
+        company = CompanyFactory(duns_number='12345678')
+
+        url = reverse('api-v4:dnb-api:related-companies', kwargs={'company_id': company.id})
+        response = api_client.get(
+            f'{url}{URL_PARENT_TRUE_SUBSIDIARY_TRUE}',
+            content_type='application/json',
+        )
+        assert response.status_code == 400
+
+    def test_company_has_no_company_id(self):
+        api_client = self.create_api_client()
+        url = reverse('api-v4:dnb-api:related-companies', kwargs={'company_id': uuid4()})
+        response = api_client.get(
+            f'{url}{URL_PARENT_TRUE_SUBSIDIARY_TRUE}',
+            content_type='application/json',
+        )
+        assert response.status_code == 404
+
+    def test_company_has_no_duns_number(self):
+        api_client = self.create_api_client()
+        company = CompanyFactory(duns_number=None)
+
+        url = reverse('api-v4:dnb-api:related-companies', kwargs={'company_id': company.id})
+        response = api_client.get(
+            f'{url}{URL_PARENT_TRUE_SUBSIDIARY_TRUE}',
+            content_type='application/json',
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize(
+        'request_exception',
+        ((ConnectionError), (DNBServiceTimeoutError)),
+    )
+    def test_related_companies_request_connection_error(self, requests_mock, request_exception):
+        """
+        Test for POST proxy.
+        """
+        api_client = self.create_api_client()
+        company = CompanyFactory(duns_number='123456789')
+
+        requests_mock.post(
+            DNB_HIERARCHY_SEARCH_URL,
+            exc=request_exception,
+        )
+
+        url = reverse('api-v4:dnb-api:related-companies', kwargs={'company_id': company.id})
+        response = api_client.get(
+            f'{url}{URL_PARENT_TRUE_SUBSIDIARY_TRUE}',
+            content_type='application/json',
+        )
+
+        assert response.status_code == status.HTTP_502_BAD_GATEWAY
+
+    def test_empty_results_returned_from_dnb_service(self, requests_mock):
+        """
+        Test for POST proxy.
+        """
+        api_client = self.create_api_client()
+        company = CompanyFactory(duns_number='123456789')
+
+        requests_mock.post(
+            DNB_HIERARCHY_SEARCH_URL,
+            status_code=200,
+            content=b'{"family_tree_members":[]}',
+        )
+
+        url = reverse('api-v4:dnb-api:related-companies', kwargs={'company_id': company.id})
+        response = api_client.get(
+            url,
+            content_type='application/json',
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            'related_companies': [],
+        }
+
+    def test_single_subsidiary_id_is_returned_when_exists_in_data_hub(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where the company returned by the DnB service does
+        match a child company found in the Data Hub dataset and then return
+        the correct id for that company
+        """
+        faker = Faker()
+        ultimate_company_dnb = {
+            'duns': '987654321',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        child_company_dnb = {
+            'duns': '123456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+
+        tree_members = [ultimate_company_dnb, child_company_dnb]
+        ultimate_company_dh = CompanyFactory(
+            duns_number=ultimate_company_dnb['duns'],
+            id='8e2e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=ultimate_company_dnb['primaryName'],
+        )
+        child_company_dh = CompanyFactory(
+            duns_number=child_company_dnb['duns'],
+            id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        params = URL_PARENT_TRUE_SUBSIDIARY_TRUE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            ultimate_company_dh,
+            params,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == [child_company_dh.id]
+
+    def test_single_parent_id_is_returned_when_exists_in_data_hub(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where the company returned by the DnB service does
+        match a parent company found in the Data Hub dataset and then return
+        the correct id for that company
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '987654321',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        child_company_dnb = {
+            'duns': '123456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        tree_members = [ultimate_company_dnb, child_company_dnb]
+        ultimate_company_dh = CompanyFactory(
+            duns_number=ultimate_company_dnb['duns'],
+            id='8e2e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=ultimate_company_dnb['primaryName'],
+        )
+        child_company_dh = CompanyFactory(
+            duns_number=child_company_dnb['duns'],
+            id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        params = URL_PARENT_TRUE_SUBSIDIARY_TRUE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            child_company_dh,
+            params,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == [ultimate_company_dh.id]
+        assert response.json() != [child_company_dh.id]
+
+    def test_all_ids_except_self_are_returned_when_all_companies_are_in_data_hub_and_params_true(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where the companies returned by the DnB service all have
+        Data Hub ids
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '113456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        direct_company_dnb = {
+            'duns': '223456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        target_company_dnb = {
+            'duns': '333456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': direct_company_dnb['duns']},
+            },
+        }
+        child_one_company_dnb = {
+            'duns': '443456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        child_two_company_dnb = {
+            'duns': '553456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        tree_members = [
+            ultimate_company_dnb,
+            direct_company_dnb,
+            target_company_dnb,
+            child_one_company_dnb,
+            child_two_company_dnb,
+        ]
+        ultimate_company_dh = CompanyFactory(
+            duns_number=ultimate_company_dnb['duns'],
+            id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=ultimate_company_dnb['primaryName'],
+        )
+        direct_company_dh = CompanyFactory(
+            duns_number=direct_company_dnb['duns'],
+            id='222e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=direct_company_dnb['primaryName'],
+        )
+        target_company_dh = CompanyFactory(
+            duns_number=target_company_dnb['duns'],
+            id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=target_company_dnb['primaryName'],
+        )
+        child_one_company_dh = CompanyFactory(
+            duns_number=child_one_company_dnb['duns'],
+            id='444e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_one_company_dnb['primaryName'],
+        )
+        child_two_company_dh = CompanyFactory(
+            duns_number=child_two_company_dnb['duns'],
+            id='555e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_two_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        params = URL_PARENT_TRUE_SUBSIDIARY_TRUE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            target_company_dh,
+            params,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == [
+            ultimate_company_dh.id,
+            direct_company_dh.id,
+            child_one_company_dh.id,
+            child_two_company_dh.id,
+        ]
+
+    def test_only_ids_are_returned_when_companies_are_in_data_hub_and_params_true(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where not all the companies returned by the DnB service have
+        a Data Hub id so only those that do should have their ID returned
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '113456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        direct_company_dnb = {
+            'duns': '223456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        target_company_dnb = {
+            'duns': '333456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': direct_company_dnb['duns']},
+            },
+        }
+        child_one_company_dnb = {
+            'duns': '443456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        child_two_company_dnb = {
+            'duns': '553456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        tree_members = [
+            ultimate_company_dnb,
+            direct_company_dnb,
+            target_company_dnb,
+            child_one_company_dnb,
+            child_two_company_dnb,
+        ]
+        ultimate_company_dh = CompanyFactory(
+            duns_number=ultimate_company_dnb['duns'],
+            id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=ultimate_company_dnb['primaryName'],
+        )
+        target_company_dh = CompanyFactory(
+            duns_number=target_company_dnb['duns'],
+            id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=target_company_dnb['primaryName'],
+        )
+        child_two_company_dh = CompanyFactory(
+            duns_number=child_two_company_dnb['duns'],
+            id='555e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_two_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        params = URL_PARENT_TRUE_SUBSIDIARY_TRUE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            target_company_dh,
+            params,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == [ultimate_company_dh.id, child_two_company_dh.id]
+
+    def test_no_ids_are_returned_when_no_companies_are_in_data_hub_and_params_true(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where the no companies returned by the DnB service have
+        IDs in a Data Hub
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '113456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        direct_company_dnb = {
+            'duns': '223456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        target_company_dnb = {
+            'duns': '333456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': direct_company_dnb['duns']},
+            },
+        }
+        child_one_company_dnb = {
+            'duns': '443456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        child_two_company_dnb = {
+            'duns': '553456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        tree_members = [
+            ultimate_company_dnb,
+            direct_company_dnb,
+            target_company_dnb,
+            child_one_company_dnb,
+            child_two_company_dnb,
+        ]
+        target_company_dh = CompanyFactory(
+            duns_number=target_company_dnb['duns'],
+            id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=target_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        params = URL_PARENT_TRUE_SUBSIDIARY_TRUE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            target_company_dh,
+            params,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_all_ids_directly_related_returned_when_all_companies_are_in_data_hub_and_params_true(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where the many companies returned by the DnB service does match
+        for companies IDs in Data Hub but only those directly related are returned
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '113456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        direct_company_dnb = {
+            'duns': '223456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        target_company_dnb = {
+            'duns': '333456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 3,
+                'parent': {'duns': direct_company_dnb['duns']},
+            },
+        }
+        child_one_company_dnb = {
+            'duns': '443456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        not_directly_related_company_dnb = {
+            'duns': '553456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        tree_members = [
+            ultimate_company_dnb,
+            direct_company_dnb,
+            target_company_dnb,
+            child_one_company_dnb,
+            not_directly_related_company_dnb,
+        ]
+        ultimate_company_dh = CompanyFactory(
+            duns_number=ultimate_company_dnb['duns'],
+            id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=ultimate_company_dnb['primaryName'],
+        )
+        direct_company_dh = CompanyFactory(
+            duns_number=direct_company_dnb['duns'],
+            id='222e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=direct_company_dnb['primaryName'],
+        )
+        target_company_dh = CompanyFactory(
+            duns_number=target_company_dnb['duns'],
+            id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=target_company_dnb['primaryName'],
+        )
+        child_one_company_dh = CompanyFactory(
+            duns_number=child_one_company_dnb['duns'],
+            id='444e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_one_company_dnb['primaryName'],
+        )
+        not_directly_related_company_dh = CompanyFactory(
+            duns_number=not_directly_related_company_dnb['duns'],
+            id='555e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=not_directly_related_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        params = URL_PARENT_TRUE_SUBSIDIARY_TRUE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            target_company_dh,
+            params,
+        )
+
+        assert response.status_code == 200
+        assert response.json() != [
+            ultimate_company_dh.id,
+            direct_company_dh.id,
+            child_one_company_dh.id,
+            not_directly_related_company_dh,
+        ]
+        assert response.json() == [
+            ultimate_company_dh.id,
+            direct_company_dh.id,
+            child_one_company_dh.id,
+        ]
+
+    def test_only_parent_ids_returned_when_include_parent_set_true_and_include_subsidiary_false(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where the companies returned by the DnB service all have
+        Data Hub ids
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '113456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        direct_company_dnb = {
+            'duns': '223456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        target_company_dnb = {
+            'duns': '333456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': direct_company_dnb['duns']},
+            },
+        }
+        child_one_company_dnb = {
+            'duns': '443456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        child_two_company_dnb = {
+            'duns': '553456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        tree_members = [
+            ultimate_company_dnb,
+            direct_company_dnb,
+            target_company_dnb,
+            child_one_company_dnb,
+            child_two_company_dnb,
+        ]
+        ultimate_company_dh = CompanyFactory(
+            duns_number=ultimate_company_dnb['duns'],
+            id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=ultimate_company_dnb['primaryName'],
+        )
+        direct_company_dh = CompanyFactory(
+            duns_number=direct_company_dnb['duns'],
+            id='222e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=direct_company_dnb['primaryName'],
+        )
+        target_company_dh = CompanyFactory(
+            duns_number=target_company_dnb['duns'],
+            id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=target_company_dnb['primaryName'],
+        )
+        child_one_company_dh = CompanyFactory(
+            duns_number=child_one_company_dnb['duns'],
+            id='444e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_one_company_dnb['primaryName'],
+        )
+        child_two_company_dh = CompanyFactory(
+            duns_number=child_two_company_dnb['duns'],
+            id='555e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_two_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        prams = URL_PARENT_TRUE_SUBSIDIARY_FALSE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            target_company_dh,
+            prams,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == [
+            ultimate_company_dh.id,
+            direct_company_dh.id,
+        ]
+        assert response.json() != [
+            child_one_company_dh.id,
+            child_two_company_dh.id,
+        ]
+
+    def test_only_subsidiary_ids_returned_when_include_parent_false_and_include_subsidiary_true(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where the companies returned by the DnB service all have
+        Data Hub ids
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '113456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        direct_company_dnb = {
+            'duns': '223456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        target_company_dnb = {
+            'duns': '333456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': direct_company_dnb['duns']},
+            },
+        }
+        child_one_company_dnb = {
+            'duns': '443456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        child_two_company_dnb = {
+            'duns': '553456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        tree_members = [
+            ultimate_company_dnb,
+            direct_company_dnb,
+            target_company_dnb,
+            child_one_company_dnb,
+            child_two_company_dnb,
+        ]
+        ultimate_company_dh = CompanyFactory(
+            duns_number=ultimate_company_dnb['duns'],
+            id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=ultimate_company_dnb['primaryName'],
+        )
+        direct_company_dh = CompanyFactory(
+            duns_number=direct_company_dnb['duns'],
+            id='222e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=direct_company_dnb['primaryName'],
+        )
+        target_company_dh = CompanyFactory(
+            duns_number=target_company_dnb['duns'],
+            id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=target_company_dnb['primaryName'],
+        )
+        child_one_company_dh = CompanyFactory(
+            duns_number=child_one_company_dnb['duns'],
+            id='444e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_one_company_dnb['primaryName'],
+        )
+        child_two_company_dh = CompanyFactory(
+            duns_number=child_two_company_dnb['duns'],
+            id='555e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_two_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        prams = URL_PARENT_FALSE_SUBSIDIARY_TRUE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            target_company_dh,
+            prams,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == [
+            child_one_company_dh.id,
+            child_two_company_dh.id,
+        ]
+        assert response.json() != [
+            ultimate_company_dh.id,
+            direct_company_dh.id,
+        ]
+
+    def test_no_ids_returned_when_include_parent_false_and_include_subsidiary_false(
+        self,
+        requests_mock,
+        opensearch_with_signals,
+    ):
+        """
+        Test the scenario where the companies returned by the DnB service all have
+        Data Hub ids
+        """
+        faker = Faker()
+
+        ultimate_company_dnb = {
+            'duns': '113456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {'hierarchyLevel': 1},
+        }
+
+        direct_company_dnb = {
+            'duns': '223456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 2,
+                'parent': {'duns': ultimate_company_dnb['duns']},
+            },
+        }
+        target_company_dnb = {
+            'duns': '333456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': direct_company_dnb['duns']},
+            },
+        }
+        child_one_company_dnb = {
+            'duns': '443456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        child_two_company_dnb = {
+            'duns': '553456789',
+            'primaryName': faker.company(),
+            'corporateLinkage': {
+                'hierarchyLevel': 4,
+                'parent': {'duns': target_company_dnb['duns']},
+            },
+        }
+        tree_members = [
+            ultimate_company_dnb,
+            direct_company_dnb,
+            target_company_dnb,
+            child_one_company_dnb,
+            child_two_company_dnb,
+        ]
+        CompanyFactory(
+            duns_number=ultimate_company_dnb['duns'],
+            id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=ultimate_company_dnb['primaryName'],
+        )
+        CompanyFactory(
+            duns_number=direct_company_dnb['duns'],
+            id='222e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=direct_company_dnb['primaryName'],
+        )
+        target_company_dh = CompanyFactory(
+            duns_number=target_company_dnb['duns'],
+            id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=target_company_dnb['primaryName'],
+        )
+        CompanyFactory(
+            duns_number=child_one_company_dnb['duns'],
+            id='444e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_one_company_dnb['primaryName'],
+        )
+        CompanyFactory(
+            duns_number=child_two_company_dnb['duns'],
+            id='555e9b35-3415-4b9b-b9ff-f97446ac8942',
+            name=child_two_company_dnb['primaryName'],
+        )
+
+        opensearch_with_signals.indices.refresh()
+
+        params = URL_PARENT_FALSE_SUBSIDIARY_FALSE
+
+        response = self._get_related_company_response(
+            requests_mock,
+            tree_members,
+            target_company_dh,
+            params,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def _get_related_company_response(
+        self,
+        requests_mock,
+        tree_members,
+        ultimate_company,
+        params,
+    ):
+        api_client = self.create_api_client()
+        requests_mock.post(
+            DNB_HIERARCHY_SEARCH_URL,
+            status_code=200,
+            content=json.dumps(
+                {
+                    'global_ultimate_duns': 'duns',
+                    'family_tree_members': tree_members,
+                    'global_ultimate_family_tree_members_count': len(tree_members),
+                },
+            ).encode('utf-8'),
+        )
+        url = reverse(
+            'api-v4:dnb-api:related-companies',
+            kwargs={'company_id': ultimate_company.id},
+        )
+        response = api_client.get(
+            f'{url}{params}',
+            content_type='application/json',
+        )
+
+        return response
+
+
 class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
     """
     DNB Company Hierarchy Search view test case.

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -37,7 +37,6 @@ DNB_HIERARCHY_SEARCH_URL = urljoin(
     'companies/hierarchy/search/',
 )
 
-
 REQUIRED_REGISTERED_ADDRESS_FIELDS = [
     f'registered_address_{field}' for field in AddressSerializer.REQUIRED_FIELDS
 ]

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -41,6 +41,19 @@ REQUIRED_REGISTERED_ADDRESS_FIELDS = [
     f'registered_address_{field}' for field in AddressSerializer.REQUIRED_FIELDS
 ]
 
+URL_PARENT_TRUE_SUBSIDIARY_TRUE = (
+    '?include_parent_companies=true&include_subsidiary_companies=true'
+)
+URL_PARENT_TRUE_SUBSIDIARY_FALSE = (
+    '?include_parent_companies=true&include_subsidiary_companies=false'
+)
+URL_PARENT_FALSE_SUBSIDIARY_TRUE = (
+    '?include_parent_companies=false&include_subsidiary_companies=true'
+)
+URL_PARENT_FALSE_SUBSIDIARY_FALSE = (
+    '?include_parent_companies=false&include_subsidiary_companies=false'
+)
+
 
 @pytest.mark.parametrize(
     'url',

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -7,6 +7,7 @@ from datahub.dnb_api.views import (
     DNBCompanyInvestigationView,
     DNBCompanyLinkView,
     DNBCompanySearchView,
+    DNBRelatedCompaniesView,
     DNBRelatedCompaniesCountView,
 )
 
@@ -40,6 +41,11 @@ urlpatterns = [
         '<company_id>/family-tree',
         DNBCompanyHierarchyView.as_view(),
         name='family-tree',
+    ),
+    path(
+        '<company_id>/related-companies',
+        DNBRelatedCompaniesView.as_view(),
+        name='related-companies',
     ),
     path(
         '<company_id>/related-companies/count',

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -7,8 +7,8 @@ from datahub.dnb_api.views import (
     DNBCompanyInvestigationView,
     DNBCompanyLinkView,
     DNBCompanySearchView,
-    DNBRelatedCompaniesView,
     DNBRelatedCompaniesCountView,
+    DNBRelatedCompaniesView,
 )
 
 urlpatterns = [

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -569,25 +569,6 @@ def validate_company_id(company_id):
     return duns_number
 
 
-def validate_company_id(company_id):
-    if not is_valid_uuid(company_id):
-        raise APIBadRequestException(f'company id "{company_id}" is not valid')
-
-    company = Company.objects.filter(id=company_id).values_list('duns_number', flat=True)
-
-    if not company:
-        raise APINotFoundException(f'company {company_id} not found')
-
-    duns_number = company.first()
-    if company and not duns_number:
-        raise APIBadRequestException(f'company {company_id} does not contain a duns number')
-
-    hierarchy_serializer = DNBCompanyHierarchySerializer(data={'duns_number': duns_number})
-    hierarchy_serializer.is_valid(raise_exception=True)
-
-    return duns_number
-
-
 def get_company_hierarchy_data(duns_number):
     """
     Get company hierarchy data

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -743,7 +743,6 @@ def create_related_company_dataframe(family_tree_members: list):
     Create a dataframe from the list of family tree members that only appends with
     Data Hub company IDs
     """
-    # append_datahub_company_ids(family_tree_members)
 
     normalized_df = pd.json_normalize(family_tree_members)
     normalized_df.replace([np.nan], [None], inplace=True)

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -743,7 +743,6 @@ def create_related_company_dataframe(family_tree_members: list):
     Create a dataframe from the list of family tree members that only appends with
     Data Hub company IDs
     """
-
     normalized_df = pd.json_normalize(family_tree_members)
     normalized_df.replace([np.nan], [None], inplace=True)
     if len(family_tree_members) == 1:

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -738,6 +738,41 @@ def append_datahub_details(family_tree_members: list):
                 break  # Stop once we've found the match
 
 
+def create_related_company_dataframe(family_tree_members: list):
+    """
+    Create a dataframe from the list of family tree members that only appends with
+    Data Hub company IDs
+    """
+    # append_datahub_company_ids(family_tree_members)
+
+    normalized_df = pd.json_normalize(family_tree_members)
+    normalized_df.replace([np.nan], [None], inplace=True)
+    if len(family_tree_members) == 1:
+        normalized_df['corporateLinkage.parent.duns'] = None
+
+    return normalized_df
+
+
+def get_datahub_company_ids(family_tree_members: list):
+    """
+    get company ids for related companies returned from D&B
+
+    """
+
+    family_tree_members_datahub_details = get_search_by_entities_query(
+        [SearchCompany],
+        term='',
+        filter_data={'duns_number': family_tree_members},
+        fields_to_include='id',
+    ).execute()
+
+    related_company_ids = []
+
+    for related_company in family_tree_members_datahub_details:
+        related_company_ids.append(related_company.id)
+    return related_company_ids
+
+
 def _batch_list(list, number_items):
     """
     Create a list of lists, with the maximum number of items in each list set to the number

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -569,6 +569,25 @@ def validate_company_id(company_id):
     return duns_number
 
 
+def validate_company_id(company_id):
+    if not is_valid_uuid(company_id):
+        raise APIBadRequestException(f'company id "{company_id}" is not valid')
+
+    company = Company.objects.filter(id=company_id).values_list('duns_number', flat=True)
+
+    if not company:
+        raise APINotFoundException(f'company {company_id} not found')
+
+    duns_number = company.first()
+    if company and not duns_number:
+        raise APIBadRequestException(f'company {company_id} does not contain a duns number')
+
+    hierarchy_serializer = DNBCompanyHierarchySerializer(data={'duns_number': duns_number})
+    hierarchy_serializer.is_valid(raise_exception=True)
+
+    return duns_number
+
+
 def get_company_hierarchy_data(duns_number):
     """
     Get company hierarchy data
@@ -755,7 +774,7 @@ def create_related_company_dataframe(family_tree_members: list):
 
 def get_datahub_company_ids(family_tree_members: list):
     """
-    get company ids for related companies returned from D&B
+    Get company ids for related companies returned from D&B
 
     """
     family_tree_members_datahub_details = get_search_by_entities_query(

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -758,14 +758,12 @@ def get_datahub_company_ids(family_tree_members: list):
     get company ids for related companies returned from D&B
 
     """
-
     family_tree_members_datahub_details = get_search_by_entities_query(
         [SearchCompany],
         term='',
         filter_data={'duns_number': family_tree_members},
         fields_to_include='id',
     ).execute()
-
     related_company_ids = []
 
     for related_company in family_tree_members_datahub_details:

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -1,8 +1,11 @@
 import logging
 
+import json
+
 from bigtree import (
     dataframe_to_tree_by_relation,
     tree_to_nested_dict,
+    find_child_by_name,
 )
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
@@ -33,7 +36,9 @@ from datahub.dnb_api.serializers import (
     SubsidiarySerializer,
 )
 from datahub.dnb_api.utils import (
+    get_datahub_company_ids,
     create_company_hierarchy_dataframe,
+    create_related_company_dataframe,
     create_investigation,
     DNBServiceConnectionError,
     DNBServiceError,

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -389,7 +389,6 @@ class DNBCompanyHierarchyView(APIView):
 
         try:
             response = get_company_hierarchy_data(duns_number)
-
         except (
             DNBServiceConnectionError,
             DNBServiceTimeoutError,

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -1,11 +1,9 @@
 import logging
 
-import json
-
 from bigtree import (
     dataframe_to_tree_by_relation,
-    tree_to_nested_dict,
     find,
+    tree_to_nested_dict,
 )
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
@@ -36,10 +34,9 @@ from datahub.dnb_api.serializers import (
     SubsidiarySerializer,
 )
 from datahub.dnb_api.utils import (
-    get_datahub_company_ids,
     create_company_hierarchy_dataframe,
-    create_related_company_dataframe,
     create_investigation,
+    create_related_company_dataframe,
     DNBServiceConnectionError,
     DNBServiceError,
     DNBServiceInvalidRequestError,

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -5,7 +5,7 @@ import json
 from bigtree import (
     dataframe_to_tree_by_relation,
     tree_to_nested_dict,
-    find_child_by_name,
+    find,
 )
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator


### PR DESCRIPTION
### Description of change

Create a new API endpoint to return company IDs for companies related to the target company by reusing the existing D&B hierarchy call.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?


* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
