### PR TITLE
Bugfix/cls2 667 limit tasks to created by or assigned to

### DIFF
--- a/datahub/search/task/test/test_views.py
+++ b/datahub/search/task/test/test_views.py
@@ -247,7 +247,7 @@ class TestTaskSearch(APITestMixin):
         Test edge case where no filter_index found in raw_query filter
         """
         not_created_by_adviser = AdviserFactory()
-        deep_get.return_value = [dict()]
+        deep_get.return_value = [{}]
         TaskFactory(
             advisers=[self.user.id],
         )

--- a/datahub/search/task/test/test_views.py
+++ b/datahub/search/task/test/test_views.py
@@ -373,6 +373,8 @@ class TestTaskInvestmentProjectSearch(APITestMixin):
     def test_search_task_by_created_by_id(self, opensearch_with_collector):
         """Tests task search by created by id."""
         adviser1 = AdviserFactory()
+        adviser1.id = self.user.id
+
         investment_project = InvestmentProjectFactory()
         TaskFactory(
             created_by=adviser1,

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -92,7 +92,11 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
             base_query.update_from_dict(
                 self.add_must_and_must_not_to_filters(base_query, must, must_not)
             )
+        # from pprint import pprint
 
+        # raw_query = base_query.to_dict()
+        # pprint("raw_query")
+        # pprint(raw_query)
         return base_query
 
     def add_must_and_must_not_to_filters(self, base_query, must, must_not):
@@ -109,14 +113,19 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
 
         if filter_index is None:
             return base_query
-
+        # (status == 'xyx' AND (created_by = user.id OR user.id in advisers))
         if len(must_not) > 0:
             filters[filter_index]['bool']['must_not'] = must_not
         if len(must) > 0:
             if 'must' not in filters[filter_index]['bool']:
                 filters[filter_index]['bool']['must'] = []
 
-            filters[filter_index]['bool']['must'] = filters[filter_index]['bool']['must'] + must
+            ## TODO Fix this with some magic. (existing must filters AND (our new shiny 'must'))
+            filters[filter_index]['bool']['must'] = filters[filter_index]['bool']['must'] + list(
+                {
+                    'bool': [] + must,
+                },
+            )
 
         raw_query['query']['bool']['filter'] = filters
         return raw_query

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -90,7 +90,7 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
 
         if len(must_not) > 0 or len(must) > 0:
             base_query.update_from_dict(
-                self.add_must_and_must_not_to_filters(base_query, must, must_not)
+                self.add_must_and_must_not_to_filters(base_query, must, must_not),
             )
         # from pprint import pprint
 
@@ -117,14 +117,12 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
         if len(must_not) > 0:
             filters[filter_index]['bool']['must_not'] = must_not
         if len(must) > 0:
-            if 'must' not in filters[filter_index]['bool']:
-                filters[filter_index]['bool']['must'] = []
+            if 'should' not in filters[filter_index]['bool']:
+                filters[filter_index]['bool']['should'] = []
 
-            ## TODO Fix this with some magic. (existing must filters AND (our new shiny 'must'))
-            filters[filter_index]['bool']['must'] = filters[filter_index]['bool']['must'] + list(
-                {
-                    'bool': [] + must,
-                },
+            # TODO Fix this with some magic. (existing must filters AND (our new shiny 'must'))
+            filters[filter_index]['bool']['should'] = (
+                filters[filter_index]['bool']['should'] + must
             )
 
         raw_query['query']['bool']['filter'] = filters

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -60,7 +60,6 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
         base_query = super().get_base_query(request, validated_data)
 
         must = self.must_limit_query_to_created_by_or_advisers(request)
-
         if request.data.get('not_created_by'):
             must_not.append(
                 {
@@ -89,39 +88,17 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
             )
 
         if len(must_not) > 0 or len(must) > 0:
-            base_query.update_from_dict(
-                self.add_must_and_must_not_to_filters(base_query, must, must_not),
-            )
+            base_query.update_from_dict(self.add_must_and_must_not_to_filters(
+                base_query, must, must_not,
+            ))
 
         return base_query
 
-    def add_must_and_must_not_to_filters(self, base_query, must, must_not):
-        raw_query = base_query.to_dict()
-        filters = self.deep_get(raw_query, 'query|bool|filter')
-        if not filters:
-            return base_query
-
-        filter_index = None
-        for index, filter in enumerate(filters):
-            if filter.get('bool') or filter.get('bool') == {}:
-                filter_index = index
-                break
-
-        if filter_index is None:
-            return base_query
-
-        if len(must_not) > 0:
-            filters[filter_index]['bool']['must_not'] = must_not
-        if len(must) > 0:
-            if 'must' not in filters[filter_index]['bool']:
-                filters[filter_index]['bool']['must'] = []
-
-            filters[filter_index]['bool']['must'].append(must)
-
-        raw_query['query']['bool']['filter'] = filters
-        return raw_query
-
     def must_limit_query_to_created_by_or_advisers(self, request):
+        """
+        Create filter that limits results to tasks that have been either created by or assigned to
+        the current user.
+        """
         must = []
         if (
             not request.data.get('advisers')
@@ -150,3 +127,33 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
                 },
             )
         return must
+
+    def add_must_and_must_not_to_filters(self, base_query, must, must_not):
+        """
+        Merge the must and must not filters into single query.
+        """
+        raw_query = base_query.to_dict()
+        filters = self.deep_get(raw_query, 'query|bool|filter')
+        if not filters:
+            return raw_query
+
+        filter_index = None
+        for index, filter in enumerate(filters):
+            if filter.get('bool') or filter.get('bool') == {}:
+                filter_index = index
+                break
+
+        if filter_index is None:
+            return raw_query
+
+        if len(must_not) > 0:
+            filters[filter_index]['bool']['must_not'] = must_not
+        if len(must) > 0:
+            if 'must' not in filters[filter_index]['bool']:
+                filters[filter_index]['bool']['must'] = []
+
+            filters[filter_index]['bool']['must'].append(must)
+
+        raw_query['query']['bool']['filter'] = filters
+
+        return raw_query

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -59,6 +59,8 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
         must_not = []
         base_query = super().get_base_query(request, validated_data)
 
+        must = self.must_limit_query_to_created_by_or_advisers(request)
+
         if request.data.get('not_created_by'):
             must_not.append(
                 {
@@ -86,23 +88,70 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
                 },
             )
 
-        if len(must_not) > 0:
-            raw_query = base_query.to_dict()
-            filters = self.deep_get(raw_query, 'query|bool|filter')
-            if not filters:
-                return base_query
+        if len(must_not) > 0 or len(must) > 0:
+            base_query.update_from_dict(
+                self.add_must_and_must_not_to_filters(base_query, must, must_not)
+            )
 
-            filter_index = None
-            for index, filter in enumerate(filters):
-                if filter.get('bool') or filter.get('bool') == {}:
-                    filter_index = index
-                    break
-
-            if filter_index is None:
-                return base_query
-
-            filters[filter_index]['bool']['must_not'] = must_not
-            raw_query['query']['bool']['filter'] = filters
-
-            base_query.update_from_dict(raw_query)
         return base_query
+
+    def add_must_and_must_not_to_filters(self, base_query, must, must_not):
+        raw_query = base_query.to_dict()
+        filters = self.deep_get(raw_query, 'query|bool|filter')
+        if not filters:
+            return base_query
+
+        filter_index = None
+        for index, filter in enumerate(filters):
+            if filter.get('bool') or filter.get('bool') == {}:
+                filter_index = index
+                break
+
+        if filter_index is None:
+            return base_query
+
+        if len(must_not) > 0:
+            filters[filter_index]['bool']['must_not'] = must_not
+        if len(must) > 0:
+            if 'must' not in filters[filter_index]['bool']:
+                filters[filter_index]['bool']['must'] = []
+
+            filters[filter_index]['bool']['must'] = filters[filter_index]['bool']['must'] + must
+
+        raw_query['query']['bool']['filter'] = filters
+        return raw_query
+
+    def must_limit_query_to_created_by_or_advisers(self, request):
+        must = []
+        if (
+            not request.data.get('advisers')
+            or str(request.user.id) not in request.data.get('advisers')
+        ) and (not request.data.get('created_by') == str(request.user.id)):
+            must.append(
+                {
+                    'match': {
+                        'created_by.id': {
+                            'operator': 'or',
+                            'query': str(request.user.id),
+                        },
+                    },
+                },
+            )
+            must.append(
+                {
+                    'bool': {
+                        'minimum_should_match': 1,
+                        'should': [
+                            {
+                                'match': {
+                                    'advisers.id': {
+                                        'operator': 'or',
+                                        'query': str(request.user.id),
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            )
+        return must


### PR DESCRIPTION
### Description of change

Ensure that calls to Tasks api only ever return Tasks that are either created by the current user or assigned to the current user.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
