### PR TITLE
Add invalid objects for merge to logging

### DIFF
--- a/datahub/company/admin/merge/step_2.py
+++ b/datahub/company/admin/merge/step_2.py
@@ -61,8 +61,10 @@ class SelectPrimaryCompanyForm(forms.Form):
         if not is_company_a_valid_merge_target(target_company):
             raise ValidationError(self.INVALID_TARGET_COMPANY_MSG)
 
-        if not is_company_a_valid_merge_source(source_company):
-            raise ValidationError(self.INVALID_SOURCE_COMPANY_MSG)
+        is_source_valid, disallowed_objects = is_company_a_valid_merge_source(source_company)
+        if not is_source_valid:
+            error_msg = f'{self.INVALID_SOURCE_COMPANY_MSG}: Invalid object: {disallowed_objects}'
+            raise ValidationError(error_msg)
 
         cleaned_data['target_company'] = target_company
         cleaned_data['source_company'] = source_company
@@ -127,7 +129,7 @@ def _build_option_context(source_company, target_company):
     merge_results, _ = get_planned_changes(target_company)
     merge_entries = transform_merge_results_to_merge_entry_summaries(merge_results)
 
-    is_source_valid = is_company_a_valid_merge_source(source_company)
+    is_source_valid, _ = is_company_a_valid_merge_source(source_company)
     is_target_valid = is_company_a_valid_merge_target(target_company)
 
     return {

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -124,26 +124,28 @@ class MergeNotAllowedError(DataHubError):
 
 
 def is_company_a_valid_merge_source(company: Company):
-    """Checks if company can be moved."""
+    """Checks if company can be moved and returns fields not allowed for merging."""
     # First, check that there are no references to the company from other objects
     # (other than via the fields specified in ALLOWED_RELATIONS_FOR_MERGING).
     relations = get_related_fields(Company)
 
-    has_related_objects = any(
-        getattr(company, relation.name).count()
-        for relation in relations
-        if relation.remote_field not in ALLOWED_RELATIONS_FOR_MERGING
-    )
+    disallowed_fields = []
+    for relation in relations:
+        if relation.remote_field not in ALLOWED_RELATIONS_FOR_MERGING:
+            if getattr(company, relation.name).count():
+                disallowed_fields.append(relation.name)
 
-    if has_related_objects:
-        return False
+    if disallowed_fields:
+        return False, disallowed_fields
 
     # Then, check that the source company itself doesn't have any references to other
     # companies.
     self_referential_fields = get_self_referential_relations(Company)
-    return not any(
-        getattr(company, field.name) for field in self_referential_fields
-    )
+    for field in self_referential_fields:
+        if getattr(company, field.name):
+            return False, [field.name]
+
+    return True, []
 
 
 def is_company_a_valid_merge_target(company: Company):

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -182,10 +182,10 @@ def merge_companies(source_company: Company, target_company: Company, user):
 
     MergeNotAllowedError will be raised if the merge is not allowed.
     """
-    if not (
-        is_company_a_valid_merge_source(source_company)
-        and is_company_a_valid_merge_target(target_company)
-    ):
+    is_source_valid, _ = is_company_a_valid_merge_source(source_company)
+    is_target_valid = is_company_a_valid_merge_target(target_company)
+
+    if not (is_source_valid and is_target_valid):
         logger.error(f'MergeNotAllowedError {source_company.id} for company {target_company.id}.')
         raise MergeNotAllowedError()
 

--- a/datahub/company/test/test_merge.py
+++ b/datahub/company/test/test_merge.py
@@ -580,11 +580,11 @@ class TestDuplicateCompanyMerger:
         assert source_company.transferred_to == target_company
 
     @pytest.mark.parametrize(
-        'valid_source,valid_target',
+        'valid_source_return_value, valid_target',
         (
-            (False, True),
-            (True, False),
-            (False, False),
+            ((False, ['field1', 'field2']), True),
+            ((True, []), False),
+            ((False, ['field1']), False),
         ),
     )
     @patch('datahub.company.merge.is_company_a_valid_merge_target')
@@ -593,14 +593,14 @@ class TestDuplicateCompanyMerger:
         self,
         is_company_a_valid_merge_source_mock,
         is_company_a_valid_merge_target_mock,
-        valid_source,
+        valid_source_return_value,
         valid_target,
     ):
         """
         Test that perform_merge() raises MergeNotAllowedError when the merge is not
         allowed.
         """
-        is_company_a_valid_merge_source_mock.return_value = valid_source
+        is_company_a_valid_merge_source_mock.return_value = valid_source_return_value
         is_company_a_valid_merge_target_mock.return_value = valid_target
 
         source_company = CompanyFactory()


### PR DESCRIPTION
### Description of change

In order to debug reasoning of failed merges, we want to expose invalid objects that prevent company merging

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
