### PR TITLE
Skip export barrier type validation if empty.

### DIFF
--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -132,6 +132,8 @@ class CaseInsensitiveMultipleChoiceField(forms.MultipleChoiceField):
     def validate(self, value):
         """Case insensitive validation of choices."""
         for val in value:
+            if not (self.required or val):
+                continue
             if not any(choice for choice in self.choices if val.lower() == choice[0].lower()):
                 raise ValidationError(
                     self.error_messages['invalid_choice'],
@@ -289,7 +291,6 @@ class InteractionCSVRowForm(forms.Form):
         added to NON_FIELD_ERRORS (but this should not happen).
         """
         super().full_clean()
-
         if not self.is_valid_and_matched():
             return
 

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -1294,6 +1294,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
             'contact_email': contact.email,
             'service': service.name,
             'communication_channel': communication_channel.name,
+            'export_barrier_type': '',
         }
         form = InteractionCSVRowForm(data=data)
 


### PR DESCRIPTION
### Description of change

This ensures that if export_barrier_type is empty in the spreadsheet, it will not raise validation error, as the field is optional.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
