### PR TITLE
bugfix/CLS2-180-only-lower-dnb-company-counts

### DIFF
--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -3044,6 +3044,26 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
             == 0
         )
 
+    def test_dnb_company_count_of_0_and_subsidiary_count_of_1_returns_1(self, requests_mock):
+        ultimate_company_dh = CompanyFactory(
+            duns_number='123456789',
+        )
+
+        CompanyFactory(global_headquarters_id=ultimate_company_dh.id)
+
+        url = reverse(
+            'api-v4:dnb-api:related-companies-count',
+            kwargs={'company_id': ultimate_company_dh.id},
+        )
+        self.set_dnb_hierarchy_mock_response(requests_mock, [])
+
+        assert (
+            self.api_client.get(
+                f'{url}?include_subsidiary_companies=true',
+            ).json()
+            == 1
+        )
+
     def test_dnb_company_count_of_1_and_subsidiary_count_of_1_returns_1(self, requests_mock):
         ultimate_company_dh = CompanyFactory(
             duns_number='123456789',

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -469,6 +469,8 @@ class DNBRelatedCompaniesCountView(APIView):
 
         hierarchy = get_company_hierarchy_data(duns_number)
         companies_count = hierarchy.get('global_ultimate_family_tree_members_count', 0)
+        if companies_count > 0:
+            companies_count -= 1  # deduct 1 as the list from dnb contains the company requested
 
         if request.query_params.get('include_subsidiary_companies') == 'true':
             subsidiary_companies_count = Company.objects.filter(
@@ -477,5 +479,5 @@ class DNBRelatedCompaniesCountView(APIView):
             companies_count += subsidiary_companies_count
 
         return Response(
-            companies_count - 1 if companies_count > 0 else 0,
-        )  # deduct 1 as the list from dnb contains the company requested
+            companies_count,
+        )


### PR DESCRIPTION
### Description of change

Only lower the dnb company count by 1, not the overall count of both  subsidiary and dnb companies. This is because the dnb response will contain the requested company, but the subsidiary query doesn't.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
