### PR TITLE
bugfix/da-and-lep-users-task-permissions-for-e2e

### DIFF
--- a/fixtures/metadata/teams.yaml
+++ b/fixtures/metadata/teams.yaml
@@ -104,6 +104,9 @@
     - - export_largecapitalopportunity
       - opportunity
       - largecapitalopportunity
+    - - view_task
+      - task
+      - task
   model: auth.group
 - fields:
     name: DA
@@ -261,6 +264,9 @@
     - - export_largecapitalopportunity
       - opportunity
       - largecapitalopportunity
+    - - view_task
+      - task
+      - task
   model: auth.group
 - fields:
     name: DIT_staff


### PR DESCRIPTION
### Description of change

The DA and LEP users have already had the `view_task` permission assigned to their permission groups in django admin, however the e2e tests are failing as they don't have them assigned in the data setup scripts

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
