### PR TITLE
bugfix/handle-exception-timeouts-from-dnb-service

### DIFF
--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -720,12 +720,13 @@ class TestDNBHierarchyData:
         """
         Test when the dnb api doesn't return a success http status code the value is not cached
         """
-        requests_mock.post(
-            DNB_HIERARCHY_SEARCH_URL,
-            status_code=500,
-            content=b'{"family_tree_members":[]}',
-        )
-        get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        with pytest.raises(DNBServiceError):
+            requests_mock.post(
+                DNB_HIERARCHY_SEARCH_URL,
+                status_code=500,
+                content=b'{"family_tree_members":[]}',
+            )
+            get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
         assert cache.get(self.FAMILY_TREE_CACHE_KEY) is None
 
 

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -751,6 +751,22 @@ class TestDNBHierarchyData:
             get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
         assert cache.get(self.FAMILY_TREE_CACHE_KEY) is None
 
+    def test_when_dnb_api_returns_status_code_not_success_response_is_not_cached(
+        self,
+        requests_mock,
+    ):
+        """
+        Test when the dnb api doesn't return a success http status code the value is not cached
+        """
+        with pytest.raises(DNBServiceError):
+            requests_mock.post(
+                DNB_HIERARCHY_SEARCH_URL,
+                status_code=500,
+                content=b'{"family_tree_members":[]}',
+            )
+            get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        assert cache.get(self.FAMILY_TREE_CACHE_KEY) is None
+
 
 class TestCompanyHierarchyDataframe:
     def test_single_company_with_nested_opensearch_field_is_null(self, opensearch_with_signals):

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -14,10 +14,12 @@ from requests.exceptions import ConnectionError, Timeout
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+
 from datahub.company.constants import OneListTierID
 from datahub.company.models import Company, CompanyPermission, OneListTier
 from datahub.company.test.factories import CompanyFactory
 from datahub.core import constants
+
 from datahub.core.serializers import AddressSerializer
 from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.dnb_api.constants import ALL_DNB_UPDATED_SERIALIZER_FIELDS
@@ -2435,10 +2437,10 @@ class TestCompanyInvestigationView(APITestMixin):
 
 
 class TestHierarchyAPITestMixin:
-    def set_dnb_hierarchy_mock_response(self, requests_mock, tree_members):
+    def set_dnb_hierarchy_mock_response(self, requests_mock, tree_members, status_code=200):
         requests_mock.post(
             DNB_HIERARCHY_SEARCH_URL,
-            status_code=200,
+            status_code=status_code,
             content=json.dumps(
                 {
                     'global_ultimate_duns': 'duns',

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -589,6 +589,9 @@ def get_company_hierarchy_data(duns_number):
             json={'duns_number': duns_number},
             timeout=10.0,
         )
+    except APIBadGatewayException as exc:
+        error_message = 'Encountered an error connecting to DNB service'
+        raise DNBServiceConnectionError(error_message) from exc
 
     except ConnectionError as exc:
         error_message = 'Encountered an error connecting to DNB service'

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -133,10 +133,6 @@ def get_company(duns_number, request=None):
         error_message = 'Encountered a timeout interacting with DNB service'
         logger.error(error_message)
         raise DNBServiceTimeoutError(error_message) from exc
-    # except ReadTimeout as exc:
-    #     error_message = 'Encountered a timeout interacting with DNB service'
-    #     logger.error(error_message)
-    #     raise DNBServiceTimeoutError(error_message) from exc
 
     if dnb_response.status_code != status.HTTP_200_OK:
         error_message = f'DNB service returned an error status: {dnb_response.status_code}'

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -587,7 +587,7 @@ def get_company_hierarchy_data(duns_number):
             'POST',
             'companies/hierarchy/search/',
             json={'duns_number': duns_number},
-            timeout=3.0,
+            timeout=10.0,
         )
 
     except ConnectionError as exc:

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -605,9 +605,8 @@ def get_company_hierarchy_data(duns_number):
     response_data = dnb_response.json()
 
     # only cache successful dnb calls
-    if dnb_response.status_code == status.HTTP_200_OK:
-        one_day_timeout = int(timedelta(days=1).total_seconds())
-        cache.set(cache_key, response_data, one_day_timeout)
+    one_day_timeout = int(timedelta(days=1).total_seconds())
+    cache.set(cache_key, response_data, one_day_timeout)
 
     return response_data
 

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -388,14 +388,7 @@ class DNBCompanyHierarchyView(APIView):
         """
         duns_number = validate_company_id(company_id)
 
-        try:
-            response = get_company_hierarchy_data(duns_number)
-        except (
-            DNBServiceConnectionError,
-            DNBServiceTimeoutError,
-            DNBServiceError,
-        ) as exc:
-            raise APIUpstreamException(str(exc))
+        response = get_company_hierarchy_data(duns_number)
 
         family_tree_members = response['family_tree_members']
         json_response = {
@@ -474,14 +467,7 @@ class DNBRelatedCompaniesView(APIView):
         """
         duns_number = validate_company_id(company_id)
 
-        try:
-            response = get_company_hierarchy_data(duns_number)
-        except (
-            DNBServiceConnectionError,
-            DNBServiceTimeoutError,
-            DNBServiceError,
-        ) as exc:
-            raise APIUpstreamException(str(exc))
+        response = get_company_hierarchy_data(duns_number)
 
         family_tree_members = response['family_tree_members']
         json_response = {

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -531,7 +531,6 @@ class DNBRelatedCompaniesCountView(APIView):
 
     def get(self, request, company_id):
         duns_number = validate_company_id(company_id)
-
         try:
             hierarchy = get_company_hierarchy_data(duns_number)
         except (


### PR DESCRIPTION
### Description of change

- Add exception handling to the dnb proxy api to raise an appropriate datahub exception, instead of the unhandled exception that is currently being raised
- Increased the dnb timeout to 10 seconds to deal with very large company trees

#### Previous API response
![image](https://github.com/uktrade/data-hub-api/assets/102232401/fa30ec94-c6ef-41e6-8d3e-97ec222f0e17)

#### New API response
![image](https://github.com/uktrade/data-hub-api/assets/102232401/cd4cf7b5-dfc5-4a52-a24a-3cc0126a1ce2)

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
