### PR TITLE
Feature/cls2 587 task filter created by

### DIFF
--- a/datahub/search/task/test/test_views.py
+++ b/datahub/search/task/test/test_views.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from unittest import mock
 
 import pytest
 
@@ -109,7 +110,6 @@ class TestTaskSearch(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_200_OK
-
         assert response.data['count'] == 1
         assert response.data['results'][0]['id'] == str(task.id)
         assert response.data['results'][0]['created_by']['id'] == str(created_by_adviser.id)
@@ -156,9 +156,60 @@ class TestTaskSearch(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_200_OK
-
         assert response.data['count'] == 1
         assert response.data['results'][0]['id'] == str(task.id)
+
+    @mock.patch('datahub.search.task.views.SearchTaskAPIView.deep_get')
+    def test_search_task_without_filters(
+        self,
+        deep_get,
+        opensearch_with_collector,
+    ):
+        """
+        Tests edge case where no filter returned from raw_query
+        """
+        deep_get.return_value = None
+        TaskFactory()
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:task')
+
+        response = self.api_client.post(
+            url,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        assert response.data['count'] == 1
+
+    @mock.patch('datahub.search.task.views.SearchTaskAPIView.deep_get')
+    def test_search_task_without_filter_index(
+        self,
+        deep_get,
+        opensearch_with_collector,
+    ):
+        """
+        Test edge case where no filter_index found in raw_query filter
+        """
+        not_created_by_adviser = AdviserFactory()
+        deep_get.return_value = [{'result': 'testing'}]
+        TaskFactory()
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:task')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'not_created_by': not_created_by_adviser.id,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        assert response.data['count'] == 1
 
     def test_search_task_due_date_ordering(self, opensearch_with_collector):
         """Tests task search ordering on due date"""

--- a/datahub/search/task/test/test_views.py
+++ b/datahub/search/task/test/test_views.py
@@ -85,6 +85,81 @@ class TestTaskSearch(APITestMixin):
         assert response.data['count'] == 1
         assert response.data['results'][0]['id'] == str(task.id)
 
+    def test_search_task_not_created_by_id(self, opensearch_with_collector):
+        """Tests task search by not created by id."""
+        created_by_adviser = AdviserFactory()
+        not_created_by_adviser = AdviserFactory()
+
+        task = TaskFactory(
+            created_by=created_by_adviser,
+        )
+        TaskFactory(
+            created_by=not_created_by_adviser,
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:task')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'not_created_by': not_created_by_adviser.id,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['id'] == str(task.id)
+        assert response.data['results'][0]['created_by']['id'] == str(created_by_adviser.id)
+
+    def test_search_task_not_created_by_id_works_in_combination_with_other_parameters(
+        self,
+        opensearch_with_collector,
+    ):
+        """
+        Tests task not created by id filter works in combination with other parameters.
+        We're testing this with an adviser.
+        """
+        created_by_adviser = AdviserFactory()
+        not_created_by_adviser = AdviserFactory()
+        adviser1 = AdviserFactory()
+
+        task = TaskFactory(
+            created_by=created_by_adviser,
+            advisers=[
+                adviser1,
+            ],
+        )
+        TaskFactory(
+            created_by=not_created_by_adviser,
+            advisers=[
+                adviser1,
+            ],
+        )
+        TaskFactory(
+            created_by=not_created_by_adviser,
+        )
+        TaskFactory()
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v4:search:task')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'not_created_by': not_created_by_adviser.id,
+                'advisers': [adviser1.id],
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['id'] == str(task.id)
+
     def test_search_task_due_date_ordering(self, opensearch_with_collector):
         """Tests task search ordering on due date"""
         yesterday_task = TaskFactory(due_date=datetime.today() - timedelta(days=1))

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -16,7 +16,7 @@ class SearchTaskAPIViewMixin:
     search_app = TaskSearchApp
     serializer_class = SearchTaskQuerySerializer
     es_sort_by_remappings = {}
-    fields_to_exclude = ()
+    fields_to_exclude = ('not_created_by',)
 
     FILTER_FIELDS = (
         'archived',
@@ -24,7 +24,6 @@ class SearchTaskAPIViewMixin:
         'title',
         'due_date',
         'created_by',
-        'not_created_by',
         'advisers',
         'company',
         'investment_project',
@@ -36,8 +35,6 @@ class SearchTaskAPIViewMixin:
         'company': 'company.id',
         'investment_project': 'investment_project.id',
     }
-
-    COMPOSITE_FILTERS = {}
 
 
 @register_v4_view()

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -55,6 +55,10 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
         )
 
     def get_base_query(self, request, validated_data):
+        """
+        Check for filters that filter for not_* parameters and extend the open search base query
+        with the must_not filters.
+        """
         must_not = []
         base_query = super().get_base_query(request, validated_data)
 

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -1,12 +1,5 @@
 from functools import reduce
 
-from opensearch_dsl.query import (
-    Bool,
-    # Exists,
-    # Range,
-    # Term,
-)
-
 from datahub.search.task import TaskSearchApp
 from datahub.search.task.serializers import (
     SearchTaskQuerySerializer,
@@ -70,16 +63,7 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
         if not filters:
             return base_query
 
-        # from pprint import pprint
-
-        # pprint("raw_query")
-        # pprint(raw_query)
-
-        # pprint("filters")
-        # pprint(filters)
-
         if request.data.get('not_created_by'):
-            # pprint('##### must_not.append')
             must_not.append(
                 {
                     'match': {
@@ -101,9 +85,7 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
             if filter_index is None:
                 return base_query
 
-            # TODO Merge existing filters and must_not filters into single Bool "object"
-            filters[filter_index] = Bool(filters[filter_index]['bool'], must_not=must_not)
-            # pprint(filters)
+            filters[filter_index]['bool']['must_not'] = must_not
             raw_query['query']['bool']['filter'] = filters
 
             base_query.update_from_dict(raw_query)

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -59,11 +59,6 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
         must_not = []
         base_query = super().get_base_query(request, validated_data)
 
-        raw_query = base_query.to_dict()
-        filters = self.deep_get(raw_query, 'query|bool|filter')
-        if not filters:
-            return base_query
-
         if request.data.get('not_created_by'):
             must_not.append(
                 {
@@ -77,6 +72,11 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
             )
 
         if len(must_not) > 0:
+            raw_query = base_query.to_dict()
+            filters = self.deep_get(raw_query, 'query|bool|filter')
+            if not filters:
+                return base_query
+
             filter_index = None
             for index, filter in enumerate(filters):
                 if filter.get('bool') or filter.get('bool') == {}:

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -1,3 +1,5 @@
+from functools import reduce
+
 from datahub.search.task import TaskSearchApp
 from datahub.search.task.serializers import (
     SearchTaskQuerySerializer,
@@ -22,6 +24,7 @@ class SearchTaskAPIViewMixin:
         'title',
         'due_date',
         'created_by',
+        'not_created_by',
         'advisers',
         'company',
         'investment_project',
@@ -39,4 +42,95 @@ class SearchTaskAPIViewMixin:
 
 @register_v4_view()
 class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
-    pass
+    """Filtered company search view."""
+
+    def deep_get(self, dictionary, keys, default=None):
+        """
+        Perform a deep search on a dictionary to find the item at the location provided in the keys
+        """
+        return reduce(
+            lambda d, key: d.get(key, default) if isinstance(d, dict) else default,
+            keys.split('|'),
+            dictionary,
+        )
+
+    def get_base_query(self, request, validated_data):
+        base_query = super().get_base_query(request, validated_data)
+
+        raw_query = base_query.to_dict()
+        filters = self.deep_get(raw_query, 'query|bool|filter')
+        if not filters:
+            return base_query
+        # from pprint import pprint
+
+        if request.data.get('not_created_by'):
+            filters = [
+                {
+                    'bool': {
+                        'must_not': [
+                            {
+                                'bool': {
+                                    'minimum_should_match': 1,
+                                    'should': [
+                                        {
+                                            'match': {
+                                                'created_by.id': {
+                                                    'operator': 'and',
+                                                    'query': request.data['not_created_by'],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]
+            raw_query['query']['bool']['filter'] = filters
+            base_query.update_from_dict(raw_query)
+
+        # filter_index = None
+        # for index, filter in enumerate(filters):
+        #     if filter.get('bool'):
+        #         filter_index = index
+        #         break
+
+        # if filter_index is None:
+        #     return base_query
+
+        # must_filters = filters[filter_index]['bool']['must']
+        # for index, filter in enumerate(must_filters):
+        #     # By default the logic to generate an opensearch query inside get_base_query uses an
+        #     # and for each column passed to it. In this use case, when we detect a query for the
+        #     # ghq headquarter id we add an addiitonal should entry into the should array
+        #     should_queries = self.deep_get(filter, 'bool|should')
+
+        #     if should_queries:
+        #         for should_query in should_queries:
+        #             if (
+        #                 self.deep_get(should_query, 'match|headquarter_type.id|query')
+        #                 == HeadquarterType.ghq.value.id
+        #             ):
+        #                 should_queries.append(
+        #                     {
+        #                         'match': {
+        #                             'is_global_ultimate': {
+        #                                 'query': True,
+        #                             },
+        #                         },
+        #                     },
+        #                 )
+        #                 break
+        #         base_query.filter('terms', tags=['search', 'python'])
+        #         raw_query['query']['bool']['filter'][filter_index]['bool']['must'][index]['bool'][
+        #             'should'
+        #         ] = should_queries
+
+        # raw_query['query']['bool']['filter'] = filters
+        # pprint("post raw_query:")
+        # pprint(raw_query)
+        # base_query.update_from_dict(raw_query)
+
+        # base_query.filter('terms', tags=['search', 'python'])
+        return base_query

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -4,7 +4,7 @@ from opensearch_dsl.query import (
     Bool,
     # Exists,
     # Range,
-    Term,
+    # Term,
 )
 
 from datahub.search.task import TaskSearchApp
@@ -72,7 +72,11 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
 
         # from pprint import pprint
 
+        # pprint("raw_query")
         # pprint(raw_query)
+
+        # pprint("filters")
+        # pprint(filters)
 
         if request.data.get('not_created_by'):
             # pprint('##### must_not.append')
@@ -87,86 +91,21 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
                 },
             )
 
-        # filter_index = None
-        # for index, filter in enumerate(filters):
-        #     if filter.get('bool'):
-        #         filter_index = index
-        #         break
-
-        # if filter_index is None:
-        #     pprint("return base_query")
-        #     return base_query
-
-        # must_filters = filters[filter_index]['bool']['must']
-        # for index, filter in enumerate(must_filters):
-        #     # By default the logic to generate an opensearch query inside get_base_query uses an
-        #     # and for each column passed to it. In this use case, when we detect a query for the
-        #     # ghq headquarter id we add an addiitonal should entry into the should array
-        #     should_queries = self.deep_get(filter, 'bool|should')
-
-        #     if should_queries:
-        #         for should_query in should_queries:
-        #             if (
-        #                 self.deep_get(should_query, 'match|headquarter_type.id|query')
-        #                 == HeadquarterType.ghq.value.id
-        #             ):
-        #                 should_queries.append(
-        #                     {
-        #                         'match': {
-        #                             'is_global_ultimate': {
-        #                                 'query': True,
-        #                             },
-        #                         },
-        #                     },
-        #                 )
-        #                 break
-        #         base_query.filter('terms', tags=['search', 'python'])
-        #         raw_query['query']['bool']['filter'][filter_index]['bool']['must'][index]['bool'][
-        #             'should'
-        #         ] = should_queries
-
-        # raw_query['query']['bool']['filter'] = filters
-        # pprint("post raw_query:")
-        # pprint(raw_query)
-        # base_query.update_from_dict(raw_query)
-
-        # base_query.filter('terms', tags=['search', 'python'])
         if len(must_not) > 0:
-            # pprint("###### if must_not")
-            must_not_filters = Bool(
-                must_not=Term(
-                    **{
-                        'minimum_should_match': 1,
-                        'should': must_not,
-                    },
-                ),
-            )
-            # pprint("raw_query")
-            # pprint(raw_query)
-            # pprint("raw_query['query']['bool']['filter']['bool']")
-            # pprint(raw_query['query']['bool']['filter'][0])
-
             filter_index = None
-            for index, filter in enumerate(raw_query['query']['bool']):
-                if filter.get('bool'):
+            for index, filter in enumerate(filters):
+                if filter.get('bool') or filter.get('bool') == {}:
                     filter_index = index
                     break
 
             if filter_index is None:
-                # pprint("return base_query")
                 return base_query
 
-            # raw_query['query']['bool']['filter'].append('bool')
-            # pprint(raw_query)
-            # filter_bool = raw_query['query']['bool']['filter']
-            # filter_bool.must_not = must_not_filters
-            # pprint("filter_bool")
-            # pprint(filter_bool)
+            # TODO Merge existing filters and must_not filters into single Bool "object"
+            filters[filter_index] = Bool(filters[filter_index]['bool'], must_not=must_not)
+            # pprint(filters)
+            raw_query['query']['bool']['filter'] = filters
 
-            raw_query['query']['bool']['filter'][filter_index] = must_not_filters
-
-            # pprint("final raw_query")
-            # pprint(raw_query)
             base_query.update_from_dict(raw_query)
 
         return base_query


### PR DESCRIPTION
### Description of change

On the Task search allow users to filter on `Not created by` in addition to the existing `created_by` filter:

> Given I have selected the ‘Created by' filter
> When the I select the checkbox labelled ‘Others’
> Then I should see the tasks created by others

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
