### PR TITLE
feature/CLS2-285-use-new-dnb-service-for-getting-counts-of-companies-in-tree

### DIFF
--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -1037,76 +1037,14 @@ class TestDNBHierarchyCount:
     VALID_DUNS_NUMBER = '123456789'
     FAMILY_TREE_CACHE_KEY = f'family_tree_count_{VALID_DUNS_NUMBER}'
 
-    # @override_settings(DNB_SERVICE_BASE_URL=None)
-    # def test_dnb_hierarchy_count_improperly_configured_url_error(self):
-    #     """
-    #     Test that we get an ImproperlyConfigured exception when the DNB_SERVICE_BASE_URL setting
-    #     is not set.
-    #     """
-    #     with pytest.raises(ImproperlyConfigured):
-    #         get_company_hierarchy_count('123456789')
-
-    # def test_the_correct_hierarchy_count_value_is_returned_from_dnb_api(self, requests_mock):
-    #     """
-    #     Test when the dnb family tree data is missing from the cache, a call is made to the dnb
-    #     api to get the data and saved into the cache
-    #     """
-    #     requests_mock.post(
-    #         DNB_HIERARCHY_COUNT_URL,
-    #         status_code=200,
-    #         content=b'15',
-    #     )
-
-    #     assert get_company_hierarchy_count(self.VALID_DUNS_NUMBER) == 15
-
-    # @pytest.mark.parametrize(
-    #     'request_exception,expected_exception',
-    #     (
-    #         (
-    #             ConnectionError,
-    #             DNBServiceConnectionError,
-    #         ),
-    #         (
-    #             ConnectTimeout,
-    #             DNBServiceConnectionError,
-    #         ),
-    #         (
-    #             Timeout,
-    #             DNBServiceTimeoutError,
-    #         ),
-    #         (
-    #             ReadTimeout,
-    #             DNBServiceTimeoutError,
-    #         ),
-    #     ),
-    # )
-    # def test_when_dnb_api_error_the_correct_exception_is_raised(
-    #     self,
-    #     requests_mock,
-    #     request_exception,
-    #     expected_exception,
-    # ):
-    #     """
-    #     Test when the dnb api raises an exception the correct wrapped exception is raised
-    #     """
-    #     with pytest.raises(expected_exception):
-    #         requests_mock.post(DNB_HIERARCHY_COUNT_URL, exc=request_exception)
-    #         get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
-
-    # def test_when_dnb_api_returns_status_code_not_success_the_correct_exception_is_raised(
-    #     self,
-    #     requests_mock,
-    # ):
-    #     """
-    #     Test when the dnb api doesn't return a success http status code the value is not cached
-    #     """
-    #     with pytest.raises(DNBServiceError):
-    #         requests_mock.post(
-    #             DNB_HIERARCHY_COUNT_URL,
-    #             status_code=500,
-    #             content=b'1',
-    #         )
-    #         get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+    @override_settings(DNB_SERVICE_BASE_URL=None)
+    def test_dnb_hierarchy_count_improperly_configured_url_error(self):
+        """
+        Test that we get an ImproperlyConfigured exception when the DNB_SERVICE_BASE_URL setting
+        is not set.
+        """
+        with pytest.raises(ImproperlyConfigured):
+            get_company_hierarchy_count('123456789')
 
     @pytest.mark.usefixtures('local_memory_cache')
     def test_when_dnb_data_not_in_cache_dnb_api_is_called(self, requests_mock):

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -40,6 +40,7 @@ from datahub.dnb_api.utils import (
     DNBServiceTimeoutError,
     format_dnb_company,
     get_company,
+    get_company_hierarchy_count,
     get_company_hierarchy_data,
     get_company_update_page,
     load_datahub_details,
@@ -57,6 +58,7 @@ DNB_HIERARCHY_SEARCH_URL = urljoin(
     f'{settings.DNB_SERVICE_BASE_URL}/',
     'companies/hierarchy/search/',
 )
+DNB_HIERARCHY_COUNT_URL = urljoin(DNB_HIERARCHY_SEARCH_URL, 'count')
 
 
 @pytest.mark.parametrize(
@@ -1025,3 +1027,193 @@ class TestRelatedCompanyDataframe:
         df = create_related_company_dataframe(tree_members)
 
         assert df['corporateLinkage.parent.duns'][0] is None
+
+
+class TestDNBHierarchyCount:
+    """
+    Tests for DNB Hierarchy count function.
+    """
+
+    VALID_DUNS_NUMBER = '123456789'
+    FAMILY_TREE_CACHE_KEY = f'family_tree_count_{VALID_DUNS_NUMBER}'
+
+    # @override_settings(DNB_SERVICE_BASE_URL=None)
+    # def test_dnb_hierarchy_count_improperly_configured_url_error(self):
+    #     """
+    #     Test that we get an ImproperlyConfigured exception when the DNB_SERVICE_BASE_URL setting
+    #     is not set.
+    #     """
+    #     with pytest.raises(ImproperlyConfigured):
+    #         get_company_hierarchy_count('123456789')
+
+    # def test_the_correct_hierarchy_count_value_is_returned_from_dnb_api(self, requests_mock):
+    #     """
+    #     Test when the dnb family tree data is missing from the cache, a call is made to the dnb
+    #     api to get the data and saved into the cache
+    #     """
+    #     requests_mock.post(
+    #         DNB_HIERARCHY_COUNT_URL,
+    #         status_code=200,
+    #         content=b'15',
+    #     )
+
+    #     assert get_company_hierarchy_count(self.VALID_DUNS_NUMBER) == 15
+
+    # @pytest.mark.parametrize(
+    #     'request_exception,expected_exception',
+    #     (
+    #         (
+    #             ConnectionError,
+    #             DNBServiceConnectionError,
+    #         ),
+    #         (
+    #             ConnectTimeout,
+    #             DNBServiceConnectionError,
+    #         ),
+    #         (
+    #             Timeout,
+    #             DNBServiceTimeoutError,
+    #         ),
+    #         (
+    #             ReadTimeout,
+    #             DNBServiceTimeoutError,
+    #         ),
+    #     ),
+    # )
+    # def test_when_dnb_api_error_the_correct_exception_is_raised(
+    #     self,
+    #     requests_mock,
+    #     request_exception,
+    #     expected_exception,
+    # ):
+    #     """
+    #     Test when the dnb api raises an exception the correct wrapped exception is raised
+    #     """
+    #     with pytest.raises(expected_exception):
+    #         requests_mock.post(DNB_HIERARCHY_COUNT_URL, exc=request_exception)
+    #         get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+
+    # def test_when_dnb_api_returns_status_code_not_success_the_correct_exception_is_raised(
+    #     self,
+    #     requests_mock,
+    # ):
+    #     """
+    #     Test when the dnb api doesn't return a success http status code the value is not cached
+    #     """
+    #     with pytest.raises(DNBServiceError):
+    #         requests_mock.post(
+    #             DNB_HIERARCHY_COUNT_URL,
+    #             status_code=500,
+    #             content=b'1',
+    #         )
+    #         get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+
+    @pytest.mark.usefixtures('local_memory_cache')
+    def test_when_dnb_data_not_in_cache_dnb_api_is_called(self, requests_mock):
+        """
+        Test when the dnb family tree count is missing from the cache, a call is made to the dnb
+        api to get the count and saved into the cache
+        """
+        matcher = requests_mock.post(
+            DNB_HIERARCHY_COUNT_URL,
+            status_code=200,
+            content=b'1',
+        )
+        get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+
+        assert matcher.called_once
+        assert cache.get(self.FAMILY_TREE_CACHE_KEY) is not None
+
+    @pytest.mark.usefixtures('local_memory_cache')
+    def test_when_called_multiple_times_only_first_call_makes_an_api_call_to_dnb(
+        self,
+        requests_mock,
+    ):
+        """
+        Test that after a successful call to the dnb api, all subsequent calls to the
+        get_company_hierarchy_count function get the data from the cache
+        """
+        matcher = requests_mock.post(
+            DNB_HIERARCHY_COUNT_URL,
+            status_code=200,
+            content=b'1',
+        )
+
+        get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+        get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+        get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+
+        assert matcher.called_once
+
+    @pytest.mark.usefixtures('local_memory_cache')
+    def test_when_dnb_data_in_cache_this_is_returned_instead_of_calling_api(self, requests_mock):
+        """
+        Test when a value is stored in the cache the dnb api is not called
+        """
+        cache.set(self.FAMILY_TREE_CACHE_KEY, 'cached')
+
+        matcher = requests_mock.post(
+            DNB_HIERARCHY_COUNT_URL,
+            status_code=200,
+            content=b'1',
+        )
+
+        result = get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+        assert result == 'cached'
+
+        get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+        get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+
+        assert not matcher.called
+
+    @pytest.mark.usefixtures('local_memory_cache')
+    @pytest.mark.parametrize(
+        'request_exception,expected_exception',
+        (
+            (
+                ConnectionError,
+                DNBServiceConnectionError,
+            ),
+            (
+                ConnectTimeout,
+                DNBServiceConnectionError,
+            ),
+            (
+                Timeout,
+                DNBServiceTimeoutError,
+            ),
+            (
+                ReadTimeout,
+                DNBServiceTimeoutError,
+            ),
+        ),
+    )
+    def test_when_dnb_api_error_response_is_not_cached(
+        self,
+        requests_mock,
+        request_exception,
+        expected_exception,
+    ):
+        """
+        Test when the dnb api raises an error the value is not cached
+        """
+        with pytest.raises(expected_exception):
+            requests_mock.post(DNB_HIERARCHY_COUNT_URL, exc=request_exception)
+            get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+        assert cache.get(self.FAMILY_TREE_CACHE_KEY) is None
+
+    def test_when_dnb_api_returns_status_code_not_success_response_is_not_cached(
+        self,
+        requests_mock,
+    ):
+        """
+        Test when the dnb api doesn't return a success http status code the value is not cached
+        """
+        with pytest.raises(DNBServiceError):
+            requests_mock.post(
+                DNB_HIERARCHY_COUNT_URL,
+                status_code=500,
+                content=b'2',
+            )
+            get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
+        assert cache.get(self.FAMILY_TREE_CACHE_KEY) is None

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -38,6 +38,7 @@ DNB_HIERARCHY_SEARCH_URL = urljoin(
     f'{settings.DNB_SERVICE_BASE_URL}/',
     'companies/hierarchy/search/',
 )
+DNB_HIERARCHY_COUNT_URL = urljoin(DNB_HIERARCHY_SEARCH_URL, 'count')
 
 REQUIRED_REGISTERED_ADDRESS_FIELDS = [
     f'registered_address_{field}' for field in AddressSerializer.REQUIRED_FIELDS
@@ -2450,6 +2451,13 @@ class TestHierarchyAPITestMixin:
             ).encode('utf-8'),
         )
 
+    def set_dnb_hierarchy_count_mock_response(self, requests_mock, count, status_code=200):
+        requests_mock.post(
+            DNB_HIERARCHY_COUNT_URL,
+            status_code=status_code,
+            content=str(count).encode(),
+        )
+
 
 class TestCompanyHierarchyView(APITestMixin, TestHierarchyAPITestMixin):
     """
@@ -3903,7 +3911,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
             kwargs={'company_id': ultimate_company_dh.id},
         )
 
-        self.set_dnb_hierarchy_mock_response(requests_mock, [])
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 0)
 
         assert (
             self.api_client.get(
@@ -3921,7 +3929,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
             'api-v4:dnb-api:related-companies-count',
             kwargs={'company_id': ultimate_company_dh.id},
         )
-        self.set_dnb_hierarchy_mock_response(requests_mock, [])
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 0)
 
         assert (
             self.api_client.get(
@@ -3940,7 +3948,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
             kwargs={'company_id': ultimate_company_dh.id},
         )
 
-        self.set_dnb_hierarchy_mock_response(requests_mock, [])
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 0)
 
         assert (
             self.api_client.get(
@@ -3960,7 +3968,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
             'api-v4:dnb-api:related-companies-count',
             kwargs={'company_id': ultimate_company_dh.id},
         )
-        self.set_dnb_hierarchy_mock_response(requests_mock, [])
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 0)
 
         assert (
             self.api_client.get(
@@ -3980,7 +3988,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
             'api-v4:dnb-api:related-companies-count',
             kwargs={'company_id': ultimate_company_dh.id},
         )
-        self.set_dnb_hierarchy_mock_response(requests_mock, [1])
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 1)
 
         assert (
             self.api_client.get(
@@ -4003,7 +4011,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
             'api-v4:dnb-api:related-companies-count',
             kwargs={'company_id': ultimate_company_dh.id},
         )
-        self.set_dnb_hierarchy_mock_response(requests_mock, [1])
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 1)
 
         assert (
             self.api_client.get(
@@ -4023,7 +4031,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
             'api-v4:dnb-api:related-companies-count',
             kwargs={'company_id': ultimate_company_dh.id},
         )
-        self.set_dnb_hierarchy_mock_response(requests_mock, [1] * 10)
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 10)
 
         assert (
             self.api_client.get(

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -44,6 +44,7 @@ from datahub.dnb_api.utils import (
     DNBServiceTimeoutError,
     get_change_request,
     get_company,
+    get_company_hierarchy_count,
     get_company_hierarchy_data,
     get_datahub_company_ids,
     request_changes,
@@ -532,7 +533,7 @@ class DNBRelatedCompaniesCountView(APIView):
     def get(self, request, company_id):
         duns_number = validate_company_id(company_id)
         try:
-            hierarchy = get_company_hierarchy_data(duns_number)
+            companies_count = get_company_hierarchy_count(duns_number)
         except (
             DNBServiceConnectionError,
             DNBServiceTimeoutError,
@@ -540,7 +541,6 @@ class DNBRelatedCompaniesCountView(APIView):
         ) as exc:
             raise APIUpstreamException(str(exc))
 
-        companies_count = hierarchy.get('global_ultimate_family_tree_members_count', 0)
         if companies_count > 0:
             companies_count -= 1  # deduct 1 as the list from dnb contains the company requested
 


### PR DESCRIPTION
### Description of change

- Switch to the new dnb service endpoint for getting the count of companies in the hierarchy
- Move the exception handling to a shared function

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
