### PR TITLE
feature/cls2-404-add-is-global-ultimate-as-or-filter

### DIFF
--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -661,6 +661,40 @@ class TestSearch(APITestMixin):
         for expected_result in expected_results:
             assert expected_result in search_results
 
+    def test_headquarter_type_not_set_response_returns_all_companies(
+        self,
+        opensearch_with_collector,
+    ):
+        ghq_company = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ghq.value.id)
+        ukhq_company = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ukhq.value.id)
+        ehq_company = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ehq.value.id)
+        ultimate_company_1 = CompanyFactory(
+            duns_number='123456789',
+            global_ultimate_duns_number='123456789',
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:company')
+        response = self.api_client.post(
+            url,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        search_results = {company['id'] for company in response.data['results']}
+        expected_results = {
+            str(company.id)
+            for company in [
+                ghq_company,
+                ehq_company,
+                ukhq_company,
+                ultimate_company_1,
+            ]
+        }
+        for expected_result in expected_results:
+            assert expected_result in search_results
+
     @pytest.mark.parametrize(
         'num_account_managers',
         (1, 2, 3),

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -618,6 +618,49 @@ class TestSearch(APITestMixin):
         for expected_result in expected_results:
             assert expected_result in search_results
 
+    def test_headquarter_type_not_containing_ghq_does_not_includes_global_ultimate_companies(
+        self,
+        opensearch_with_collector,
+    ):
+        CompanyFactory(headquarter_type_id=constants.HeadquarterType.ghq.value.id)
+        ukhq_company = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ukhq.value.id)
+        ehq_company = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ehq.value.id)
+        CompanyFactory(headquarter_type_id=constants.HeadquarterType.ehq.value.id)
+        CompanyFactory(
+            duns_number='123456789',
+            global_ultimate_duns_number='123456789',
+        )
+        CompanyFactory(
+            duns_number='987654321',
+            global_ultimate_duns_number='987654321',
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:company')
+        response = self.api_client.post(
+            url,
+            {
+                'headquarter_type': [
+                    constants.HeadquarterType.ehq.value.id,
+                    constants.HeadquarterType.ukhq.value.id,
+                ],
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        search_results = {company['id'] for company in response.data['results']}
+        expected_results = {
+            str(company.id)
+            for company in [
+                ehq_company,
+                ukhq_company,
+            ]
+        }
+        for expected_result in expected_results:
+            assert expected_result in search_results
+
     @pytest.mark.parametrize(
         'num_account_managers',
         (1, 2, 3),

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -5,7 +5,7 @@ from django.db.models.fields import CharField
 from django.db.models.functions import Cast, Concat, Upper
 
 
-from opensearch_dsl import Search
+# from opensearch_dsl import Search
 
 from config.settings.types import HawkScope
 from datahub.company.models import Company as DBCompany, CompanyExportCountry
@@ -163,7 +163,9 @@ class SearchCompanyAPIView(SearchCompanyAPIViewMixin, SearchAPIView):
                     'should'
                 ] = should_queries
 
-        return Search.from_dict(raw_query)
+#        return Search.from_dict(raw_query)
+        base_query.raw_query = raw_query
+        return base_query
 
 
 @register_v4_view(is_public=True)

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -4,9 +4,6 @@ from django.db.models.expressions import Case, Value, When
 from django.db.models.fields import CharField
 from django.db.models.functions import Cast, Concat, Upper
 
-
-# from opensearch_dsl import Search
-
 from config.settings.types import HawkScope
 from datahub.company.models import Company as DBCompany, CompanyExportCountry
 from datahub.core.auth import PaaSIPAuthentication
@@ -159,12 +156,12 @@ class SearchCompanyAPIView(SearchCompanyAPIViewMixin, SearchAPIView):
                             },
                         )
                         break
+                base_query.filter('terms', tags=['search', 'python'])
                 raw_query['query']['bool']['filter'][filter_index]['bool']['must'][index]['bool'][
                     'should'
                 ] = should_queries
 
-#        return Search.from_dict(raw_query)
-        base_query.raw_query = raw_query
+        base_query.update_from_dict(raw_query)
         return base_query
 
 


### PR DESCRIPTION
### Description of change

Refactor and amend how Opensearch handles returning Ultimate HQ companies alongside  Global HQ companies  

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
