### PR TITLE
Update advisers email addresses if the contain @trade

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_advisors_contact_email_addresses.py
+++ b/datahub/dbmaintenance/management/commands/update_advisors_contact_email_addresses.py
@@ -1,0 +1,27 @@
+import reversion
+
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_email, parse_uuid
+from datahub.company.models import Contact
+
+
+class Command(CSVBaseCommand):
+    """Command to update the email for contacts that have with @trade in it."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one row"""
+        pk = parse_uuid(row['Adviser ID'])
+        email = parse_email(row['New Contact email'])
+        contact = Contact.objects.get(pk=pk)
+
+        if '@trade' not in contact.email:
+            return
+
+        contact.email = email
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            contact.save(update_fields=('email',))
+            reversion.set_comment('Loaded email from spreadsheet.')


### PR DESCRIPTION
### Description of change

<!--
Create a function to take a spreadsheet and update the email address of advisers if they currently have '@trade.gov.uk' email
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
