### PR TITLE
Fix email auth

### DIFF
--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -146,6 +146,64 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'Domain "gmail.com" not present in DIT_EMAIL_DOMAINS setting.'
             ),
         ),
+        # Domain which is not on DIT_EMAIL_DOMAINS setting, fails validation.
+        # multiple auth methods
+        (
+            'joe.bloggs@gmail.com',
+            [
+                '\n'.join([
+                    'mx.google.com;',
+                    'dkim=pass header.i=@gmail.com header.s=selector1 header.b=foobar;',
+                    'spf=pass (google.com: domain of joe.bloggs@gmail.com designates '
+                    'XX.XXX.XX.XX as permitted sender) ',
+                    'smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
+                    'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
+                    'header.from=digital.trade.gov.uk;',
+                ]),
+                '\n'.join([
+                    'mx.google.com;',
+                    'dkim=pass header.i=@example.com header.s=selector1 header.b=foobar;',
+                    'spf=pass (google.com: domain of joe.bloggs@gmail.com designates '
+                    'XX.XXX.XX.XX as permitted sender) ',
+                    'smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
+                    'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
+                    'header.from=digital.trade.gov.uk;',
+                ]),
+            ],
+            False,
+            (
+                'Domain "gmail.com" not present in DIT_EMAIL_DOMAINS setting.'
+            ),
+        ),
+        # Valid digital.trade.gov.uk email, ensure whitelist is case insensitive
+        # multiple auth methods
+        (
+            'bill.Adama@digital.trade.gov.uk',
+            [
+                '\n'.join([
+                    'mx.google.com;',
+                    'dkim=pass header.i=@digital.trade.gov.uk header.s=selector1 header.b=foobar;',
+                    'spf=pass (google.com: domain of bill.adama@digital.trade.gov.uk designates '
+                    'XX.XXX.XX.XX as permitted sender) ',
+                    'smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
+                    'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
+                    'header.from=digital.trade.gov.uk',
+                    'compauth=pass (reason=109)',
+                ]),
+                '\n'.join([
+                    'mx.google.com;',
+                    'dkim=pass header.i=@digital.trade.gov.uk header.s=selector1 header.b=foobar;',
+                    'spf=pass (google.com: domain of bill.adama@digital.trade.gov.uk designates '
+                    'XX.XXX.XX.XX as permitted sender) ',
+                    'smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
+                    'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
+                    'header.from=digital.trade.gov.uk',
+                    'compauth=pass (reason=109)',
+                ]),
+            ],
+            True,
+            None,
+        ),
         # Blacklisted email
         (
             'blacklisted@trade.gov.uk',


### PR DESCRIPTION
### Description of change

When message passes through multiple mail servers, the `authentication_results` becomes an array. When this happens the `was_email_sent_by_dit` fails. 
This fixes it by looking at the top result if `authentication_results` is an array.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
