### PR TITLE
feature/CLS2-392-objective-count-endpoint

### DIFF
--- a/datahub/company/urls/objective.py
+++ b/datahub/company/urls/objective.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from datahub.company.views import (
-    CompanyObjectiveCountV4ViewSet,
+    CompanyObjectiveArchivedCountV4ViewSet,
     CompanyObjectiveV4ViewSet,
     SingleObjectiveV4ViewSet,
 )
@@ -26,7 +26,7 @@ urls_v4 = [
     path('company/<uuid:company_id>/objective', Objective_v4_collection, name='list'),
     path(
         'company/<uuid:company_id>/objective/count',
-        CompanyObjectiveCountV4ViewSet.as_view(),
+        CompanyObjectiveArchivedCountV4ViewSet.as_view(),
         name='count',
     ),
     path('company/<uuid:company_id>/objective/<uuid:pk>', Objective_v4_item, name='detail'),

--- a/datahub/company/urls/objective.py
+++ b/datahub/company/urls/objective.py
@@ -1,6 +1,10 @@
 from django.urls import path
 
-from datahub.company.views import CompanyObjectiveV4ViewSet, SingleObjectiveV4ViewSet
+from datahub.company.views import (
+    CompanyObjectiveCountV4ViewSet,
+    CompanyObjectiveV4ViewSet,
+    SingleObjectiveV4ViewSet,
+)
 
 
 Objective_v4_collection = CompanyObjectiveV4ViewSet.as_view(
@@ -17,7 +21,13 @@ Objective_v4_item = SingleObjectiveV4ViewSet.as_view(
     },
 )
 
+
 urls_v4 = [
     path('company/<uuid:company_id>/objective', Objective_v4_collection, name='list'),
+    path(
+        'company/<uuid:company_id>/objective/count',
+        CompanyObjectiveCountV4ViewSet.as_view(),
+        name='count',
+    ),
     path('company/<uuid:company_id>/objective/<uuid:pk>', Objective_v4_item, name='detail'),
 ]

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -738,6 +738,23 @@ class CompanyObjectiveV4ViewSet(ArchivableViewSetMixin, CoreViewSet):
         )
 
 
+class CompanyObjectiveCountV4ViewSet(APIView):
+    """Objectives for getting count of objectives for a company"""
+
+    permission_classes = [
+        IsAuthenticated,
+    ]
+
+    def get(self, request, company_id):
+        queryset = Objective.objects.filter(company=company_id)
+        archived = request.query_params.get('archived')
+
+        if archived is not None:
+            queryset = queryset.filter(archived=True if archived == 'true' else False)
+
+        return Response(queryset.count())
+
+
 @transaction.non_atomic_requests
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -738,8 +738,8 @@ class CompanyObjectiveV4ViewSet(ArchivableViewSetMixin, CoreViewSet):
         )
 
 
-class CompanyObjectiveCountV4ViewSet(APIView):
-    """Objectives for getting count of objectives for a company"""
+class CompanyObjectiveArchivedCountV4ViewSet(APIView):
+    """Objectives for getting archived counts of objectives for a company"""
 
     permission_classes = [
         IsAuthenticated,

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -746,13 +746,15 @@ class CompanyObjectiveCountV4ViewSet(APIView):
     ]
 
     def get(self, request, company_id):
-        queryset = Objective.objects.filter(company=company_id)
-        archived = request.query_params.get('archived')
+        archived_count = Objective.objects.filter(company=company_id, archived=True).count()
+        not_archived_count = Objective.objects.filter(company=company_id, archived=False).count()
 
-        if archived is not None:
-            queryset = queryset.filter(archived=True if archived == 'true' else False)
-
-        return Response(queryset.count())
+        return Response(
+            {
+                'archived_count': archived_count,
+                'not_archived_count': not_archived_count,
+            },
+        )
 
 
 @transaction.non_atomic_requests


### PR DESCRIPTION
### Description of change

Added a new endpoint to return the counts of archived objectives. This is needed in the frontend when determining whether to display a button

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
