### PR TITLE
remove any statsd reference and calls

### DIFF
--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1,6 +1,6 @@
 import json
 import operator
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 from urllib.parse import urljoin
 from uuid import UUID, uuid4
 
@@ -367,65 +367,6 @@ class TestDNBCompanySearchAPI(APITestMixin):
         )
         assert response.status_code == response_status_code
         assert json.loads(response.content) == response_data
-
-    def test_monitoring_success(
-        self,
-        monkeypatch,
-        requests_mock,
-    ):
-        """
-        Test that the right counter is incremented for the given status code
-        returned by the dnb-service.
-        """
-        statsd_mock = Mock()
-        monkeypatch.setattr('datahub.dnb_api.utils.statsd', statsd_mock)
-        requests_mock.post(
-            DNB_V2_SEARCH_URL,
-            status_code=status.HTTP_200_OK,
-            json={},
-        )
-        self.api_client.post(
-            reverse('api-v4:dnb-api:company-search'),
-            content_type='application/json',
-        )
-        statsd_mock.incr.assert_called_once_with(
-            f'dnb.search.{status.HTTP_200_OK}',
-        )
-
-    @pytest.mark.parametrize(
-        'response_status_code',
-        (
-            status.HTTP_400_BAD_REQUEST,
-            status.HTTP_401_UNAUTHORIZED,
-            status.HTTP_403_FORBIDDEN,
-            status.HTTP_500_INTERNAL_SERVER_ERROR,
-        ),
-    )
-    def test_monitoring_errors(
-        self,
-        monkeypatch,
-        requests_mock,
-        response_status_code,
-    ):
-        """
-        Test that the right counter is incremented for the given status code
-        returned by the dnb-service.
-        """
-        statsd_mock = Mock()
-        monkeypatch.setattr('datahub.dnb_api.utils.statsd', statsd_mock)
-        requests_mock.post(
-            DNB_V2_SEARCH_URL,
-            status_code=response_status_code,
-            json={},
-        )
-
-        self.api_client.post(
-            reverse('api-v4:dnb-api:company-search'),
-            content_type='application/json',
-        )
-        statsd_mock.incr.assert_called_once_with(
-            f'dnb.search.{response_status_code}',
-        )
 
 
 class TestDNBCompanyCreateAPI(APITestMixin):
@@ -967,70 +908,6 @@ class TestDNBCompanyCreateAPI(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    @pytest.mark.parametrize(
-        'response_status_code',
-        (
-            status.HTTP_200_OK,
-            status.HTTP_400_BAD_REQUEST,
-            status.HTTP_401_UNAUTHORIZED,
-            status.HTTP_403_FORBIDDEN,
-            status.HTTP_500_INTERNAL_SERVER_ERROR,
-        ),
-    )
-    def test_monitoring_search(
-        self,
-        monkeypatch,
-        requests_mock,
-        response_status_code,
-    ):
-        """
-        Test that the right counter is incremented for the given status code
-        returned by the dnb-service.
-        """
-        statsd_mock = Mock()
-        monkeypatch.setattr('datahub.dnb_api.utils.statsd', statsd_mock)
-        requests_mock.post(
-            DNB_V2_SEARCH_URL,
-            status_code=response_status_code,
-            json={},
-        )
-        self.api_client.post(
-            reverse('api-v4:dnb-api:company-create'),
-            data={
-                'duns_number': 123456789,
-            },
-        )
-        statsd_mock.incr.assert_called_once_with(
-            f'dnb.search.{response_status_code}',
-        )
-
-    def test_monitoring_create(
-        self,
-        monkeypatch,
-        dnb_response_uk,
-        requests_mock,
-    ):
-        """
-        Test that the right counter is incremented when a company gets
-        created using dnb-service.
-        """
-        statsd_mock = Mock()
-        monkeypatch.setattr('datahub.dnb_api.views.statsd', statsd_mock)
-        requests_mock.post(
-            DNB_V2_SEARCH_URL,
-            status_code=status.HTTP_200_OK,
-            json=dnb_response_uk,
-        )
-        self.api_client.post(
-            reverse('api-v4:dnb-api:company-create'),
-            data={
-                'duns_number': 123456789,
-            },
-        )
-        statsd_mock.incr.assert_called_with(
-            'dnb.create.company',
-        )
 
 
 class TestCompanyLinkView(APITestMixin):

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -22,7 +22,6 @@ from rest_framework import serializers, status
 from reversion.models import Version
 
 from datahub.company.models import Company
-from datahub.core import statsd
 from datahub.core.api_client import APIClient, TokenAuth
 from datahub.core.exceptions import (
     APIBadGatewayException,
@@ -115,7 +114,7 @@ def search_dnb(query_params, request=None):
             timeout=3.0,
         )
 
-    response = call_api_request_with_exception_handling(api_request, 'dnb.search')
+    response = call_api_request_with_exception_handling(api_request)
 
     return response
 
@@ -942,15 +941,13 @@ def get_company_hierarchy_count(duns_number):
     return companies_count
 
 
-def call_api_request_with_exception_handling(api_request_function, statsd_stat=None):
+def call_api_request_with_exception_handling(api_request_function):
     """
     Call the dnb service api client and handle any common errors
     """
     api_client = _get_api_client()
     try:
         result = api_request_function(api_client)
-        if statsd_stat:
-            statsd.incr(f'{statsd_stat}.{result.status_code}')
 
     except APIBadGatewayException as exc:
         error_message = 'Encountered an error connecting to DNB service'

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -14,7 +14,6 @@ from rest_framework.views import APIView
 
 from datahub.company.models import Company, CompanyPermission
 from datahub.company.serializers import CompanySerializer
-from datahub.core import statsd
 from datahub.core.exceptions import (
     APIBadRequestException,
     APIUpstreamException,
@@ -226,7 +225,6 @@ class DNBCompanyCreateView(APIView):
             dnb_modified_on=now(),
         )
 
-        statsd.incr('dnb.create.company')
         return Response(
             company_serializer.to_representation(datahub_company),
         )


### PR DESCRIPTION
### Description of change

DNB calls fail from DH given we deprecated StatSD server. Given we rely on it to count DNB requests, it failed for any request that triggered statsd.

We decided to remove this reference in favour of implementing a monitoring/tracking of calls directly in DNB service. This is not a huge risk given our quote is large, and we never exceeded it and have a 2x quote threshold before getting charged more, which is very unlikely at this point.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
