### PR TITLE
feature/CLS2-488-use-generic-reminder-model

### DIFF
--- a/datahub/reminder/models.py
+++ b/datahub/reminder/models.py
@@ -4,6 +4,8 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
+from datahub.task.models import Task
+
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -226,7 +228,7 @@ class UpcomingTaskReminder(BaseReminder):
     """
 
     task = models.ForeignKey(
-        'task.Task',
+        Task,
         on_delete=models.CASCADE,
         related_name='task',
     )

--- a/datahub/reminder/serializers.py
+++ b/datahub/reminder/serializers.py
@@ -17,10 +17,13 @@ from datahub.reminder.models import (
     TaskAssignedToMeFromOthersSubscription,
     UpcomingEstimatedLandDateReminder,
     UpcomingEstimatedLandDateSubscription,
-    UpcomingInvestmentProjectTaskReminder,
+    UpcomingTaskReminder,
     UpcomingTaskReminderSubscription,
 )
-from datahub.task.serializers import NestedInvestmentProjectTaskDueDateField
+from datahub.task.models import Task
+from datahub.task.serializers import (
+    NestedInvestmentProjectTaskField,
+)
 
 
 class NoRecentExportInteractionSubscriptionSerializer(serializers.ModelSerializer):
@@ -169,16 +172,33 @@ class NoRecentExportInteractionReminderSerializer(serializers.ModelSerializer):
         fields = ('id', 'created_on', 'last_interaction_date', 'event', 'company', 'interaction')
 
 
-class UpcomingInvestmentProjectTaskReminderSerializer(serializers.ModelSerializer):
-    """Serializer for Upcoming Investment Project Task Reminder."""
+class ReminderTaskSerializer(serializers.ModelSerializer):
+    """Serializer for the task in a reminder"""
 
-    investment_project_task = NestedInvestmentProjectTaskDueDateField()
+    investment_project_task = NestedInvestmentProjectTaskField(
+        read_only=True,
+        source='task_investmentprojecttask',
+    )
 
     class Meta:
-        model = UpcomingInvestmentProjectTaskReminder
+        model = Task
         fields = (
             'id',
-            'created_on',
-            'event',
             'investment_project_task',
+            'due_date',
+        )
+
+
+class UpcomingTaskReminderSerializer(serializers.ModelSerializer):
+    """Serializer for Upcoming Investment Project Task Reminder."""
+
+    task = ReminderTaskSerializer()
+
+    class Meta:
+        model = UpcomingTaskReminder
+        fields = (
+            'id',
+            'event',
+            'created_on',
+            'task',
         )

--- a/datahub/reminder/test/factories.py
+++ b/datahub/reminder/test/factories.py
@@ -14,11 +14,10 @@ from datahub.reminder.models import (
     TaskAssignedToMeFromOthersSubscription,
     UpcomingEstimatedLandDateReminder,
     UpcomingEstimatedLandDateSubscription,
-    UpcomingInvestmentProjectTaskReminder,
     UpcomingTaskReminder,
     UpcomingTaskReminderSubscription,
 )
-from datahub.task.test.factories import InvestmentProjectTaskFactory
+from datahub.task.test.factories import InvestmentProjectTaskFactory, TaskFactory
 
 
 class BaseSubscriptionFactory(factory.django.DjangoModelFactory):
@@ -90,16 +89,10 @@ class UpcomingEstimatedLandDateReminderFactory(BaseReminderFactory):
 
 
 class UpcomingTaskReminderFactory(BaseReminderFactory):
+    task = factory.SubFactory(TaskFactory)
 
     class Meta:
         model = UpcomingTaskReminder
-
-
-class UpcomingInvestmentProjectTaskReminderFactory(BaseReminderFactory):
-    investment_project_task = factory.SubFactory(InvestmentProjectTaskFactory)
-
-    class Meta:
-        model = UpcomingInvestmentProjectTaskReminder
 
 
 class InvestmentProjectTaskTaskAssignedToMeFromOthersReminderFactory(BaseReminderFactory):

--- a/datahub/reminder/test/test_reminder_views.py
+++ b/datahub/reminder/test/test_reminder_views.py
@@ -20,15 +20,16 @@ from datahub.reminder.models import (
     NoRecentExportInteractionReminder,
     NoRecentInvestmentInteractionReminder,
     UpcomingEstimatedLandDateReminder,
-    UpcomingInvestmentProjectTaskReminder,
+    UpcomingTaskReminder,
 )
 from datahub.reminder.test.factories import (
     NewExportInteractionReminderFactory,
     NoRecentExportInteractionReminderFactory,
     NoRecentInvestmentInteractionReminderFactory,
     UpcomingEstimatedLandDateReminderFactory,
-    UpcomingInvestmentProjectTaskReminderFactory,
+    UpcomingTaskReminderFactory,
 )
+from datahub.task.test.factories import InvestmentProjectTaskFactory
 
 
 @pytest.fixture()
@@ -485,11 +486,14 @@ class TestUpcomingTaskDueDateReminderViewset(APITestMixin, ReminderTestMixin):
 
     url_name = 'api-v4:reminder:my-tasks-due-date-approaching-reminder'
     detail_url_name = 'api-v4:reminder:my-tasks-due-date-approaching-reminder-detail'
-    factory = UpcomingInvestmentProjectTaskReminderFactory
-    tested_model = UpcomingInvestmentProjectTaskReminder
+    factory = UpcomingTaskReminderFactory
+    tested_model = UpcomingTaskReminder
 
-    def test_get_reminders(self):
-        """Given some reminders, these should be returned"""
+    def test_get_generic_task_reminders(self):
+        """
+        Given some reminders for generic tasks, these should be returned without any references to
+        other task types
+        """
         reminder_count = 3
         reminders = self.factory.create_batch(
             reminder_count,
@@ -509,27 +513,50 @@ class TestUpcomingTaskDueDateReminderViewset(APITestMixin, ReminderTestMixin):
             'id': str(reminders[0].id),
             'created_on': '2022-05-05T17:00:00Z',
             'event': reminders[0].event,
-            'investment_project_task': {
-                'id': str(reminders[0].investment_project_task.id),
-                'task': {
-                    'id': str(reminders[0].investment_project_task.task.id),
-                    'due_date': None,
-                },
-                'investment_project': {
-                    'id': str(reminders[0].investment_project_task.investment_project.id),
-                    'name': reminders[0].investment_project_task.investment_project.name,
-                    'project_code': reminders[
-                        0
-                    ].investment_project_task.investment_project.project_code,
-                    'investor_company': {
-                        'id': str(
-                            reminders[
-                                0
-                            ].investment_project_task.investment_project.investor_company.id,
-                        ),
-                        'name': reminders[
-                            0
-                        ].investment_project_task.investment_project.investor_company.name,
+            'task': {
+                'id': str(reminders[0].task.id),
+                'due_date': None,
+                'investment_project_task': None,
+            },
+        }
+
+    def test_get_investment_project_task_reminders(self):
+        """
+        Given some reminders for investment project tasks, these should be returned with the
+        correct investment project task data
+        """
+        investment_project_task = InvestmentProjectTaskFactory()
+        investment_project = investment_project_task.task
+
+        reminders = self.factory.create_batch(
+            3,
+            adviser=self.user,
+            task=investment_project_task.task,
+        )
+        response = self.get_response
+        data = response.json()
+        results = data.get('results', [])
+        reminders = sorted(reminders, key=lambda x: x.pk)
+
+        assert results[0] == {
+            'id': str(reminders[0].id),
+            'created_on': '2022-05-05T17:00:00Z',
+            'event': reminders[0].event,
+            'task': {
+                'id': str(reminders[0].task.id),
+                'due_date': None,
+                'investment_project_task': {
+                    'id': str(investment_project_task.id),
+                    'investment_project': {
+                        'name': investment_project.name,
+                        'project_code': investment_project.project_code,
+                        'investor_company': {
+                            'name': investment_project.investor_company.name,
+                            'id': str(
+                                investment_project.investor_company.id,
+                            ),
+                        },
+                        'id': str(investment_project.id),
                     },
                 },
             },
@@ -594,7 +621,7 @@ class TestGetReminderSummaryView(APITestMixin):
             adviser=self.user,
         )
         NoRecentExportInteractionReminderFactory.create_batch(2)
-        UpcomingInvestmentProjectTaskReminderFactory.create_batch(
+        UpcomingTaskReminderFactory.create_batch(
             reminder_count,
             adviser=self.user,
         )
@@ -687,7 +714,7 @@ class TestGetReminderSummaryView(APITestMixin):
             reminder_count,
             adviser=self.user,
         )
-        UpcomingInvestmentProjectTaskReminderFactory.create_batch(
+        UpcomingTaskReminderFactory.create_batch(
             reminder_count,
             adviser=self.user,
         )

--- a/datahub/reminder/test/test_reminder_views.py
+++ b/datahub/reminder/test/test_reminder_views.py
@@ -526,7 +526,7 @@ class TestUpcomingTaskDueDateReminderViewset(APITestMixin, ReminderTestMixin):
         correct investment project task data
         """
         investment_project_task = InvestmentProjectTaskFactory()
-        investment_project = investment_project_task.task
+        investment_project = investment_project_task.investment_project
 
         reminders = self.factory.create_batch(
             3,

--- a/datahub/reminder/urls.py
+++ b/datahub/reminder/urls.py
@@ -11,7 +11,7 @@ from datahub.reminder.views import (
     reminder_summary_view,
     UpcomingEstimatedLandDateReminderViewset,
     UpcomingEstimatedLandDateSubscriptionViewset,
-    UpcomingInvestmentProjectTaskReminderViewset,
+    UpcomingTaskReminderViewset,
 )
 
 urlpatterns = [
@@ -134,7 +134,7 @@ urlpatterns = [
     ),
     path(
         'reminder/my-tasks-due-date-approaching',
-        UpcomingInvestmentProjectTaskReminderViewset.as_view(
+        UpcomingTaskReminderViewset.as_view(
             {
                 'get': 'list',
             },
@@ -143,7 +143,7 @@ urlpatterns = [
     ),
     path(
         'reminder/my-tasks-due-date-approaching/<uuid:pk>',
-        UpcomingInvestmentProjectTaskReminderViewset.as_view(
+        UpcomingTaskReminderViewset.as_view(
             {
                 'delete': 'destroy',
             },

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -27,6 +27,7 @@ from datahub.reminder.models import (
     ReminderStatus,
     UpcomingEstimatedLandDateReminder,
     UpcomingEstimatedLandDateSubscription,
+    UpcomingTaskReminder,
     UpcomingTaskReminderSubscription,
 )
 from datahub.reminder.serializers import (
@@ -38,8 +39,7 @@ from datahub.reminder.serializers import (
     NoRecentInvestmentInteractionSubscriptionSerializer,
     UpcomingEstimatedLandDateReminderSerializer,
     UpcomingEstimatedLandDateSubscriptionSerializer,
-    UpcomingInvestmentProjectTaskReminder,
-    UpcomingInvestmentProjectTaskReminderSerializer,
+    UpcomingTaskReminderSerializer,
     UpcomingTaskReminderSubscriptionSerializer,
 )
 
@@ -165,9 +165,9 @@ class UpcomingEstimatedLandDateReminderViewset(BaseReminderViewset):
     model_class = UpcomingEstimatedLandDateReminder
 
 
-class UpcomingInvestmentProjectTaskReminderViewset(BaseReminderViewset):
-    serializer_class = UpcomingInvestmentProjectTaskReminderSerializer
-    model_class = UpcomingInvestmentProjectTaskReminder
+class UpcomingTaskReminderViewset(BaseReminderViewset):
+    serializer_class = UpcomingTaskReminderSerializer
+    model_class = UpcomingTaskReminder
 
 
 @transaction.non_atomic_requests
@@ -208,7 +208,7 @@ def reminder_summary_view(request):
         no_recent_export_interaction = 0
         new_export_interaction = 0
 
-    task_due_date_approaching = UpcomingInvestmentProjectTaskReminder.objects.filter(
+    task_due_date_approaching = UpcomingTaskReminder.objects.filter(
         adviser=request.user,
     ).count()
 


### PR DESCRIPTION
### Description of change

Change the endpoint for task reminders to point at the new generic task reminder model, instead of the investment project task reminder

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
