### PR TITLE
feature/CLS2-509-add-views-for-due-date-approaching-task

### DIFF
--- a/datahub/reminder/urls.py
+++ b/datahub/reminder/urls.py
@@ -11,8 +11,8 @@ from datahub.reminder.views import (
     reminder_summary_view,
     UpcomingEstimatedLandDateReminderViewset,
     UpcomingEstimatedLandDateSubscriptionViewset,
-    UpcomingTaskReminderViewset,
     UpcomingTaskReminderSubscriptionViewset,
+    UpcomingTaskReminderViewset,
 )
 
 urlpatterns = [

--- a/datahub/reminder/urls.py
+++ b/datahub/reminder/urls.py
@@ -12,6 +12,7 @@ from datahub.reminder.views import (
     UpcomingEstimatedLandDateReminderViewset,
     UpcomingEstimatedLandDateSubscriptionViewset,
     UpcomingTaskReminderViewset,
+    UpcomingTaskReminderSubscriptionViewset,
 )
 
 urlpatterns = [
@@ -149,6 +150,16 @@ urlpatterns = [
             },
         ),
         name='my-tasks-due-date-approaching-reminder-detail',
+    ),
+    path(
+        'reminder/subscription/my-tasks-due-date-approaching',
+        UpcomingTaskReminderSubscriptionViewset.as_view(
+            {
+                'get': 'retrieve',
+                'patch': 'partial_update',
+            },
+        ),
+        name='my-tasks-due-date-approaching-subscription',
     ),
     path(
         'reminder/summary',


### PR DESCRIPTION
### Description of change

- Refactored common tests into mixins
- Added url and tests for due date approaching subscription

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
