### PR TITLE
bugfix/CLS2-418-fix-mandatory-adviser-validation

### DIFF
--- a/datahub/task/serializers.py
+++ b/datahub/task/serializers.py
@@ -16,6 +16,7 @@ class TaskSerializer(serializers.ModelSerializer):
     created_by = NestedAdviserField(read_only=True)
     advisers = NestedAdviserField(
         many=True,
+        allow_empty=False,
     )
     archived = serializers.BooleanField(read_only=True)
 

--- a/datahub/task/test/test_views.py
+++ b/datahub/task/test/test_views.py
@@ -109,6 +109,19 @@ class TestAddTask(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert list(response.json().keys()) == ['advisers']
 
+    def test_create_task_with_empty_advisors_returns_bad_request(self):
+        faker = Faker()
+
+        url = reverse('api-v4:task:collection')
+
+        response = self.api_client.post(
+            url,
+            data={'title': faker.word(), 'advisers': []},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert list(response.json().keys()) == ['advisers']
+
     def test_create_task_with_valid_mandatory_fields_returns_success_created(self):
         faker = Faker()
 


### PR DESCRIPTION
### Description of change

Ensure advisors is not an empty array when creating a new task

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
