### PR TITLE
expose valid email field on contact search view

### DIFF
--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -62,6 +62,7 @@ class Contact(BaseSearchModel):
     primary = Boolean()
     full_telephone_number = Keyword()
     title = fields.id_name_field()
+    valid_email = Boolean()
 
     MAPPINGS = {
         'adviser': dict_utils.contact_or_adviser_dict,

--- a/datahub/search/contact/serializers.py
+++ b/datahub/search/contact/serializers.py
@@ -27,6 +27,7 @@ class SearchContactQuerySerializer(EntitySearchQuerySerializer):
     address_area = SingleOrListField(child=StringUUIDField(), required=False)
     created_by = SingleOrListField(child=StringUUIDField(), required=False)
     created_on_exists = serializers.BooleanField(required=False)
+    valid_email = serializers.BooleanField(required=False)
 
     SORT_BY_FIELDS = (
         'address_country.name',

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -45,6 +45,7 @@ def test_contact_dbmodel_to_dict(opensearch):
         'notes',
         'company_sector',
         'company_uk_region',
+        'valid_email',
     }
 
     assert set(result.keys()) == keys

--- a/datahub/search/contact/test/test_opensearch.py
+++ b/datahub/search/contact/test/test_opensearch.py
@@ -277,6 +277,7 @@ def test_mapping(opensearch):
                 },
                 'type': 'object',
             },
+            'valid_email': {'type': 'boolean'},
         },
         'dynamic': 'false',
     }


### PR DESCRIPTION
### Description of change

expose valid_email field so it could be used in the FE

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
