### PR TITLE
feature/CLS2-646-create-duplicate-task-urls

### DIFF
--- a/datahub/reminder/test/test_reminder_views.py
+++ b/datahub/reminder/test/test_reminder_views.py
@@ -580,8 +580,8 @@ class TestTaskAssignedToMeFromOthersReminderViewset(
     Tests for the task assigned to me from others reminder view.
     """
 
-    url_name = 'api-v4:reminder:task-assigned-to-me-from-others-reminder'
-    detail_url_name = 'api-v4:reminder:task-assigned-to-me-from-others-reminder-detail'
+    url_name = 'api-v4:reminder:my-tasks-task-assigned-to-me-from-others-reminder'
+    detail_url_name = 'api-v4:reminder:my-tasks-task-assigned-to-me-from-others-reminder-detail'
     factory = TaskAssignedToMeFromOthersReminderFactory
     tested_model = TaskAssignedToMeFromOthersReminder
 

--- a/datahub/reminder/test/test_subscription_views.py
+++ b/datahub/reminder/test/test_subscription_views.py
@@ -221,11 +221,11 @@ class TestTaskOverdueReminderSubscriptionViewset(
     'url_name,factory',
     [
         (
-            'api-v4:reminder:task-assigned-to-me-from-others-subscription',
+            'api-v4:reminder:my-tasks-task-assigned-to-me-from-others-subscription',
             TaskAssignedToMeFromOthersSubscriptionFactory,
         ),
         (
-            'api-v4:reminder:task-amended-by-others-subscription',
+            'api-v4:reminder:my-tasks-task-amended-by-others-subscription',
             TaskAmendedByOthersSubscriptionFactory,
         ),
         (

--- a/datahub/reminder/urls.py
+++ b/datahub/reminder/urls.py
@@ -169,32 +169,32 @@ urlpatterns = [
         name='my-tasks-due-date-approaching-subscription',
     ),
     path(
-        'reminder/task-assigned-to-me-from-others',
+        'reminder/my-tasks-task-assigned-to-me-from-others',
         TaskAssignedToMeFromOthersReminderViewset.as_view(
             {
                 'get': 'list',
             },
         ),
-        name='task-assigned-to-me-from-others-reminder',
+        name='my-tasks-task-assigned-to-me-from-others-reminder',
     ),
     path(
-        'reminder/task-assigned-to-me-from-others/<uuid:pk>',
+        'reminder/my-tasks-task-assigned-to-me-from-others/<uuid:pk>',
         TaskAssignedToMeFromOthersReminderViewset.as_view(
             {
                 'delete': 'destroy',
             },
         ),
-        name='task-assigned-to-me-from-others-reminder-detail',
+        name='my-tasks-task-assigned-to-me-from-others-reminder-detail',
     ),
     path(
-        'reminder/subscription/task-assigned-to-me-from-others',
+        'reminder/subscription/my-tasks-task-assigned-to-me-from-others',
         TaskAssignedToMeFromOthersSubscriptionViewset.as_view(
             {
                 'get': 'retrieve',
                 'patch': 'partial_update',
             },
         ),
-        name='task-assigned-to-me-from-others-subscription',
+        name='my-tasks-task-assigned-to-me-from-others-subscription',
     ),
     path(
         'reminder/my-tasks-task-overdue',
@@ -225,14 +225,14 @@ urlpatterns = [
         name='my-tasks-task-overdue-subscription',
     ),
     path(
-        'reminder/subscription/task-amended-by-others',
+        'reminder/subscription/my-tasks-task-amended-by-others',
         TaskAmendedByOthersSubscriptionViewset.as_view(
             {
                 'get': 'retrieve',
                 'patch': 'partial_update',
             },
         ),
-        name='task-amended-by-others-subscription',
+        name='my-tasks-task-amended-by-others-subscription',
     ),
     path(
         'reminder/my-tasks-task-completed',
@@ -266,5 +266,44 @@ urlpatterns = [
         'reminder/summary',
         reminder_summary_view,
         name='summary',
+    ),
+    # Legacy urls to be removed once the FE is pointed at the new urls starting with 'my-tasks'
+    path(
+        'reminder/subscription/task-amended-by-others',
+        TaskAmendedByOthersSubscriptionViewset.as_view(
+            {
+                'get': 'retrieve',
+                'patch': 'partial_update',
+            },
+        ),
+        name='task-amended-by-others-subscription',
+    ),
+    path(
+        'reminder/subscription/task-assigned-to-me-from-others',
+        TaskAssignedToMeFromOthersSubscriptionViewset.as_view(
+            {
+                'get': 'retrieve',
+                'patch': 'partial_update',
+            },
+        ),
+        name='task-assigned-to-me-from-others-subscription',
+    ),
+    path(
+        'reminder/task-assigned-to-me-from-others',
+        TaskAssignedToMeFromOthersReminderViewset.as_view(
+            {
+                'get': 'list',
+            },
+        ),
+        name='task-assigned-to-me-from-others-reminder',
+    ),
+    path(
+        'reminder/task-assigned-to-me-from-others/<uuid:pk>',
+        TaskAssignedToMeFromOthersReminderViewset.as_view(
+            {
+                'delete': 'destroy',
+            },
+        ),
+        name='task-assigned-to-me-from-others-reminder-detail',
     ),
 ]


### PR DESCRIPTION
### Description of change

Some of the reminder urls were created incorrectly. This PR adds new correct urls, whilst leaving the existing urls there to allow this to be deployed without introducing any breaking changes in the FE.

Once the FE has been updated to use these new urls, there is another ticket to remove the legacy urls from the codebase

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
