### PR TITLE
bugfix/CLS2-376-include-manually-linked-when-no-dnb-companies-found

### DIFF
--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -406,7 +406,9 @@ class DNBCompanyHierarchyView(APIView):
             'ultimate_global_company': {},
             'ultimate_global_companies_count': 0,
             'family_tree_companies_count': 0,
-            'manually_verified_subsidiaries': [],
+            'manually_verified_subsidiaries': self.get_manually_verified_subsidiaries(
+                company_id,
+            ),
             'reduced_tree': hierarchy_data.reduced,
         }
         if not hierarchy_data.data:
@@ -416,9 +418,6 @@ class DNBCompanyHierarchyView(APIView):
 
         json_response['ultimate_global_company'] = nested_tree
         json_response['ultimate_global_companies_count'] = companies_count + 1
-        json_response['manually_verified_subsidiaries'] = self.get_manually_verified_subsidiaries(
-            company_id,
-        )
         json_response['family_tree_companies_count'] = hierarchy_data.count
 
         return Response(json_response)


### PR DESCRIPTION
### Description of change

Return manually linked subsidiaries even when no related DNB companies are found

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
