### PR TITLE
bugfix/use-task-serializer-for-reminders

### DIFF
--- a/datahub/reminder/serializers.py
+++ b/datahub/reminder/serializers.py
@@ -7,7 +7,6 @@ from datahub.company.serializers import NestedAdviserWithTeamField
 from datahub.interaction.models import Interaction
 from datahub.interaction.serializers import BaseInteractionSerializer
 from datahub.investment.project.models import InvestmentProject
-from datahub.investment.project.serializers import NestedInvestmentProjectInvestorCompanyField
 from datahub.reminder.models import (
     NewExportInteractionReminder,
     NewExportInteractionSubscription,

--- a/datahub/reminder/serializers.py
+++ b/datahub/reminder/serializers.py
@@ -7,6 +7,7 @@ from datahub.company.serializers import NestedAdviserWithTeamField
 from datahub.interaction.models import Interaction
 from datahub.interaction.serializers import BaseInteractionSerializer
 from datahub.investment.project.models import InvestmentProject
+from datahub.investment.project.serializers import NestedInvestmentProjectInvestorCompanyField
 from datahub.reminder.models import (
     NewExportInteractionReminder,
     NewExportInteractionSubscription,
@@ -200,10 +201,24 @@ class NoRecentExportInteractionReminderSerializer(serializers.ModelSerializer):
         fields = ('id', 'created_on', 'last_interaction_date', 'event', 'company', 'interaction')
 
 
+class ReminderTaskSerializer(TaskSerializer):
+    """Serializer for the task in a reminder"""
+
+    class Meta:
+        model = Task
+        fields = (
+            'id',
+            'title',
+            'investment_project',
+            'company',
+            'due_date',
+        )
+
+
 class UpcomingTaskReminderSerializer(serializers.ModelSerializer):
     """Serializer for Upcoming Investment Project Task Reminder."""
 
-    task = TaskSerializer()
+    task = ReminderTaskSerializer()
 
     class Meta:
         model = UpcomingTaskReminder
@@ -218,7 +233,7 @@ class UpcomingTaskReminderSerializer(serializers.ModelSerializer):
 class TaskAssignedToMeFromOthersReminderSerializer(serializers.ModelSerializer):
     """Serializer for task assigned to me from others"""
 
-    task = TaskSerializer()
+    task = ReminderTaskSerializer()
 
     class Meta:
         model = TaskAssignedToMeFromOthersReminder
@@ -233,7 +248,7 @@ class TaskAssignedToMeFromOthersReminderSerializer(serializers.ModelSerializer):
 class TaskOverdueReminderSerializer(serializers.ModelSerializer):
     """Serializer for task overdue"""
 
-    task = TaskSerializer()
+    task = ReminderTaskSerializer()
 
     class Meta:
         model = TaskOverdueReminder
@@ -248,7 +263,7 @@ class TaskOverdueReminderSerializer(serializers.ModelSerializer):
 class TaskCompletedReminderSerializer(serializers.ModelSerializer):
     """Serializer for task completed"""
 
-    task = TaskSerializer()
+    task = ReminderTaskSerializer()
 
     class Meta:
         model = TaskCompletedReminder
@@ -263,7 +278,7 @@ class TaskCompletedReminderSerializer(serializers.ModelSerializer):
 class TaskAmendedByOthersReminderSerializer(serializers.ModelSerializer):
     """Serializer for task completed"""
 
-    task = TaskSerializer()
+    task = ReminderTaskSerializer()
 
     class Meta:
         model = TaskCompletedReminder

--- a/datahub/reminder/serializers.py
+++ b/datahub/reminder/serializers.py
@@ -7,7 +7,6 @@ from datahub.company.serializers import NestedAdviserWithTeamField
 from datahub.interaction.models import Interaction
 from datahub.interaction.serializers import BaseInteractionSerializer
 from datahub.investment.project.models import InvestmentProject
-from datahub.investment.project.serializers import NestedInvestmentProjectInvestorCompanyField
 from datahub.reminder.models import (
     NewExportInteractionReminder,
     NewExportInteractionSubscription,
@@ -28,6 +27,7 @@ from datahub.reminder.models import (
     UpcomingTaskReminderSubscription,
 )
 from datahub.task.models import Task
+from datahub.task.serializers import TaskSerializer
 
 
 class NoRecentExportInteractionSubscriptionSerializer(serializers.ModelSerializer):
@@ -200,26 +200,10 @@ class NoRecentExportInteractionReminderSerializer(serializers.ModelSerializer):
         fields = ('id', 'created_on', 'last_interaction_date', 'event', 'company', 'interaction')
 
 
-class ReminderTaskSerializer(serializers.ModelSerializer):
-    """Serializer for the task in a reminder"""
-
-    investment_project = NestedInvestmentProjectInvestorCompanyField(
-        read_only=True,
-    )
-
-    class Meta:
-        model = Task
-        fields = (
-            'id',
-            'investment_project',
-            'due_date',
-        )
-
-
 class UpcomingTaskReminderSerializer(serializers.ModelSerializer):
     """Serializer for Upcoming Investment Project Task Reminder."""
 
-    task = ReminderTaskSerializer()
+    task = TaskSerializer()
 
     class Meta:
         model = UpcomingTaskReminder
@@ -234,7 +218,7 @@ class UpcomingTaskReminderSerializer(serializers.ModelSerializer):
 class TaskAssignedToMeFromOthersReminderSerializer(serializers.ModelSerializer):
     """Serializer for task assigned to me from others"""
 
-    task = ReminderTaskSerializer()
+    task = TaskSerializer()
 
     class Meta:
         model = TaskAssignedToMeFromOthersReminder
@@ -249,7 +233,7 @@ class TaskAssignedToMeFromOthersReminderSerializer(serializers.ModelSerializer):
 class TaskOverdueReminderSerializer(serializers.ModelSerializer):
     """Serializer for task overdue"""
 
-    task = ReminderTaskSerializer()
+    task = TaskSerializer()
 
     class Meta:
         model = TaskOverdueReminder
@@ -264,7 +248,7 @@ class TaskOverdueReminderSerializer(serializers.ModelSerializer):
 class TaskCompletedReminderSerializer(serializers.ModelSerializer):
     """Serializer for task completed"""
 
-    task = ReminderTaskSerializer()
+    task = TaskSerializer()
 
     class Meta:
         model = TaskCompletedReminder
@@ -279,7 +263,7 @@ class TaskCompletedReminderSerializer(serializers.ModelSerializer):
 class TaskAmendedByOthersReminderSerializer(serializers.ModelSerializer):
     """Serializer for task completed"""
 
-    task = ReminderTaskSerializer()
+    task = TaskSerializer()
 
     class Meta:
         model = TaskCompletedReminder

--- a/datahub/reminder/test/test_reminder_views.py
+++ b/datahub/reminder/test/test_reminder_views.py
@@ -185,7 +185,9 @@ class TaskReminderMixin:
             'event': reminders[0].event,
             'task': {
                 'id': str(reminders[0].task.id),
+                'title': str(reminders[0].task.title),
                 'due_date': None,
+                'company': None,
                 'investment_project': None,
             },
         }
@@ -214,7 +216,14 @@ class TaskReminderMixin:
             'event': reminders[0].event,
             'task': {
                 'id': str(reminders[0].task.id),
+                'title': str(reminders[0].task.title),
                 'due_date': None,
+                'company': {
+                    'name': investment_project.investor_company.name,
+                    'id': str(
+                        investment_project.investor_company.id,
+                    ),
+                },
                 'investment_project': {
                     'name': investment_project.name,
                     'project_code': investment_project.project_code,
@@ -226,6 +235,42 @@ class TaskReminderMixin:
                     },
                     'id': str(investment_project.id),
                 },
+            },
+        }
+
+    def test_get_company_task_reminders(self):
+        """
+        Given some reminders for tasks with a company, these should be returned with
+        the correct company data
+        """
+        company = CompanyFactory()
+        task = TaskFactory(company=company)
+
+        reminders = self.factory.create_batch(
+            3,
+            adviser=self.user,
+            task=task,
+        )
+        response = self.get_response
+        data = response.json()
+        results = data.get('results', [])
+        reminders = sorted(reminders, key=lambda x: x.pk)
+
+        assert results[0] == {
+            'id': str(reminders[0].id),
+            'created_on': '2022-05-05T17:00:00Z',
+            'event': reminders[0].event,
+            'task': {
+                'id': str(reminders[0].task.id),
+                'title': str(reminders[0].task.title),
+                'due_date': None,
+                'company': {
+                    'name': company.name,
+                    'id': str(
+                        company.id,
+                    ),
+                },
+                'investment_project': None,
             },
         }
 


### PR DESCRIPTION
### Description of change

Update the ReminderTaskSerializer to extend the TaskSerializer to allow retrieval of the calculated company field in the reminders endpoint


### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
