### PR TITLE
feature/rename-api-query-param

### DIFF
--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -3915,7 +3915,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
 
         assert (
             self.api_client.get(
-                f'{url}?include_subsidiary_companies=false',
+                f'{url}?include_manually_linked_companies=false',
             ).json()
             == 0
         )
@@ -3933,7 +3933,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
 
         assert (
             self.api_client.get(
-                f'{url}?include_subsidiary_companies=true',
+                f'{url}?include_manually_linked_companies=true',
             ).json()
             == 0
         )
@@ -3952,7 +3952,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
 
         assert (
             self.api_client.get(
-                f'{url}?include_subsidiary_companies=false',
+                f'{url}?include_manually_linked_companies=false',
             ).json()
             == 0
         )
@@ -3972,7 +3972,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
 
         assert (
             self.api_client.get(
-                f'{url}?include_subsidiary_companies=true',
+                f'{url}?include_manually_linked_companies=true',
             ).json()
             == 1
         )
@@ -3992,7 +3992,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
 
         assert (
             self.api_client.get(
-                f'{url}?include_subsidiary_companies=true',
+                f'{url}?include_manually_linked_companies=true',
             ).json()
             == 1
         )
@@ -4015,7 +4015,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
 
         assert (
             self.api_client.get(
-                f'{url}?include_subsidiary_companies=false',
+                f'{url}?include_manually_linked_companies=false',
             ).json()
             == 0
         )
@@ -4035,7 +4035,7 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
 
         assert (
             self.api_client.get(
-                f'{url}?include_subsidiary_companies=true',
+                f'{url}?include_manually_linked_companies=true',
             ).json()
             == 12
         )

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -544,7 +544,7 @@ class DNBRelatedCompaniesCountView(APIView):
         if companies_count > 0:
             companies_count -= 1  # deduct 1 as the list from dnb contains the company requested
 
-        if request.query_params.get('include_subsidiary_companies') == 'true':
+        if request.query_params.get('include_manually_linked_companies') == 'true':
             subsidiary_companies_count = Company.objects.filter(
                 global_headquarters_id=company_id,
             ).count()


### PR DESCRIPTION
### Description of change

Change the name of the query param on the related companies count endpoint to better describe what can be included. This is needed as the DNB companies also mention subsidiaries, but in this endpoint the argument refers to manually linked companies.

This endpoint is not yet being used by the front end, and will not cause a breaking change by renaming the argument. This is the PR that will use it https://github.com/uktrade/data-hub-frontend/pull/5787/files

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
