### PR TITLE
feature/CLS2-180-index-global-duns-values

### DIFF
--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -64,6 +64,7 @@ class Company(BaseSearchModel):
     export_sub_segment = Text()
     one_list_tier = fields.id_name_field()
     number_of_employees = Integer()
+    global_ultimate_duns_number = Keyword()
 
     COMPUTED_MAPPINGS = {
         'address': partial(dict_utils.address_dict, prefix='address'),
@@ -103,6 +104,7 @@ class Company(BaseSearchModel):
         'uk_based': bool,
         'uk_region': dict_utils.id_name_dict,
         'one_list_tier': dict_utils.id_name_dict,
+        'global_ultimate_duns_number': dict_utils.empty_string_to_null,
     }
 
     SEARCH_FIELDS = (

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -38,6 +38,7 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
     duns_number = SingleOrListField(child=serializers.CharField(), required=False)
     number_of_employees = serializers.IntegerField(required=False)
     company_number = SingleOrListField(child=serializers.CharField(), required=False)
+    global_ultimate_duns_number = SingleOrListField(child=serializers.CharField(), required=False)
 
     SORT_BY_FIELDS = (
         'modified_on',

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -377,7 +377,7 @@ class TestSearch(APITestMixin):
                         'name': company.one_list_tier.name,
                     },
                     'number_of_employees': company.number_of_employees,
-                    'global_ultimate_duns_number': company.global_ultimate_duns_number,
+                    'global_ultimate_duns_number': None,
                 },
             ],
         }

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -377,6 +377,7 @@ class TestSearch(APITestMixin):
                         'name': company.one_list_tier.name,
                     },
                     'number_of_employees': company.number_of_employees,
+                    'global_ultimate_duns_number': company.global_ultimate_duns_number,
                 },
             ],
         }

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -56,6 +56,7 @@ class TestCompanySearchModel:
             'export_segment',
             'export_sub_segment',
             'number_of_employees',
+            'global_ultimate_duns_number',
         }
 
         assert set(result.keys()) == keys

--- a/datahub/search/company/test/test_opensearch.py
+++ b/datahub/search/company/test/test_opensearch.py
@@ -405,6 +405,7 @@ def test_mapping(opensearch):
                 'type': 'object',
             },
             'number_of_employees': {'type': 'integer'},
+            'global_ultimate_duns_number': {'type': 'keyword'},
         },
     }
 

--- a/datahub/search/company/test/test_opensearch.py
+++ b/datahub/search/company/test/test_opensearch.py
@@ -718,4 +718,5 @@ def test_indexed_doc(opensearch):
         'export_segment',
         'one_list_tier',
         'number_of_employees',
+        'global_ultimate_duns_number',
     }

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -4,8 +4,10 @@ def _attrgetter_with_default(attr, default):
     of attr or the default.
     Useful to convert None values to ''.
     """
+
     def _getter(obj):
         return getattr(obj, attr) or default
+
     return _getter
 
 
@@ -18,6 +20,12 @@ def id_name_dict(obj):
         'id': str(obj.id),
         'name': obj.name,
     }
+
+
+def empty_string_to_null(obj):
+    if not obj:
+        return None
+    return obj
 
 
 def id_name_list_of_dicts(manager):
@@ -123,6 +131,7 @@ def adviser_dict_with_team(obj):
 
 def _computed_nested_dict(nested_field, dict_func):
     """Creates a dictionary from a nested field using dict_func."""
+
     def get_dict(obj):
         fields = nested_field.split('.', maxsplit=1)
         if len(fields) != 2:
@@ -143,6 +152,7 @@ def _computed_nested_dict(nested_field, dict_func):
 
 def computed_field_function(function_name, dict_func):
     """Create a dictionary from a result of provided function call."""
+
     def get_dict(obj):
         field = getattr(obj, function_name, None)
         if field is None:
@@ -196,9 +206,12 @@ def sector_dict(obj):
     return {
         'id': str(obj.id),
         'name': obj.name,
-        'ancestors': [{
-            'id': str(ancestor.id),
-        } for ancestor in obj.get_ancestors()],
+        'ancestors': [
+            {
+                'id': str(ancestor.id),
+            }
+            for ancestor in obj.get_ancestors()
+        ],
     }
 
 

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -408,8 +408,15 @@ def test_computed_field_function_not_a_function():
         dict_utils.computed_field_function('get_cats_name', dict_utils.id_name_dict)(obj)
 
 
-def test_empty_string_to_null():
+def test_empty_string_to_null_when_obj_is_falsey():
     """Tests _id_name_dict."""
     res = dict_utils.empty_string_to_null('')
 
     assert res is None
+
+
+def test_empty_string_to_null_when_obj_is_truthy():
+    """Tests _id_name_dict."""
+    res = dict_utils.empty_string_to_null('abc')
+
+    assert res == 'abc'

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -46,10 +46,7 @@ def test_id_name_list_of_dicts():
         {'id': '12', 'name': 'test A'},
         {'id': '99', 'name': 'testing B'},
     ]
-    objects = [
-        construct_mock(**mock_data)
-        for mock_data in data
-    ]
+    objects = [construct_mock(**mock_data) for mock_data in data]
 
     manager = mock.Mock(
         all=mock.Mock(return_value=objects),
@@ -98,7 +95,6 @@ def test_id_uri_dict():
                 'trading_names': ['Trading 1', 'Trading 2'],
             },
         ),
-
         # minimal object
         (
             construct_mock(
@@ -112,7 +108,6 @@ def test_id_uri_dict():
                 'trading_names': [],
             },
         ),
-
         # None
         (
             None,
@@ -144,14 +139,12 @@ def test_company_dict(obj, expected_dict):
             'address',
             None,
         ),
-
         # returns None when obj is None
         (
             None,
             'address',
             None,
         ),
-
         # all fields converted into a dict
         (
             construct_mock(
@@ -180,8 +173,6 @@ def test_company_dict(obj, expected_dict):
                 'area': None,
             },
         ),
-
-
         # None values converted to ''
         (
             construct_mock(
@@ -285,7 +276,6 @@ def test_contact_or_adviser_dict():
                 },
             },
         ),
-
         # with dit_team = None
         (
             construct_mock(
@@ -318,10 +308,7 @@ def test_contact_or_adviser_list_of_dicts():
         {'id': '12', 'first_name': 'first A', 'last_name': 'last A', 'name': 'test A'},
         {'id': '99', 'first_name': 'first B', 'last_name': 'last B', 'name': 'testing B'},
     ]
-    objects = [
-        construct_mock(**data_item)
-        for data_item in data
-    ]
+    objects = [construct_mock(**data_item) for data_item in data]
 
     manager = mock.Mock(
         all=mock.Mock(return_value=objects),
@@ -360,7 +347,6 @@ def test_ch_company_dict():
                 'name': 'Cats',
             },
         ),
-
         # None first level field
         (
             construct_mock(
@@ -368,7 +354,6 @@ def test_ch_company_dict():
             ),
             None,
         ),
-
         # None second level field
         (
             construct_mock(
@@ -421,3 +406,10 @@ def test_computed_field_function_not_a_function():
 
     with raises(ValueError):
         dict_utils.computed_field_function('get_cats_name', dict_utils.id_name_dict)(obj)
+
+
+def test_empty_string_to_null():
+    """Tests _id_name_dict."""
+    res = dict_utils.empty_string_to_null('')
+
+    assert res is None


### PR DESCRIPTION
### Description of change

Include the value for `global_ultimate_duns_number` field in the opensearch index. This is needed for the some upcoming changes in the front end

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
