### PR TITLE
Cls2 579 filter by company and projects

### DIFF
--- a/datahub/task/test/test_views.py
+++ b/datahub/task/test/test_views.py
@@ -1,12 +1,12 @@
 import datetime
 
+from operator import attrgetter
+
 from uuid import uuid4
 
 import factory
 
 import pytest
-
-from operator import attrgetter
 
 from django.utils.timezone import now
 

--- a/datahub/task/test/test_views.py
+++ b/datahub/task/test/test_views.py
@@ -23,6 +23,10 @@ from datahub.investment.project.test.factories import InvestmentProjectFactory
 from datahub.task.test.factories import TaskFactory
 from datahub.task.test.utils import BaseEditTaskTests, BaseListTaskTests, BaseTaskTests
 
+from datahub.task.views import (
+
+    get_tasks_companies_and_projects,
+)
 
 class TestListTask(BaseListTaskTests):
     """Test the LIST task endpoint"""
@@ -555,3 +559,22 @@ class TestArchiveTask(BaseTaskTests):
         }
         assert response.data['archived_reason'] == 'completed'
         assert response.data['id'] == str(task.id)
+
+class TestAssociatedCompanyAndProject(APITestMixin):
+    ""
+    reverse_url = 'api-v4:task:companies-and-projects'
+    def test_return_empty_companies_and_projects(self):
+        adviser = AdviserFactory()
+        TaskFactory(created_by=adviser)
+
+        url = reverse(self.reverse_url)
+        print('This is the url', url)
+        response = self.api_client.get(url).json()
+        expected_response = {
+            'company': [],
+            'investment_project': [],
+        }
+
+        assert response == expected_response
+    
+

--- a/datahub/task/test/test_views.py
+++ b/datahub/task/test/test_views.py
@@ -6,12 +6,11 @@ import factory
 
 import pytest
 
-from django.utils.timezone import now
-
 from operator import attrgetter
 
-from faker import Faker
+from django.utils.timezone import now
 
+from faker import Faker
 
 from rest_framework import status
 from rest_framework.reverse import reverse

--- a/datahub/task/urls.py
+++ b/datahub/task/urls.py
@@ -2,8 +2,8 @@ from django.urls import path
 
 
 from datahub.task.views import (
-    TaskV4ViewSet,
     get_tasks_companies_and_projects,
+    TaskV4ViewSet,
 )
 
 
@@ -30,7 +30,7 @@ urls_v4 = [
     path(
         'task/companies-and-projects',
         get_tasks_companies_and_projects,
-        name='companies-and-projects'
+        name='companies-and-projects',
     ),
 
 ]

--- a/datahub/task/urls.py
+++ b/datahub/task/urls.py
@@ -1,7 +1,10 @@
 from django.urls import path
 
 
-from datahub.task.views import TaskV4ViewSet
+from datahub.task.views import (
+    TaskV4ViewSet,
+    get_tasks_companies_and_projects,
+)
 
 
 Task_v4_item = TaskV4ViewSet.as_view(
@@ -20,11 +23,11 @@ Task_v4_collection = TaskV4ViewSet.as_view(
 
 task_archive = TaskV4ViewSet.as_action_view('archive')
 
-task_v4_tasks_companies_and_projects = TaskV4ViewSet.as_view(
-    {
-        'get': 'list',
-    },
-)
+# task_v4_tasks_companies_and_projects = TaskV4ViewSet.as_view(
+#     {
+#         'get': 'list',
+#     },
+# )
 
 urls_v4 = [
     path('task', Task_v4_collection, name='collection'),
@@ -32,6 +35,8 @@ urls_v4 = [
     path('task/<uuid:pk>/archive', task_archive, name='task_archive'),
     path(
         'task/companies-and-projects',
-        task_v4_tasks_companies_and_projects,
-        name='task_companies_and_projects',)
+        get_tasks_companies_and_projects,
+        name='task_companies_and_projects'
+        ),
+
 ]

--- a/datahub/task/urls.py
+++ b/datahub/task/urls.py
@@ -23,12 +23,6 @@ Task_v4_collection = TaskV4ViewSet.as_view(
 
 task_archive = TaskV4ViewSet.as_action_view('archive')
 
-# task_v4_tasks_companies_and_projects = TaskV4ViewSet.as_view(
-#     {
-#         'get': 'list',
-#     },
-# )
-
 urls_v4 = [
     path('task', Task_v4_collection, name='collection'),
     path('task/<uuid:pk>', Task_v4_item, name='item'),
@@ -36,7 +30,7 @@ urls_v4 = [
     path(
         'task/companies-and-projects',
         get_tasks_companies_and_projects,
-        name='task_companies_and_projects'
-        ),
+        name='companies-and-projects'
+    ),
 
 ]

--- a/datahub/task/urls.py
+++ b/datahub/task/urls.py
@@ -20,8 +20,18 @@ Task_v4_collection = TaskV4ViewSet.as_view(
 
 task_archive = TaskV4ViewSet.as_action_view('archive')
 
+task_v4_tasks_companies_and_projects = TaskV4ViewSet.as_view(
+    {
+        'get': 'list',
+    },
+)
+
 urls_v4 = [
     path('task', Task_v4_collection, name='collection'),
     path('task/<uuid:pk>', Task_v4_item, name='item'),
     path('task/<uuid:pk>/archive', task_archive, name='task_archive'),
+    path(
+        'task/companies-and-projects',
+        task_v4_tasks_companies_and_projects,
+        name='task_companies_and_projects',)
 ]

--- a/datahub/task/views.py
+++ b/datahub/task/views.py
@@ -54,33 +54,27 @@ class TaskV4ViewSet(ArchivableViewSetMixin, TasksMixin):
         return super().get_tasks(self.request)
 
 
-    @transaction.non_atomic_requests
-    @api_view(['GET'])
-    @permission_classes([IsAuthenticated])
-    def get_tasks_companies_and_projects(request):
-        """
-        Get the list of companies and projects that have tasks
-        """
-        # queryset = (
-        #     Task.objects.all()
-        #     .select_related('investment_project')
-        #     .select_related('company')
-        # )
+@transaction.non_atomic_requests
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_tasks_companies_and_projects(request):
+    """
+    Get the list of companies and projects that have tasks
+    """
+    print("helloooooooooooooooo", request.user.id)
+    queryset = (
+        Task.objects.all(advisers=str(request.user.id))
+        .prefetch_related('advisers')
+        .select_related('investment_project')
+        .select_related('company')
+    )
 
-        # archived = request.query_params.get('archived')
-        # advisers = request.query_params.get('advisers')
+    companies = queryset.values_list('company__id', flat=True).distinct()
+    projects = queryset.values_list('investment_project__id', flat=True).distinct()
 
-        # if archived is not None:
-        #     queryset = queryset.filter(archived=archived == 'true')
-        # if advisers is not None:
-        #     queryset = queryset.filter(advisers__in=[advisers])
-
-        # companies = queryset.values_list('company__id', flat=True).distinct()
-        # projects = queryset.values_list('investment_project__id', flat=True).distinct()
-
-        return Response(
-            {
-                'companies': [],
-                'projects': [],
-            },
-        )
+    return Response(
+        {
+            'companies': companies,
+            'projects': projects,
+        },
+    )

--- a/datahub/task/views.py
+++ b/datahub/task/views.py
@@ -106,7 +106,7 @@ def get_tasks_companies_and_projects(request):
                 pk__in=projects_queryset.values_list(
                     'investor_company__id',
                     flat=True,
-                )
+                ),
             ),
         )
         .values('id', 'name')

--- a/datahub/task/views.py
+++ b/datahub/task/views.py
@@ -4,6 +4,7 @@ from django_filters.rest_framework import (
 from rest_framework.decorators import api_view, permission_classes
 
 from django.db import transaction
+from django.db.models import Q
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -61,16 +62,16 @@ def get_tasks_companies_and_projects(request):
     """
     Get the list of companies and projects that have tasks
     """
-    print("helloooooooooooooooo", request.user.id)
+    user_id = request.user.id
     queryset = (
-        Task.objects.all(advisers=str(request.user.id))
+        Task.objects.filter(Q(advisers__in=[user_id]) | Q(created_by=user_id))
         .prefetch_related('advisers')
         .select_related('investment_project')
         .select_related('company')
     )
 
-    companies = queryset.values_list('company__id', flat=True).distinct()
-    projects = queryset.values_list('investment_project__id', flat=True).distinct()
+    companies = queryset.values_list('company__name', flat=True).distinct()
+    projects = queryset.values_list('investment_project__name', flat=True).distinct()
 
     return Response(
         {

--- a/datahub/task/views.py
+++ b/datahub/task/views.py
@@ -62,16 +62,16 @@ def get_tasks_companies_and_projects(request):
     """
     Get the list of companies and projects that have tasks
     """
+   
     user_id = request.user.id
     queryset = (
         Task.objects.filter(Q(advisers__in=[user_id]) | Q(created_by=user_id))
-        .prefetch_related('advisers')
         .select_related('investment_project')
         .select_related('company')
     )
 
-    companies = queryset.values_list('company__name', flat=True).distinct()
-    projects = queryset.values_list('investment_project__name', flat=True).distinct()
+    companies = queryset.values('company__name', 'company__id').distinct()
+    projects = queryset.values('investment_project__name', 'investment_project__id').distinct()
 
     return Response(
         {

--- a/datahub/task/views.py
+++ b/datahub/task/views.py
@@ -1,10 +1,12 @@
 from django_filters.rest_framework import (
     DjangoFilterBackend,
 )
+from rest_framework.decorators import api_view, permission_classes
 
-
+from django.db import transaction
 from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 
 from datahub.core.mixins import ArchivableViewSetMixin
@@ -50,3 +52,35 @@ class TaskV4ViewSet(ArchivableViewSetMixin, TasksMixin):
 
     def get_queryset(self):
         return super().get_tasks(self.request)
+
+
+    @transaction.non_atomic_requests
+    @api_view(['GET'])
+    @permission_classes([IsAuthenticated])
+    def get_tasks_companies_and_projects(request):
+        """
+        Get the list of companies and projects that have tasks
+        """
+        # queryset = (
+        #     Task.objects.all()
+        #     .select_related('investment_project')
+        #     .select_related('company')
+        # )
+
+        # archived = request.query_params.get('archived')
+        # advisers = request.query_params.get('advisers')
+
+        # if archived is not None:
+        #     queryset = queryset.filter(archived=archived == 'true')
+        # if advisers is not None:
+        #     queryset = queryset.filter(advisers__in=[advisers])
+
+        # companies = queryset.values_list('company__id', flat=True).distinct()
+        # projects = queryset.values_list('investment_project__id', flat=True).distinct()
+
+        return Response(
+            {
+                'companies': [],
+                'projects': [],
+            },
+        )

--- a/datahub/task/views.py
+++ b/datahub/task/views.py
@@ -70,8 +70,11 @@ def get_tasks_companies_and_projects(request):
         .select_related('company')
     )
 
-    companies = queryset.values('company__name', 'company__id').distinct()
-    projects = queryset.values('investment_project__name', 'investment_project__id').distinct()
+    companies_queryset = queryset.values('company__name', 'company__id').distinct()
+    projects_queryset = queryset.values('investment_project__name', 'investment_project__id').distinct()
+
+    companies = [{'name': c['company__name'], 'id': c['company__id']} for c in companies_queryset] if companies_queryset.exists() else []
+    projects = [{'name': p['investment_project__name'], 'id': p['investment_project__id']} for p in projects_queryset] if projects_queryset.exists() else []
 
     return Response(
         {


### PR DESCRIPTION
### Description of change

A new endpoint that returns a list of companies and investment projects associated to tasks for the active user. This endpoint is to be used by two filters on the `my-tasks` page for sorting by company and by investment project.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
