### PR TITLE
feature/CLS2-301-related-companies-handle-large-trees

### DIFF
--- a/datahub/dnb_api/constants.py
+++ b/datahub/dnb_api/constants.py
@@ -40,3 +40,5 @@ ALL_DNB_UPDATED_MODEL_FIELDS = (
     'global_ultimate_duns_number',
     'company_number',
 )
+
+MAX_COMPANIES_IN_TREE_COUNT = 1000

--- a/datahub/dnb_api/models.py
+++ b/datahub/dnb_api/models.py
@@ -1,0 +1,5 @@
+class HierarchyData:
+    def __init__(self, data, count: int, reduced: bool) -> None:
+        self.data = data
+        self.count = count
+        self.reduced = reduced

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -49,8 +49,8 @@ from datahub.dnb_api.utils import (
     get_cached_dnb_company,
     get_company,
     get_company_hierarchy_count,
-    get_company_hierarchy_data,
     get_company_update_page,
+    get_full_company_hierarchy_data,
     get_reduced_company_hierarchy_data,
     load_datahub_details,
     RevisionNotFoundError,
@@ -654,7 +654,7 @@ class TestFormatDNBCompany:
         assert company['is_turnover_estimated'] is None
 
 
-class TestDNBHierarchyData:
+class TestDNBFullHierarchyData:
     """
     Tests for DNB Hierarchy function.
     """
@@ -669,7 +669,7 @@ class TestDNBHierarchyData:
         is not set.
         """
         with pytest.raises(ImproperlyConfigured):
-            get_company_hierarchy_data('123456789')
+            get_full_company_hierarchy_data('123456789')
 
     @pytest.mark.usefixtures('local_memory_cache')
     def test_when_dnb_data_not_in_cache_dnb_api_is_called(self, requests_mock):
@@ -682,7 +682,7 @@ class TestDNBHierarchyData:
             status_code=200,
             content=b'{"family_tree_members":[]}',
         )
-        get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
 
         assert matcher.called_once
         assert cache.get(self.FAMILY_TREE_CACHE_KEY) is not None
@@ -694,17 +694,16 @@ class TestDNBHierarchyData:
     ):
         """
         Test that after a successful call to the dnb api, all subsequent calls to the
-        get_company_hierarchy_data function get the data from the cache
+        get_full_company_hierarchy_data function get the data from the cache
         """
         matcher = requests_mock.post(
             DNB_HIERARCHY_SEARCH_URL,
-            status_code=200,
             content=b'{"family_tree_members":[]}',
         )
 
-        get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
-        get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
-        get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
 
         assert matcher.called_once
 
@@ -717,15 +716,14 @@ class TestDNBHierarchyData:
 
         matcher = requests_mock.post(
             DNB_HIERARCHY_SEARCH_URL,
-            status_code=200,
             content=b'{"family_tree_members":[]}',
         )
 
-        result = get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        result = get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
         assert result == 'cached'
 
-        get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
-        get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+        get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
 
         assert not matcher.called
 
@@ -762,7 +760,7 @@ class TestDNBHierarchyData:
         """
         with pytest.raises(expected_exception):
             requests_mock.post(DNB_HIERARCHY_SEARCH_URL, exc=request_exception)
-            get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+            get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
         assert cache.get(self.FAMILY_TREE_CACHE_KEY) is None
 
     def test_when_dnb_api_returns_status_code_not_success_response_is_not_cached(
@@ -778,7 +776,7 @@ class TestDNBHierarchyData:
                 status_code=500,
                 content=b'{"family_tree_members":[]}',
             )
-            get_company_hierarchy_data(self.VALID_DUNS_NUMBER)
+            get_full_company_hierarchy_data(self.VALID_DUNS_NUMBER)
         assert cache.get(self.FAMILY_TREE_CACHE_KEY) is None
 
 
@@ -1066,7 +1064,6 @@ class TestDNBHierarchyCount:
         """
         matcher = requests_mock.post(
             DNB_HIERARCHY_COUNT_URL,
-            status_code=200,
             content=b'1',
         )
         get_company_hierarchy_count(self.VALID_DUNS_NUMBER)
@@ -1085,7 +1082,6 @@ class TestDNBHierarchyCount:
         """
         matcher = requests_mock.post(
             DNB_HIERARCHY_COUNT_URL,
-            status_code=200,
             content=b'5',
         )
 
@@ -1104,7 +1100,6 @@ class TestDNBHierarchyCount:
 
         matcher = requests_mock.post(
             DNB_HIERARCHY_COUNT_URL,
-            status_code=200,
             content=b'1',
         )
 

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -3105,7 +3105,7 @@ class TestCompanyHierarchyView(APITestMixin, TestHierarchyAPITestMixin):
             assert response.json()['reduced_tree'] is True
 
 
-class TestRelatedCompanyView(APITestMixin):
+class TestRelatedCompanyView(APITestMixin, TestHierarchyAPITestMixin):
     """
     DNB Company Hierarchy Search view test case.
     """
@@ -3156,6 +3156,7 @@ class TestRelatedCompanyView(APITestMixin):
             DNB_HIERARCHY_SEARCH_URL,
             exc=request_exception,
         )
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 2)
 
         url = reverse('api-v4:dnb-api:related-companies', kwargs={'company_id': company.id})
         response = api_client.get(
@@ -3177,6 +3178,7 @@ class TestRelatedCompanyView(APITestMixin):
             status_code=200,
             content=b'{"family_tree_members":[]}',
         )
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, 2)
 
         url = reverse('api-v4:dnb-api:related-companies', kwargs={'company_id': company.id})
         response = api_client.get(
@@ -3185,8 +3187,10 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
+
         assert response.json() == {
             'related_companies': [],
+            'reduced_tree': None,
         }
 
     def test_single_subsidiary_id_is_returned_when_exists_in_data_hub(
@@ -3239,7 +3243,10 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() == [child_company_dh.id]
+        assert response.json() == {
+            'related_companies': [child_company_dh.id],
+            'reduced_tree': False,
+        }
 
     def test_single_parent_id_is_returned_when_exists_in_data_hub(
         self,
@@ -3291,8 +3298,12 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() == [ultimate_company_dh.id]
-        assert response.json() != [child_company_dh.id]
+        assert response.json() == {
+            'related_companies': [
+                ultimate_company_dh.id,
+            ],
+            'reduced_tree': False,
+        }
 
     def test_all_ids_except_self_are_returned_when_all_companies_are_in_data_hub_and_params_true(
         self,
@@ -3388,12 +3399,16 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() == [
-            ultimate_company_dh.id,
-            direct_company_dh.id,
-            child_one_company_dh.id,
-            child_two_company_dh.id,
-        ]
+
+        assert response.json() == {
+            'related_companies': [
+                ultimate_company_dh.id,
+                direct_company_dh.id,
+                child_one_company_dh.id,
+                child_two_company_dh.id,
+            ],
+            'reduced_tree': False,
+        }
 
     def test_only_ids_are_returned_when_companies_are_in_data_hub_and_params_true(
         self,
@@ -3479,7 +3494,11 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() == [ultimate_company_dh.id, child_two_company_dh.id]
+
+        assert response.json() == {
+            'related_companies': [ultimate_company_dh.id, child_two_company_dh.id],
+            'reduced_tree': False,
+        }
 
     def test_no_ids_are_returned_when_no_companies_are_in_data_hub_and_params_true(
         self,
@@ -3555,7 +3574,11 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() == []
+
+        assert response.json() == {
+            'related_companies': [],
+            'reduced_tree': False,
+        }
 
     def test_all_ids_directly_related_returned_when_all_companies_are_in_data_hub_and_params_true(
         self,
@@ -3633,11 +3656,11 @@ class TestRelatedCompanyView(APITestMixin):
             id='444e9b35-3415-4b9b-b9ff-f97446ac8942',
             name=child_one_company_dnb['primaryName'],
         )
-        not_directly_related_company_dh = CompanyFactory(
+        CompanyFactory(
             duns_number=not_directly_related_company_dnb['duns'],
             id='555e9b35-3415-4b9b-b9ff-f97446ac8942',
             name=not_directly_related_company_dnb['primaryName'],
-        )
+        )  # not_directly_related_company_dh
 
         opensearch_with_signals.indices.refresh()
 
@@ -3651,17 +3674,15 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() != [
-            ultimate_company_dh.id,
-            direct_company_dh.id,
-            child_one_company_dh.id,
-            not_directly_related_company_dh,
-        ]
-        assert response.json() == [
-            ultimate_company_dh.id,
-            direct_company_dh.id,
-            child_one_company_dh.id,
-        ]
+
+        assert response.json() == {
+            'related_companies': [
+                ultimate_company_dh.id,
+                direct_company_dh.id,
+                child_one_company_dh.id,
+            ],
+            'reduced_tree': False,
+        }
 
     def test_only_parent_ids_returned_when_include_parent_set_true_and_include_subsidiary_false(
         self,
@@ -3734,16 +3755,16 @@ class TestRelatedCompanyView(APITestMixin):
             id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
             name=target_company_dnb['primaryName'],
         )
-        child_one_company_dh = CompanyFactory(
+        CompanyFactory(
             duns_number=child_one_company_dnb['duns'],
             id='444e9b35-3415-4b9b-b9ff-f97446ac8942',
             name=child_one_company_dnb['primaryName'],
-        )
-        child_two_company_dh = CompanyFactory(
+        )  # child_one_company_dh
+        CompanyFactory(
             duns_number=child_two_company_dnb['duns'],
             id='555e9b35-3415-4b9b-b9ff-f97446ac8942',
             name=child_two_company_dnb['primaryName'],
-        )
+        )  # child_two_company_dh
 
         opensearch_with_signals.indices.refresh()
 
@@ -3757,14 +3778,11 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() == [
-            ultimate_company_dh.id,
-            direct_company_dh.id,
-        ]
-        assert response.json() != [
-            child_one_company_dh.id,
-            child_two_company_dh.id,
-        ]
+
+        assert response.json() == {
+            'related_companies': [ultimate_company_dh.id, direct_company_dh.id],
+            'reduced_tree': False,
+        }
 
     def test_only_subsidiary_ids_returned_when_include_parent_false_and_include_subsidiary_true(
         self,
@@ -3822,16 +3840,16 @@ class TestRelatedCompanyView(APITestMixin):
             child_one_company_dnb,
             child_two_company_dnb,
         ]
-        ultimate_company_dh = CompanyFactory(
+        CompanyFactory(
             duns_number=ultimate_company_dnb['duns'],
             id='111e9b35-3415-4b9b-b9ff-f97446ac8942',
             name=ultimate_company_dnb['primaryName'],
-        )
-        direct_company_dh = CompanyFactory(
+        )  # ultimate_company_dh
+        CompanyFactory(
             duns_number=direct_company_dnb['duns'],
             id='222e9b35-3415-4b9b-b9ff-f97446ac8942',
             name=direct_company_dnb['primaryName'],
-        )
+        )  # direct_company_dh
         target_company_dh = CompanyFactory(
             duns_number=target_company_dnb['duns'],
             id='333e9b35-3415-4b9b-b9ff-f97446ac8942',
@@ -3860,14 +3878,10 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() == [
-            child_one_company_dh.id,
-            child_two_company_dh.id,
-        ]
-        assert response.json() != [
-            ultimate_company_dh.id,
-            direct_company_dh.id,
-        ]
+        assert response.json() == {
+            'related_companies': [child_one_company_dh.id, child_two_company_dh.id],
+            'reduced_tree': False,
+        }
 
     def test_no_ids_returned_when_include_parent_false_and_include_subsidiary_false(
         self,
@@ -3963,7 +3977,7 @@ class TestRelatedCompanyView(APITestMixin):
         )
 
         assert response.status_code == 200
-        assert response.json() == []
+        assert response.json() == {'related_companies': [], 'reduced_tree': False}
 
     def _get_related_company_response(
         self,
@@ -3984,6 +3998,7 @@ class TestRelatedCompanyView(APITestMixin):
                 },
             ).encode('utf-8'),
         )
+        self.set_dnb_hierarchy_count_mock_response(requests_mock, len(tree_members))
         url = reverse(
             'api-v4:dnb-api:related-companies',
             kwargs={'company_id': ultimate_company.id},

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -48,8 +48,6 @@ logger = logging.getLogger(__name__)
 MAX_DUNS_NUMBERS_PER_REQUEST = 1024
 MAX_COMPANIES_IN_TREE_COUNT = 1000
 
-# HierarchyData = namedtuple('HierarchyData', ['data', 'count', 'reduced'])
-
 
 class DNBServiceBaseError(Exception):
     """

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -36,6 +36,7 @@ from datahub.core.serializers import AddressSerializer
 from datahub.dnb_api.constants import (
     ALL_DNB_UPDATED_MODEL_FIELDS,
     ALL_DNB_UPDATED_SERIALIZER_FIELDS,
+    MAX_COMPANIES_IN_TREE_COUNT,
 )
 from datahub.dnb_api.models import HierarchyData
 from datahub.dnb_api.serializers import DNBCompanyHierarchySerializer, DNBCompanySerializer
@@ -46,7 +47,6 @@ from datahub.search.query_builder import get_search_by_entities_query
 
 logger = logging.getLogger(__name__)
 MAX_DUNS_NUMBERS_PER_REQUEST = 1024
-MAX_COMPANIES_IN_TREE_COUNT = 1000
 
 
 class DNBServiceBaseError(Exception):


### PR DESCRIPTION
### Description of change

Refactor the logic around getting a company tree hierarchy into a new function, that first calculates whether the request will be above the max and will request the reduced family tree instead.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
