### PR TITLE
bugfix/exclude-task-creator-from-notifications-on-task-creation

### DIFF
--- a/datahub/task/tasks.py
+++ b/datahub/task/tasks.py
@@ -232,9 +232,15 @@ def notify_adviser_added_to_task(task, adviser_id):
     """
     Send a notification to the adviser added to the task
     """
+    if adviser_id == task.created_by.id:
+        return
+    if adviser_id == task.modified_by.id:
+        return
     adviser = Advisor.objects.filter(id=str(adviser_id)).first()
+
     if not adviser:
         return
+
     reminder = TaskAssignedToMeFromOthersReminder.objects.create(
         adviser=adviser,
         event=f'{task} assigned to me by {task.modified_by.name}',

--- a/datahub/task/test/test_tasks.py
+++ b/datahub/task/test/test_tasks.py
@@ -476,6 +476,38 @@ class TestTaskReminders:
 
 
 class TestTasksAssignedToMeFromOthers:
+    def test_no_notification_created_for_the_adviser_who_created_task(
+        self,
+    ):
+        adviser1 = AdviserFactory()
+        adviser2 = AdviserFactory()
+        task1 = TaskFactory(advisers=[adviser1, adviser2], created_by=adviser1)
+
+        notify_adviser_added_to_task(task1, adviser1.id)
+        notify_adviser_added_to_task(task1, adviser2.id)
+
+        assert (
+            TaskAssignedToMeFromOthersReminder.objects.filter(adviser=adviser1).exists() is False
+        )
+        assert TaskAssignedToMeFromOthersReminder.objects.filter(adviser=adviser2).count() == 1
+
+    def test_no_notification_created_for_the_adviser_who_modified_task(
+        self,
+    ):
+        adviser1 = AdviserFactory()
+        adviser2 = AdviserFactory()
+        task1 = TaskFactory(advisers=[adviser1], created_by=adviser2, modified_by=adviser1)
+
+        notify_adviser_added_to_task(task1, adviser1.id)
+        notify_adviser_added_to_task(task1, adviser2.id)
+
+        assert (
+            TaskAssignedToMeFromOthersReminder.objects.filter(adviser=adviser1).exists() is False
+        )
+        assert (
+            TaskAssignedToMeFromOthersReminder.objects.filter(adviser=adviser2).exists() is False
+        )
+
     def test_creation_of_multiple_adviser_subscriptions_on_task_creation(
         self,
         mock_notify_adviser_by_rq_email,


### PR DESCRIPTION
### Description of change

The adviser who creates a task is getting a notification they have been assigned to a task. This PR excludes the creator and modifier from receiving notifications about being assigned to that task

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
