### PR TITLE
feature/CLS2-640-add-company-to-task-view-and-serializer

### DIFF
--- a/datahub/task/models.py
+++ b/datahub/task/models.py
@@ -69,6 +69,10 @@ class Task(ArchivableModel, BaseModel):
 
     def get_company(self):
         """
-        Return the company from the related BaseTaskType model implementation.
+        Get the company from the available foreign keys
         """
-        return self.investment_project.investor_company if self.investment_project else None
+        if self.investment_project:
+            return self.investment_project.investor_company
+        if self.company:
+            return self.company
+        return None

--- a/datahub/task/serializers.py
+++ b/datahub/task/serializers.py
@@ -25,6 +25,15 @@ class TaskSerializer(serializers.ModelSerializer):
         required=False,
     )
 
+    def validate(self, data):
+        """
+        Check that start is before finish.
+        """
+        print('*****validate', data)
+        # if data['start'] > data['finish']:
+        #     raise serializers.ValidationError("finish must occur after start")
+        return data
+
     class Meta:
         model = Task
         fields = (

--- a/datahub/task/serializers.py
+++ b/datahub/task/serializers.py
@@ -25,15 +25,6 @@ class TaskSerializer(serializers.ModelSerializer):
         required=False,
     )
 
-    def validate(self, data):
-        """
-        Check that start is before finish.
-        """
-        print('*****validate', data)
-        # if data['start'] > data['finish']:
-        #     raise serializers.ValidationError("finish must occur after start")
-        return data
-
     class Meta:
         model = Task
         fields = (

--- a/datahub/task/test/test_models.py
+++ b/datahub/task/test/test_models.py
@@ -1,7 +1,8 @@
 import datetime
-from datahub.company.test.factories import CompanyFactory
 
 import pytest
+
+from datahub.company.test.factories import CompanyFactory
 
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 

--- a/datahub/task/test/test_models.py
+++ b/datahub/task/test/test_models.py
@@ -1,4 +1,5 @@
 import datetime
+from datahub.company.test.factories import CompanyFactory
 
 import pytest
 
@@ -43,9 +44,18 @@ class TestTaskModel:
         obj.save()
         assert obj.reminder_date == datetime.date(2030, 10, 2)
 
-    def test_task_get_company_for_investment_project(self):
+    def test_task_get_company_for_investment_project_task(self):
         investment_project_task = TaskFactory(investment_project=InvestmentProjectFactory())
         assert (
             investment_project_task.get_company()
             == investment_project_task.investment_project.investor_company
         )
+
+    def test_task_get_company_for_company_task(self):
+        company = CompanyFactory()
+        company_task = TaskFactory(company=company)
+        assert company_task.get_company() == company
+
+    def test_task_get_company_for_generic_task(self):
+        generic_task = TaskFactory()
+        assert generic_task.get_company() is None

--- a/datahub/task/views.py
+++ b/datahub/task/views.py
@@ -21,7 +21,10 @@ class TasksMixin(CoreViewSet):
         Get the task queryset that is filtered using common filters from the query params
         """
         queryset = (
-            Task.objects.all().prefetch_related('advisers').select_related('investment_project')
+            Task.objects.all()
+            .prefetch_related('advisers')
+            .select_related('investment_project')
+            .select_related('company')
         )
 
         archived = request.query_params.get('archived')
@@ -41,7 +44,7 @@ class TaskV4ViewSet(ArchivableViewSetMixin, TasksMixin):
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     permission_classes = [IsAuthenticated]
     ordering_fields = ['title', 'due_date', 'created_on']
-    filterset_fields = ['investment_project']
+    filterset_fields = ['investment_project', 'company']
 
     serializer_class = TaskSerializer
 


### PR DESCRIPTION
### Description of change

- Added the ability to assign a company to a task
- Added validation to the serialiser to block setting both a company and an investment project on a task
- In the serialiser, override the `company` prop to use the `get_company` function on the model, which correctly calculates the company based on the type of task

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
