### PR TITLE
Add company and investment project names to sort by

### DIFF
--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -177,7 +177,7 @@ def investment_project_field():
     return Object(
         properties={
             'id': Keyword(),
-            'name': Text(index=False),
+            'name': NormalizedKeyword(),
             'project_code': Text(index=False),
             'investor_company': id_unindexed_name_field(),
         },

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -444,7 +444,7 @@ def _apply_sorting_to_query(query, ordering):
 
     sort_params = {
         'order': ordering.direction,
-        'missing': '_first' if ordering.is_descending else '_last',
+        'missing': '_last' if ordering.is_descending else '_first',
     }
 
     return query.sort(

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -444,7 +444,7 @@ def _apply_sorting_to_query(query, ordering):
 
     sort_params = {
         'order': ordering.direction,
-        'missing': '_last' if ordering.is_descending else '_first',
+        'missing': '_first' if ordering.is_descending else '_last',
     }
 
     return query.sort(

--- a/datahub/search/task/serializers.py
+++ b/datahub/search/task/serializers.py
@@ -29,4 +29,6 @@ class SearchTaskQuerySerializer(EntitySearchQuerySerializer):
     SORT_BY_FIELDS = (
         'modified_on',
         'due_date',
+        'company.name',
+        'investment_project.name',
     )


### PR DESCRIPTION
### Description of change

Add `company.name` and `investment_project.name` to list of sort fields

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
