### PR TITLE
feature/CLS2-680-include-global-account-manager-in-investment-project-index

### DIFF
--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -405,22 +405,9 @@ class Company(ArchivableModel, BaseModel):
         db_index=True,
     )
 
-    # Stores one list account owner id before change to avoid calling sync of
-    # subsidiary company's investment projects on each save.
-    __original_one_list_account_owner_id = None
-
+    @transaction.atomic()
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
-        # Only run sync when one_list_acocunt_owner_id has changed.
-        if (self.__original_one_list_account_owner_id is not self.one_list_account_owner_id):
-            from datahub.search.company.tasks import (
-                schedule_sync_investment_projects_of_subsidiary_companies,
-            )
-            schedule_sync_investment_projects_of_subsidiary_companies(self)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__original_one_list_account_owner_id = self.one_list_account_owner_id
 
     def __str__(self):
         """Admin displayed human readable name."""

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -409,10 +409,6 @@ class Company(ArchivableModel, BaseModel):
     # subsidiary company's investment projects on each save.
     __original_one_list_account_owner_id = None
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.__original_one_list_account_owner_id = self.one_list_account_owner_id
-
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
         # Only run sync when one_list_acocunt_owner_id has changed.
@@ -421,6 +417,10 @@ class Company(ArchivableModel, BaseModel):
                 schedule_sync_investment_projects_of_subsidiary_companies,
             )
             schedule_sync_investment_projects_of_subsidiary_companies(self)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__original_one_list_account_owner_id = self.one_list_account_owner_id
 
     def __str__(self):
         """Admin displayed human readable name."""

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -405,6 +405,23 @@ class Company(ArchivableModel, BaseModel):
         db_index=True,
     )
 
+    # Stores one list account owner id before change to avoid calling sync of
+    # subsidiary company's investment projects on each save.
+    __original_one_list_account_owner_id = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__original_one_list_account_owner_id = self.one_list_account_owner_id
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        # Only run sync when one_list_acocunt_owner_id has changed.
+        if (self.__original_one_list_account_owner_id is not self.one_list_account_owner_id):
+            from datahub.search.company.tasks import (
+                schedule_sync_investment_projects_of_subsidiary_companies,
+            )
+            schedule_sync_investment_projects_of_subsidiary_companies(self)
+
     def __str__(self):
         """Admin displayed human readable name."""
         return self.name

--- a/datahub/company/signals.py
+++ b/datahub/company/signals.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 
 @receiver(pre_save, sender=Company)
-def company_one_list_acount_owner_changed(sender, instance, **kwargs):
+def company_one_list_account_owner_changed(sender, instance, **kwargs):
     try:
         original = sender.objects.get(pk=instance.pk)
     except sender.DoesNotExist:

--- a/datahub/company/signals.py
+++ b/datahub/company/signals.py
@@ -28,7 +28,10 @@ def company_one_list_acount_owner_changed(sender, instance, **kwargs):
         pass
     else:
         if (original.one_list_account_owner_id is not instance.one_list_account_owner_id):
-            schedule_sync_investment_projects_of_subsidiary_companies(instance)
+            schedule_sync_investment_projects_of_subsidiary_companies(
+                instance,
+                original.modified_on,
+            )
 
 
 @receiver(

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -70,7 +70,7 @@ class TestOneListAccountOwner():
     """
 
     mock_schedule_sync_investment_projects_of_subsidiary_companies_target = \
-        'datahub.search.company.tasks.schedule_sync_investment_projects_of_subsidiary_companies'
+        'datahub.company.signals.schedule_sync_investment_projects_of_subsidiary_companies'
 
     def test_one_list_account_owner_changed(self, monkeypatch: pytest.MonkeyPatch):
         one_list_account_owner = AdviserFactory()

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -1,8 +1,10 @@
+from unittest.mock import Mock
 import pytest
+
 from django.db.utils import IntegrityError
 
 from datahub.company.models import Company
-from datahub.company.test.factories import CompanyFactory
+from datahub.company.test.factories import CompanyFactory, AdviserFactory
 from datahub.core.test_utils import APITestMixin
 
 
@@ -53,3 +55,41 @@ def test_is_global_ultimate(duns_number, global_ultimate_duns_number, expected_i
         global_ultimate_duns_number=global_ultimate_duns_number,
     )
     assert company.is_global_ultimate == expected_is_global_ultimate
+
+
+class TestOneListAccountOwner():
+    """
+    Test schedule_sync_investment_projects_of_subsidiary_companies is only called when
+    one_list_account_owner has changed.
+    """
+
+    def test_one_list_account_owner_changed(self, monkeypatch):
+        one_list_account_owner = AdviserFactory()
+        company = CompanyFactory()
+
+        mock_schedule_sync_investment_projects_of_subsidiary_companies = Mock()
+        monkeypatch.setattr(
+            'datahub.search.company.tasks.' +
+            'schedule_sync_investment_projects_of_subsidiary_companies',
+            mock_schedule_sync_investment_projects_of_subsidiary_companies,
+        )
+
+        # Mock call to schedule_sync_investment_projects_of_subsidiary_companies
+        company.one_list_account_owner = one_list_account_owner
+        company.save()
+        mock_schedule_sync_investment_projects_of_subsidiary_companies.assert_called_once_with(
+            company,
+        )
+
+    def test_one_list_account_owner_not_changed(self, monkeypatch):
+        company = CompanyFactory()
+
+        mock_schedule_sync_investment_projects_of_subsidiary_companies = Mock()
+        monkeypatch.setattr(
+            ('datahub.search.company.tasks.' +
+                'schedule_sync_investment_projects_of_subsidiary_companies'),
+            mock_schedule_sync_investment_projects_of_subsidiary_companies,
+        )
+
+        company.save()
+        mock_schedule_sync_investment_projects_of_subsidiary_companies.assert_not_called()

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -1,10 +1,12 @@
+from typing import Literal
 from unittest.mock import Mock
+
 import pytest
 
 from django.db.utils import IntegrityError
 
 from datahub.company.models import Company
-from datahub.company.test.factories import CompanyFactory, AdviserFactory
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core.test_utils import APITestMixin
 
 
@@ -45,7 +47,11 @@ class TestPendingDNBInvestigation(APITestMixin):
         ('999999999', '123456789', False),
     ),
 )
-def test_is_global_ultimate(duns_number, global_ultimate_duns_number, expected_is_global_ultimate):
+def test_is_global_ultimate(
+    duns_number: Literal['', '123456789', '999999999'] | None,
+    global_ultimate_duns_number: Literal['', '123456789'],
+    expected_is_global_ultimate: bool,
+):
     """
     Test that the `Company.is_global_ultimate` property returns the correct response
     for a variety of scenarios.
@@ -63,14 +69,16 @@ class TestOneListAccountOwner():
     one_list_account_owner has changed.
     """
 
-    def test_one_list_account_owner_changed(self, monkeypatch):
+    mock_schedule_sync_investment_projects_of_subsidiary_companies_target = \
+        'datahub.search.company.tasks.schedule_sync_investment_projects_of_subsidiary_companies'
+
+    def test_one_list_account_owner_changed(self, monkeypatch: pytest.MonkeyPatch):
         one_list_account_owner = AdviserFactory()
         company = CompanyFactory()
 
         mock_schedule_sync_investment_projects_of_subsidiary_companies = Mock()
         monkeypatch.setattr(
-            'datahub.search.company.tasks.' +
-            'schedule_sync_investment_projects_of_subsidiary_companies',
+            self.mock_schedule_sync_investment_projects_of_subsidiary_companies_target,
             mock_schedule_sync_investment_projects_of_subsidiary_companies,
         )
 
@@ -81,13 +89,12 @@ class TestOneListAccountOwner():
             company,
         )
 
-    def test_one_list_account_owner_not_changed(self, monkeypatch):
+    def test_one_list_account_owner_not_changed(self, monkeypatch: pytest.MonkeyPatch):
         company = CompanyFactory()
 
         mock_schedule_sync_investment_projects_of_subsidiary_companies = Mock()
         monkeypatch.setattr(
-            ('datahub.search.company.tasks.' +
-                'schedule_sync_investment_projects_of_subsidiary_companies'),
+            self.mock_schedule_sync_investment_projects_of_subsidiary_companies_target,
             mock_schedule_sync_investment_projects_of_subsidiary_companies,
         )
 

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -84,9 +84,12 @@ class TestOneListAccountOwner():
 
         # Mock call to schedule_sync_investment_projects_of_subsidiary_companies
         company.one_list_account_owner = one_list_account_owner
+        modified_on = company.modified_on
         company.save()
+
         mock_schedule_sync_investment_projects_of_subsidiary_companies.assert_called_once_with(
             company,
+            modified_on,
         )
 
     def test_one_list_account_owner_not_changed(self, monkeypatch: pytest.MonkeyPatch):

--- a/datahub/search/company/signals.py
+++ b/datahub/search/company/signals.py
@@ -22,6 +22,13 @@ def company_subsidiaries_sync_search(instance):
     )
 
 
+def company_investment_projects_sync_search(instance):
+    """Sync investment projects to OpenSearch."""
+    transaction.on_commit(
+        lambda: sync_related_objects_async(instance, 'investor_investment_projects'),
+    )
+
+
 def sync_related_company_to_opensearch(instance):
     """Sync related company."""
     transaction.on_commit(
@@ -32,5 +39,6 @@ def sync_related_company_to_opensearch(instance):
 receivers = (
     SignalReceiver(post_save, DBCompany, company_sync_search),
     SignalReceiver(post_save, DBCompany, company_subsidiaries_sync_search),
+    SignalReceiver(post_save, DBCompany, company_investment_projects_sync_search),
     SignalReceiver(post_save, DBInteraction, sync_related_company_to_opensearch),
 )

--- a/datahub/search/company/tasks.py
+++ b/datahub/search/company/tasks.py
@@ -1,0 +1,39 @@
+import logging
+
+from datahub.company.models.company import Company
+from datahub.core.queues.constants import HALF_DAY_IN_SECONDS
+from datahub.core.queues.job_scheduler import job_scheduler
+from datahub.core.queues.scheduler import LONG_RUNNING_QUEUE
+from datahub.search.sync_object import sync_related_objects_async
+
+logger = logging.getLogger(__name__)
+
+
+def schedule_sync_investment_projects_of_subsidiary_companies(company):
+    job = job_scheduler(
+        queue_name=LONG_RUNNING_QUEUE,
+        function=sync_investment_projects_of_subsidiary_companies,
+        function_kwargs={
+            'company': company,
+        },
+        job_timeout=HALF_DAY_IN_SECONDS,
+        max_retries=3,
+    )
+    logger.info(
+        f'Task {job.id} schedule_sync_investment_projects_of_subsidiary_companies '
+        f'scheduled company {company}',
+    )
+    return job
+
+
+def sync_investment_projects_of_subsidiary_companies(company):
+    """
+    When the one list account owner has changed this should be updated on all related
+    investment projects for all subsidiary companies.
+    """
+    subsidiary_companies = Company.objects.filter(
+        global_headquarters_id=company.id,
+    )
+
+    for subsidiary_company in subsidiary_companies:
+        sync_related_objects_async(subsidiary_company, 'investor_investment_projects')

--- a/datahub/search/company/tasks.py
+++ b/datahub/search/company/tasks.py
@@ -9,15 +9,17 @@ from datahub.search.sync_object import sync_related_objects_async
 logger = logging.getLogger(__name__)
 
 
-def schedule_sync_investment_projects_of_subsidiary_companies(company):
+def schedule_sync_investment_projects_of_subsidiary_companies(company, original_modified_on):
     job = job_scheduler(
         queue_name=LONG_RUNNING_QUEUE,
         function=sync_investment_projects_of_subsidiary_companies,
         function_kwargs={
             'company': company,
+            'original_modified_on': original_modified_on,
         },
         job_timeout=HALF_DAY_IN_SECONDS,
-        max_retries=3,
+        max_retries=5,
+        retry_backoff=True,
     )
     logger.info(
         f'Task {job.id} schedule_sync_investment_projects_of_subsidiary_companies '
@@ -26,11 +28,24 @@ def schedule_sync_investment_projects_of_subsidiary_companies(company):
     return job
 
 
-def sync_investment_projects_of_subsidiary_companies(company):
+def sync_investment_projects_of_subsidiary_companies(company, original_modified_on):
     """
     When the one list account owner has changed this should be updated on all related
     investment projects for all subsidiary companies.
     """
+    # Avoid race condition. Data currently in database should have been modified by save method
+    # after original_modified_on, if not fail so scheduler can try again.
+    current = Company.objects.get(pk=company.pk)
+    if original_modified_on >= current.modified_on:
+        # Fail job and retry.
+        try:
+            raise Exception('Race condition in sync_investment_projects_of_subsidiary_companies')
+        except Exception as exception:
+            exception.extra_info = f'Company id: {company.id}, ' + \
+                f'Company modified_on: {company.modified_on}, ' + \
+                f'original_modified_on: {original_modified_on}.'
+            raise
+
     subsidiary_companies = Company.objects.filter(
         global_headquarters_id=company.id,
     )

--- a/datahub/search/company/test/test_tasks.py
+++ b/datahub/search/company/test/test_tasks.py
@@ -68,6 +68,6 @@ def test_sync_investment_projects_of_subsidiary_companies(
 
     # Map UUID to str for correct comparison
     investment_project_ids = map(attrgetter('id'), investment_projects)
-    investment_project_ids = map(lambda x: str(x), investment_project_ids)
+    investment_project_ids = map(str, investment_project_ids)
 
     assert set(map(attrgetter('id'), result.hits)) == set(investment_project_ids)

--- a/datahub/search/company/test/test_tasks.py
+++ b/datahub/search/company/test/test_tasks.py
@@ -1,35 +1,73 @@
+import logging
+from operator import attrgetter
+from unittest.mock import Mock
+
 import pytest
+
+from datahub.company.test.factories import AdviserFactory, CompanyFactory, SubsidiaryFactory
+from datahub.investment.project.test.factories import InvestmentProjectFactory
+
+from datahub.search.company.tasks import (
+    schedule_sync_investment_projects_of_subsidiary_companies,
+    sync_investment_projects_of_subsidiary_companies,
+)
+from datahub.search.investment.models import InvestmentProject
+from datahub.search.query_builder import get_search_by_entities_query
 
 pytestmark = pytest.mark.django_db
 
 
-def test_schedule_sync_investment_projects_of_subsidiary_companies(opensearch_with_signals):
-    pass
-    # """Tests if company gets synced to OpenSearch."""
-    # test_name = 'very_hard_to_find_company'
-    # CompanyFactory(
-    #     name=test_name,
-    # )
-    # opensearch_with_signals.indices.refresh()
+def test_schedule_sync_investment_projects_of_subsidiary_companies(caplog, monkeypatch):
+    """
+    Test that the sync_investment_projects_of_subsidiary_companies function is called from the
+    scheduler.
+    """
+    caplog.set_level(logging.INFO, logger='datahub.search.company.tasks')
+    subsidiary = SubsidiaryFactory()
+    job = schedule_sync_investment_projects_of_subsidiary_companies(subsidiary.global_headquarters)
+    assert caplog.messages == [
+        f'Task {job.id} schedule_sync_investment_projects_of_subsidiary_companies '
+        f'scheduled company {subsidiary.global_headquarters}',
+    ]
 
-    # result = get_basic_search_query(Company, test_name).execute()
+    mock_schedule_sync_investment_projects_of_subsidiary_companies = Mock()
+    monkeypatch.setattr(
+        'datahub.search.company.tasks.sync_investment_projects_of_subsidiary_companies',
+        mock_schedule_sync_investment_projects_of_subsidiary_companies,
+    )
 
-    # assert result.hits.total.value == 1
 
+def test_sync_investment_projects_of_subsidiary_companies(
+        opensearch_with_collector,
+        monkeypatch,
+):
 
-def test_sync_investment_projects_of_subsidiary_companies(opensearch_with_signals):
-    pass
-    # """Tests if company gets updated in OpenSearch."""
-    # test_name = 'very_hard_to_find_company_international'
-    # company = CompanyFactory(
-    #     name=test_name,
-    # )
-    # new_test_name = 'very_hard_to_find_company_local'
-    # company.name = new_test_name
-    # company.save()
-    # opensearch_with_signals.indices.refresh()
+    unrelated_owner = AdviserFactory()
+    unrelated_company = CompanyFactory()
+    unrelated_company.one_list_account_owner = unrelated_owner
+    InvestmentProjectFactory.create_batch(
+        3,
+        investor_company=unrelated_company,
+    )
+    account_owner = AdviserFactory()
+    subsidiary = SubsidiaryFactory()
+    investment_projects = InvestmentProjectFactory.create_batch(3, investor_company=subsidiary)
+    subsidiary.global_headquarters.one_list_account_owner = account_owner
+    subsidiary.global_headquarters.save()
+    opensearch_with_collector.flush_and_refresh()
 
-    # result = get_basic_search_query(Company, new_test_name).execute()
+    sync_investment_projects_of_subsidiary_companies(subsidiary.global_headquarters)
 
-    # assert result.hits.total.value == 1
-    # assert result.hits[0].id == str(company.id)
+    result = get_search_by_entities_query(
+        [InvestmentProject],
+        term='',
+        filter_data={'one_list_group_global_account_manager.id': account_owner.id},
+    ).execute()
+
+    assert result.hits.total.value == 3
+
+    # Map UUID to str for correct comparison
+    investment_project_ids = map(attrgetter('id'), investment_projects)
+    investment_project_ids = map(lambda x: str(x), investment_project_ids)
+
+    assert set(map(attrgetter('id'), result.hits)) == set(investment_project_ids)

--- a/datahub/search/company/test/test_tasks.py
+++ b/datahub/search/company/test/test_tasks.py
@@ -1,0 +1,35 @@
+import pytest
+
+pytestmark = pytest.mark.django_db
+
+
+def test_schedule_sync_investment_projects_of_subsidiary_companies(opensearch_with_signals):
+    pass
+    # """Tests if company gets synced to OpenSearch."""
+    # test_name = 'very_hard_to_find_company'
+    # CompanyFactory(
+    #     name=test_name,
+    # )
+    # opensearch_with_signals.indices.refresh()
+
+    # result = get_basic_search_query(Company, test_name).execute()
+
+    # assert result.hits.total.value == 1
+
+
+def test_sync_investment_projects_of_subsidiary_companies(opensearch_with_signals):
+    pass
+    # """Tests if company gets updated in OpenSearch."""
+    # test_name = 'very_hard_to_find_company_international'
+    # company = CompanyFactory(
+    #     name=test_name,
+    # )
+    # new_test_name = 'very_hard_to_find_company_local'
+    # company.name = new_test_name
+    # company.save()
+    # opensearch_with_signals.indices.refresh()
+
+    # result = get_basic_search_query(Company, new_test_name).execute()
+
+    # assert result.hits.total.value == 1
+    # assert result.hits[0].id == str(company.id)

--- a/datahub/search/company/test/test_tasks.py
+++ b/datahub/search/company/test/test_tasks.py
@@ -121,9 +121,9 @@ def test_race_condition_sync_investment_projects_of_subsidiary_companies(
     assert mock_sync_investment_projects_of_subsidiary_companies.called is True
     hq = subsidiary.global_headquarters
     assert exception_info.value.extra_info == (
-        f"Company id: {hq.id}, "
-        f"Company modified_on: {hq.modified_on}, "
-        f"original_modified_on: {original_modified_on}."
+        f'Company id: {hq.id}, '
+        f'Company modified_on: {hq.modified_on}, '
+        f'original_modified_on: {original_modified_on}.'
     )
     # Due to error investment projects shouldn't have been updated
     result = get_search_by_entities_query(

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -260,6 +260,5 @@ def _list_of_dicts(dict_factory, manager):
 def nested_company_global_account_manager(obj, company_prop_name):
     field = getattr(obj, company_prop_name, None)
     if field is None:
-        raise ValueError(f'The company prop "{company_prop_name}" does not exist.')
-
+        return None
     return contact_or_adviser_dict(field.get_one_list_group_global_account_manager())

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -255,3 +255,11 @@ def interaction_dict(obj):
 def _list_of_dicts(dict_factory, manager):
     """Creates a list of dicts with ID and name keys from a manager."""
     return [dict_factory(obj) for obj in manager.all()]
+
+
+def nested_company_global_account_manager(obj, company_prop_name):
+    field = getattr(obj, company_prop_name, None)
+    if field is None:
+        raise ValueError(f'The company prop "{company_prop_name}" does not exist.')
+
+    return contact_or_adviser_dict(field.get_one_list_group_global_account_manager())

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -51,6 +51,7 @@ class InvestmentSearchApp(SearchApp):
         'specific_programme',
         'stage',
         'uk_company',
+        'investor_company__one_list_account_owner',
     ).prefetch_related(
         'actual_uk_regions',
         'delivery_partners',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -1,3 +1,4 @@
+from functools import partial
 from opensearch_dsl import Boolean, Date, Double, Integer, Keyword, Long, Object, Text
 
 from datahub.search import dict_utils
@@ -7,11 +8,13 @@ from datahub.search.models import BaseSearchModel
 
 def _related_investment_project_field():
     """Field for a related investment project."""
-    return Object(properties={
-        'id': Keyword(),
-        'name': fields.NormalizedKeyword(),
-        'project_code': fields.NormalizedKeyword(),
-    })
+    return Object(
+        properties={
+            'id': Keyword(),
+            'name': fields.NormalizedKeyword(),
+            'project_code': fields.NormalizedKeyword(),
+        }
+    )
 
 
 class InvestmentProject(BaseSearchModel):
@@ -127,11 +130,16 @@ class InvestmentProject(BaseSearchModel):
     latest_interaction = fields.interaction_field()
 
     gross_value_added = Double()
+    one_list_group_global_account_manager = fields.contact_or_adviser_field()
+
+    COMPUTED_MAPPINGS = {
+        'one_list_group_global_account_manager': partial(
+            dict_utils.nested_company_global_account_manager, company_prop_name='investor_company'
+        ),
+    }
 
     MAPPINGS = {
-        'actual_uk_regions': lambda col: [
-            dict_utils.id_name_dict(c) for c in col.all()
-        ],
+        'actual_uk_regions': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'archived_by': dict_utils.contact_or_adviser_dict,
         'associated_non_fdi_r_and_d_project': dict_utils.investment_project_dict,
         'average_salary': dict_utils.id_name_dict,
@@ -141,9 +149,7 @@ class InvestmentProject(BaseSearchModel):
         'country_lost_to': dict_utils.id_name_dict,
         'country_investment_originates_from': dict_utils.id_name_dict,
         'created_by': dict_utils.adviser_dict_with_team,
-        'delivery_partners': lambda col: [
-            dict_utils.id_name_dict(c) for c in col.all()
-        ],
+        'delivery_partners': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'fdi_type': dict_utils.id_name_dict,
         'fdi_value': dict_utils.id_name_dict,
         'intermediate_company': dict_utils.id_name_dict,
@@ -168,9 +174,7 @@ class InvestmentProject(BaseSearchModel):
             dict_utils.contact_or_adviser_dict(c.adviser, include_dit_team=True) for c in col.all()
         ],
         'uk_company': dict_utils.id_name_dict,
-        'uk_region_locations': lambda col: [
-            dict_utils.id_name_dict(c) for c in col.all()
-        ],
+        'uk_region_locations': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
     }
 
     SEARCH_FIELDS = (

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 from opensearch_dsl import Boolean, Date, Double, Integer, Keyword, Long, Object, Text
 
 from datahub.search import dict_utils
@@ -13,7 +14,7 @@ def _related_investment_project_field():
             'id': Keyword(),
             'name': fields.NormalizedKeyword(),
             'project_code': fields.NormalizedKeyword(),
-        }
+        },
     )
 
 
@@ -134,7 +135,8 @@ class InvestmentProject(BaseSearchModel):
 
     COMPUTED_MAPPINGS = {
         'one_list_group_global_account_manager': partial(
-            dict_utils.nested_company_global_account_manager, company_prop_name='investor_company'
+            dict_utils.nested_company_global_account_manager,
+            company_prop_name='investor_company',
         ),
     }
 

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -52,6 +52,10 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
     show_summary = serializers.BooleanField(required=False, default=False)
     include_parent_companies = serializers.BooleanField(required=False, default=False)
     include_subsidiary_companies = serializers.BooleanField(required=False, default=False)
+    one_list_group_global_account_manager = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
 
     SORT_BY_FIELDS = (
         'created_on',

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -147,6 +147,7 @@ def test_investment_project_to_dict(opensearch):
         'country_investment_originates_from',
         'level_of_involvement_simplified',
         'latest_interaction',
+        'one_list_group_global_account_manager',
     }
 
     assert set(result.keys()) == keys

--- a/datahub/search/investment/test/test_opensearch.py
+++ b/datahub/search/investment/test/test_opensearch.py
@@ -677,6 +677,30 @@ def test_mapping(opensearch):
                 'type': 'object',
             },
             'will_new_jobs_last_two_years': {'type': 'boolean'},
+            'one_list_group_global_account_manager': {
+                'properties': {
+                    'first_name': {
+                        'normalizer': 'lowercase_asciifolding_normalizer',
+                        'type': 'keyword',
+                    },
+                    'id': {'type': 'keyword'},
+                    'last_name': {
+                        'normalizer': 'lowercase_asciifolding_normalizer',
+                        'type': 'keyword',
+                    },
+                    'name': {
+                        'fields': {
+                            'keyword': {
+                                'normalizer': 'lowercase_asciifolding_normalizer',
+                                'type': 'keyword',
+                            },
+                            'trigram': {'analyzer': 'trigram_analyzer', 'type': 'text'},
+                        },
+                        'type': 'text',
+                    },
+                },
+                'type': 'object',
+            },
         },
     }
 

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -288,6 +288,11 @@ class TestSearch(APITestMixin):
         )
         InvestmentProjectTeamMemberFactory(adviser=adviser, investment_project=project_6)
 
+        # Investment Project for project where its head quarters has the adviser listed as its one
+        # list account owner
+        hq = CompanyFactory(one_list_account_owner=adviser)
+        project_7 = InvestmentProjectFactory(investor_company__global_headquarters=hq)
+
         opensearch_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:investment_project')
@@ -301,7 +306,7 @@ class TestSearch(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
-        assert response_data['count'] == 5
+        assert response_data['count'] == 6
         results = response_data['results']
         expected_ids = {
             str(project_1.pk),
@@ -309,6 +314,7 @@ class TestSearch(APITestMixin):
             str(project_4.pk),
             str(project_5.pk),
             str(project_6.pk),
+            str(project_7.pk),
         }
         assert {result['id'] for result in results} == expected_ids
 

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -65,6 +65,7 @@ class SearchInvestmentProjectAPIViewMixin:
         'gross_value_added_end',
         'name',
         'project_code',
+        'one_list_group_global_account_manager',
     )
 
     REMAP_FIELDS = {
@@ -76,6 +77,7 @@ class SearchInvestmentProjectAPIViewMixin:
         'likelihood_to_land': 'likelihood_to_land.id',
         'uk_region_location': 'uk_region_locations.id',
         'country_investment_originates_from': 'country_investment_originates_from.id',
+        'one_list_group_global_account_manager': 'one_list_group_global_account_manager.id',
     }
 
     COMPOSITE_FILTERS = {

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -83,6 +83,7 @@ class SearchInvestmentProjectAPIViewMixin:
     COMPOSITE_FILTERS = {
         'adviser': [
             'client_relationship_manager.id',
+            'one_list_group_global_account_manager.id',
             'project_assurance_adviser.id',
             'project_manager.id',
             'team_members.id',

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
 
 import pytest
 from pytest import raises
@@ -485,9 +486,25 @@ def test_task_interaction_dict_returns_interaction_task():
     )
 
 
-def test_nested_company_global_account_manager_raises_error_when_prop_missing():
+@pytest.mark.django_db
+def test_nested_company_global_account_manager_returns_expected_value():
+    investment_project = mock.MagicMock()
+    one_list_account_owner = AdviserFactory()
+    investment_project.investor_company = CompanyFactory(
+        one_list_account_owner=one_list_account_owner
+    )
+
+    assert dict_utils.nested_company_global_account_manager(
+        investment_project, 'investor_company'
+    ) == dict_utils.contact_or_adviser_dict(one_list_account_owner)
+
+
+def test_nested_company_global_account_manager_returns_none_when_prop_missing():
     investment_project = mock.MagicMock()
 
     investment_project.investor_company = None
-    with raises(ValueError):
+
+    assert (
         dict_utils.nested_company_global_account_manager(investment_project, 'investor_company')
+        is None
+    )

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -1,9 +1,9 @@
 from unittest import mock
-from datahub.company.test.factories import AdviserFactory, CompanyFactory
 
 import pytest
 from pytest import raises
 
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core.test_utils import construct_mock
 from datahub.search import dict_utils
 
@@ -491,11 +491,12 @@ def test_nested_company_global_account_manager_returns_expected_value():
     investment_project = mock.MagicMock()
     one_list_account_owner = AdviserFactory()
     investment_project.investor_company = CompanyFactory(
-        one_list_account_owner=one_list_account_owner
+        one_list_account_owner=one_list_account_owner,
     )
 
     assert dict_utils.nested_company_global_account_manager(
-        investment_project, 'investor_company'
+        investment_project,
+        'investor_company',
     ) == dict_utils.contact_or_adviser_dict(one_list_account_owner)
 
 

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -483,3 +483,11 @@ def test_task_interaction_dict_returns_interaction_task():
     assert dict_utils.task_interaction_dict(task) == dict_utils.interaction_dict(
         interaction,
     )
+
+
+def test_nested_company_global_account_manager_raises_error_when_prop_missing():
+    investment_project = mock.MagicMock()
+
+    investment_project.investor_company = None
+    with raises(ValueError):
+        dict_utils.nested_company_global_account_manager(investment_project, 'investor_company')


### PR DESCRIPTION
### Description of change

Add the `one_list_group_global_account_manager` field to the investment project search index. This field comes from the investor company or its global headquarters company the project is assigned to.

The opensearch index for investment projects is reindex when a company one list account owner is updated. 

### Test instructions
You should be able to see the additional field `one_list_group_global_account_manager` when querying the Investment project on open search 
E.g. `http://localhost:8000/v3/search/investment_project`

Sample field structure:
```
------>8------
"one_list_group_global_account_manager": {
    "name": "Barry Oling",
    "last_name": "Oling",
    "id": "a80ff5fd-8904-4940-bf96-fe8047e34be5",
    "first_name": "Barry"
},
------8<------
```

There are two cases for investment projects belong to: 

1. Investor company
   - Create/select an investment project for a company.
   - Assign it an `One list account owner` through the admin.
   - This should now be listed in the `one_list_group_global_account_manager` field when queried through open search.
2. Global headquarters company
   - Create/select a subsidiary company.
   - Create/select an investment project for the subsidiary company.
   - Assign another company as its `Global headquarters`.
   - For the Global headquarters company assign an `One list account owner` through the admin.
   - The investment project of the subsidiary company should have the One list account owner assigned to the Global headquarters as the `one_list_group_global_account_manager` value when queried through open search.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
