### PR TITLE
Add archive end point for company objectives

### DIFF
--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -307,5 +307,11 @@ class ObjectiveFactory(factory.django.DjangoModelFactory):
         step=10,
     )
 
+    created_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
+    created_on = now()
+
+    archived = False
+
     class Meta:
         model = 'company.Objective'

--- a/datahub/company/urls/objective.py
+++ b/datahub/company/urls/objective.py
@@ -21,6 +21,7 @@ Objective_v4_item = SingleObjectiveV4ViewSet.as_view(
     },
 )
 
+objective_archive = SingleObjectiveV4ViewSet.as_action_view('archive')
 
 urls_v4 = [
     path('company/<uuid:company_id>/objective', Objective_v4_collection, name='list'),
@@ -30,4 +31,9 @@ urls_v4 = [
         name='count',
     ),
     path('company/<uuid:company_id>/objective/<uuid:pk>', Objective_v4_item, name='detail'),
+    path(
+        'company/objective/<uuid:pk>/archive',
+        objective_archive,
+        name='archive',
+    ),
 ]


### PR DESCRIPTION
### Description of change

Create an end point to allow for archiving of a Company's objectives.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
The branch should not be stale or have conflicts at the time reviews are requested.

Also included a small refactor of repeated code. 
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
