### PR TITLE
feature/CLS2-387-archived-filtering

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -1231,6 +1231,7 @@ class CompanyExportSerializer(serializers.ModelSerializer):
 
 class ObjectiveV4Serializer(PermittedFieldsModelSerializer):
     modified_by = NestedAdviserField(read_only=True)
+    archived_by = NestedAdviserField(read_only=True)
     company = NestedRelatedField(Company)
 
     class Meta:

--- a/datahub/company/test/test_company_objective_view.py
+++ b/datahub/company/test/test_company_objective_view.py
@@ -87,7 +87,7 @@ class TestGettingObjectivesForCompany(APITestMixin):
         assert expected_ids == actual_ids
         assert response.status_code == status.HTTP_200_OK
 
-    @pytest.mark.parametrize('archived', ((True), (False)))
+    @pytest.mark.parametrize('archived', ((True), (False), (None)))
     def test_company_objectives_archived_filtering(self, archived):
         user = create_test_user(
             permission_codenames=(
@@ -109,9 +109,13 @@ class TestGettingObjectivesForCompany(APITestMixin):
         api_client = self.create_api_client(user=user)
         response = api_client.get(f'{url}?archived={archived}')
 
-        expected_ids = {
-            str(archived_objective.id) if archived else str(not_archived_objective.id),
-        }
+        expected_ids = (
+            {str(archived_objective.id), str(not_archived_objective.id)}
+            if archived is None
+            else {
+                str(archived_objective.id) if archived else str(not_archived_objective.id),
+            }
+        )
         actual_ids = {result['id'] for result in response.json()['results']}
 
         assert expected_ids == actual_ids

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -705,7 +705,11 @@ class SingleObjectiveV4ViewSet(ArchivableViewSetMixin, CoreViewSet):
         IsAuthenticated,
     ]
 
-    queryset = Objective.objects.all()
+    queryset = Objective.objects.all().select_related(
+        'company',
+        'archived_by',
+        'modified_by',
+    )
     serializer_class = ObjectiveV4Serializer
 
 
@@ -719,6 +723,7 @@ class CompanyObjectiveV4ViewSet(ArchivableViewSetMixin, CoreViewSet):
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     ordering_fields = ['target_date']
     ordering = ['target_date']
+    filterset_fields = ['archived']
 
     def get_queryset(self):
         """
@@ -726,7 +731,11 @@ class CompanyObjectiveV4ViewSet(ArchivableViewSetMixin, CoreViewSet):
         with a specific company
         """
         company_id = self.kwargs['company_id']
-        return Objective.objects.filter(company=company_id)
+        return Objective.objects.filter(company=company_id).select_related(
+            'company',
+            'archived_by',
+            'modified_by',
+        )
 
 
 @transaction.non_atomic_requests


### PR DESCRIPTION
### Description of change

- Add the ability to filter on the archived status of a companies objectives
- Add `select_related` to the objective queries to improve the performance on nested references
- Add the `archived_by` to the objective serialiser so both name and id get returned in the json

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
