### PR TITLE
Add headquarter type to company tree endpoint

### DIFF
--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -2660,6 +2660,7 @@ class TestCompanyHierarchyView(APITestMixin, TestHierarchyAPITestMixin):
                     'name': ultimate_company_dh.sector.name,
                 },
                 'trading_names': trading_names,
+                'headquarter_type': ultimate_company_dh.headquarter_type,
                 'uk_region': {
                     'id': str(ultimate_company_dh.uk_region.id),
                     'name': ultimate_company_dh.uk_region.name,
@@ -2769,6 +2770,7 @@ class TestCompanyHierarchyView(APITestMixin, TestHierarchyAPITestMixin):
                     'name': ultimate_company_dh.sector.name,
                 },
                 'trading_names': [ultimate_tree_member_level_1.get('tradeStyleNames')[0]['name']],
+                'headquarter_type': ultimate_company_dh.headquarter_type,
                 'uk_region': {
                     'id': str(ultimate_company_dh.uk_region.id),
                     'name': ultimate_company_dh.uk_region.name,
@@ -2789,6 +2791,7 @@ class TestCompanyHierarchyView(APITestMixin, TestHierarchyAPITestMixin):
                         'registered_address': None,
                         'sector': None,
                         'trading_names': [],
+                        'headquarter_type': None,
                         'uk_region': None,
                         'one_list_tier': None,
                         'archived': False,
@@ -2804,6 +2807,7 @@ class TestCompanyHierarchyView(APITestMixin, TestHierarchyAPITestMixin):
                                 'registered_address': None,
                                 'sector': None,
                                 'trading_names': [],
+                                'headquarter_type': None,
                                 'uk_region': None,
                                 'one_list_tier': None,
                                 'archived': False,
@@ -4415,6 +4419,7 @@ class TestCompanyHierarchyReducedView(APITestMixin, TestHierarchyAPITestMixin):
                         'name': global_company.sector.name,
                     },
                     'trading_names': [],
+                    'headquarter_type': global_company.headquarter_type,
                     'uk_region': {
                         'id': str(global_company.uk_region.id),
                         'name': global_company.uk_region.name,

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -4461,6 +4461,7 @@ class TestCompanyHierarchyReducedView(APITestMixin, TestHierarchyAPITestMixin):
                                 'name': company.sector.name,
                             },
                             'trading_names': [],
+                            'headquarter_type': company.headquarter_type,
                             'uk_region': {
                                 'id': str(company.uk_region.id),
                                 'name': company.uk_region.name,

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -707,6 +707,7 @@ def create_company_tree(companies: list, duns_number):
             'numberOfEmployees': 'number_of_employees',
             'oneListTier': 'one_list_tier',
             'tradeStyleNames': 'trading_names',
+            'headquarterType': 'headquarter_type',
         },
     )
 
@@ -761,6 +762,9 @@ def create_company_hierarchy_dataframe(family_tree_members: list, duns_number):
             'country': {'id': 'country.id', 'name': 'country.name'},
         },
     )
+    _merge_columns_into_single_column(
+        normalized_df, 'headquarterType', ['headquarterType.id', 'headquarterType.name']
+    )
     _move_requested_duns_to_start_of_subsidiary_list(normalized_df, duns_number)
     return normalized_df
 
@@ -809,6 +813,7 @@ def append_datahub_details(family_tree_members: list):
                 )
                 family_member['archived'] = datahub_detail.get('archived')
                 family_member['oneListTier'] = datahub_detail.get('one_list_tier')
+                family_member['headquarterType'] = datahub_detail.get('headquarter_type')
                 if not number_of_employees:
                     family_member['numberOfEmployees'] = datahub_detail.get('number_of_employees')
                 break  # Stop once we've found the match
@@ -889,6 +894,7 @@ def load_datahub_details(family_tree_members_duns):
                 'archived',
                 'one_list_tier',
                 'number_of_employees',
+                'headquarter_type',
             ),
         )[0:MAX_DUNS_NUMBERS_PER_REQUEST]
         opensearch_results = execute_search_query(query)

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -763,7 +763,7 @@ def create_company_hierarchy_dataframe(family_tree_members: list, duns_number):
         },
     )
     _merge_columns_into_single_column(
-        normalized_df, 'headquarterType', ['headquarterType.id', 'headquarterType.name']
+        normalized_df, 'headquarterType', ['headquarterType.id', 'headquarterType.name'],
     )
     _move_requested_duns_to_start_of_subsidiary_list(normalized_df, duns_number)
     return normalized_df


### PR DESCRIPTION
### Description of change

Headquarter_type is now returned on the company tree. It can be seen when using this endpoint:
`v4/dnb/{companyId/family-tree`

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
