### PR TITLE
feature/CLS2-325-related-companies-return-summary

### DIFF
--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -4193,7 +4193,8 @@ class TestRelatedCompaniesCountView(APITestMixin, TestHierarchyAPITestMixin):
         assert response['reduced_tree'] is not True
 
     def test_dnb_company_count_of_10000_and_subsidiary_count_of_3_returns_10002_and_reduced_tree(
-        self, requests_mock
+        self,
+        requests_mock,
     ):
         ultimate_company_dh = CompanyFactory(
             duns_number='123456789',


### PR DESCRIPTION
### Description of change

Amend endpoint to return a broken down summary of counts instead of just a single value. This will help the front end in an upcoming ticket to determine whether a full tree can be shown or a reduced one.

This endpoint is not yet being consumed by the front end so no concerns about introducing breaking changes

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
