### PR TITLE
Create management command to update area id for given state and country

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_company_area_id.py
+++ b/datahub/dbmaintenance/management/commands/update_company_area_id.py
@@ -1,0 +1,45 @@
+from logging import getLogger
+
+import reversion
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from datahub.company.models import Company
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Command to update address_area_id to None for companies with a given company id
+    and area id match.
+    """
+
+    help = ('Updates address_area_id to None for companies with the specified '
+            'company_id and area_id criteria.')
+
+    def add_arguments(self, parser):
+        parser.add_argument('area_id', type=str, help='UUID of the AdministrativeArea')
+        parser.add_argument('company_id', type=str, help='UUID of the Company')
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        area_id = options['area_id']
+        company_id = options['company_id']
+
+        # Fetch companies based on criteria
+        matching_companies = Company.objects.filter(
+            address_area_id=area_id,
+            id=company_id,
+        )
+
+        # Update the companies in a versioned way
+        with reversion.create_revision():
+            matching_companies.update(address_area_id=None)
+            reversion.set_comment('Set address_area_id to None for the given company and area id')
+
+        # Output message
+        self.stdout.write(self.style.SUCCESS(
+            f'Updated {matching_companies.count()} companies, set address_area_id to None.',
+        ))

--- a/datahub/dbmaintenance/management/commands/update_company_area_id.py
+++ b/datahub/dbmaintenance/management/commands/update_company_area_id.py
@@ -1,45 +1,54 @@
 from logging import getLogger
 
 import reversion
-
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
 from datahub.company.models import Company
+
 
 logger = getLogger(__name__)
 
 
 class Command(BaseCommand):
     """
-    Command to update address_area_id to None for companies with a given company id
+    Command to update address_area_id to None for companies with a given company address_country_id
     and area id match.
     """
 
     help = ('Updates address_area_id to None for companies with the specified '
-            'company_id and area_id criteria.')
+            'address_country_id and area_id criteria.')
 
     def add_arguments(self, parser):
         parser.add_argument('area_id', type=str, help='UUID of the AdministrativeArea')
-        parser.add_argument('company_id', type=str, help='UUID of the Company')
+        parser.add_argument(
+            'address_country_id',
+            type=str,
+            help='UUID of the Company’s address country',
+        )
 
     @transaction.atomic
     def handle(self, *args, **options):
         area_id = options['area_id']
-        company_id = options['company_id']
+        address_country_id = options['address_country_id']
 
         # Fetch companies based on criteria
         matching_companies = Company.objects.filter(
             address_area_id=area_id,
-            id=company_id,
+            address_country_id=address_country_id,
         )
 
-        # Update the companies in a versioned way
-        with reversion.create_revision():
-            matching_companies.update(address_area_id=None)
-            reversion.set_comment('Set address_area_id to None for the given company and area id')
+        if matching_companies.exists():
+            # Update the companies in a versioned way
+            with reversion.create_revision():
+                matching_companies.update(address_area_id=None)
+                reversion.set_comment('Set address_area_id to None')
 
-        # Output message
-        self.stdout.write(self.style.SUCCESS(
-            f'Updated {matching_companies.count()} companies, set address_area_id to None.',
-        ))
+            # Output message
+            self.stdout.write(self.style.SUCCESS(
+                f'Updated {matching_companies.count()} companies, set address_area_id to None.',
+            ))
+        else:
+            self.stdout.write(self.style.WARNING(
+                'No matching companies found. No updates were made.',
+            ))

--- a/datahub/dbmaintenance/test/commands/test_update_company_area_id.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_area_id.py
@@ -1,0 +1,58 @@
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.company.test.factories import CompanyFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_successful_update_area_id():
+    """Test successful address_area_id update."""
+    company = CompanyFactory(
+        address_area_id='c35c119a-bc4d-4e48-9ace-167dbe8cb695',
+        address_country_id='80756b9a-5d95-e211-a939-e4115bead28a',
+    )
+    call_command(
+        'update_company_area_id',
+        'c35c119a-bc4d-4e48-9ace-167dbe8cb695',
+        '80756b9a-5d95-e211-a939-e4115bead28a',
+    )
+    company.refresh_from_db()
+    assert company.address_area_id is None
+
+
+def test_no_update_needed_area_id():
+    """Test that no changes are made if the address_area_id is already None."""
+    company = CompanyFactory(
+        address_area_id=None,
+        address_country_id='80756b9a-5d95-e211-a939-e4115bead28a',
+    )
+    call_command(
+        'update_company_area_id',
+        'c35c119a-bc4d-4e48-9ace-167dbe8cb695',
+        '80756b9a-5d95-e211-a939-e4115bead28a',
+    )
+    company.refresh_from_db()
+    assert company.address_area_id is None
+
+    versions = Version.objects.get_for_object(company)
+    assert versions.count() == 0
+
+
+def test_no_company_with_given_country_id():
+    """Test that no changes are made if no company matches the given address_country_id."""
+    company = CompanyFactory(
+        address_area_id='c35c119a-bc4d-4e48-9ace-167dbe8cb695',
+        address_country_id='80756b9a-5d95-e211-a939-e4115bead28a',
+    )
+    call_command(
+        'update_company_area_id',
+        'c35c119a-bc4d-4e48-9ace-167dbe8cb695',
+        'dcba4321-dcba-4321-dcba-0987654321dc',
+    )
+    company.refresh_from_db()
+    assert str(company.address_area_id) == 'c35c119a-bc4d-4e48-9ace-167dbe8cb695'
+
+    versions = Version.objects.get_for_object(company)
+    assert versions.count() == 0


### PR DESCRIPTION
### Description of change

We currently have countries set to Colombia, yet area id is set to "US Columbia District".

The ask is to have these set to None as the area id is incorrect for Colombian companies.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
