### PR TITLE
feature/CLS2-657-sort-task-search

### DIFF
--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -442,13 +442,8 @@ def _apply_sorting_to_query(query, ordering):
     if ordering is None:
         return query.sort('_score', 'id')
 
-    sort_params = {
-        'order': ordering.direction,
-        'missing': '_last' if ordering.is_descending else '_first',
-    }
-
     return query.sort(
-        {ordering.field: sort_params},
+        ordering,
         'id',
     )
 

--- a/datahub/search/task/views.py
+++ b/datahub/search/task/views.py
@@ -163,3 +163,6 @@ class SearchTaskAPIView(SearchTaskAPIViewMixin, SearchAPIView):
         raw_query['query']['bool']['filter'] = filters
 
         return raw_query
+
+    def get_missing_sort_behaviour(self, ordering):
+        return '_last'

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -508,7 +508,7 @@ def test_build_entity_permission_query_no_conditions(filters, expected):
                     UUID('00000000-0000-0000-0000-000000000000'),
                 ),
             ],
-            SearchOrdering('id', SortDirection.desc),
+            {'id': {'order': SortDirection.desc, 'missing': '_last'}},
             ['id'],
             ['name'],
             {

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -15,7 +15,7 @@ from datahub.search.query_builder import (
 )
 from datahub.search.test.search_support.relatedmodel.apps import RelatedModelSearchApp
 from datahub.search.test.search_support.simplemodel.apps import SimpleModelSearchApp
-from datahub.search.utils import SearchOrdering, SortDirection
+from datahub.search.utils import SortDirection
 
 
 @pytest.mark.parametrize(

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -224,7 +224,7 @@ class SearchAPIView(APIView):
             filter_data=filter_data,
             composite_field_mapping=self.COMPOSITE_FILTERS,
             permission_filters=permission_filters,
-            ordering=ordering,
+            ordering=self.get_sort(ordering),
             fields_to_include=self.fields_to_include,
             fields_to_exclude=fields_to_exclude,
         )
@@ -233,6 +233,18 @@ class SearchAPIView(APIView):
         if extra_filters:
             return query.filter(extra_filters)
         return query
+
+    def get_sort(self, ordering):
+        if ordering is None:
+            return None
+        sort_params = {
+            'order': ordering.direction,
+            'missing': self.get_missing_sort_behaviour(ordering),
+        }
+        return {ordering.field: sort_params}
+
+    def get_missing_sort_behaviour(self, ordering):
+        return '_last' if ordering.is_descending else '_first'
 
     def get_extra_filters(self, validated_data):
         """Get any extra filters to apply to the base query."""


### PR DESCRIPTION
### Description of change

The A-Z sorting for task projects and companies is putting missing values at the start of the list as we are using ascending sorting. This PR replaces this logic, and puts the missing values at the end

### Before
![image](https://github.com/uktrade/data-hub-api/assets/102232401/e80b44cb-87e0-453c-a6ee-906aade6faf4)

### After 
![image](https://github.com/uktrade/data-hub-api/assets/102232401/548d15eb-afac-4aa4-a58a-c2551e84f327)

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
