### PR TITLE
feature/CLS2-428-add-sorting-to-task-endpoint

### DIFF
--- a/datahub/task/test/test_views.py
+++ b/datahub/task/test/test_views.py
@@ -1,5 +1,6 @@
-from uuid import uuid4
+import datetime
 
+from uuid import uuid4
 
 from django.utils.timezone import now
 
@@ -23,6 +24,22 @@ class TestListTask(BaseListTaskTests):
     """Test the LIST task endpoint"""
 
     reverse_url = 'api-v4:task:collection'
+
+    def test_get_all_tasks_returns_ordered_results_when_sortby_param_is_used(self):
+        earliest_task = TaskFactory(due_date=datetime.date.today() - datetime.timedelta(days=1))
+        latest_task = TaskFactory(due_date=datetime.date.today() + datetime.timedelta(days=1))
+        middle_task = TaskFactory(due_date=datetime.date.today())
+
+        url = f'{reverse(self.reverse_url)}?sortby=due_date'
+
+        response = self.api_client.get(url).json()
+
+        ordered_ids_response = [result['id'] for result in response['results']]
+        assert ordered_ids_response == [
+            str(earliest_task.id),
+            str(middle_task.id),
+            str(latest_task.id),
+        ]
 
 
 class TestGetTask(APITestMixin):

--- a/datahub/task/views.py
+++ b/datahub/task/views.py
@@ -42,6 +42,7 @@ class TasksMixin(CoreViewSet):
 
 class BaseTaskTypeV4ViewSet(TasksMixin, ABC):
     task_type_model_class = None
+    ordering_fields = ['task__due_date']
 
     def get_filtered_task_by_type(self, request):
         """
@@ -129,7 +130,7 @@ class TaskV4ViewSet(ArchivableViewSetMixin, TasksMixin):
 
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     permission_classes = [IsAuthenticated, IsAdviserPermittedToEditTask]
-    ordering_fields = ['title']
+    ordering_fields = ['title', 'due_date']
 
     serializer_class = TaskSerializer
 


### PR DESCRIPTION
### Description of change

Added the ability to sort on the task endpoints

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
