### PR TITLE
feature/CLS2-558-task-amended-by-others-reminders

### DIFF
--- a/datahub/task/emails.py
+++ b/datahub/task/emails.py
@@ -38,6 +38,10 @@ class EmailTemplate(ABC):
         return f'Completed by: {self.task.modified_by.name}'
 
     @property
+    def adviser_amending_task(self):
+        return f'Amended by: {self.task.modified_by.name}'
+
+    @property
     def task_due_date(self):
         return (
             f'Date due: {self.task.due_date.strftime("%-d %B %Y")}' if self.task.due_date else None
@@ -128,4 +132,22 @@ class TaskCompletedEmailTemplate(EmailTemplate):
             self.company_name,
             self.task_due_date,
             self.adviser_completing_task,
+        ]
+
+
+class TaskAmendedByOthersEmailTemplate(EmailTemplate):
+    def __init__(self, task: Task):
+        super().__init__(task)
+
+    @property
+    def subject(self):
+        return 'Task amended'
+
+    @property
+    def fields_to_include(self):
+        return [
+            self.investment_project,
+            self.company_name,
+            self.task_due_date,
+            self.adviser_amending_task,
         ]

--- a/datahub/task/signals.py
+++ b/datahub/task/signals.py
@@ -3,10 +3,12 @@ from django.dispatch import receiver
 
 from datahub.task.models import Task
 from datahub.task.tasks import (
+    schedule_create_task_amended_by_others_subscription_task,
     schedule_create_task_assigned_to_me_from_others_subscription_task,
     schedule_create_task_completed_subscription_task,
     schedule_create_task_overdue_subscription_task,
     schedule_create_task_reminder_subscription_task,
+    schedule_notify_advisers_task_amended_by_others,
     schedule_notify_advisers_task_completed,
 )
 
@@ -30,6 +32,7 @@ def set_task_subscriptions_and_schedule_notifications(sender, **kwargs):
             schedule_create_task_assigned_to_me_from_others_subscription_task(task, adviser_id)
             schedule_create_task_overdue_subscription_task(adviser_id)
             schedule_create_task_completed_subscription_task(adviser_id)
+            schedule_create_task_amended_by_others_subscription_task(adviser_id)
 
 
 @receiver(
@@ -42,3 +45,4 @@ def save_task(sender, instance, created, **kwargs):
     Triggers when a task is saved
     """
     schedule_notify_advisers_task_completed(instance, created)
+    schedule_notify_advisers_task_amended_by_others(instance, created)

--- a/datahub/task/signals.py
+++ b/datahub/task/signals.py
@@ -26,6 +26,7 @@ def set_task_subscriptions_and_schedule_notifications(sender, **kwargs):
     task = kwargs.pop('instance', None)
     pk_set = kwargs.pop('pk_set', None)
     action = kwargs.pop('action', None)
+
     if action == 'post_add' and pk_set is not None and task is not None:
         for adviser_id in pk_set:
             schedule_create_task_reminder_subscription_task(adviser_id)
@@ -44,5 +45,12 @@ def save_task(sender, instance, created, **kwargs):
     """
     Triggers when a task is saved
     """
+    # As the adviser field is an m2m field, it will never contain the changed value in this signal.
+    # Adviser changes are reflected in a separate m2m changed signal. As the scheduled jobs run in
+    # a queue, there can be a mismatch between the advisers in this signal and the advisers
+    # available when the queue function runs. This loads the advisers into a list as it is before
+    # any m2m changes are triggered by the m2m signal
+    adviser_ids_pre_m2m_change = list(instance.advisers.all().values_list('id', flat=True))
+
     schedule_notify_advisers_task_completed(instance, created)
-    schedule_notify_advisers_task_amended_by_others(instance, created)
+    schedule_notify_advisers_task_amended_by_others(instance, created, adviser_ids_pre_m2m_change)

--- a/datahub/task/tasks.py
+++ b/datahub/task/tasks.py
@@ -374,6 +374,11 @@ def update_task_amended_by_others_email_status(email_notification_id, reminder_i
         reminder.email_notification_id = email_notification_id
         reminder.save()
 
+    logger.info(
+        'Task update_task_amended_by_others_email_status completed'
+        f'email_notification_id to {email_notification_id} and reminder_ids set to {reminder_ids}',
+    )
+
 
 def create_task_amended_by_others_subscription(adviser_id):
     """
@@ -451,10 +456,13 @@ def schedule_notify_advisers_task_amended_by_others(task, created):
     logger.info(
         f'Task {job.id} notify_adviser_task_amended_by_others',
     )
-    return
 
 
 def send_task_email(adviser, task, reminder, update_task, email_template_class):
+    logger.info(
+        f'Sending an email for Task {task.id} and reminder {reminder.id} to adviser {adviser.id}',
+    )
+
     notify_adviser_by_rq_email(
         adviser=adviser,
         template_identifier=settings.TASK_REMINDER_EMAIL_TEMPLATE_ID,

--- a/datahub/task/tasks.py
+++ b/datahub/task/tasks.py
@@ -11,6 +11,8 @@ from datahub.core.queues.scheduler import LONG_RUNNING_QUEUE
 from datahub.feature_flag.utils import is_user_feature_flag_active
 from datahub.reminder import ADVISER_TASKS_USER_FEATURE_FLAG_NAME
 from datahub.reminder.models import (
+    TaskAmendedByOthersReminder,
+    TaskAmendedByOthersSubscription,
     TaskAssignedToMeFromOthersReminder,
     TaskAssignedToMeFromOthersSubscription,
     TaskCompletedReminder,
@@ -21,6 +23,7 @@ from datahub.reminder.models import (
 )
 from datahub.reminder.tasks import notify_adviser_by_rq_email
 from datahub.task.emails import (
+    TaskAmendedByOthersEmailTemplate,
     TaskAssignedToOthersEmailTemplate,
     TaskCompletedEmailTemplate,
     UpcomingTaskEmailTemplate,
@@ -363,6 +366,92 @@ def schedule_notify_advisers_task_completed(task, created):
     logger.info(
         f'Task {job.id} schedule_notify_advisers_task_completed',
     )
+
+
+def update_task_amended_by_others_email_status(email_notification_id, reminder_ids):
+    reminders = TaskAmendedByOthersReminder.all_objects.filter(id__in=reminder_ids)
+    for reminder in reminders:
+        reminder.email_notification_id = email_notification_id
+        reminder.save()
+
+
+def create_task_amended_by_others_subscription(adviser_id):
+    """
+    Creates a task amended by others subscription for an adviser if the adviser doesn't have
+    a subscription already.
+    """
+    if not TaskAmendedByOthersSubscription.objects.filter(
+        adviser_id=adviser_id,
+    ).first():
+        TaskAmendedByOthersSubscription.objects.create(
+            adviser_id=adviser_id,
+            email_reminders_enabled=True,
+        )
+
+
+def notify_adviser_task_amended_by_others(task, created):
+    """
+    Send a notification to all advisers, excluding the adviser who marked the task as completed,
+    when task is amended
+    """
+    if created:
+        return
+
+    if task.archived:
+        return
+
+    advisers_to_notify = task.advisers.exclude(id=task.modified_by.id)
+
+    if not advisers_to_notify.exists():
+        return
+
+    for adviser in advisers_to_notify:
+        reminder = TaskAmendedByOthersReminder.objects.create(
+            adviser=adviser,
+            event=f'{task} amended by {task.modified_by.name}',
+            task=task,
+        )
+
+        adviser_subscription = TaskAmendedByOthersSubscription.objects.filter(
+            adviser=adviser,
+        ).first()
+        if not adviser_subscription:
+            return
+
+        if adviser_subscription.email_reminders_enabled is True and is_user_feature_flag_active(
+            ADVISER_TASKS_USER_FEATURE_FLAG_NAME,
+            adviser,
+        ):
+            send_task_email(
+                adviser=adviser,
+                task=task,
+                reminder=reminder,
+                update_task=update_task_amended_by_others_email_status,
+                email_template_class=TaskAmendedByOthersEmailTemplate,
+            )
+
+
+def schedule_create_task_amended_by_others_subscription_task(adviser_id):
+    job = job_scheduler(
+        queue_name=LONG_RUNNING_QUEUE,
+        function=create_task_amended_by_others_subscription,
+        function_args=(adviser_id,),
+    )
+    logger.info(
+        f'Task {job.id} create_task_amended_by_others_subscription',
+    )
+
+
+def schedule_notify_advisers_task_amended_by_others(task, created):
+    job = job_scheduler(
+        queue_name=LONG_RUNNING_QUEUE,
+        function=notify_adviser_task_amended_by_others,
+        function_args=(task, created),
+    )
+    logger.info(
+        f'Task {job.id} notify_adviser_task_amended_by_others',
+    )
+    return
 
 
 def send_task_email(adviser, task, reminder, update_task, email_template_class):

--- a/datahub/task/test/factories.py
+++ b/datahub/task/test/factories.py
@@ -6,8 +6,7 @@ from django.utils.timezone import now
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test.factories import to_many_field
-from datahub.investment.project.test.factories import InvestmentProjectFactory
-from datahub.task.models import InvestmentProjectTask, Task
+from datahub.task.models import Task
 
 
 class TaskFactory(factory.django.DjangoModelFactory):
@@ -30,17 +29,3 @@ class TaskFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Task
-
-
-class InvestmentProjectTaskFactory(factory.django.DjangoModelFactory):
-    """Factory for creating investment project tasks"""
-
-    created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SelfAttribute('created_by')
-    created_on = now()
-
-    task = factory.SubFactory(TaskFactory)
-    investment_project = factory.SubFactory(InvestmentProjectFactory)
-
-    class Meta:
-        model = InvestmentProjectTask

--- a/datahub/task/test/factories.py
+++ b/datahub/task/test/factories.py
@@ -18,6 +18,7 @@ class TaskFactory(factory.django.DjangoModelFactory):
     created_on = now()
     title = factory.Faker('company')
     investment_project = None
+    reminder_days = factory.Faker('random_int', max=90)
 
     archived = False
 

--- a/datahub/task/test/factories.py
+++ b/datahub/task/test/factories.py
@@ -6,7 +6,8 @@ from django.utils.timezone import now
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test.factories import to_many_field
-from datahub.task.models import Task
+from datahub.investment.project.test.factories import InvestmentProjectFactory
+from datahub.task.models import InvestmentProjectTask, Task
 
 
 class TaskFactory(factory.django.DjangoModelFactory):
@@ -29,3 +30,17 @@ class TaskFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Task
+
+
+class InvestmentProjectTaskFactory(factory.django.DjangoModelFactory):
+    """Factory for creating investment project tasks"""
+
+    created_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
+    created_on = now()
+
+    task = factory.SubFactory(TaskFactory)
+    investment_project = factory.SubFactory(InvestmentProjectFactory)
+
+    class Meta:
+        model = InvestmentProjectTask

--- a/datahub/task/test/test_signals.py
+++ b/datahub/task/test/test_signals.py
@@ -20,6 +20,7 @@ def patch_all_task_subscription_functions(f):
         'datahub.task.signals.schedule_create_task_overdue_subscription_task',
     )
     @patch('datahub.task.signals.schedule_create_task_completed_subscription_task')
+    @patch('datahub.task.signals.schedule_create_task_amended_by_others_subscription_task')
     @functools.wraps(f)
     def functor(*args, **kwargs):
         return f(*args, **kwargs)
@@ -32,6 +33,7 @@ class TestTaskAdviserChangedSubscriptions:
     @patch_all_task_subscription_functions
     def test_schedule_functions_called_for_each_adviser(
         self,
+        schedule_create_task_amended_by_others_subscription_task,
         schedule_create_task_completed_subscription_task,
         schedule_create_task_overdue_subscription_task,
         schedule_create_task_assigned_to_me_from_others_subscription_task,
@@ -56,10 +58,15 @@ class TestTaskAdviserChangedSubscriptions:
             [call(adviser.id) for adviser in advisers],
             any_order=True,
         )
+        schedule_create_task_amended_by_others_subscription_task.assert_has_calls(
+            [call(adviser.id) for adviser in advisers],
+            any_order=True,
+        )
 
     @patch_all_task_subscription_functions
     def test_pk_set_to_none_does_not_trigger_scheduled_tasks(
         self,
+        schedule_create_task_amended_by_others_subscription_task,
         schedule_create_task_completed_subscription_task,
         schedule_create_task_overdue_subscription_task,
         schedule_create_task_assigned_to_me_from_others_subscription_task,
@@ -72,10 +79,12 @@ class TestTaskAdviserChangedSubscriptions:
         schedule_create_task_assigned_to_me_from_others_subscription_task.assert_not_called()
         schedule_create_task_overdue_subscription_task.assert_not_called()
         schedule_create_task_completed_subscription_task.assert_not_called()
+        schedule_create_task_amended_by_others_subscription_task.assert_not_called()
 
     @patch_all_task_subscription_functions
     def test_instance_set_to_none_does_not_trigger_scheduled_tasks(
         self,
+        schedule_create_task_amended_by_others_subscription_task,
         schedule_create_task_completed_subscription_task,
         schedule_create_task_overdue_subscription_task,
         schedule_create_task_assigned_to_me_from_others_subscription_task,
@@ -88,10 +97,12 @@ class TestTaskAdviserChangedSubscriptions:
         schedule_create_task_assigned_to_me_from_others_subscription_task.assert_not_called()
         schedule_create_task_overdue_subscription_task.assert_not_called()
         schedule_create_task_completed_subscription_task.assert_not_called()
+        schedule_create_task_amended_by_others_subscription_task.assert_not_called()
 
     @patch_all_task_subscription_functions
     def test_removing_adviser_does_not_trigger_scheduled_tasks(
         self,
+        schedule_create_task_amended_by_others_subscription_task,
         schedule_create_task_completed_subscription_task,
         schedule_create_task_overdue_subscription_task,
         schedule_create_task_assigned_to_me_from_others_subscription_task,
@@ -104,6 +115,7 @@ class TestTaskAdviserChangedSubscriptions:
         schedule_create_task_assigned_to_me_from_others_subscription_task.reset_mock()
         schedule_create_task_overdue_subscription_task.reset_mock()
         schedule_create_task_completed_subscription_task.reset_mock()
+        schedule_create_task_amended_by_others_subscription_task.reset_mock()
 
         task.advisers.remove(advisers[0])
 
@@ -111,6 +123,7 @@ class TestTaskAdviserChangedSubscriptions:
         schedule_create_task_assigned_to_me_from_others_subscription_task.assert_not_called()
         schedule_create_task_overdue_subscription_task.assert_not_called()
         schedule_create_task_completed_subscription_task.assert_not_called()
+        schedule_create_task_amended_by_others_subscription_task.assert_not_called()
 
 
 @pytest.mark.django_db
@@ -141,6 +154,42 @@ class TestTaskAdviserCompletedSubscriptions:
         task.save()
 
         schedule_notify_advisers_task_completed.assert_has_calls(
+            [
+                call(task, True),
+                call(task, False),
+                call(task, False),
+            ],
+        )
+
+
+@pytest.mark.django_db
+class TestTaskAmededByOthersSubscriptions:
+    @mute_signals(m2m_changed)
+    @patch('datahub.task.signals.schedule_notify_advisers_task_amended_by_others')
+    def test_creating_task_triggers_notify_advisers_task_amended_by_others_scheduled_task(
+        self,
+        schedule_notify_advisers_task_amended_by_others,
+    ):
+        task = TaskFactory(advisers=[AdviserFactory()])
+
+        schedule_notify_advisers_task_amended_by_others.assert_has_calls(
+            [
+                call(task, True),
+                call(task, False),
+            ],
+        )
+
+    @mute_signals(m2m_changed)
+    @patch('datahub.task.signals.schedule_notify_advisers_task_amended_by_others')
+    def test_modifying_task_triggers_notify_advisers_task_amended_by_others_scheduled_task(
+        self,
+        schedule_notify_advisers_task_amended_by_others,
+    ):
+        task = TaskFactory(archived=False)
+        task.archived = True
+        task.save()
+
+        schedule_notify_advisers_task_amended_by_others.assert_has_calls(
             [
                 call(task, True),
                 call(task, False),

--- a/datahub/task/test/test_signals.py
+++ b/datahub/task/test/test_signals.py
@@ -170,12 +170,13 @@ class TestTaskAmededByOthersSubscriptions:
         self,
         schedule_notify_advisers_task_amended_by_others,
     ):
-        task = TaskFactory(advisers=[AdviserFactory()])
+        adviser = AdviserFactory()
+        task = TaskFactory(advisers=[adviser])
 
         schedule_notify_advisers_task_amended_by_others.assert_has_calls(
             [
-                call(task, True),
-                call(task, False),
+                call(task, True, []),
+                call(task, False, [adviser.id]),
             ],
         )
 
@@ -185,14 +186,15 @@ class TestTaskAmededByOthersSubscriptions:
         self,
         schedule_notify_advisers_task_amended_by_others,
     ):
-        task = TaskFactory(archived=False)
+        adviser = AdviserFactory()
+        task = TaskFactory(archived=False, advisers=[adviser])
         task.archived = True
         task.save()
 
         schedule_notify_advisers_task_amended_by_others.assert_has_calls(
             [
-                call(task, True),
-                call(task, False),
-                call(task, False),
+                call(task, True, []),
+                call(task, False, [adviser.id]),
+                call(task, False, [adviser.id]),
             ],
         )

--- a/datahub/task/test/test_tasks.py
+++ b/datahub/task/test/test_tasks.py
@@ -14,6 +14,8 @@ from django.utils import timezone
 from datahub.feature_flag.test.factories import UserFeatureFlagFactory
 from datahub.reminder import ADVISER_TASKS_USER_FEATURE_FLAG_NAME
 from datahub.reminder.models import (
+    TaskAmendedByOthersReminder,
+    TaskAmendedByOthersSubscription,
     TaskAssignedToMeFromOthersReminder,
     TaskAssignedToMeFromOthersSubscription,
     TaskCompletedReminder,
@@ -22,24 +24,29 @@ from datahub.reminder.models import (
     UpcomingTaskReminderSubscription,
 )
 from datahub.reminder.test.factories import (
+    TaskAmendedByOthersReminderFactory,
     TaskAssignedToMeFromOthersReminderFactory,
     TaskCompletedReminderFactory,
     UpcomingTaskReminderFactory,
 )
 from datahub.task.emails import (
+    TaskAmendedByOthersEmailTemplate,
     TaskAssignedToOthersEmailTemplate,
     TaskCompletedEmailTemplate,
     UpcomingTaskEmailTemplate,
 )
 
 from datahub.task.tasks import (
+    create_task_amended_by_others_subscription,
     create_task_completed_subscription,
     create_task_reminder_subscription_task,
     create_upcoming_task_reminder,
     generate_reminders_upcoming_tasks,
     notify_adviser_added_to_task,
     notify_adviser_completed_task,
+    notify_adviser_task_amended_by_others,
     schedule_reminders_upcoming_tasks,
+    update_task_amended_by_others_email_status,
     update_task_assigned_to_me_from_others_email_status,
     update_task_completed_email_status,
     update_task_reminder_email_status,
@@ -494,6 +501,24 @@ def mock_notify_adviser_task_completed_call(task, adviser, template_id):
     )
 
 
+def mock_notify_adviser_task_amended_by_others_call(task, adviser, template_id):
+    reminder = TaskAmendedByOthersReminderFactory(
+        adviser=adviser,
+        task=task,
+        event=f'{task} amended by {task.modified_by.name}',
+    )
+    reminder.id = ANY
+    reminder.pk = ANY
+
+    return mock.call(
+        adviser=adviser,
+        template_identifier=template_id,
+        context=TaskAmendedByOthersEmailTemplate(task).get_context(),
+        update_task=update_task_amended_by_others_email_status,
+        reminders=[reminder],
+    )
+
+
 @pytest.mark.django_db
 @pytest.mark.usefixtures('mute_signals')
 class TestTasksAssignedToMeFromOthers:
@@ -732,7 +757,7 @@ class TestTaskCompleted:
 
     def test_no_reminders_created_when_a_task_is_created(self):
         task = TaskFactory()
-        notify_adviser_completed_task(task, False)
+        notify_adviser_completed_task(task, True)
         assert TaskCompletedReminder.objects.exists() is False
 
     def test_no_reminders_created_when_a_task_is_not_archived(self):
@@ -744,7 +769,11 @@ class TestTaskCompleted:
         self,
     ):
         adviser = AdviserFactory()
-        task = TaskFactory(archived=True, modified_by=adviser, advisers=[adviser])
+        task = TaskFactory(
+            archived=True,
+            modified_by=adviser,
+            advisers=[adviser],
+        )
 
         notify_adviser_completed_task(task, False)
 
@@ -925,9 +954,6 @@ class TestTaskCompleted:
     def test_task_completed_assigns_email_notification_id_to_all_reminders(
         self,
     ):
-        """
-        Test it updates reminder data with the connected email notification information.
-        """
         task = TaskFactory()
         reminder_number = 3
         notification_id = str(uuid4())
@@ -942,6 +968,215 @@ class TestTaskCompleted:
         )
 
         linked_reminders = TaskCompletedReminder.objects.filter(
+            email_notification_id=notification_id,
+        )
+        assert linked_reminders.count() == (reminder_number)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('mute_signals')
+class TestTaskAmendedByOthers:
+    def test_creation_of_multiple_adviser_subscriptions_on_task_creation(self):
+        TaskFactory()
+
+        advisers = AdviserFactory.create_batch(3)
+
+        TaskFactory(advisers=[advisers[0], advisers[1]])
+        create_task_amended_by_others_subscription(advisers[0].id)
+        create_task_amended_by_others_subscription(advisers[1].id)
+
+        subscriptions = TaskAmendedByOthersSubscription.objects.filter(
+            adviser__in=[advisers[0], advisers[1]],
+        )
+
+        assert subscriptions.count() == 2
+
+        TaskFactory(advisers=advisers)
+        create_task_amended_by_others_subscription(advisers[2].id)
+        subscriptions = TaskAmendedByOthersSubscription.objects.filter(
+            adviser__in=advisers,
+        )
+
+        assert subscriptions.count() == 3
+
+    def test_no_reminders_created_when_a_task_is_created(self):
+        task = TaskFactory()
+        notify_adviser_task_amended_by_others(task, True)
+        assert TaskAmendedByOthersReminder.objects.exists() is False
+
+    def test_no_reminders_created_when_a_task_is_archived(self):
+        task = TaskFactory(archived=True)
+        notify_adviser_task_amended_by_others(task, True)
+        assert TaskAmendedByOthersReminder.objects.exists() is False
+
+    def test_no_reminders_created_when_adviser_that_amends_task_is_the_only_adviser(
+        self,
+    ):
+        adviser = AdviserFactory()
+        task = TaskFactory(
+            archived=False,
+            modified_by=adviser,
+            advisers=[adviser],
+        )
+
+        notify_adviser_task_amended_by_others(task, False)
+
+        assert TaskAmendedByOthersReminder.objects.exists() is False
+
+    def test_adviser_that_amends_task_does_not_receive_notification_about_that_task_amends(
+        self,
+    ):
+        modified_by_adviser = AdviserFactory()
+        adviser = AdviserFactory()
+        task = TaskFactory(
+            archived=False,
+            modified_by=modified_by_adviser,
+            advisers=[
+                modified_by_adviser,
+                adviser,
+            ],
+        )
+
+        notify_adviser_task_amended_by_others(task, False)
+
+        assert (
+            TaskAmendedByOthersReminder.objects.filter(adviser=modified_by_adviser).exists()
+            is False
+        )
+        assert TaskAmendedByOthersReminder.objects.filter(adviser=adviser).exists() is True
+
+    def test_notification_received_but_no_email_sent_to_adviser_without_subscription(
+        self,
+        mock_notify_adviser_by_rq_email,
+    ):
+        adviser = AdviserFactory()
+        task = TaskFactory(
+            archived=False,
+            advisers=[
+                adviser,
+            ],
+        )
+
+        notify_adviser_task_amended_by_others(task, False)
+
+        assert TaskAmendedByOthersReminder.objects.filter(adviser=adviser).count() == 1
+        mock_notify_adviser_by_rq_email.assert_not_called()
+
+    def test_notification_received_but_no_email_sent_to_adviser_with_email_off(
+        self,
+        mock_notify_adviser_by_rq_email,
+    ):
+        adviser = AdviserFactory()
+        task = TaskFactory(
+            archived=False,
+            advisers=[
+                adviser,
+            ],
+        )
+
+        TaskAmendedByOthersSubscription.objects.create(
+            adviser_id=adviser.id,
+            email_reminders_enabled=False,
+        )
+
+        notify_adviser_task_amended_by_others(task, False)
+
+        assert TaskAmendedByOthersReminder.objects.filter(adviser=adviser).count() == 1
+        mock_notify_adviser_by_rq_email.assert_not_called()
+
+    def test_notification_received_but_no_email_sent_to_adviser_with_email_on_with_no_feature_flag(
+        self,
+        mock_notify_adviser_by_rq_email,
+    ):
+        adviser = AdviserFactory()
+        task = TaskFactory(
+            archived=False,
+            advisers=[
+                adviser,
+            ],
+        )
+
+        create_task_amended_by_others_subscription(adviser_id=adviser.id)
+
+        notify_adviser_task_amended_by_others(task, False)
+
+        assert TaskAmendedByOthersReminder.objects.filter(adviser=adviser).count() == 1
+        mock_notify_adviser_by_rq_email.assert_not_called()
+
+    def test_notification_received_but_no_email_for_adviser_with_email_off_with_feature_flag_on(
+        self,
+        adviser_tasks_user_feature_flag,
+        mock_notify_adviser_by_rq_email,
+    ):
+        adviser = AdviserFactory()
+        add_user_feature_flag(adviser_tasks_user_feature_flag, adviser)
+        task = TaskFactory(
+            archived=False,
+            advisers=[
+                adviser,
+            ],
+        )
+
+        TaskAmendedByOthersSubscription.objects.create(
+            adviser_id=adviser.id,
+            email_reminders_enabled=False,
+        )
+
+        notify_adviser_task_amended_by_others(task, False)
+
+        assert TaskAmendedByOthersReminder.objects.filter(adviser=adviser).count() == 1
+        mock_notify_adviser_by_rq_email.assert_not_called()
+
+    def test_email_sent_for_adviser_with_email_on_with_feature_flag_on(
+        self,
+        adviser_tasks_user_feature_flag,
+        mock_notify_adviser_by_rq_email,
+    ):
+        adviser = AdviserFactory()
+        add_user_feature_flag(adviser_tasks_user_feature_flag, adviser)
+        create_task_amended_by_others_subscription(adviser.id)
+
+        template_id = str(uuid4())
+        with override_settings(
+            TASK_REMINDER_EMAIL_TEMPLATE_ID=template_id,
+        ):
+            task = TaskFactory(
+                advisers=[adviser],
+                archived=False,
+            )
+
+            notify_adviser_task_amended_by_others(
+                task,
+                False,
+            )
+
+            mock_notify_adviser_by_rq_email.assert_has_calls(
+                [
+                    mock_notify_adviser_task_amended_by_others_call(
+                        task,
+                        adviser,
+                        template_id,
+                    ),
+                ],
+            )
+
+    def test_task_amended_assigns_email_notification_id_to_all_reminders(
+        self,
+    ):
+        task = TaskFactory()
+        reminder_number = 3
+        notification_id = str(uuid4())
+        reminders = TaskAmendedByOthersReminderFactory.create_batch(
+            reminder_number,
+            task_id=task.id,
+        )
+
+        update_task_amended_by_others_email_status(
+            notification_id,
+            [reminder.id for reminder in reminders],
+        )
+
+        linked_reminders = TaskAmendedByOthersReminder.objects.filter(
             email_notification_id=notification_id,
         )
         assert linked_reminders.count() == (reminder_number)


### PR DESCRIPTION
### Description of change

Added functionality for generating reminders when a task is amended by others

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
