### PR TITLE
Add investment name and project code to search

### DIFF
--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -46,6 +46,8 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
     )
     gross_value_added_start = serializers.IntegerField(required=False, min_value=0)
     gross_value_added_end = serializers.IntegerField(required=False, min_value=0)
+    name = SingleOrListField(child=serializers.CharField(), required=False)
+    project_code = SingleOrListField(child=serializers.CharField(), required=False)
 
     show_summary = serializers.BooleanField(required=False, default=False)
     include_parent_companies = serializers.BooleanField(required=False, default=False)

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -63,6 +63,8 @@ class SearchInvestmentProjectAPIViewMixin:
         'likelihood_to_land',
         'gross_value_added_start',
         'gross_value_added_end',
+        'name',
+        'project_code',
     )
 
     REMAP_FIELDS = {


### PR DESCRIPTION
### Description of change

The `name` and `project_code` fields have been added to the investment project search endpoint. This is required for an upcoming reactification ticket.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
