### PR TITLE
Add post_delete signal to ensure Tasks are removed from opensearch

### DIFF
--- a/datahub/search/task/signals.py
+++ b/datahub/search/task/signals.py
@@ -5,8 +5,8 @@ from datahub.search.deletion import delete_document
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async
 from datahub.search.task import TaskSearchApp
-from datahub.task.models import Task as DBTask
 from datahub.search.task.models import Task as SearchDBTask
+from datahub.task.models import Task as DBTask
 
 
 def sync_task_to_opensearch(instance):

--- a/datahub/search/task/signals.py
+++ b/datahub/search/task/signals.py
@@ -15,7 +15,7 @@ def sync_task_to_opensearch(instance):
     )
 
 
-def removetask_from_opensearch(instance):
+def remove_task_from_opensearch(instance):
     """Remove investor profile from es."""
     transaction.on_commit(
         lambda pk=instance.pk: delete_document(DBTask, pk),
@@ -25,6 +25,6 @@ def removetask_from_opensearch(instance):
 receivers = (
     SignalReceiver(post_save, DBTask, sync_task_to_opensearch),
     SignalReceiver(
-        post_delete, DBTask, removetask_from_opensearch,
+        post_delete, DBTask, remove_task_from_opensearch,
     ),
 )

--- a/datahub/search/task/signals.py
+++ b/datahub/search/task/signals.py
@@ -6,6 +6,7 @@ from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async
 from datahub.search.task import TaskSearchApp
 from datahub.task.models import Task as DBTask
+from datahub.search.task.models import Task as SearchDBTask
 
 
 def sync_task_to_opensearch(instance):
@@ -18,7 +19,7 @@ def sync_task_to_opensearch(instance):
 def remove_task_from_opensearch(instance):
     """Remove task from es."""
     transaction.on_commit(
-        lambda pk=instance.pk: delete_document(DBTask, pk),
+        lambda pk=instance.pk: delete_document(SearchDBTask, pk),
     )
 
 

--- a/datahub/search/task/signals.py
+++ b/datahub/search/task/signals.py
@@ -16,7 +16,7 @@ def sync_task_to_opensearch(instance):
 
 
 def remove_task_from_opensearch(instance):
-    """Remove investor profile from es."""
+    """Remove task from es."""
     transaction.on_commit(
         lambda pk=instance.pk: delete_document(DBTask, pk),
     )

--- a/datahub/search/task/test/test_signals.py
+++ b/datahub/search/task/test/test_signals.py
@@ -55,7 +55,7 @@ def test_delete_from_opensearch(
             assert _get_documents(opensearch_with_signals, task.pk) is None
 
     with mock.patch(
-        'datahub.search.tasks.signals.delete_document',
+        'datahub.search.task.signals.delete_document',
     ) as mock_delete_document:
         task.delete()
         opensearch_with_signals.indices.refresh()

--- a/datahub/search/task/test/test_signals.py
+++ b/datahub/search/task/test/test_signals.py
@@ -1,10 +1,21 @@
+from unittest import mock
+
 import pytest
 
+from opensearchpy.exceptions import NotFoundError
 
 from datahub.search.task.apps import TaskSearchApp
 from datahub.task.test.factories import TaskFactory
 
+
 pytestmark = pytest.mark.django_db
+
+
+def _get_documents(setup_opensearch, pk):
+    return setup_opensearch.get(
+        index=TaskSearchApp.search_model.get_read_alias(),
+        id=pk,
+    )
 
 
 def test_new_task_synced(opensearch_with_signals):
@@ -16,3 +27,36 @@ def test_new_task_synced(opensearch_with_signals):
         index=TaskSearchApp.search_model.get_write_index(),
         id=task.pk,
     )
+
+
+@pytest.mark.parametrize(
+    'task_factory,expected_in_index,expected_to_call_delete',
+    (
+        (TaskFactory, True, True),
+    ),
+)
+def test_delete_from_opensearch(
+    task_factory,
+    expected_in_index,
+    expected_to_call_delete,
+    opensearch_with_signals,
+):
+    """
+    Test that when a task is deleted from db it is also
+    calls delete document to delete from OpenSearch.
+    """
+    task = task_factory()
+    opensearch_with_signals.indices.refresh()
+
+    if expected_in_index:
+        assert _get_documents(opensearch_with_signals, task.pk)
+    else:
+        with pytest.raises(NotFoundError):
+            assert _get_documents(opensearch_with_signals, task.pk) is None
+
+    with mock.patch(
+        'datahub.search.tasks.signals.delete_document',
+    ) as mock_delete_document:
+        task.delete()
+        opensearch_with_signals.indices.refresh()
+        assert mock_delete_document.called == expected_in_index


### PR DESCRIPTION
### Description of change

This PR aims at ensuring a Task is removed from opensearch through a post_delete signal once it gets deleted from the database

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

* [x] Is the CircleCI build passing?
