### PR TITLE
Add task assigned to me from others to reminder setting endpoints

### DIFF
--- a/datahub/reminder/serializers.py
+++ b/datahub/reminder/serializers.py
@@ -101,7 +101,7 @@ class TaskAssignedToMeFromOthersSubscriptionSerializer(serializers.ModelSerializ
 
     class Meta:
         model = TaskAssignedToMeFromOthersSubscription
-        fields = 'email_reminders_enabled'
+        fields = ('email_reminders_enabled',)
 
 
 class NestedInvestmentProjectSerializer(serializers.ModelSerializer):

--- a/datahub/reminder/test/test_reminder_views.py
+++ b/datahub/reminder/test/test_reminder_views.py
@@ -23,6 +23,7 @@ from datahub.reminder.models import (
     UpcomingTaskReminder,
 )
 from datahub.reminder.test.factories import (
+    InvestmentProjectTaskTaskAssignedToMeFromOthersReminderFactory,
     NewExportInteractionReminderFactory,
     NoRecentExportInteractionReminderFactory,
     NoRecentInvestmentInteractionReminderFactory,
@@ -590,7 +591,7 @@ class TestGetReminderSummaryView(APITestMixin):
             ],
         )
         reminder_count = 3
-        reminder_categories = 6  # used for finding the total number of reminders in this test
+        reminder_categories = 7  # used for finding the total number of reminders in this test
         UpcomingEstimatedLandDateReminderFactory.create_batch(
             reminder_count,
             adviser=self.user,
@@ -625,6 +626,10 @@ class TestGetReminderSummaryView(APITestMixin):
             reminder_count,
             adviser=self.user,
         )
+        InvestmentProjectTaskTaskAssignedToMeFromOthersReminderFactory.create_batch(
+            reminder_count,
+            adviser=self.user,
+        )
 
         total_reminders = reminder_count * reminder_categories
         url = reverse(self.url_name)
@@ -643,7 +648,10 @@ class TestGetReminderSummaryView(APITestMixin):
                 'new_interaction': reminder_count,
                 'no_recent_interaction': reminder_count,
             },
-            'my_tasks': {'due_date_approaching': reminder_count},
+            'my_tasks': {
+                'due_date_approaching': reminder_count,
+                'task_assigned_to_me_from_others': reminder_count,
+            },
         }
 
     def test_get_zeroes_if_no_reminders(self):
@@ -663,7 +671,10 @@ class TestGetReminderSummaryView(APITestMixin):
                 'new_interaction': 0,
                 'no_recent_interaction': 0,
             },
-            'my_tasks': {'due_date_approaching': 0},
+            'my_tasks': {
+                'due_date_approaching': 0,
+                'task_assigned_to_me_from_others': 0,
+            },
         }
 
     @pytest.mark.parametrize(
@@ -718,8 +729,13 @@ class TestGetReminderSummaryView(APITestMixin):
             reminder_count,
             adviser=self.user,
         )
+        InvestmentProjectTaskTaskAssignedToMeFromOthersReminderFactory.create_batch(
+            reminder_count,
+            adviser=self.user,
+        )
 
-        total_reminders = reminder_count * (int(investment) * 3 + int(export) * 2) + reminder_count
+        myTasksCount = reminder_count * 2
+        total_reminders = reminder_count * (int(investment) * 3 + int(export) * 2) + myTasksCount
         url = reverse(self.url_name)
         response = self.api_client.get(url)
 
@@ -736,5 +752,8 @@ class TestGetReminderSummaryView(APITestMixin):
                 'new_interaction': reminder_count if export else 0,
                 'no_recent_interaction': reminder_count if export else 0,
             },
-            'my_tasks': {'due_date_approaching': reminder_count},
+            'my_tasks': {
+                'due_date_approaching': reminder_count,
+                'task_assigned_to_me_from_others': reminder_count,
+            },
         }

--- a/datahub/reminder/test/test_reminder_views.py
+++ b/datahub/reminder/test/test_reminder_views.py
@@ -734,8 +734,8 @@ class TestGetReminderSummaryView(APITestMixin):
             adviser=self.user,
         )
 
-        myTasksCount = reminder_count * 2
-        total_reminders = reminder_count * (int(investment) * 3 + int(export) * 2) + myTasksCount
+        my_tasks_count = reminder_count * 2
+        total_reminders = reminder_count * (int(investment) * 3 + int(export) * 2) + my_tasks_count
         url = reverse(self.url_name)
         response = self.api_client.get(url)
 

--- a/datahub/reminder/test/test_subscription_views.py
+++ b/datahub/reminder/test/test_subscription_views.py
@@ -276,6 +276,9 @@ class TestGetReminderSubscriptionSummaryView(APITestMixin):
                 'email_reminders_enabled': True,
                 'reminder_days': [10, 20, 40],
             },
+            'task_assigned_to_me_from_others': {
+                'email_reminders_enabled': True,
+            },
         }
 
     def test_no_subscriptions(self):
@@ -304,5 +307,8 @@ class TestGetReminderSubscriptionSummaryView(APITestMixin):
             'upcoming_task_reminder': {
                 'email_reminders_enabled': False,
                 'reminder_days': [],
+            },
+            'task_assigned_to_me_from_others': {
+                'email_reminders_enabled': False,
             },
         }

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -18,6 +18,8 @@ from datahub.reminder import (
     INVESTMENT_NOTIFICATIONS_FEATURE_GROUP_NAME,
 )
 from datahub.reminder.models import (
+    InvestmentProjectTaskTaskAssignedToMeFromOthersReminder as TaskAssignedToMeFromOthersReminder,
+    TaskAssignedToMeFromOthersSubscription,
     NewExportInteractionReminder,
     NewExportInteractionSubscription,
     NoRecentExportInteractionReminder,
@@ -37,6 +39,7 @@ from datahub.reminder.serializers import (
     NoRecentExportInteractionSubscriptionSerializer,
     NoRecentInvestmentInteractionReminderSerializer,
     NoRecentInvestmentInteractionSubscriptionSerializer,
+    TaskAssignedToMeFromOthersSubscriptionSerializer,
     UpcomingEstimatedLandDateReminderSerializer,
     UpcomingEstimatedLandDateSubscriptionSerializer,
     UpcomingTaskReminderSerializer,
@@ -118,6 +121,9 @@ def reminder_subscription_summary_view(request):
     upcoming_task_reminder = UpcomingTaskReminderSubscriptionSerializer(
         get_object(UpcomingTaskReminderSubscription.objects.all()),
     ).data
+    task_assigned_to_me_from_others = TaskAssignedToMeFromOthersSubscriptionSerializer(
+        get_object(TaskAssignedToMeFromOthersSubscription.objects.all()),
+    ).data
 
     return Response(
         {
@@ -126,6 +132,7 @@ def reminder_subscription_summary_view(request):
             'no_recent_export_interaction': no_recent_export_interaction,
             'new_export_interaction': new_export_interaction,
             'upcoming_task_reminder': upcoming_task_reminder,
+            'task_assigned_to_me_from_others': task_assigned_to_me_from_others,
         },
     )
 
@@ -212,6 +219,10 @@ def reminder_summary_view(request):
         adviser=request.user,
     ).count()
 
+    task_assigned_to_me_from_others = TaskAssignedToMeFromOthersReminder.objects.filter(
+        adviser=request.user,
+    ).count()
+
     total_count = sum(
         [
             estimated_land_date,
@@ -220,6 +231,7 @@ def reminder_summary_view(request):
             no_recent_export_interaction,
             new_export_interaction,
             task_due_date_approaching,
+            task_assigned_to_me_from_others,
         ],
     )
 
@@ -235,6 +247,9 @@ def reminder_summary_view(request):
                 'no_recent_interaction': no_recent_export_interaction,
                 'new_interaction': new_export_interaction,
             },
-            'my_tasks': {'due_date_approaching': task_due_date_approaching},
+            'my_tasks': {
+                'due_date_approaching': task_due_date_approaching,
+                'task_assigned_to_me_from_others': task_assigned_to_me_from_others
+            },
         },
     )

--- a/datahub/reminder/views.py
+++ b/datahub/reminder/views.py
@@ -19,7 +19,6 @@ from datahub.reminder import (
 )
 from datahub.reminder.models import (
     InvestmentProjectTaskTaskAssignedToMeFromOthersReminder as TaskAssignedToMeFromOthersReminder,
-    TaskAssignedToMeFromOthersSubscription,
     NewExportInteractionReminder,
     NewExportInteractionSubscription,
     NoRecentExportInteractionReminder,
@@ -27,6 +26,7 @@ from datahub.reminder.models import (
     NoRecentInvestmentInteractionReminder,
     NoRecentInvestmentInteractionSubscription,
     ReminderStatus,
+    TaskAssignedToMeFromOthersSubscription,
     UpcomingEstimatedLandDateReminder,
     UpcomingEstimatedLandDateSubscription,
     UpcomingTaskReminder,
@@ -249,7 +249,7 @@ def reminder_summary_view(request):
             },
             'my_tasks': {
                 'due_date_approaching': task_due_date_approaching,
-                'task_assigned_to_me_from_others': task_assigned_to_me_from_others
+                'task_assigned_to_me_from_others': task_assigned_to_me_from_others,
             },
         },
     )


### PR DESCRIPTION
### Description of change

`task_assigned_to_me_from_others` is added to the reminder summary data and count endpoints 

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
