### PR TITLE
Feature/cps 505 update interaction email template

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,3 +578,16 @@ If making requests to this endpoint locally, you must manually add this header o
 ### Hawk authentication
 
 In general, Hawk authentication hashing the HTTP payload and `Content-Type` header, and using a nonce, are both _optional_. Here, as with the Activity Stream endpoints in other DIT projects, both are _required_. `Content-Type` may be the empty string, and if there is no payload, then it should be treated as the empty string.
+
+### Emails
+
+Email templates are created in [GOV UK Notify](https://www.notifications.service.gov.uk/). You can create a personal account for testing new templates or template changes locally. To test locally you need to update the API Keys and template ID environment variables.
+
+#### Updating emails
+Only update the live email templates once your changes are pushed live. Extra parameters passed to email templates are ignored but not sending parameters required by an email template will cause the emails to error.
+
+Example of environment variables for updating the interaction notification email template:
+```
+INTERACTION_NOTIFICATION_API_KEY=<noftify-api-key>
+EXPORT_NOTIFICATION_NEW_INTERACTION_TEMPLATE_ID=<template-id>
+```

--- a/datahub/reminder/emails.py
+++ b/datahub/reminder/emails.py
@@ -32,6 +32,8 @@ def get_interaction_item(interaction):
         'last_interaction_created_by': interaction.created_by.name,
         'last_interaction_type': interaction.get_kind_display(),
         'last_interaction_subject': interaction.subject,
+        'date_of_interaction': interaction.date.strftime('%-d %B %Y'),
+        'link_to_interaction': interaction.get_absolute_url(),
     }
 
 

--- a/datahub/reminder/test/test_emails.py
+++ b/datahub/reminder/test/test_emails.py
@@ -245,6 +245,8 @@ class TestEmailFunctions:
                     'last_interaction_created_by': interaction.created_by.name,
                     'last_interaction_type': interaction.get_kind_display(),
                     'last_interaction_subject': interaction.subject,
+                    'date_of_interaction': interaction.date.strftime(DATE_FORMAT),
+                    'link_to_interaction': interaction.get_absolute_url(),
                     'settings_url': settings.DATAHUB_FRONTEND_REMINDER_SETTINGS_URL,
                     'time_period': timesince(
                         last_interaction_date,


### PR DESCRIPTION
### Description of change

Support have requested more content in the email sent out when an interaction is created.
Currently there was no link to the interaction or the date the interaction occurred in the email. This change passes the extra parameters to the GOV UK Notify email template.

The email template will need updated once these changes are live (notify can ignore extra params but will error if its expecting a param in the template and its not getting it).

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?

### General points

Template before:
![Picture1 (2)](https://github.com/uktrade/data-hub-api/assets/22541658/73f9116a-e677-4ead-9378-037f1d2ed37b)

Template after (ignore date without year, that is just hard coded for testing):
<img width="664" alt="Screenshot 2023-10-02 at 13 07 18" src="https://github.com/uktrade/data-hub-api/assets/22541658/45d33448-2749-4796-9c1b-646a6b966eff">

