### PR TITLE
Add update endpoint and Django admin for Wins.

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -1,0 +1,37 @@
+from django.contrib import admin
+from django.contrib.admin import DateFieldListFilter
+from reversion.admin import VersionAdmin
+
+from datahub.core.admin import BaseModelAdminMixin
+from datahub.export_win.models import Win
+
+
+@admin.register(Win)
+class WinAdmin(BaseModelAdminMixin, VersionAdmin):
+    """Admin for Wins."""
+
+    list_display = (
+        'company',
+        'created_on',
+    )
+    list_filter = (
+        ('created_on', DateFieldListFilter),
+    )
+    readonly_fields = (
+        'id',
+        'created_on',
+        'modified_on',
+    )
+    search_fields = (
+        'adviser__name',
+        'company__name',
+        'pk',
+    )
+    list_select_related = (
+        'adviser',
+        'company',
+    )
+    raw_id_fields = (
+        'adviser',
+        'company',
+    )


### PR DESCRIPTION
### Description of change

This adds update Win endpoint and Django admin for Wins.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
