### PR TITLE
Feature/cls2 180 endpoint to return count of related companies

### DIFF
--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -2957,6 +2957,35 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
     DNB Company Hierarchy Search view test case.
     """
 
+    def test_company_id_is_valid(self):
+        assert (
+            self.api_client.get(
+                reverse(
+                    'api-v4:dnb-api:related-companies-count', kwargs={'company_id': '11223344'}
+                ),
+            ).status_code
+            == 400
+        )
+
+    def test_company_has_no_company_id(self):
+        assert (
+            self.api_client.get(
+                reverse('api-v4:dnb-api:related-companies-count', kwargs={'company_id': uuid4()}),
+            ).status_code
+            == 404
+        )
+
+    def test_company_has_no_duns_number(self):
+        company = CompanyFactory(duns_number=None)
+        assert (
+            self.api_client.get(
+                reverse(
+                    'api-v4:dnb-api:related-companies-count', kwargs={'company_id': company.id}
+                ),
+            ).status_code
+            == 400
+        )
+
     def test_dnb_company_count_of_0_returns_0(self, requests_mock):
         ultimate_company_dh = CompanyFactory(
             duns_number='123456789',

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -2961,7 +2961,8 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
         assert (
             self.api_client.get(
                 reverse(
-                    'api-v4:dnb-api:related-companies-count', kwargs={'company_id': '11223344'}
+                    'api-v4:dnb-api:related-companies-count',
+                    kwargs={'company_id': '11223344'},
                 ),
             ).status_code
             == 400
@@ -2980,7 +2981,8 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
         assert (
             self.api_client.get(
                 reverse(
-                    'api-v4:dnb-api:related-companies-count', kwargs={'company_id': company.id}
+                    'api-v4:dnb-api:related-companies-count',
+                    kwargs={'company_id': company.id},
                 ),
             ).status_code
             == 400

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -2422,7 +2422,22 @@ class TestCompanyInvestigationView(APITestMixin):
         assert response.status_code == status.HTTP_502_BAD_GATEWAY
 
 
-class TestCompanyHierarchyView(APITestMixin):
+class TestHierarchyAPITestMixin:
+    def set_dnb_hierarchy_mock_response(self, requests_mock, tree_members):
+        requests_mock.post(
+            DNB_HIERARCHY_SEARCH_URL,
+            status_code=200,
+            content=json.dumps(
+                {
+                    'global_ultimate_duns': 'duns',
+                    'family_tree_members': tree_members,
+                    'global_ultimate_family_tree_members_count': len(tree_members),
+                },
+            ).encode('utf-8'),
+        )
+
+
+class TestCompanyHierarchyView(APITestMixin, TestHierarchyAPITestMixin):
     """
     DNB Company Hierarchy Search view test case.
     """
@@ -2699,17 +2714,7 @@ class TestCompanyHierarchyView(APITestMixin):
         ultimate_company,
     ):
         api_client = self.create_api_client()
-        requests_mock.post(
-            DNB_HIERARCHY_SEARCH_URL,
-            status_code=200,
-            content=json.dumps(
-                {
-                    'global_ultimate_duns': 'duns',
-                    'family_tree_members': tree_members,
-                    'global_ultimate_family_tree_members_count': len(tree_members),
-                },
-            ).encode('utf-8'),
-        )
+        self.set_dnb_hierarchy_mock_response(requests_mock, tree_members)
 
         url = reverse('api-v4:dnb-api:family-tree', kwargs={'company_id': ultimate_company.id})
         response = api_client.get(
@@ -2759,7 +2764,9 @@ class TestCompanyHierarchyView(APITestMixin):
         opensearch_with_signals.indices.refresh()
 
         response = self._get_family_tree_response(
-            requests_mock, [ultimate_tree_member_level_1], ultimate_company_dh,
+            requests_mock,
+            [ultimate_tree_member_level_1],
+            ultimate_company_dh,
         )
 
         assert response.json()['manually_verified_subsidiaries'] == []
@@ -2784,7 +2791,9 @@ class TestCompanyHierarchyView(APITestMixin):
         )
 
         response = self._get_family_tree_response(
-            requests_mock, [ultimate_tree_member_level_1], ultimate_company_dh,
+            requests_mock,
+            [ultimate_tree_member_level_1],
+            ultimate_company_dh,
         )
         assert response.json()['manually_verified_subsidiaries'] == [
             {
@@ -2856,7 +2865,9 @@ class TestCompanyHierarchyView(APITestMixin):
         opensearch_with_signals.indices.refresh()
 
         response = self._get_family_tree_response(
-            requests_mock, [ultimate_tree_member_level_1], ultimate_company_dh,
+            requests_mock,
+            [ultimate_tree_member_level_1],
+            ultimate_company_dh,
         )
 
         response.json()['manually_verified_subsidiaries'].sort(
@@ -2939,3 +2950,43 @@ class TestCompanyHierarchyView(APITestMixin):
                 'hierarchy': '0',
             },
         ]
+
+
+class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
+    """
+    DNB Company Hierarchy Search view test case.
+    """
+
+    def test_dnb_company_count_of_0_returns_0(self, requests_mock):
+        ultimate_company_dh = CompanyFactory(
+            duns_number='123456789',
+        )
+        self.set_dnb_hierarchy_mock_response(requests_mock, [])
+
+        assert (
+            self.api_client.get(
+                reverse(
+                    'api-v4:dnb-api:related-companies-count',
+                    kwargs={'company_id': ultimate_company_dh.id},
+                ),
+            ).json()
+            == 0
+        )
+
+    def test_dnb_company_count_of_0_and_subsidiary_count_of_0_returns_0(self, requests_mock):
+        ultimate_company_dh = CompanyFactory(
+            duns_number='123456789',
+        )
+
+        url = reverse(
+            'api-v4:dnb-api:related-companies-count',
+            kwargs={'company_id': ultimate_company_dh.id},
+        )
+        self.set_dnb_hierarchy_mock_response(requests_mock, [])
+
+        assert (
+            self.api_client.get(
+                f'{url}?include_subsidiary_companies=true',
+            ).json()
+            == 0
+        )

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -7,6 +7,7 @@ from datahub.dnb_api.views import (
     DNBCompanyInvestigationView,
     DNBCompanyLinkView,
     DNBCompanySearchView,
+    DNBRelatedCompaniesCountView,
 )
 
 urlpatterns = [
@@ -42,7 +43,7 @@ urlpatterns = [
     ),
     path(
         '<company_id>/related-companies/count',
-        DNBCompanyHierarchyView.as_view(),
-        name='family-tree',
+        DNBRelatedCompaniesCountView.as_view(),
+        name='related-companies-count',
     ),
 ]

--- a/datahub/dnb_api/urls.py
+++ b/datahub/dnb_api/urls.py
@@ -40,4 +40,9 @@ urlpatterns = [
         DNBCompanyHierarchyView.as_view(),
         name='family-tree',
     ),
+    path(
+        '<company_id>/related-companies/count',
+        DNBCompanyHierarchyView.as_view(),
+        name='family-tree',
+    ),
 ]

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -497,7 +497,8 @@ class DNBRelatedCompaniesCountView(APIView):
 
         hierarchy = get_company_hierarchy_data(duns_number)
         companies_count = hierarchy.get('global_ultimate_family_tree_members_count', 0)
-        if request.query_params.get('include_subsidiary_companies'):
+
+        if request.query_params.get('include_subsidiary_companies') == 'true':
             subsidiary_companies_count = Company.objects.filter(
                 global_headquarters_id=company_id,
             ).count()

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -16,7 +16,6 @@ from datahub.company.serializers import CompanySerializer
 from datahub.core import statsd
 from datahub.core.exceptions import (
     APIBadRequestException,
-    APINotFoundException,
     APIUpstreamException,
 )
 from datahub.core.permissions import HasPermissions
@@ -25,7 +24,6 @@ from datahub.dnb_api.link_company import CompanyAlreadyDNBLinkedError, link_comp
 from datahub.dnb_api.queryset import get_company_queryset
 from datahub.dnb_api.serializers import (
     DNBCompanyChangeRequestSerializer,
-    DNBCompanyHierarchySerializer,
     DNBCompanyInvestigationSerializer,
     DNBCompanyLinkSerializer,
     DNBCompanySerializer,
@@ -45,7 +43,6 @@ from datahub.dnb_api.utils import (
     get_change_request,
     get_company,
     get_company_hierarchy_data,
-    is_valid_uuid,
     request_changes,
     search_dnb,
     validate_company_id,


### PR DESCRIPTION
### Description of change

Added a new endpoint to return the count of related companies a company has. There is an optional parameter to include manually linked subsidiaries in the count. 

This logic is currently in a node controller used by a nunjucks template, moving into the api to help refactoring that into react

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
