### PR TITLE
feature/CLS2-196-allow-searching-on-company-ids

### DIFF
--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -11,6 +11,7 @@ from datahub.search.serializers import (
 class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
     """Serialiser used to validate company search POST bodies."""
 
+    id = SingleOrListField(child=StringUUIDField(), required=False)
     archived = serializers.BooleanField(required=False)
     headquarter_type = SingleOrListField(
         child=StringUUIDField(allow_null=True),

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -1067,11 +1067,11 @@ class TestSearch(APITestMixin):
         )
 
         search_results = [company['id'] for company in response.data['results']]
-        expected_results = [str(company3.id), str(company1.id)]
+        expected_results = [str(company1.id), str(company3.id)]
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
-        assert search_results == expected_results
+        assert set(search_results) == set(expected_results)
 
 
 class TestCompanyExportView(APITestMixin):

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -1044,6 +1044,35 @@ class TestSearch(APITestMixin):
         assert area['id'] in ids
         assert area['name'] in names
 
+    def test_company_ids(self, opensearch_with_collector):
+        """Validate searching by multiple id's returns all matches"""
+        company1 = CompanyFactory(
+            name='abc',
+        )
+        CompanyFactory(
+            name='def',
+        )
+        company3 = CompanyFactory(
+            name='ghi',
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+        url = reverse('api-v4:search:company')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'id': [company1.id, company3.id],
+            },
+        )
+
+        search_results = [company['id'] for company in response.data['results']]
+        expected_results = [str(company3.id), str(company1.id)]
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+        assert search_results == expected_results
+
 
 class TestCompanyExportView(APITestMixin):
     """Tests the company export view."""

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -41,6 +41,7 @@ class SearchCompanyAPIViewMixin:
     )
 
     FILTER_FIELDS = (
+        'id',
         'archived',
         'headquarter_type',
         'name',


### PR DESCRIPTION
### Description of change

Allow the company search endpoint to accept queries using multiple company id's. This allows much faster front end queries, instead of calling the `/v4/company` endpoint for each company

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
