### PR TITLE
Extract email data for interaction.

### DIFF
--- a/datahub/interaction/test/email_processors/conftest.py
+++ b/datahub/interaction/test/email_processors/conftest.py
@@ -7,7 +7,7 @@ from datahub.interaction.test.factories import CompanyInteractionFactory
 
 
 @pytest.fixture()
-def calendar_data_fixture():
+def interaction_email_fixture():
     """
     Create advisers, contacts and companies so that our email samples can be
     attributed to some DB entities.


### PR DESCRIPTION
### Description of change

This adds another email parser that extracts interaction information without the need for calendar invite.


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
