### PR TITLE
bugfix/return-uuid-from-mock-api-client

### DIFF
--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -1,7 +1,7 @@
 import warnings
 
-from uuid import uuid4
 from unittest import mock
+from uuid import uuid4
 
 from django.conf import settings
 from notifications_python_client.notifications import NotificationsAPIClient

--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -1,3 +1,4 @@
+from uuid import uuid4
 import warnings
 from unittest import mock
 
@@ -33,7 +34,7 @@ class NotifyGateway:
                 #    execution path when the API key is unset.
 
                 client = mock.Mock(spec_set=NotificationsAPIClient)
-                client.send_email_notification.return_value = {'id': 'abc123'}
+                client.send_email_notification.return_value = {'id': uuid4()}
                 clients[service_name] = client
                 warnings.warn(
                     f'`settings.{api_key_setting_name}` not specified therefore notifications '

--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -1,5 +1,6 @@
-from uuid import uuid4
 import warnings
+
+from uuid import uuid4
 from unittest import mock
 
 from django.conf import settings


### PR DESCRIPTION
### Description of change

The mock gov notify client returns the id as `abc123`, however gov notify id's are a guid data type. This PR will return a new uuid4 value, to allow saving this value into the pytest django DB without causing integrity errors

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
