### PR TITLE
Make Win type optional.

### DIFF
--- a/datahub/export_win/serializers.py
+++ b/datahub/export_win/serializers.py
@@ -122,7 +122,7 @@ class WinSerializer(ModelSerializer):
     )
     team_members = NestedAdviserField(many=True, required=False)
     customer_location = NestedRelatedField(UKRegion)
-    type = NestedRelatedField(WinType)
+    type = NestedRelatedField(WinType, required=False)
     country = NestedRelatedField(Country)
     goods_vs_services = NestedRelatedField(ExpectedValueRelation)
     sector = NestedRelatedField(Sector)

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -325,9 +325,6 @@ class TestCreateWinView(APITestMixin):
             'name_of_export': 'Sand',
             'date': date_won,
             'country': CountryConstant.canada.value.id,
-            'type': {
-                'id': WinTypeConstant.both.value.id,
-            },
             'total_expected_export_value': 1000000,
             'total_expected_non_export_value': 1000000,
             'total_expected_odi_value': 1000000,
@@ -459,7 +456,7 @@ class TestCreateWinView(APITestMixin):
             'total_expected_export_value': win.total_expected_export_value,
             'total_expected_non_export_value': win.total_expected_non_export_value,
             'total_expected_odi_value': win.total_expected_odi_value,
-            'type': {'id': str(win.type_id), 'name': win.type.name},
+            'type': None,
             'type_of_support': [{'id': str(type_of_support.id), 'name': type_of_support.name}],
             'team_members': [],
             'advisers': [],


### PR DESCRIPTION
### Description of change

This makes `type` of `Win` no longer required.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
