### PR TITLE
bugfix/CLS2-672-remove-duplicate-companies

### DIFF
--- a/datahub/company/autocomplete.py
+++ b/datahub/company/autocomplete.py
@@ -1,6 +1,6 @@
-from django.db.models import BooleanField, Case, Q, Value, When
-
+from django.db.models import Exists, OuterRef
 from datahub.core.autocomplete import _apply_autocomplete_filter_to_queryset, AutocompleteFilter
+from datahub.user.company_list.models import CompanyListItem
 
 
 class WithListAutocompleteFilter(AutocompleteFilter):
@@ -18,14 +18,9 @@ class WithListAutocompleteFilter(AutocompleteFilter):
         adviser = self.parent.request.user
 
         queryset = queryset.annotate(
-            is_in_adviser_list=Case(
-                When(
-                    Q(company_list_items__list__adviser=adviser),
-                    then=Value(True),
-                ),
-                default=Value(False),
-                output_field=BooleanField(),
-            ),
+            is_in_adviser_list=Exists(
+                CompanyListItem.objects.filter(company=OuterRef('pk'), list__adviser=adviser)
+            )
         )
 
         return _apply_autocomplete_filter_to_queryset(

--- a/datahub/company/autocomplete.py
+++ b/datahub/company/autocomplete.py
@@ -1,4 +1,5 @@
 from django.db.models import Exists, OuterRef
+
 from datahub.core.autocomplete import _apply_autocomplete_filter_to_queryset, AutocompleteFilter
 from datahub.user.company_list.models import CompanyListItem
 
@@ -19,8 +20,11 @@ class WithListAutocompleteFilter(AutocompleteFilter):
 
         queryset = queryset.annotate(
             is_in_adviser_list=Exists(
-                CompanyListItem.objects.filter(company=OuterRef('pk'), list__adviser=adviser)
-            )
+                CompanyListItem.objects.filter(
+                    company=OuterRef('pk'),
+                    list__adviser=adviser,
+                ),
+            ),
         )
 
         return _apply_autocomplete_filter_to_queryset(

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -126,6 +126,29 @@ class TestListCompanies(APITestMixin):
         assert companies[3]['name'] == 'Average'
         assert companies[3]['is_in_adviser_list'] is False
 
+    def test_autocomplete_companies_in_multiple_lists(self):
+        """Test that a company in multiple lists is only returned once"""
+        company1 = CompanyFactory(name='Apple')
+        CompanyFactory(name='Aardvark')
+        CompanyFactory(name='Banana')
+
+        list1 = CompanyListFactory(adviser=self.user)
+        CompanyListItemFactory(company=company1, list=list1)
+
+        list2 = CompanyListFactory()
+        CompanyListItemFactory(company=company1, list=list2)
+
+        url = reverse(viewname='api-v4:company:collection')
+        response = self.api_client.get(url, data={'autocomplete': 'A'})
+
+        assert response.status_code == status.HTTP_200_OK
+
+        companies = response.json()['results']
+
+        assert len(companies) == 2
+        assert companies[0]['name'] == 'Apple'
+        assert companies[1]['name'] == 'Aardvark'
+
     def test_filter_by_global_headquarters(self):
         """Test filtering by global_headquarters_id."""
         ghq = CompanyFactory()


### PR DESCRIPTION
### Description of change

The autocomplete endpoint was returning duplicate company values, which increased by 1 each time a company is added to a company list.

Using an annotate across multiple tables with a Case statement is a known bug in django https://code.djangoproject.com/ticket/10060, this PR switches to an exists query that doesnt have that issue

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
