### PR TITLE
bugfix/CLS2-556-fix-v3-field-errors

### DIFF
--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -17,8 +17,12 @@ from datahub.search.apps import EXCLUDE_ALL, get_global_search_apps_as_mapping
 
 MAX_RESULTS = 10000
 V3_FIELD_EXCLUSIONS = ('archived',)
-# the V3 search endpoints use a MultiMatch query that cause issues with columns that do not have
-# an issue in the V4 endpoint.
+# The V3 search endpoint use a MultiMatch query, that combines every column defined in the
+# SEARCH_FIELDS property in each sub app of the main search app into a single query. When
+# adding a column to the list of fields that represent a boolean column in the search index,
+# for example 'archived', the MultiMatch query fails with a parsing error when a text value
+# is provided to the search endpoint. The error is due to opensearch attempting to parse a
+# text value into a boolean value of 'true' or 'false'
 
 
 class MatchNone(Query):

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -16,6 +16,9 @@ from opensearch_dsl.query import (
 from datahub.search.apps import EXCLUDE_ALL, get_global_search_apps_as_mapping
 
 MAX_RESULTS = 10000
+V3_FIELD_EXCLUSIONS = ('archived',)
+# the V3 search endpoints use a MultiMatch query that cause issues with columns that do not have
+# an issue in the V4 endpoint.
 
 
 class MatchNone(Query):
@@ -25,13 +28,13 @@ class MatchNone(Query):
 
 
 def get_basic_search_query(
-        entity,
-        term,
-        permission_filters_by_entity=None,
-        offset=0,
-        limit=100,
-        fields_to_exclude=None,
-        fuzzy=False,
+    entity,
+    term,
+    permission_filters_by_entity=None,
+    offset=0,
+    limit=100,
+    fields_to_exclude=None,
+    fuzzy=False,
 ):
     """
     Performs basic search for the given term in the given entity using the SEARCH_FIELDS.
@@ -46,11 +49,7 @@ def get_basic_search_query(
 
     search_apps = tuple(get_global_search_apps_as_mapping().values())
     indices = [app.search_model.get_read_alias() for app in search_apps]
-    fields = set(chain.from_iterable(app.search_model.SEARCH_FIELDS for app in search_apps))
-
-    # Sort the fields so that this function is deterministic
-    # and the same query is always generated with the same inputs
-    fields = sorted(fields)
+    fields = _get_search_fields(search_apps)
 
     query = _build_term_query(term, fields=fields, fuzzy=fuzzy)
     search = Search(index=indices).query(query)
@@ -59,35 +58,55 @@ def get_basic_search_query(
     if permission_query:
         search = search.filter(permission_query)
 
-    search = search.post_filter(
-        Bool(
-            should=Term(_document_type=entity.get_app_name()),
-        ),
-    ).sort(
-        '_score',
-        'id',
-    ).source(
-        excludes=fields_to_exclude,
-    ).extra(
-        track_total_hits=True,
+    search = (
+        search.post_filter(
+            Bool(
+                should=Term(_document_type=entity.get_app_name()),
+            ),
+        )
+        .sort(
+            '_score',
+            'id',
+        )
+        .source(
+            excludes=fields_to_exclude,
+        )
+        .extra(
+            track_total_hits=True,
+        )
     )
 
     search.aggs.bucket(
-        'count_by_type', 'terms', field='_document_type',
+        'count_by_type',
+        'terms',
+        field='_document_type',
     )
 
-    return search[offset:offset + limit]
+    offset_limit = offset + limit
+    return search[offset:offset_limit]
+
+
+def _get_search_fields(search_apps):
+    """Get all search fields that should be included in this query"""
+    fields = set(chain.from_iterable(app.search_model.SEARCH_FIELDS for app in search_apps))
+    for field in V3_FIELD_EXCLUSIONS:
+        fields.discard(field)
+
+    # Sort the fields so that this function is deterministic
+    # and the same query is always generated with the same inputs
+    fields = sorted(fields)
+    return fields
 
 
 def get_search_by_entities_query(
-        entities,
-        term=None,
-        filter_data=None,
-        composite_field_mapping=None,
-        permission_filters=None,
-        ordering=None,
-        fields_to_include=None,
-        fields_to_exclude=None,
+    entities,
+    term=None,
+    filter_data=None,
+    composite_field_mapping=None,
+    permission_filters=None,
+    ordering=None,
+    fields_to_include=None,
+    fields_to_exclude=None,
 ):
     """
     Performs filtered search for the given term across given entities.
@@ -103,15 +122,16 @@ def get_search_by_entities_query(
     # document must match all filters in the list (and)
     must_filter = _build_must_queries(filters, ranges, composite_field_mapping)
 
-    search = Search(
-        index=[
-            entity.get_read_alias()
-            for entity in entities
-        ],
-    ).query(
-        Bool(must=query),
-    ).extra(
-        track_total_hits=True,
+    search = (
+        Search(
+            index=[entity.get_read_alias() for entity in entities],
+        )
+        .query(
+            Bool(must=query),
+        )
+        .extra(
+            track_total_hits=True,
+        )
     )
 
     permission_query = _build_entity_permission_query(permission_filters)
@@ -130,7 +150,8 @@ def get_search_by_entities_query(
 def limit_search_query(query, offset=0, limit=100):
     """Limits search query to the page defined by offset and limit."""
     limit = _clip_limit(offset, limit)
-    return query[offset:offset + limit]
+    offset_limit = offset + limit
+    return query[offset:offset_limit]
 
 
 def _split_range_fields(fields):
@@ -141,7 +162,7 @@ def _split_range_fields(fields):
     for k, v in fields.items():
         range_type = _get_range_type(k)
         if range_type:
-            range_key = k[:k.rindex('_')]
+            range_key = k[: k.rindex('_')]
             ranges[range_key][range_type] = fields[k]
             continue
 
@@ -279,16 +300,18 @@ def _build_fuzzy_term_query(term, fields=None):
     trigram_fields = [field for field in fields if field.endswith('.trigram')]
 
     fuzzy_queries = [
-        Match(**{
-            # Drop '.trigram' from field to get predictable fuzzy matching
-            field.replace('.trigram', ''): {
-                'query': term,
-                'fuzziness': 'AUTO',
-                'operator': 'AND',
-                'prefix_length': '2',
-                'minimum_should_match': '80%',
+        Match(
+            **{
+                # Drop '.trigram' from field to get predictable fuzzy matching
+                field.replace('.trigram', ''): {
+                    'query': term,
+                    'fuzziness': 'AUTO',
+                    'operator': 'AND',
+                    'prefix_length': '2',
+                    'minimum_should_match': '80%',
+                },
             },
-        })
+        )
         for field in trigram_fields
     ]
     should_query = [
@@ -311,7 +334,7 @@ def _build_fuzzy_term_query(term, fields=None):
 
 def _build_exists_query(field, value):
     """Builds an exists query."""
-    real_field = field[:field.rindex('_')]
+    real_field = field[: field.rindex('_')]
 
     kind = 'must' if value else 'must_not'
     query = {
@@ -344,9 +367,7 @@ def _build_field_query(field, value):
     """Builds a field query."""
     if isinstance(value, list):
         # perform "or" query
-        should_filter = [
-            _build_single_field_query(field, single_value) for single_value in value
-        ]
+        should_filter = [_build_single_field_query(field, single_value) for single_value in value]
         return Bool(should=should_filter, minimum_should_match=1)
 
     return _build_single_field_query(field, value)
@@ -357,18 +378,12 @@ def _build_field_queries(filters):
     Builds field queries.
     Same as _build_field_query but expects a dict of field/values and returns a list of queries.
     """
-    return [
-        _build_field_query(field, value)
-        for field, value in filters.items()
-    ]
+    return [_build_field_query(field, value) for field, value in filters.items()]
 
 
 def _build_range_queries(filters):
     """Builds range queries."""
-    return [
-        Range(**{field: value})
-        for field, value in filters.items()
-    ]
+    return [Range(**{field: value}) for field, value in filters.items()]
 
 
 def _build_nested_queries(field, nested_filters):

--- a/datahub/search/test/search_support/migrations/0006_add_archived_to_simple_model.py
+++ b/datahub/search/test/search_support/migrations/0006_add_archived_to_simple_model.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('search_support', '0005_add_address_to_simple_model'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='simplemodel',
+            name='archived',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/datahub/search/test/search_support/models.py
+++ b/datahub/search/test/search_support/models.py
@@ -8,6 +8,7 @@ class SimpleModel(BaseModel):
     Simple model extending BaseModel.
     """
 
+    archived = models.BooleanField(default=False)
     name = models.CharField(max_length=500)
     country = models.CharField(max_length=50, blank=True)
     address = models.CharField(max_length=500, blank=True)

--- a/datahub/search/test/search_support/simplemodel/models.py
+++ b/datahub/search/test/search_support/simplemodel/models.py
@@ -1,4 +1,4 @@
-from opensearch_dsl import Date, Keyword, Text
+from opensearch_dsl import Boolean, Date, Keyword, Text
 
 from datahub.search import fields
 from datahub.search.models import BaseSearchModel
@@ -8,6 +8,7 @@ class SearchSimpleModel(BaseSearchModel):
     """OpenSearch representation of SimpleModel model."""
 
     id = Keyword()
+    archived = Boolean()
     name = Text(
         fields={
             'keyword': fields.NormalizedKeyword(),
@@ -32,4 +33,5 @@ class SearchSimpleModel(BaseSearchModel):
         'name.trigram',
         'country.trigram',
         'address.trigram',
+        'archived',
     )

--- a/datahub/search/test/search_support/simplemodel/serializers.py
+++ b/datahub/search/test/search_support/simplemodel/serializers.py
@@ -8,5 +8,6 @@ class SearchSimpleModelSerializer(EntitySearchQuerySerializer):
 
     name = serializers.CharField(required=False)
     country = serializers.CharField(required=False)
+    archived = serializers.BooleanField(required=False)
 
     SORT_BY_FIELDS = ('date', 'name')

--- a/datahub/search/test/search_support/simplemodel/views.py
+++ b/datahub/search/test/search_support/simplemodel/views.py
@@ -13,7 +13,10 @@ class SearchSimpleModelAPIViewMixin:
         'name': 'name.keyword',
     }
 
-    FILTER_FIELDS = ('name',)
+    FILTER_FIELDS = (
+        'name',
+        'archived',
+    )
 
 
 @register_v3_view()

--- a/datahub/search/test/test_models.py
+++ b/datahub/search/test/test_models.py
@@ -28,6 +28,7 @@ class TestBaseSearchModel:
             'address': '123 Fake Street',
             'country': 'uk',
             'date': None,
+            'archived': False,
         }
 
         expected_doc = {
@@ -89,13 +90,12 @@ def test_validate_model_search_fields(search_app):
     search_model = search_app.search_model
     mapping = search_model._doc_type.mapping
     invalid_fields = {
-        field for field in search_model.SEARCH_FIELDS
-        if not mapping.resolve_field(field)
+        field for field in search_model.SEARCH_FIELDS if not mapping.resolve_field(field)
     }
 
-    assert not invalid_fields, (
-        f'Invalid search fields {invalid_fields} detected on {search_model.__name__} search model'
-    )
+    assert (
+        not invalid_fields
+    ), f'Invalid search fields {invalid_fields} detected on {search_model.__name__} search model'
 
 
 def _get_db_model_fields(db_model):

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -334,7 +334,8 @@ def test_build_fuzzy_term_query_no_fields():
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    'offset,limit,expected_size', (
+    'offset,limit,expected_size',
+    (
         (8950, 1000, 1000),
         (9950, 1000, 50),
         (10000, 1000, 0),
@@ -343,7 +344,10 @@ def test_build_fuzzy_term_query_no_fields():
 def test_offset_near_max_results(offset, limit, expected_size):
     """Tests limit clipping when near max_results."""
     query = get_basic_search_query(
-        mock.Mock(), 'test', offset=offset, limit=limit,
+        mock.Mock(),
+        'test',
+        offset=offset,
+        limit=limit,
     )
 
     query_dict = query.to_dict()
@@ -470,6 +474,7 @@ def test_build_entity_permission_query_no_conditions(filters, expected):
                                                     'name.trigram',
                                                     'country.trigram',
                                                     'address.trigram',
+                                                    'archived',
                                                 ),
                                                 'type': 'cross_fields',
                                                 'operator': 'and',
@@ -486,7 +491,6 @@ def test_build_entity_permission_query_no_conditions(filters, expected):
                 'track_total_hits': True,
             },
         ),
-
         # complete
         (
             'search term',
@@ -530,6 +534,7 @@ def test_build_entity_permission_query_no_conditions(filters, expected):
                                                     'name.trigram',
                                                     'country.trigram',
                                                     'address.trigram',
+                                                    'archived',
                                                 ),
                                                 'type': 'cross_fields',
                                                 'operator': 'and',
@@ -670,6 +675,7 @@ def test_get_search_by_multiple_entities_query():
                                             'name.trigram',
                                             'country.trigram',
                                             'address.trigram',
+                                            'archived',
                                         ),
                                         'operator': 'and',
                                         'query': None,
@@ -705,7 +711,8 @@ def test_get_search_by_multiple_entities_query():
             },
         },
         'sort': [
-            '_score', 'id',
+            '_score',
+            'id',
         ],
         'track_total_hits': True,
     }


### PR DESCRIPTION
### Description of change

Hide archived from the v3 opensearch queries, but available in the v4 search. A future ticket is going to add archived as a filterable column, however as the v3 search endpoints use a fuzzy search with a MultiMatch query, having archived in the list of queryable columns causes a text to bool parsing issue

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
