### PR TITLE
feature/CLS2-648-remove-legacy-urls

### DIFF
--- a/datahub/reminder/urls.py
+++ b/datahub/reminder/urls.py
@@ -286,43 +286,4 @@ urlpatterns = [
         reminder_summary_view,
         name='summary',
     ),
-    # Legacy urls to be removed once the FE is pointed at the new urls starting with 'my-tasks'
-    path(
-        'reminder/subscription/task-amended-by-others',
-        TaskAmendedByOthersSubscriptionViewset.as_view(
-            {
-                'get': 'retrieve',
-                'patch': 'partial_update',
-            },
-        ),
-        name='task-amended-by-others-subscription',
-    ),
-    path(
-        'reminder/subscription/task-assigned-to-me-from-others',
-        TaskAssignedToMeFromOthersSubscriptionViewset.as_view(
-            {
-                'get': 'retrieve',
-                'patch': 'partial_update',
-            },
-        ),
-        name='task-assigned-to-me-from-others-subscription',
-    ),
-    path(
-        'reminder/task-assigned-to-me-from-others',
-        TaskAssignedToMeFromOthersReminderViewset.as_view(
-            {
-                'get': 'list',
-            },
-        ),
-        name='task-assigned-to-me-from-others-reminder',
-    ),
-    path(
-        'reminder/task-assigned-to-me-from-others/<uuid:pk>',
-        TaskAssignedToMeFromOthersReminderViewset.as_view(
-            {
-                'delete': 'destroy',
-            },
-        ),
-        name='task-assigned-to-me-from-others-reminder-detail',
-    ),
 ]


### PR DESCRIPTION
### Description of change

The front end has been updated to point at the new urls that are prefixed with `my-task`, these legacy urls can now be removed
### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
