### PR TITLE
fix-signal-task-tests

### DIFF
--- a/datahub/task/signals.py
+++ b/datahub/task/signals.py
@@ -34,6 +34,7 @@ def set_task_subscriptions_and_schedule_notifications(sender, **kwargs):
     pk_set = kwargs.pop('pk_set', None)
     action = kwargs.pop('action', None)
     if action == 'post_add' and pk_set is not None and task is not None:
+        print(pk_set)
         for adviser_id in pk_set:
             schedule_create_task_reminder_subscription_task(adviser_id)
             schedule_create_task_assigned_to_me_from_others_subscription_task(task, adviser_id)

--- a/datahub/task/signals.py
+++ b/datahub/task/signals.py
@@ -33,6 +33,7 @@ def set_task_subscriptions_and_schedule_notifications(sender, **kwargs):
     task = kwargs.pop('instance', None)
     pk_set = kwargs.pop('pk_set', None)
     action = kwargs.pop('action', None)
+    print('*****set_task_subscriptions_and_schedule_notifications')
     if action == 'post_add' and pk_set is not None and task is not None:
         for adviser_id in pk_set:
             schedule_create_task_reminder_subscription_task(adviser_id)

--- a/datahub/task/signals.py
+++ b/datahub/task/signals.py
@@ -33,7 +33,6 @@ def set_task_subscriptions_and_schedule_notifications(sender, **kwargs):
     task = kwargs.pop('instance', None)
     pk_set = kwargs.pop('pk_set', None)
     action = kwargs.pop('action', None)
-    print('*****set_task_subscriptions_and_schedule_notifications')
     if action == 'post_add' and pk_set is not None and task is not None:
         for adviser_id in pk_set:
             schedule_create_task_reminder_subscription_task(adviser_id)

--- a/datahub/task/signals.py
+++ b/datahub/task/signals.py
@@ -34,7 +34,6 @@ def set_task_subscriptions_and_schedule_notifications(sender, **kwargs):
     pk_set = kwargs.pop('pk_set', None)
     action = kwargs.pop('action', None)
     if action == 'post_add' and pk_set is not None and task is not None:
-        print(pk_set)
         for adviser_id in pk_set:
             schedule_create_task_reminder_subscription_task(adviser_id)
             schedule_create_task_assigned_to_me_from_others_subscription_task(task, adviser_id)

--- a/datahub/task/test/test_signals.py
+++ b/datahub/task/test/test_signals.py
@@ -2,7 +2,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from django.db.models import signals
+from django.db.models.signals import m2m_changed
 from factory.django import mute_signals
 
 from datahub.company.test.factories import AdviserFactory
@@ -12,7 +12,7 @@ from datahub.task.test.factories import InvestmentProjectTaskFactory, TaskFactor
 
 @pytest.mark.django_db
 class TestDeleteInvestmentProjectTask:
-    @mute_signals(signals.m2m_changed)
+    @mute_signals(m2m_changed)
     def test_delete_investment_project_task__without_linked_tasks_does_nothing(self):
         task = TaskFactory()
         task_id = task.id
@@ -24,7 +24,7 @@ class TestDeleteInvestmentProjectTask:
         obj = Task.objects.filter(pk=task_id).first()
         assert obj is None
 
-    @mute_signals(signals.m2m_changed)
+    @mute_signals(m2m_changed)
     def test_delete_investment_project_task_deletes_linked_task(self):
         task = TaskFactory()
         task_id = task.id

--- a/datahub/task/test/test_signals.py
+++ b/datahub/task/test/test_signals.py
@@ -1,19 +1,18 @@
-from unittest import mock
 from unittest.mock import call, patch
+
 import pytest
 
+from django.db.models import signals
+from factory.django import mute_signals
+
 from datahub.company.test.factories import AdviserFactory
-from datahub.reminder.models import (
-    TaskAssignedToMeFromOthersSubscription,
-    TaskOverdueSubscription,
-    UpcomingTaskReminderSubscription,
-)
 from datahub.task.models import Task
 from datahub.task.test.factories import InvestmentProjectTaskFactory, TaskFactory
 
 
 @pytest.mark.django_db
 class TestDeleteInvestmentProjectTask:
+    @mute_signals(signals.m2m_changed)
     def test_delete_investment_project_task__without_linked_tasks_does_nothing(self):
         task = TaskFactory()
         task_id = task.id
@@ -25,6 +24,7 @@ class TestDeleteInvestmentProjectTask:
         obj = Task.objects.filter(pk=task_id).first()
         assert obj is None
 
+    @mute_signals(signals.m2m_changed)
     def test_delete_investment_project_task_deletes_linked_task(self):
         task = TaskFactory()
         task_id = task.id
@@ -34,61 +34,6 @@ class TestDeleteInvestmentProjectTask:
 
         obj = Task.objects.filter(pk=task_id).first()
         assert obj is None
-
-
-class SubscriptionBaseTestMixin:
-    def test_creation_of_single_adviser_subscription_on_task_creation(self):
-        TaskFactory()
-        adviser = AdviserFactory()
-        TaskFactory(advisers=[adviser])
-        subscriptions = self.subscription.objects.filter(adviser=adviser)
-
-        assert subscriptions.count() == 1
-
-        TaskFactory()
-        TaskFactory()
-        TaskFactory(advisers=[adviser])
-        subscriptions = self.subscription.objects.filter(adviser=adviser)
-
-        assert subscriptions.count() == 1
-
-    def test_creation_of_multiple_adviser_subscription_on_task_creation(self):
-        TaskFactory()
-        adviser1 = AdviserFactory()
-        adviser2 = AdviserFactory()
-        AdviserFactory()
-        TaskFactory(advisers=[adviser1, adviser2])
-        subscriptions = self.subscription.objects.filter(
-            adviser__in=[adviser1, adviser2],
-        )
-
-        assert subscriptions.count() == 2
-
-        """
-        Test that only additional subscriptions for new advisers is created
-        """
-        adviser3 = AdviserFactory()
-        TaskFactory(advisers=[adviser1, adviser2, adviser3])
-        subscriptions = self.subscription.objects.filter(
-            adviser__in=[adviser1, adviser2, adviser3],
-        )
-
-        assert subscriptions.count() == 3
-
-
-@pytest.mark.django_db
-class TestTaskReminderSubscription(SubscriptionBaseTestMixin):
-    subscription = UpcomingTaskReminderSubscription
-
-
-@pytest.mark.django_db
-class TestTaskOverdueSubscription(SubscriptionBaseTestMixin):
-    subscription = TaskOverdueSubscription
-
-
-@pytest.mark.django_db
-class TestTaskAssignedToMeFromOthersSubscription(SubscriptionBaseTestMixin):
-    subscription = TaskAssignedToMeFromOthersSubscription
 
 
 @pytest.mark.django_db

--- a/datahub/task/test/test_signals.py
+++ b/datahub/task/test/test_signals.py
@@ -1,3 +1,4 @@
+import functools
 from unittest.mock import call, patch
 
 import pytest
@@ -7,7 +8,23 @@ from factory.django import mute_signals
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.task.models import Task
+from datahub.task.signals import set_task_subscriptions_and_schedule_notifications
 from datahub.task.test.factories import InvestmentProjectTaskFactory, TaskFactory
+
+
+def patch_all_task_subscription_functions(f):
+    @patch('datahub.task.signals.schedule_create_task_reminder_subscription_task')
+    @patch(
+        'datahub.task.signals.schedule_create_task_assigned_to_me_from_others_subscription_task',
+    )
+    @patch(
+        'datahub.task.signals.schedule_create_task_overdue_subscription_task',
+    )
+    @functools.wraps(f)
+    def functor(*args, **kwargs):
+        return f(*args, **kwargs)
+
+    return functor
 
 
 @pytest.mark.django_db
@@ -38,13 +55,7 @@ class TestDeleteInvestmentProjectTask:
 
 @pytest.mark.django_db
 class TestTaskAdviserChangedSubscriptions:
-    @patch('datahub.task.signals.schedule_create_task_reminder_subscription_task')
-    @patch(
-        'datahub.task.signals.schedule_create_task_assigned_to_me_from_others_subscription_task',
-    )
-    @patch(
-        'datahub.task.signals.schedule_create_task_overdue_subscription_task',
-    )
+    @patch_all_task_subscription_functions
     def test_schedule_functions_called_for_each_adviser(
         self,
         schedule_create_task_overdue_subscription_task,
@@ -67,14 +78,50 @@ class TestTaskAdviserChangedSubscriptions:
             any_order=True,
         )
 
-    def test_modifications_to_task_advisers(self):
-        pass
+    @patch_all_task_subscription_functions
+    def test_pk_set_to_none_does_not_trigger_scheduled_tasks(
+        self,
+        schedule_create_task_overdue_subscription_task,
+        schedule_create_task_assigned_to_me_from_others_subscription_task,
+        schedule_create_task_reminder_subscription_task,
+    ):
+        myargs = {'action': 'post_add', 'instance': 'a task'}
+        set_task_subscriptions_and_schedule_notifications(sender=None, **myargs)
 
-    def test_pk_set_none(self):
-        pass
+        schedule_create_task_reminder_subscription_task.assert_not_called()
+        schedule_create_task_assigned_to_me_from_others_subscription_task.assert_not_called()
+        schedule_create_task_overdue_subscription_task.assert_not_called()
 
-    def test_task_none(self):
-        pass
+    @patch_all_task_subscription_functions
+    def test_instance_set_to_none_does_not_trigger_scheduled_tasks(
+        self,
+        schedule_create_task_overdue_subscription_task,
+        schedule_create_task_assigned_to_me_from_others_subscription_task,
+        schedule_create_task_reminder_subscription_task,
+    ):
+        myargs = {'action': 'post_add', 'pk_set': 'some advisers'}
+        set_task_subscriptions_and_schedule_notifications(sender=None, **myargs)
 
-    def test_removing_adviser_does_not_trigger_signals(self):
-        pass
+        schedule_create_task_reminder_subscription_task.assert_not_called()
+        schedule_create_task_assigned_to_me_from_others_subscription_task.assert_not_called()
+        schedule_create_task_overdue_subscription_task.assert_not_called()
+
+    @patch_all_task_subscription_functions
+    def test_removing_adviser_does_not_trigger_scheduled_tasks(
+        self,
+        schedule_create_task_overdue_subscription_task,
+        schedule_create_task_assigned_to_me_from_others_subscription_task,
+        schedule_create_task_reminder_subscription_task,
+    ):
+        advisers = AdviserFactory.create_batch(2)
+        task = TaskFactory(advisers=advisers)
+
+        schedule_create_task_reminder_subscription_task.reset_mock()
+        schedule_create_task_assigned_to_me_from_others_subscription_task.reset_mock()
+        schedule_create_task_overdue_subscription_task.reset_mock()
+
+        task.advisers.remove(advisers[0])
+
+        schedule_create_task_reminder_subscription_task.assert_not_called()
+        schedule_create_task_assigned_to_me_from_others_subscription_task.assert_not_called()
+        schedule_create_task_overdue_subscription_task.assert_not_called()

--- a/datahub/task/test/test_signals.py
+++ b/datahub/task/test/test_signals.py
@@ -66,3 +66,15 @@ class TestTaskAdviserChangedSubscriptions:
             [call(adviser.id) for adviser in advisers],
             any_order=True,
         )
+
+    def test_modifications_to_task_advisers(self):
+        pass
+
+    def test_pk_set_none(self):
+        pass
+
+    def test_task_none(self):
+        pass
+
+    def test_removing_adviser_does_not_trigger_signals(self):
+        pass

--- a/datahub/task/test/test_tasks.py
+++ b/datahub/task/test/test_tasks.py
@@ -28,7 +28,6 @@ from datahub.reminder.test.factories import (
 from datahub.task.emails import TaskAssignedToOthersEmailTemplate, UpcomingTaskEmailTemplate
 
 from datahub.task.tasks import (
-    create_task_assigned_to_me_from_others_subscription,
     create_task_reminder_subscription_task,
     generate_reminders_upcoming_tasks,
     notify_adviser_added_to_task,
@@ -442,100 +441,10 @@ def mock_notify_adviser_task_assigned_from_others_call(task, adviser, template_i
         reminders=[reminder],
     )
 
-    # class TaskRemindersSubscriptionsMixin:
-    def test_creation_of_adviser_subscription_on_task_creation_where_adviser_has_no_subscription(
-        self,
-    ):
-        adviser1 = AdviserFactory()
-        AdviserFactory()
-        TaskFactory(advisers=[adviser1])
-        subscriptions = self.subscription.objects.filter(adviser=adviser1)
-        assert subscriptions.count() == 1
-
-    def test_creation_of_multiple_adviser_subscriptions_on_task_creation(self):
-        TaskFactory()
-        adviser1 = AdviserFactory()
-        adviser2 = AdviserFactory()
-        AdviserFactory()
-        AdviserFactory()
-        TaskFactory(advisers=[adviser1, adviser2])
-        subscriptions = self.subscription.objects.filter(
-            adviser__in=[adviser1, adviser2],
-        )
-
-        assert subscriptions.count() == 2
-
-        adviser3 = AdviserFactory()
-        TaskFactory(advisers=[adviser1, adviser2, adviser3])
-        subscriptions = self.subscription.objects.filter(
-            adviser__in=[adviser1, adviser2, adviser3],
-        )
-
-        assert subscriptions.count() == 3
-
-    def test_removal_of_adviser_from_task_that_subscription_remains(self):
-        TaskFactory()
-        adviser1 = AdviserFactory()
-        adviser2 = AdviserFactory()
-        AdviserFactory()
-        AdviserFactory()
-        TaskFactory(advisers=[adviser1, adviser2])
-        subscriptions = self.subscription.objects.filter(
-            adviser__in=[adviser1, adviser2],
-        )
-
-        assert subscriptions.count() == 2
-
-        TaskFactory(advisers=[adviser1])
-        subscriptions = self.subscription.objects.filter(
-            adviser__in=[adviser1, adviser2],
-        )
-
-        assert subscriptions.count() == 2
-
-    def test_notification_created_when_single_adviser_assigned_to_task(self):
-        adviser = AdviserFactory()
-        TaskFactory(advisers=[adviser])
-        reminders = self.reminder.objects.filter(adviser=adviser)
-
-        assert reminders.count() == 1
-
-        TaskFactory(advisers=[adviser])
-        reminders = self.reminder.objects.filter(adviser=adviser)
-
-        assert reminders.count() == 2
-
-    def test_notification_not_sent_when_single_adviser_removed_from_task(self):
-        # create a single task and assign to an adviser
-        adviser1 = AdviserFactory()
-        adviser2 = AdviserFactory()
-        task = TaskFactory(advisers=[adviser1, adviser2])
-        reminders = self.reminder.objects.filter(adviser=adviser1)
-
-        assert reminders.count() == 1
-
-        # remove the adviser from the task
-        task.advisers.remove(adviser1)
-        reminders_adviser1 = self.reminder.objects.filter(adviser=adviser1)
-        reminders_adviser2 = self.reminder.objects.filter(adviser=adviser2)
-
-        assert reminders_adviser1.count() == 1
-        assert reminders_adviser2.count() == 1
-
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures('mute_signals')
 class TestTasksAssignedToMeFromOthers:
-    # Removed as a duplicate
-    # def test_creation_of_adviser_subscription_on_task_creation_where_adviser_has_no_subscription(
-    #     self,
-    # ):
-    #     adviser1 = AdviserFactory()
-    #     AdviserFactory()
-    #     TaskFactory(advisers=[adviser1])
-    #     subscriptions = TaskAssignedToMeFromOthersSubscription.objects.filter(adviser=adviser1)
-    #     assert subscriptions.count() == 1
-
     def test_creation_of_multiple_adviser_subscriptions_on_task_creation(self):
         TaskFactory()
 
@@ -559,27 +468,6 @@ class TestTasksAssignedToMeFromOthers:
 
         assert subscriptions.count() == 3
 
-    # Removed due to not being needed
-    # def test_removal_of_adviser_from_task_that_subscription_remains(self):
-    #     TaskFactory()
-    #     adviser1 = AdviserFactory()
-    #     adviser2 = AdviserFactory()
-    #     AdviserFactory()
-    #     AdviserFactory()
-    #     TaskFactory(advisers=[adviser1, adviser2])
-    #     subscriptions = TaskAssignedToMeFromOthersSubscription.objects.filter(
-    #         adviser__in=[adviser1, adviser2],
-    #     )
-
-    #     assert subscriptions.count() == 2
-
-    #     TaskFactory(advisers=[adviser1])
-    #     subscriptions = TaskAssignedToMeFromOthersSubscription.objects.filter(
-    #         adviser__in=[adviser1, adviser2],
-    #     )
-
-    #     assert subscriptions.count() == 2
-
     def test_notification_created_when_single_adviser_assigned_to_task(self):
         adviser = AdviserFactory()
         task1 = TaskFactory(advisers=[adviser])
@@ -593,26 +481,6 @@ class TestTasksAssignedToMeFromOthers:
         reminders = TaskAssignedToMeFromOthersReminder.objects.filter(adviser=adviser)
 
         assert reminders.count() == 2
-
-    # Deleted due to test moving to the signals test file
-    # def test_notification_not_sent_when_single_adviser_removed_from_task(self):
-    #     # create a single task and assign to an adviser
-    #     adviser1 = AdviserFactory()
-    #     adviser2 = AdviserFactory()
-    #     task = TaskFactory(advisers=[adviser1, adviser2])
-    #     notify_adviser_added_to_task(task, adviser1.id)
-    #     notify_adviser_added_to_task(task, adviser2.id)
-
-    #     assert TaskAssignedToMeFromOthersReminder.objects.count() == 2
-
-    #     # remove the adviser from the task
-    #     task.advisers.remove(adviser1)
-    #     # notify_adviser_added_to_task(task, adviser2.id)
-    #     reminders_adviser1 = TaskAssignedToMeFromOthersReminder.objects.filter(adviser=adviser1)
-    #     reminders_adviser2 = TaskAssignedToMeFromOthersReminder.objects.filter(adviser=adviser2)
-
-    #     assert reminders_adviser1.count() == 1
-    #     assert reminders_adviser2.count() == 1
 
     def test_email_sent_for_adviser_with_no_subscription_set(
         self,


### PR DESCRIPTION
### Description of change

The datahub/task/test/test_tasks.py file was relying on the Task signals to create objects in the django DB, however this was causing issues with large numbers of Task model objects being created as the signals were causing transaction issues.

This refactor disables the signals in the datahub/task/test/test_tasks.py file, and moves those tests to the datahub/task/test/test_signals.py

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
