### PR TITLE
bugfix/CLS2-659-use-raw-field-for-large-datasets

### DIFF
--- a/datahub/task/admin.py
+++ b/datahub/task/admin.py
@@ -41,5 +41,10 @@ class TaskAdmin(BaseModelAdminMixin, VersionAdmin):
         'title',
         'due_date',
     ]
+    raw_id_fields = (
+        'investment_project',
+        'company',
+        'interaction',
+    )
 
     form = TaskAdminForm


### PR DESCRIPTION
### Description of change

The task form is trying to load all the companies, interactions and investment projects. Switch to the django search field in the form to improve performance (the underlying django model is unchanged)

### Before
![image](https://github.com/uktrade/data-hub-api/assets/102232401/f56bf191-c089-434d-8eea-f6d3463fba24)

### After
![image](https://github.com/uktrade/data-hub-api/assets/102232401/a8bfff69-4785-47ae-a3d7-b03ff6e4fa41)
### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
