### PR TITLE
Feature RR-1280 resend export win

### DIFF
--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -1355,7 +1355,7 @@ class TestResendExportWinView(APITestMixin):
         response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == {'message': 'Email has successfully been resent'}
+        assert response.data == {'message': 'Email has successfully been re-sent'}
         created_token = CustomerResponseToken.objects.get(id=new_token.id)
         assert created_token.company_contact == mock_contact
         assert created_token.customer_response == customer_response

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -33,6 +33,12 @@ from datahub.core.test_utils import (
     format_date_or_datetime,
 )
 from datahub.export_win.models import CustomerResponseToken, Win
+from datahub.export_win.tasks import (
+    create_token_for_contact,
+    get_all_fields_for_client_email_receipt,
+    notify_export_win_contact_by_rq_email,
+    update_customer_response_token_for_email_notification_id,
+)
 from datahub.export_win.test.factories import (
     BreakdownFactory,
     CustomerResponseFactory,
@@ -64,6 +70,35 @@ def export_wins():
         unconfirmed,
         awaiting,
     ]
+
+
+def mock_export_win_create_token(monkeypatch):
+    mock_create_token = mock.Mock()
+    monkeypatch.setattr(
+        'datahub.export_win.tasks.create_token_for_contact',
+        mock_create_token,
+    )
+    return mock_create_token
+
+
+@pytest.fixture()
+def mock_export_win_get_all_fields(monkeypatch):
+    mock_get_all_fields = mock.Mock()
+    monkeypatch.setattr(
+        'datahub.export_win.tasks.get_all_fields_for_client_email_receipt',
+        mock_get_all_fields,
+    )
+    return mock_get_all_fields
+
+
+@pytest.fixture()
+def mock_notify_export_win_contact_by_rq_email(monkeypatch):
+    mock_contact_by_rq_email = mock.Mock()
+    monkeypatch.setattr(
+        'datahub.export_win.tasks.notify_export_win_contact_by_rq_email',
+        mock_contact_by_rq_email,
+    )
+    return mock_contact_by_rq_email
 
 
 class TestGetWinView(APITestMixin):
@@ -1281,3 +1316,44 @@ class TestUpdateWinView(APITestMixin):
         assert Version.objects.get_for_object(win).count() == 1
         version = Version.objects.get_for_object(win).first()
         assert version.revision.user == self.user
+
+
+class TestResendExportWinView(APITestMixin):
+    """Tests for the resend_export_win view."""
+
+    def test_resend_export_win_no_permissions(self, api_client):
+        """Test attempting to resend without the required permissions."""
+        user = create_test_user(dit_team=TeamFactory())
+        api_client = self.create_api_client(user=user)
+        win = WinFactory()
+        url = reverse('api-v4:export-win:win-resend', kwargs={'pk': win.pk})
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert 'You do not have permission to perform this action.' in response.data['detail']
+
+    def test_resend_export_win_success(
+            self,
+            mock_notify_export_win_contact_by_rq_email,
+    ):
+        mock_contact = ContactFactory()
+        win = WinFactory(company_contacts=[mock_contact])
+        customer_response = CustomerResponseFactory(win=win)
+        new_token = create_token_for_contact(mock_contact, customer_response)
+        context = get_all_fields_for_client_email_receipt(
+            new_token,
+            customer_response,
+        )
+        template_id = 'mock_template_id'
+        notify_export_win_contact_by_rq_email(
+            mock_contact.email,
+            template_id,
+            context,
+            update_customer_response_token_for_email_notification_id,
+            new_token.id,
+        )
+        url = reverse('api-v4:export-win:win-resend', kwargs={'pk': win.pk})
+
+        response = self.api_client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == {'message': 'Email has successfully been resent'}

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -1333,8 +1333,8 @@ class TestResendExportWinView(APITestMixin):
 
     def test_resend_export_win_success(
             self,
-            mock_notify_export_win_contact_by_rq_email,
     ):
+        """Test to resend win to the right contact"""
         mock_contact = ContactFactory()
         win = WinFactory(company_contacts=[mock_contact])
         customer_response = CustomerResponseFactory(win=win)
@@ -1352,8 +1352,10 @@ class TestResendExportWinView(APITestMixin):
             new_token.id,
         )
         url = reverse('api-v4:export-win:win-resend', kwargs={'pk': win.pk})
-
         response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data == {'message': 'Email has successfully been resent'}
+        created_token = CustomerResponseToken.objects.get(id=new_token.id)
+        assert created_token.company_contact == mock_contact
+        assert created_token.customer_response == customer_response

--- a/datahub/export_win/urls.py
+++ b/datahub/export_win/urls.py
@@ -15,6 +15,10 @@ win_item = WinViewSet.as_view({
     'patch': 'partial_update',
 })
 
+resend_export_win = WinViewSet.as_action_view(
+    'resend_export_win',
+)
+
 customer_response = CustomerResponseViewSet.as_view({
     'get': 'retrieve',
     'patch': 'partial_update',
@@ -24,4 +28,5 @@ urls = [
     path('export-win', win_collection, name='collection'),
     path('export-win/<uuid:pk>', win_item, name='item'),
     path('export-win/review/<uuid:token_pk>', customer_response, name='customer-response'),
+    path('export-win/<uuid:pk>/resend-win', resend_export_win, name='win-resend'),
 ]

--- a/datahub/export_win/views.py
+++ b/datahub/export_win/views.py
@@ -114,7 +114,7 @@ class WinViewSet(CoreViewSet):
             new_token.id,
         )
         data = {
-            'message': 'Email has successfully been resent',
+            'message': 'Email has successfully been re-sent',
         }
         return Response(data, status=status.HTTP_200_OK)
 

--- a/datahub/export_win/views.py
+++ b/datahub/export_win/views.py
@@ -1,15 +1,20 @@
 from datetime import datetime
 
-from django.http import Http404
+from django.conf import settings
 
+from django.http import Http404
 from django_filters.rest_framework import (
     DjangoFilterBackend,
     Filter,
     FilterSet,
 )
+
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.permissions import AllowAny
 from rest_framework.views import Response
+
+from datahub.core.schemas import StubSchema
 
 from datahub.core.viewsets import CoreViewSet
 from datahub.export_win.models import (
@@ -20,6 +25,12 @@ from datahub.export_win.models import (
 from datahub.export_win.serializers import (
     CustomerResponseSerializer,
     WinSerializer,
+)
+from datahub.export_win.tasks import (
+    create_token_for_contact,
+    get_all_fields_for_client_email_receipt,
+    notify_export_win_contact_by_rq_email,
+    update_customer_response_token_for_email_notification_id,
 )
 
 
@@ -80,6 +91,32 @@ class WinViewSet(CoreViewSet):
     )
     filter_backends = [DjangoFilterBackend]
     filterset_class = ConfirmedFilterSet
+
+    @action(methods=['post'], detail=True, schema=StubSchema())
+    def resend_export_win(self, request, *args, **kwargs):
+        """
+        Resend email manually via ITA dashboard
+        """
+        win = self.get_object()
+        contact = win.company_contacts.first()
+        customer_response = win.customer_response
+        new_token = create_token_for_contact(contact, customer_response)
+        context = get_all_fields_for_client_email_receipt(
+            new_token,
+            customer_response,
+        )
+        template_id = settings.EXPORT_WIN_CLIENT_RECEIPT_TEMPLATE_ID
+        notify_export_win_contact_by_rq_email(
+            contact.email,
+            template_id,
+            context,
+            update_customer_response_token_for_email_notification_id,
+            new_token.id,
+        )
+        data = {
+            'message': 'Email has successfully been resent',
+        }
+        return Response(data, status=status.HTTP_200_OK)
 
 
 class CustomerResponseViewSet(CoreViewSet):


### PR DESCRIPTION
### Description of change

<!--
This is to implement endpoint to resend export win manually to client
-->

### Checklist

* [✅] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [✅ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
