### PR TITLE
feature/rr-1262-function-for-token-generation

### DIFF
--- a/datahub/export_win/tasks.py
+++ b/datahub/export_win/tasks.py
@@ -22,15 +22,10 @@ def get_all_fields_for_client_email_receipt(token, customer_response):
 
 def create_token_for_contact(contact, customer_response):
     # set existing unexpired token to expire (if there is)
-    if has_unexpired_token_for_contact(contact):
-        existing_tokens = CustomerResponseToken.objects.filter(
-            company_contact=contact,
-            customer_response=customer_response,
-            expires_on__gt=datetime.utcnow(),
-        )
-        for existing_token in existing_tokens:
-            existing_token.expires_on = datetime.utcnow()
-            existing_token.save()
+    CustomerResponseToken.objects.filter(
+        company_contact=contact,
+        customer_response=customer_response,
+        expires_on__gte=datetime.utcnow()).update(expires_on=datetime.utcnow())
     # create a new token
     expires_on = datetime.utcnow() + timedelta(days=7)
     new_token = CustomerResponseToken.objects.create(
@@ -39,12 +34,3 @@ def create_token_for_contact(contact, customer_response):
         customer_response=customer_response,
     )
     return new_token
-
-
-def has_unexpired_token_for_contact(contact):
-    now = datetime.utcnow()
-    unexpired_token_exists = CustomerResponseToken.objects.filter(
-        company_contact__id=contact.id,
-        expires_on__gt=now,
-    ).exists()
-    return unexpired_token_exists

--- a/datahub/export_win/tasks.py
+++ b/datahub/export_win/tasks.py
@@ -21,12 +21,13 @@ def get_all_fields_for_client_email_receipt(token, customer_response):
 
 
 def create_token_for_contact(contact, customer_response):
-    # set existing unexpired token to expire (if there is)
+    """
+    Generate new token and set all existing unexpired token to expire
+    """
     CustomerResponseToken.objects.filter(
         company_contact=contact,
         customer_response=customer_response,
         expires_on__gte=datetime.utcnow()).update(expires_on=datetime.utcnow())
-    # create a new token
     expires_on = datetime.utcnow() + timedelta(days=7)
     new_token = CustomerResponseToken.objects.create(
         expires_on=expires_on,

--- a/datahub/export_win/tasks.py
+++ b/datahub/export_win/tasks.py
@@ -1,4 +1,8 @@
+from datetime import datetime, timedelta
+
 from django.conf import settings
+
+from datahub.export_win.models import CustomerResponseToken
 
 
 def get_all_fields_for_client_email_receipt(token, customer_response):
@@ -14,3 +18,33 @@ def get_all_fields_for_client_email_receipt(token, customer_response):
     }
 
     return details
+
+
+def create_token_for_contact(contact, customer_response):
+    # set existing unexpired token to expire (if there is)
+    if has_unexpired_token_for_contact(contact):
+        existing_tokens = CustomerResponseToken.objects.filter(
+            company_contact=contact,
+            customer_response=customer_response,
+            expires_on__gt=datetime.utcnow(),
+        )
+        for existing_token in existing_tokens:
+            existing_token.expires_on = datetime.utcnow()
+            existing_token.save()
+    # create a new token
+    expires_on = datetime.utcnow() + timedelta(days=7)
+    new_token = CustomerResponseToken.objects.create(
+        expires_on=expires_on,
+        company_contact=contact,
+        customer_response=customer_response,
+    )
+    return new_token
+
+
+def has_unexpired_token_for_contact(contact):
+    now = datetime.utcnow()
+    unexpired_token_exists = CustomerResponseToken.objects.filter(
+        company_contact__id=contact.id,
+        expires_on__gt=now,
+    ).exists()
+    return unexpired_token_exists

--- a/datahub/export_win/test/test_tasks.py
+++ b/datahub/export_win/test/test_tasks.py
@@ -14,7 +14,6 @@ from datahub.export_win.models import CustomerResponseToken
 from datahub.export_win.tasks import (
     create_token_for_contact,
     get_all_fields_for_client_email_receipt,
-    has_unexpired_token_for_contact,
 )
 from datahub.export_win.test.factories import CustomerResponseFactory, CustomerResponseTokenFactory
 
@@ -158,21 +157,3 @@ def test_create_token_with_existing_expired_and_unexpired_tokens():
     # Check if the existing unexpired token is set to expire (set to current time)
     existing_token.refresh_from_db()
     assert existing_token.expires_on <= utc_now
-
-
-@pytest.mark.django_db
-def test_has_unexpired_token_for_contact():
-    # Create instances for CustomerResponse and Contact
-    mock_customer_response = CustomerResponseFactory()
-    mock_contact = ContactFactory()
-    # Initially, there should be no unexpired token for this contact
-    assert not has_unexpired_token_for_contact(mock_contact)
-    # Create a new token that will expire 2 days from now
-    expires_on = datetime.utcnow() + timedelta(days=2)
-    CustomerResponseToken.objects.create(
-        expires_on=expires_on,
-        company_contact=mock_contact,
-        customer_response=mock_customer_response,
-    )
-    # Now, there should be an unexpired token for this contact
-    assert has_unexpired_token_for_contact(mock_contact)

--- a/datahub/export_win/test/test_tasks.py
+++ b/datahub/export_win/test/test_tasks.py
@@ -38,56 +38,49 @@ def test_get_all_fields_for_client_email_receipt_success(
     mock_customer_response_token: MagicMock,
     mock_win: MagicMock,
 ):
-    # Create mocked instances
+    """
+    Testing to get all fields for client email receipt
+    """
     mock_customer_response_instance = MagicMock()
     mock_customer_response_token_instance = MagicMock()
-    # Set up mock object attributes
     mock_customer_response_instance.win = mock_win
     mock_customer_response_token_instance.company_contact.email = 'test@example.com'
     mock_customer_response_token_instance.company_contact.first_name = 'John'
     mock_win.country = 'Country'
     mock_win.lead_officer.name = 'Adviser Name'
     mock_win.goods_vs_services = 'Goods and Services'
-    # Patch the necessary methods with mock objects
     with patch('datahub.export_win.models.CustomerResponse.objects.get') as mock_response_get, \
          patch('datahub.export_win.models.CustomerResponseToken.objects.get') as mock_token_get:
-        # Set up return values for the mocked methods
         mock_response_get.return_value = mock_customer_response_instance
         mock_token_get.return_value = mock_customer_response_token_instance
-        # Generate a specific ID for the mock token instance
         mock_token_id = uuid.uuid4()
         mock_customer_response_token_instance.id = mock_token_id
-        # Call the function under test with mock data objects
         result = get_all_fields_for_client_email_receipt(
             mock_customer_response_token_instance, mock_customer_response_instance)
-        # Assertions for the expected values
         assert result['customer_email'] == 'test@example.com'
         assert result['country_destination'] == 'Country'
         assert result['client_firstname'] == 'John'
         assert result['lead_officer_name'] == 'Adviser Name'
         assert result['goods_services'] == 'Goods and Services'
-        # Compare the generated URL with the expected URL using the specific ID
         assert result['url'] == f'{settings.EXPORT_WIN_CLIENT_REVIEW_WIN_URL}/{mock_token_id}'
 
 
 @pytest.mark.django_db
 @freeze_time('2023-12-11')
 def test_create_token_for_contact_without_existing_unexpired_token():
-    # Create instances for CustomerResponse and Contact
+    """
+    Testing the create token where no existing unexpired token
+    """
     mock_customer_response = CustomerResponseFactory()
     mock_contact = ContactFactory()
-    # Call the function being tested
     new_token = create_token_for_contact(mock_contact, mock_customer_response)
-    # Check if a token was created for the given contact and customer response
-    assert new_token.id is not None  # Assert that the token ID is not None
+    assert new_token.id is not None
     token_exists = CustomerResponseToken.objects.filter(
         id=new_token.id,
         company_contact=mock_contact,
         customer_response=mock_customer_response,
     ).exists()
-    # Assert that a token was created with new id for the given contact and customer response
     assert token_exists is True
-    # Validate the expiry time without formatting
     expected_time = datetime.utcnow() + timedelta(days=7)
     assert expected_time == new_token.expires_on
 
@@ -95,28 +88,23 @@ def test_create_token_for_contact_without_existing_unexpired_token():
 @pytest.mark.django_db
 @freeze_time('2023-12-11')
 def test_create_token_with_existing_unexpired_token():
-    # Create instances for CustomerResponse and Contact
+    """
+    Testing the creation token where there is existing unexpired token
+    """
     mock_customer_response = CustomerResponseFactory()
     mock_contact = ContactFactory()
-    # Create an existing unexpired token for the contact and customer response
-    with freeze_time('2023-12-10'):  # Freeze time for creating the existing token
+    with freeze_time('2023-12-10'):
         existing_token = CustomerResponseTokenFactory(
             company_contact=mock_contact,
             customer_response=mock_customer_response,
-            expires_on=datetime.utcnow() + timedelta(days=1),  # Assuming 1 day from now
+            expires_on=datetime.utcnow() + timedelta(days=1),
         )
-    # Call the function being tested
     new_token = create_token_for_contact(mock_contact, mock_customer_response)
-    # Check if a new token was created for the given contact and customer response
     assert new_token.id is not None
-    # Assert that a new token was created with a different ID
     assert new_token.id != existing_token.id
-    # Validate the expiry time of the new token (7 days from now)
     expected_time = datetime.utcnow() + timedelta(days=7)
     assert expected_time == new_token.expires_on
-    # Check if the existing token is set to expire (set to current time)
     existing_token.refresh_from_db()
-    # Make datetime.utcnow() timezone-aware
     utc_now = datetime.utcnow().replace(tzinfo=pytz.UTC)
     assert existing_token.expires_on <= utc_now
 
@@ -124,36 +112,31 @@ def test_create_token_with_existing_unexpired_token():
 @pytest.mark.django_db
 @freeze_time('2023-12-11')
 def test_create_token_with_existing_expired_and_unexpired_tokens():
-    # Create instances for CustomerResponse and Contact
+    """
+    Testing the creation of a token where there are existing multiple tokens,
+    both in expired and unexpired states
+    """
     mock_customer_response = CustomerResponseFactory()
     mock_contact = ContactFactory()
-    # Create an existing expired token for the contact and customer response
-    with freeze_time('2023-12-09'):  # Freeze time for creating the expired token
+    with freeze_time('2023-12-09'):
         expired_token = CustomerResponseTokenFactory(
             company_contact=mock_contact,
             customer_response=mock_customer_response,
-            expires_on=datetime.utcnow() - timedelta(days=1),  # Expired 1 day ago
+            expires_on=datetime.utcnow() - timedelta(days=1),
         )
-    # Create an existing unexpired token for the contact and customer response
-    with freeze_time('2023-12-10'):  # Freeze time for creating the unexpired token
+    with freeze_time('2023-12-10'):
         existing_token = CustomerResponseTokenFactory(
             company_contact=mock_contact,
             customer_response=mock_customer_response,
-            expires_on=datetime.utcnow() + timedelta(days=1),  # Expires 1 day from now
+            expires_on=datetime.utcnow() + timedelta(days=1),
         )
-    # Call the function being tested
     new_token = create_token_for_contact(mock_contact, mock_customer_response)
-    # Check if a new token was created for the given contact and customer response
     assert new_token.id is not None
-    # Assert that a new token was created with a different ID than the existing token
     assert new_token.id != existing_token.id
-    # Validate the expiry time of the new token (7 days from now)
     expected_time = datetime.utcnow() + timedelta(days=7)
     assert expected_time == new_token.expires_on
-    # Check if the existing expired token is still expired
     expired_token.refresh_from_db()
     utc_now = datetime.utcnow().replace(tzinfo=pytz.UTC)
     assert expired_token.expires_on <= utc_now
-    # Check if the existing unexpired token is set to expire (set to current time)
     existing_token.refresh_from_db()
     assert existing_token.expires_on <= utc_now


### PR DESCRIPTION
### Description of change

This PR is for story [RR-1162](https://uktrade.atlassian.net/jira/software/projects/RR/boards/242?selectedIssue=RR-1262) which about developing a function that create a token that is valid for 7 days and set any existing token to expire. A new token will be return when this function is called

### Checklist

* [✅] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [✅] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.


[RR-1162]: https://uktrade.atlassian.net/browse/RR-1162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ