### PR TITLE
Ingest plain email interactions

### DIFF
--- a/datahub/email_ingestion/emails.py
+++ b/datahub/email_ingestion/emails.py
@@ -8,7 +8,7 @@ from django.utils.timezone import now
 
 from datahub.documents import utils as documents
 from datahub.email_ingestion.models import MailboxLogging, MailboxProcessingStatus
-from datahub.interaction.email_processors.processors import CalendarInteractionEmailProcessor
+from datahub.interaction.email_processors.processors import InteractionPlainEmailProcessor
 
 logger = getLogger(__name__)
 
@@ -49,7 +49,7 @@ def process_ingestion_emails():
     """
     Gets all new mail documents in the bucket and process each message.
     """
-    processor = CalendarInteractionEmailProcessor()
+    processor = InteractionPlainEmailProcessor()
 
     for message in get_mail_docs_in_bucket():
         source = message['source']

--- a/datahub/email_ingestion/test/test_emails.py
+++ b/datahub/email_ingestion/test/test_emails.py
@@ -47,7 +47,7 @@ class TestMailbox:
         monkeypatch.setattr('datahub.documents.utils.delete_document', mock_delete)
         monkeypatch.setattr(
             'datahub.interaction.email_processors.processors.'
-            'CalendarInteractionEmailProcessor.process_email',
+            'InteractionPlainEmailProcessor.process_email',
             mock_process,
         )
 
@@ -78,7 +78,7 @@ class TestMailbox:
         monkeypatch.setattr('datahub.documents.utils.delete_document', mock_delete)
         monkeypatch.setattr(
             'datahub.interaction.email_processors.processors.'
-            'CalendarInteractionEmailProcessor.process_email',
+            'InteractionPlainEmailProcessor.process_email',
             mock_process,
         )
 
@@ -110,7 +110,7 @@ class TestMailbox:
         monkeypatch.setattr('datahub.documents.utils.delete_document', mock_delete)
         monkeypatch.setattr(
             'datahub.interaction.email_processors.processors.'
-            'CalendarInteractionEmailProcessor.process_email',
+            'InteractionPlainEmailProcessor.process_email',
             mock_process,
         )
 


### PR DESCRIPTION
### Description of change

This changes the email ingestion task to use plain email processor instead of calendar.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
