### PR TITLE
bugfix/allow-nulls-in-task-serializer-for-nullable-columns

### DIFF
--- a/datahub/task/serializers.py
+++ b/datahub/task/serializers.py
@@ -27,10 +27,12 @@ class TaskSerializer(serializers.ModelSerializer):
     archived = serializers.BooleanField(read_only=True)
     investment_project = NestedInvestmentProjectInvestorCompanyField(
         required=False,
+        allow_null=True,
     )
     company = NestedRelatedField(
         Company,
         required=False,
+        allow_null=True,
     )
 
     def to_representation(self, instance):

--- a/datahub/task/test/test_views.py
+++ b/datahub/task/test/test_views.py
@@ -290,7 +290,7 @@ class TestEditGenericTask(BaseEditTaskTests):
 
 
 class TestTaskForInvestmentProject(APITestMixin):
-    @pytest.mark.parametrize('investment_project_id', ('abc', '', uuid4()))
+    @pytest.mark.parametrize('investment_project_id', ('abc', uuid4()))
     def test_create_task_with_invalid_investment_project_id_returns_bad_request(
         self,
         investment_project_id,
@@ -390,7 +390,7 @@ class TestTaskForInvestmentProject(APITestMixin):
 
 
 class TestTaskForCompany(APITestMixin):
-    @pytest.mark.parametrize('company_id', ('abc', '', uuid4()))
+    @pytest.mark.parametrize('company_id', ('abc', uuid4()))
     def test_create_task_with_invalid_company_id_returns_bad_request(
         self,
         company_id,


### PR DESCRIPTION
### Description of change

Allow nulls for the company and investment project columns in the task serialiser. These columns are already nullable in the model

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
