### PR TITLE
Allow export countries related to interaction to update and sync

### DIFF
--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -354,10 +354,9 @@ class BaseInteractionSerializer(serializers.ModelSerializer):
     def _save_export_countries(self, interaction, validated_export_countries):
         """
         Adds export countries related to an interaction.
-        Update is not allowed yet.
-        An attempt to update will result in `NotImplementedError` exception.
 
-        Syncs interaction export countries into company export countries.
+        Syncs interaction export countries into company export countries
+        when interaction is created.
         """
         existing_country_mapping = {
             export_country.country: export_country

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -221,26 +221,6 @@ class BaseInteractionSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(SERVICE_LEAF_NODE_NOT_SELECTED_MESSAGE)
         return value
 
-    def validate_were_countries_discussed(self, were_countries_discussed):
-        """
-        Make sure `were_countries_discussed` field is not being updated.
-        Updates are not allowed on this field.
-        """
-        if self.instance is None:
-            return were_countries_discussed
-
-        raise serializers.ValidationError(self.INVALID_FOR_UPDATE)
-
-    def validate_export_countries(self, export_countries):
-        """
-        Make sure `export_countries` field is not being updated.
-        updates are not allowed on this field.
-        """
-        if self.instance is None:
-            return export_countries
-
-        raise serializers.ValidationError(self.INVALID_FOR_UPDATE)
-
     def to_internal_value(self, data):
         """
         Add support for both `company` and `companies` field.

--- a/datahub/interaction/test/views/test_interaction_v4.py
+++ b/datahub/interaction/test/views/test_interaction_v4.py
@@ -2294,175 +2294,185 @@ class TestUpdateInteraction(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == error_response
 
-    @pytest.mark.parametrize(
-        'data,error_response',
-        (
-            (
+    @freeze_time('2017-04-18 13:25:30.986208')
+    @pytest.mark.parametrize('permissions', NON_RESTRICTED_ADD_PERMISSIONS)
+    def test_add_export_countries_interaction_without_existing_country_mapping(self, permissions):
+        """
+        Test that a user can update the interaction
+        when the interaction without existing export country set
+        """
+        adviser = create_test_user(
+            permission_codenames=permissions, dit_team=TeamFactory(),
+        )
+        company = CompanyFactory()
+        contact = ContactFactory(company=company)
+        communication_channel = random_obj_for_model(CommunicationChannel)
+
+        url = reverse('api-v4:interaction:collection')
+        request_data = {
+            'kind': Interaction.Kind.INTERACTION,
+            'communication_channel': communication_channel.pk,
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_participants': [
+                {'adviser': adviser.pk},
+            ],
+            'company': company.pk,
+            'contacts': [contact.pk],
+            'service': Service.inbound_referral.value.id,
+            'was_policy_feedback_provided': False,
+            'theme': Interaction.Theme.EXPORT,
+            'were_countries_discussed': True,
+            'export_countries': [
                 {
-                    'were_countries_discussed': False,
+                    'country': {
+                        'id': Country.canada.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                 },
                 {
-                    'were_countries_discussed': [
-                        'This field is invalid for interaction updates.',
-                    ],
-                },
-            ),
-            (
-                {
-                    'were_countries_discussed': True,
-                    'export_countries': [
-                        {
-                            'country': {
-                                'id': Country.greece.value.id,
-                            },
-                            'status': CompanyExportCountry.Status.CURRENTLY_EXPORTING,
-                        },
-                    ],
+                    'country': {
+                        'id': Country.japan.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.FUTURE_INTEREST,
                 },
                 {
-                    'were_countries_discussed': [
-                        'This field is invalid for interaction updates.',
-                    ],
-                    'export_countries': [
-                        'This field is invalid for interaction updates.',
-                    ],
+                    'country': {
+                        'id': Country.azerbaijan.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.NOT_INTERESTED
                 },
-            ),
-            (
-                {
-                    'export_countries': [
-                        {
-                            'country': {
-                                'id': Country.greece.value.id,
-                            },
-                            'status': CompanyExportCountry.Status.CURRENTLY_EXPORTING,
-                        },
-                    ],
-                },
-                {
-                    'export_countries': [
-                        'This field is invalid for interaction updates.',
-                    ],
-                },
-            ),
-        ),
-    )
-    @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
+            ],
+            'has_related_trade_agreements': True,
+            'related_trade_agreements': ['50cf99fd-1150-421d-9e1c-b23750ebf5ca'],
+        }
+
+        api_client = self.create_api_client(user=adviser)
+        response = api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        export_countries = company.export_countries.all()
+        assert export_countries.count() == 3
+
+        assert str(export_countries[0].country.id) == Country.canada.value.id
+        currently_exporting = CompanyExportCountry.Status.CURRENTLY_EXPORTING
+        assert export_countries[0].status == currently_exporting
+
+        assert str(export_countries[1].country.id) == Country.japan.value.id
+        future_interest = CompanyExportCountry.Status.FUTURE_INTEREST
+        assert export_countries[1].status == future_interest
+
+        assert str(export_countries[2].country.id) == Country.azerbaijan.value.id
+        not_interested = CompanyExportCountry.Status.NOT_INTERESTED
+        assert export_countries[2].status == not_interested
+
     @pytest.mark.parametrize('flag', ((True, False)))
     @freeze_time('2017-04-18 13:25:30.986208')
-    def test_clean_interaction_update_export_countries_validation_error(
-        self,
-        permissions,
-        data,
-        error_response,
-        flag,
-    ):
+    @pytest.mark.parametrize('permissions', NON_RESTRICTED_ADD_PERMISSIONS)
+    def test_update_export_countries_interaction_with_existing_country_mapping(self, permissions, flag):
         """
-        Test that a user can't update export countries in an interaction
-        when the interaction doesn't have any export countries.
+        Test that a user can update the interaction
+        when the interaction with existing export country
         """
-        requester = create_test_user(permission_codenames=permissions)
-        interaction = CompanyInteractionFactory(
-            subject='I am a subject',
-            theme=Interaction.Theme.EXPORT,
+        adviser = create_test_user(
+            permission_codenames=permissions, dit_team=TeamFactory(),
         )
+        company = CompanyFactory()
+        contact = ContactFactory(company=company)
+        communication_channel = random_obj_for_model(CommunicationChannel)
 
-        assert (
-            len(Interaction.objects.get(pk=interaction.pk).export_countries.all()) == 0
-        )
-
-        api_client = self.create_api_client(user=requester)
-        url = reverse('api-v4:interaction:item', kwargs={'pk': interaction.pk})
-        data = resolve_data(data)
-        response = api_client.patch(url, data=data)
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == error_response
-
-    @pytest.mark.parametrize(
-        'data,error_response',
-        (
-            (
+        url = reverse('api-v4:interaction:collection')
+        request_data = {
+            'kind': Interaction.Kind.INTERACTION,
+            'communication_channel': communication_channel.pk,
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_participants': [
+                {'adviser': adviser.pk},
+            ],
+            'company': company.pk,
+            'contacts': [contact.pk],
+            'service': Service.inbound_referral.value.id,
+            'was_policy_feedback_provided': False,
+            'theme': Interaction.Theme.EXPORT,
+            'were_countries_discussed': True,
+            'export_countries': [
                 {
-                    'were_countries_discussed': False,
+                    'country': {
+                        'id': Country.canada.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.CURRENTLY_EXPORTING,
                 },
                 {
-                    'were_countries_discussed': [
-                        'This field is invalid for interaction updates.',
-                    ],
-                },
-            ),
-            (
-                {
-                    'were_countries_discussed': True,
-                    'export_countries': [
-                        {
-                            'country': {
-                                'id': Country.greece.value.id,
-                            },
-                            'status': CompanyExportCountry.Status.CURRENTLY_EXPORTING,
-                        },
-                    ],
+                    'country': {
+                        'id': Country.japan.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.FUTURE_INTEREST,
                 },
                 {
-                    'were_countries_discussed': [
-                        'This field is invalid for interaction updates.',
-                    ],
-                    'export_countries': [
-                        'This field is invalid for interaction updates.',
-                    ],
+                    'country': {
+                        'id': Country.azerbaijan.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.NOT_INTERESTED
                 },
-            ),
-            (
-                {
-                    'export_countries': [
-                        {
-                            'country': {
-                                'id': Country.greece.value.id,
-                            },
-                            'status': CompanyExportCountry.Status.CURRENTLY_EXPORTING,
-                        },
-                    ],
-                },
-                {
-                    'export_countries': [
-                        'This field is invalid for interaction updates.',
-                    ],
-                },
-            ),
-        ),
-    )
-    @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
-    @pytest.mark.parametrize('flag', ((True, False)))
-    @freeze_time('2017-04-18 13:25:30.986208')
-    def test_update_export_countries_validation_error(
-        self,
-        permissions,
-        data,
-        error_response,
-        flag,
-    ):
-        """
-        Test that a user can't update export countries in an interaction
-        when the interaction already has export countries set.
-        """
-        requester = create_test_user(permission_codenames=permissions)
-        interaction = ExportCountriesInteractionFactory(
-            export_countries__country_id=Country.canada.value.id,
-            export_countries__status=CompanyExportCountry.Status.NOT_INTERESTED,
-        )
+            ],
+            'has_related_trade_agreements': True,
+            'related_trade_agreements': ['50cf99fd-1150-421d-9e1c-b23750ebf5ca'],
+        }
 
-        assert (
-            len(Interaction.objects.get(pk=interaction.pk).export_countries.all()) > 0
-        )
+        new_request_data = {
+            'kind': Interaction.Kind.INTERACTION,
+            'communication_channel': communication_channel.pk,
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_participants': [
+                {'adviser': adviser.pk},
+            ],
+            'company': company.pk,
+            'contacts': [contact.pk],
+            'service': Service.inbound_referral.value.id,
+            'was_policy_feedback_provided': False,
+            'theme': Interaction.Theme.EXPORT,
+            'were_countries_discussed': True,
+            'export_countries': [
+                {
+                    'country': {
+                        'id': Country.france.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.CURRENTLY_EXPORTING,
+                },
+                {
+                    'country': {
+                        'id': Country.argentina.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.FUTURE_INTEREST,
+                },
+                {
+                    'country': {
+                        'id': Country.anguilla.value.id,
+                    },
+                    'status': CompanyExportCountry.Status.NOT_INTERESTED
+                },
+            ],
+            'has_related_trade_agreements': True,
+            'related_trade_agreements': ['50cf99fd-1150-421d-9e1c-b23750ebf5ca'],
+        }
 
-        api_client = self.create_api_client(user=requester)
-        url = reverse('api-v4:interaction:item', kwargs={'pk': interaction.pk})
-        data = resolve_data(data)
-        response = api_client.patch(url, data=data)
+        api_client = self.create_api_client(user=adviser)
+        response = api_client.post(url, request_data)
 
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == error_response
+        assert response.status_code == status.HTTP_201_CREATED
+
+        export_countries = company.export_countries.all()
+        assert export_countries.count() == 3
+
+        new_response = api_client.post(url, new_request_data)
+
+        assert new_response.status_code == status.HTTP_201_CREATED
+
+        export_countries = company.export_countries.all()
+        assert export_countries.count() == 6
 
     @pytest.mark.parametrize('flag', ((True, False)))
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)


### PR DESCRIPTION
### Description of change
At present, export countries related to interaction wasn't allow to update and synchronise in the database. Now, the DH API has ability to add and updates list of export countries including statuses related to interaction.

Implementation reference(Legacy): https://github.com/uktrade/data-hub-api/blob/main/datahub/interaction/serializers.py#L374

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [X] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [X] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
