### PR TITLE
Sector and sub sector filter results

### DIFF
--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -68,7 +68,9 @@ class CompanyFactory(factory.django.DjangoModelFactory):
     registered_address_country_id = constants.Country.united_kingdom.value.id
 
     business_type_id = BusinessTypeConstant.private_limited_company.value.id
-    sector_id = constants.Sector.aerospace_assembly_aircraft.value.id
+    sector_id = factory.LazyFunction(
+        lambda: choice(list(constants.Sector)).value.id,
+    )
     archived = False
     uk_region_id = constants.UKRegion.england.value.id
     export_experience_category = factory.LazyFunction(

--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -107,6 +107,18 @@ class Sector(Enum):
         'Aerospace : Manufacturing and assembly : Aircraft',
         'b422c9d2-5f95-e211-a939-e4115bead28a',
     )
+    defence_air = Constant(
+        'Defence: Air',
+        '03dbd3fb-24e4-421e-bcc1-1dfcd63b2eeb',
+    )
+    defence_land = Constant(
+        'Defence: Land',
+        '7c432bdc-77e0-49ac-8d5f-1eece499ae2a',
+    )
+    mining_mining_vehicles_transport_equipment = Constant(
+        'Mining: Mining vehicles, transport and equipment',
+        'e17c69f9-8c65-457e-9a65-fd7c52a45700',
+    )
     renewable_energy_wind = Constant(
         'Energy : Renewable energy : Fixed-bottom offshore wind',
         'a4959812-6095-e211-a939-e4115bead28a',

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -687,7 +687,7 @@ class TestEntitySearch(APITestMixin):
         """
         Test that the sector_descends filter excludes ancestor sectors
         (where a child sector already exists) for interactions.
-        
+
         """
         num_sectors = len(hierarchical_sectors)
         sectors_ids = [sector.pk for sector in hierarchical_sectors]
@@ -748,7 +748,7 @@ class TestEntitySearch(APITestMixin):
         """
         Test that the sector_descends filter excludes ancestor sectors
         (where a child sector already exists) for companies.
-        
+
         """
         num_sectors = len(hierarchical_sectors)
         sectors_ids = [sector.pk for sector in hierarchical_sectors]

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -685,7 +685,9 @@ class TestEntitySearch(APITestMixin):
         opensearch_with_collector,
     ):
         """
-        Test that the sector_descends filter excludes ancestor sectors (where a child sector already exists) for interactions.
+        Test that the sector_descends filter excludes ancestor sectors
+        (where a child sector already exists) for interactions.
+        
         """
         num_sectors = len(hierarchical_sectors)
         sectors_ids = [sector.pk for sector in hierarchical_sectors]
@@ -744,7 +746,9 @@ class TestEntitySearch(APITestMixin):
         opensearch_with_collector,
     ):
         """
-        Test that the sector_descends filter excludes ancestor sectors (where a child sector already exists) for companies.
+        Test that the sector_descends filter excludes ancestor sectors
+        (where a child sector already exists) for companies.
+        
         """
         num_sectors = len(hierarchical_sectors)
         sectors_ids = [sector.pk for sector in hierarchical_sectors]


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR implements a fix to behaviour of the sector and sub-sector filters when refining the search results of Companies and Interactions.

#### Old Behaviour

Filters previously behaved in an additive fashion. For example, when selecting a parent sector along with one of it's decedent sub-sectors (e.g. `Defence` and `Defence : Air`), the results included those that exist in `Defence` **OR** `Defence : Air` - essentially nullifying the need to select `Defence : Air` as the results for `Defence` would include any and all child sub-sectors.

Additionally, selecting an un-related parent sector or child sub-sector, would add to the results.

#### New Behaviour

When a parent sector and one of its descendant sub-sectors are selected, then the results shown are those that exist in both the parent sector **AND** descendant sub-sector - essentially nullifying the need to select `Defence` when `Defence : Air` is already selected. It was felt this was a more intuitive behaviour.

Moreover, when a parent sector and an unrelated sector/sub-sector are selected then only results which exist in either the parent sector or unrelated sector are shown. Intentionally, this is the same behaviour as before.

### Test Instructions

We have added two tests which can found in `datahub/search/test/test_views.py`. You can run these specifically by invoking:

```
pytest datahub/search/test/test_views.py -k test_sector_descends_filter_excludes_ancestors_for_interactions
pytest datahub/search/test/test_views.py -k test_sector_descends_filter_excludes_ancestors_for_companies
``` 

You can also try out the filtering by running the API locally, along with the frontend. Before trying the filters, be sure to generate some additional interactions; you can do this from the API Docker container:

```
api-repo > make start-dev
frontend-repo > npm run develop
api-docker-container > python manage.py shell
```

```python
from datahub.interaction.test.factories import CompanyInteractionFactory
CompanyInteractionFactory.create_batch(50)
```

Once the `Interactions` are generated, and the `rq workers` are finished syncing, you should be able to see the described behaviour when filtering by the sectors:

- Defence
- ---Defence : Air
- ---Defence : Land
- Mining

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
