### PR TITLE
Add Global Investment Summit 2023 and remove Global Investment Summit 2021

### DIFF
--- a/datahub/metadata/migrations/0068_update_services.py
+++ b/datahub/metadata/migrations/0068_update_services.py
@@ -1,0 +1,34 @@
+from pathlib import PurePath
+
+import mptt
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0017_update_services.yaml'
+    )
+
+
+def rebuild_tree(apps, _):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0067_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0068_update_services.py
+++ b/datahub/metadata/migrations/0068_update_services.py
@@ -1,6 +1,7 @@
 from pathlib import PurePath
 
 import mptt
+
 from django.db import migrations
 
 from datahub.core.migration_utils import load_yaml_data_in_migration
@@ -9,7 +10,7 @@ from datahub.core.migration_utils import load_yaml_data_in_migration
 def load_services(apps, _):
     load_yaml_data_in_migration(
         apps,
-        PurePath(__file__).parent / '0017_update_services.yaml'
+        PurePath(__file__).parent / '0068_update_services.yaml'
     )
 
 

--- a/datahub/metadata/migrations/0068_update_services.yaml
+++ b/datahub/metadata/migrations/0068_update_services.yaml
@@ -1,0 +1,13 @@
+- model: metadata.service
+  pk: c010e25f-641c-41ce-9ffa-8880321a165f
+  fields:
+    disabled_on: ~
+    order: 516.0
+    segment: Global Investment Summit (2023)
+    parent:
+    contexts:
+      ["event", "investment_interaction", "investment_project_interaction"]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0

--- a/datahub/metadata/migrations/0069_disable_unused_services.py
+++ b/datahub/metadata/migrations/0069_disable_unused_services.py
@@ -1,0 +1,23 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0069_disable_unused_services.yaml'
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0068_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0069_disable_unused_services.yaml
+++ b/datahub/metadata/migrations/0069_disable_unused_services.yaml
@@ -1,0 +1,4 @@
+- model: metadata.service
+  pk: 4e1daab0-7ad5-4a8d-bf45-3a83880e1323
+  fields:
+    disabled_on: "2023-11-24T14:52:03Z"


### PR DESCRIPTION
### Description of change

Created a migration for creating a new Global Investment Summit 2023 service.
Created a migration to disable Global Investment Summit 2021.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
