### PR TITLE
Update email notification URLs to include UTMs

### DIFF
--- a/datahub/task/test/test_emails.py
+++ b/datahub/task/test/test_emails.py
@@ -52,6 +52,7 @@ class BaseTaskEmailTemplateTests(APITestMixin):
         return task.get_company().name
 
     email_template_class = None
+    utm_url_snake_case = None
 
     default_generic_fields = [('Date due', due_date)]
     additional_generic_fields = []
@@ -97,21 +98,37 @@ class BaseTaskEmailTemplateTests(APITestMixin):
         ]
         assert email.get_task_fields() == '\n'.join(labels)
 
+    def test_email_utm_url(self):
+        test_utm_url = self.email_template_class.UTM_URL_BASE.format(
+            self.expected_utm_campaign
+        )
+
+        task = TaskFactory(due_date=datetime.date.today())
+        email = self.email_template_class(task)
+        task_url = email.get_context()['task_url']
+
+        
+        assert test_utm_url in task_url
+
 
 class TestUpcomingTaskEmailTemplate(BaseTaskEmailTemplateTests):
     email_template_class = UpcomingTaskEmailTemplate
+    expected_utm_campaign = 'upcoming_task'
 
 
 class TestTaskAssignedToOthersEmailTemplate(BaseTaskEmailTemplateTests):
     email_template_class = TaskAssignedToOthersEmailTemplate
+    expected_utm_campaign = 'task_assigned_to_others'
 
 
 class TestTaskOverdueEmailTemplate(BaseTaskEmailTemplateTests):
     email_template_class = TaskOverdueEmailTemplate
+    expected_utm_campaign = 'task_overdue'
 
 
 class TestTaskCompletedEmailTemplate(BaseTaskEmailTemplateTests):
     email_template_class = TaskCompletedEmailTemplate
+    expected_utm_campaign = 'task_completed'
 
     def completed_by(self, task):
         return task.modified_by.name
@@ -123,6 +140,7 @@ class TestTaskCompletedEmailTemplate(BaseTaskEmailTemplateTests):
 
 class TestTaskAmendedByOthersEmailTemplate(BaseTaskEmailTemplateTests):
     email_template_class = TaskAmendedByOthersEmailTemplate
+    expected_utm_campaign = 'task_amended_by_others'
 
     def amended_by(self, task):
         return task.modified_by.name


### PR DESCRIPTION
### Description of change

This task adds tracked URLs to the Task email reminders. The UTM_CAMPAIGN is generated by inspecting the class name and converting it to snake case

Jira ticket [here](https://uktrade.atlassian.net/browse/CLS2-645)

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?
