### PR TITLE
Ensure logger error is thrown when step 2 fails

### DIFF
--- a/datahub/company/admin/merge/step_2.py
+++ b/datahub/company/admin/merge/step_2.py
@@ -1,3 +1,5 @@
+import logging
+
 from django import forms
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.core.exceptions import PermissionDenied, SuspiciousOperation, ValidationError
@@ -14,6 +16,8 @@ from datahub.company.merge import (
     transform_merge_results_to_merge_entry_summaries,
 )
 from datahub.core.utils import reverse_with_query_string
+
+logger = logging.getLogger(__name__)
 
 
 class SelectPrimaryCompanyForm(forms.Form):
@@ -64,6 +68,7 @@ class SelectPrimaryCompanyForm(forms.Form):
         is_source_valid, disallowed_objects = is_company_a_valid_merge_source(source_company)
         if not is_source_valid:
             error_msg = f'{self.INVALID_SOURCE_COMPANY_MSG}: Invalid object: {disallowed_objects}'
+            logger.error(error_msg)
             raise ValidationError(error_msg)
 
         cleaned_data['target_company'] = target_company

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -182,11 +182,15 @@ def merge_companies(source_company: Company, target_company: Company, user):
 
     MergeNotAllowedError will be raised if the merge is not allowed.
     """
-    is_source_valid, _ = is_company_a_valid_merge_source(source_company)
+    is_source_valid, invalid_obj = is_company_a_valid_merge_source(source_company)
     is_target_valid = is_company_a_valid_merge_target(target_company)
 
     if not (is_source_valid and is_target_valid):
-        logger.error(f'MergeNotAllowedError {source_company.id} for company {target_company.id}.')
+        logger.error(
+            f"""MergeNotAllowedError {source_company.id}
+            for company {target_company.id}.
+            Invalid bojects: {invalid_obj}""",
+        )
         raise MergeNotAllowedError()
 
     with reversion.create_revision():


### PR DESCRIPTION
### Description of change

Ensure logger error is thrown when step 2 fails

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
