### PR TITLE
Fix company export admin.

### DIFF
--- a/datahub/company/admin/export.py
+++ b/datahub/company/admin/export.py
@@ -35,4 +35,24 @@ class CompanyExportAdmin(BaseModelAdminMixin, VersionAdmin):
         'modified_on',
         'modified_by',
     )
+    search_fields = (
+        'title',
+        'id',
+        'company__pk',
+        'owner__pk',
+    )
+    autocomplete_fields = (
+        'company',
+        'contacts',
+        'owner',
+        'team_members',
+    )
+    read_only_fields = (
+        'id',
+    )
+    list_display = (
+        'title',
+        'company',
+        'owner',
+    )
     form = CompanyExportAdminForm


### PR DESCRIPTION
### Description of change

This updates Company Export admin, so that the form doesn't load all objects for owner, team members and so on causing the page to time out. Those fields are replaced with autocompletes.

It also adds basic search by ids and expands the columns, so that the company and owner are shown.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
