### PR TITLE
bugfix/CPS-486-last-won-date-blank

### DIFF
--- a/datahub/investment/project/test/factories.py
+++ b/datahub/investment/project/test/factories.py
@@ -67,7 +67,7 @@ class InvestmentProjectFactory(factory.django.DjangoModelFactory):
     referral_source_adviser = factory.SubFactory(AdviserFactory)
     likelihood_to_land_id = LikelihoodToLand.high.value.id
     archived_documents_url_path = factory.Faker('uri_path')
-    created_on = now()
+    created_on = factory.LazyFunction(now)
 
     @to_many_field
     def business_activities(self):

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -11,7 +11,8 @@ import factory
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
-from django.utils.timezone import utc
+from django.utils.timezone import now, utc
+
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -1444,14 +1445,14 @@ class TestSummaryAggregation(APITestMixin):
         opensearch_with_collector,
     ):
         """Details of last won project should be shown in won summary for a investor company"""
+        early_created = InvestmentProjectFactory(
+            stage_id=constants.InvestmentProjectStage.won.value.id,
+            created_on=now() - datetime.timedelta(days=7),
+        )
         newly_created_investment = InvestmentProjectFactory(
             stage_id=constants.InvestmentProjectStage.won.value.id,
+            investor_company=early_created.investor_company,
             created_on=datetime.date.today(),
-        )
-        InvestmentProjectFactory(
-            stage_id=constants.InvestmentProjectStage.won.value.id,
-            investor_company=newly_created_investment.investor_company,
-            created_on=datetime.date.today() - datetime.timedelta(weeks=1),
         )
 
         # Update all this companies project logs to not be won, so the DB query in the view

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -356,15 +356,15 @@ class SearchInvestmentProjectAPIView(SearchInvestmentProjectAPIViewMixin, Search
                 'name': project_stage_log.investment_project.name,
                 'created_on': project_stage_log.created_on,
             }
-
         project_log = (
             InvestmentProject.objects.filter(
                 stage_id=InvestmentProjectStage.won.value.id,
                 investor_company_id=investor_company_id,
             )
-            .order_by('created_on')
+            .order_by('-created_on')
             .first()
         )
+
         if project_log:
             return {
                 'id': project_log.id,

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -362,7 +362,7 @@ class SearchInvestmentProjectAPIView(SearchInvestmentProjectAPIViewMixin, Search
                 stage_id=InvestmentProjectStage.won.value.id,
                 investor_company_id=investor_company_id,
             )
-            .order_by('-created_on')
+            .order_by('created_on')
             .first()
         )
         if project_log:

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -1339,7 +1339,7 @@
     modified_on: "2017-03-05T15:00:00Z"
 
 - model: investment.investmentproject
-  pk: 5d341b34-1fc8-4638-b4b1-a0922ebf401e
+  pk: fbac25ef-8437-4db6-97db-551210daf9a6
   fields:
     name: New airport
     description: This is a dummy investment project for testing

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -1542,9 +1542,9 @@
 - model: investment.investmentproject
   pk: 5d43a289-d152-461c-ae23-c594abdd890a
   fields:
-    name: Green tea plantation
+    name: An awesome project we won
     description: This is a dummy investment project for testing a won value
-    stage: 7606cc19-20da-4b74-aba1-2cec0d753ad8 # Active
+    stage: 945ea6d1-eee3-4f5b-9144-84a75b71b8e6 # Won
     status: won
     actual_land_date: 2020-01-01
     investment_type: 3e143372-496c-4d1e-8278-6fdd3da9b48b # FDI

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -1539,6 +1539,44 @@
     modified_on: "2017-09-18T13:00:00Z"
     modified_by: 5a644146-5298-4741-91f3-d5d7558adf47
 
+- model: investment.investmentproject
+  pk: 5d43a289-d152-461c-ae23-c594abdd890a
+  fields:
+    name: Green tea plantation
+    description: This is a dummy investment project for testing a won value
+    stage: 7606cc19-20da-4b74-aba1-2cec0d753ad8 # Active
+    status: won
+    actual_land_date: 2020-01-01
+    investment_type: 3e143372-496c-4d1e-8278-6fdd3da9b48b # FDI
+    investor_company: 0f5216e0-849f-11e6-ae22-56b6b6499611
+    client_contacts:
+      - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
+    client_relationship_manager: e83a608e-84a4-11e6-ae22-56b6b6499611
+    referral_source_adviser: e83a608e-84a4-11e6-ae22-56b6b6499611
+    referral_source_activity: aba8f653-264f-48d8-950e-07f9c418c7b0
+    fdi_type: f8447013-cfdc-4f35-a146-6619665388b3
+    sector: 034be3be-5329-e511-b6bc-e4115bead28a
+    business_activities:
+      - a2dbd807-ae52-421c-8d1d-88adfc7a506b
+    client_cannot_provide_total_investment: false
+    total_investment: 1000000.0
+    client_cannot_provide_foreign_investment: false
+    foreign_equity_investment: 200000.0
+    government_assistance: true
+    number_new_jobs: 20
+    average_salary: 2943bf3d-32dd-43be-8ad4-969b006dee7b
+    site_decided: false
+    client_considering_other_countries: false
+    uk_region_locations:
+      - 814cd12a-6095-e211-a939-e4115bead28a
+    client_requirements: Anywhere
+    strategic_drivers:
+      - 382aa6d1-a362-4166-a09d-f579d9f3be75
+    project_manager: d7493b4e-5d7b-4834-98d9-28b78a74052a
+    project_assurance_adviser: 5a644146-5298-4741-91f3-d5d7558adf47
+    created_on: "2017-10-08T10:00:00Z"
+    modified_on: "2017-11-08T10:00:00Z"
+
 - model: investment.investmentprojectteammember
   pk: 5
   fields:


### PR DESCRIPTION
### Description of change

The query to calculate the last won project uses the `InvestmentProjectStageLog` model, however we have discovered that this model is only updated when a change to the `InvestmentProject` status is detected. 

There is a scenario where an `InvestmentProject` could be created by a migration or in django admin, with the status already set to Won. In this scenario, the `InvestmentProjectStageLog` entry would never be added, as a change to the `InvestmentProject` status is not made

This PR adds a fallback, so when an company has no `Won` projects in its `InvestmentProjectStageLog` a query on the `InvestmentProject` that are marked `Won` ordered on created date will be used instead.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
