### PR TITLE
Bump memory to 3GB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,3 +4,5 @@ applications:
       - https://github.com/cloudfoundry/python-buildpack.git#v1.8.12
     stack: cflinuxfs4
     timeout: 180
+    memory: 3G
+    disk_quota: 2G


### PR DESCRIPTION
### Description of change

We suspect that the recent database spikes are caused by the memory running out. I've increased the memory to 3GB in the manifest file which should fix this.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
