### PR TITLE
feature/CLS2-291-caching-datahub-tree

### DIFF
--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -44,6 +44,7 @@ from datahub.search.query_builder import get_search_by_entities_query
 
 logger = logging.getLogger(__name__)
 MAX_DUNS_NUMBERS_PER_REQUEST = 1024
+COMPANY_TREE_TIMEOUT = int(timedelta(days=1).total_seconds())
 
 
 class DNBServiceBaseError(Exception):
@@ -602,8 +603,7 @@ def get_full_company_hierarchy_data(duns_number) -> HierarchyData:
     )
 
     # only cache successful dnb calls
-    one_day_timeout = int(timedelta(days=1).total_seconds())
-    cache.set(cache_key, hierarchy_data, one_day_timeout)
+    cache.set(cache_key, hierarchy_data, COMPANY_TREE_TIMEOUT)
 
     return hierarchy_data
 
@@ -932,8 +932,7 @@ def get_company_hierarchy_count(duns_number):
         companies_count = companies_count - 1
 
     # only cache successful dnb calls
-    one_day_timeout = int(timedelta(days=1).total_seconds())
-    cache.set(cache_key, companies_count, one_day_timeout)
+    cache.set(cache_key, companies_count, COMPANY_TREE_TIMEOUT)
 
     return companies_count
 
@@ -1056,8 +1055,7 @@ def get_cached_dnb_company(duns_number):
     company_response = get_dnb_company_data(duns_number)
 
     # only cache successful dnb calls
-    one_day_timeout = int(timedelta(days=1).total_seconds())
-    cache.set(cache_key, company_response, one_day_timeout)
+    cache.set(cache_key, company_response, COMPANY_TREE_TIMEOUT)
 
     return company_response
 

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -1,9 +1,13 @@
 import logging
 
+
 from django.conf import settings
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from django.utils.timezone import now
+from django.views.decorators.cache import cache_page
+
+
 from rest_framework import serializers
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -32,6 +36,7 @@ from datahub.dnb_api.serializers import (
     SubsidiarySerializer,
 )
 from datahub.dnb_api.utils import (
+    COMPANY_TREE_TIMEOUT,
     create_company_tree,
     create_investigation,
     DNBServiceConnectionError,
@@ -381,6 +386,7 @@ class DNBCompanyHierarchyView(APIView):
         ),
     )
 
+    @method_decorator(cache_page(COMPANY_TREE_TIMEOUT, key_prefix='company_hierarchy'))
     def get(self, request, company_id):
         """
         Given a Company Id, get the data for the company hierarchy from dnb-service.
@@ -482,6 +488,7 @@ class DNBRelatedCompaniesView(APIView):
         ),
     )
 
+    @method_decorator(cache_page(COMPANY_TREE_TIMEOUT, key_prefix='related_companies'))
     def get(self, request, company_id):
         """
         Given a Company Id, get the data for the company hierarchy from dnb-service


### PR DESCRIPTION
### Description of change

Added django view caching for the company tree and related companies endpoints. This caches the entire json output for 1 day, using the `cache_page` function

This has been tested on UAT

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
