### PR TITLE
Hotfix for failing tests after changes to sector assignment in CompanyFactory

### DIFF
--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -108,15 +108,15 @@ class Sector(Enum):
         'b422c9d2-5f95-e211-a939-e4115bead28a',
     )
     defence_air = Constant(
-        'Defence: Air',
+        'Defence : Air',
         '03dbd3fb-24e4-421e-bcc1-1dfcd63b2eeb',
     )
     defence_land = Constant(
-        'Defence: Land',
+        'Defence : Land',
         '7c432bdc-77e0-49ac-8d5f-1eece499ae2a',
     )
     mining_mining_vehicles_transport_equipment = Constant(
-        'Mining: Mining vehicles, transport and equipment',
+        'Mining : Mining vehicles, transport and equipment',
         'e17c69f9-8c65-457e-9a65-fd7c52a45700',
     )
     renewable_energy_wind = Constant(

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -705,14 +705,16 @@ class TestBasicSearch(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
 
-        sector_name = Sector.aerospace_assembly_aircraft.value.name
-        assert sector_name == response.data['results'][0]['company_sector']['name']
+        # company sector is randomly assigned so need to assert if value is valid
+        valid_sector_names = [sector.value.name for sector in Sector]
+        company_sector_name = response.data['results'][0]['company_sector']['name']
+        assert company_sector_name in valid_sector_names
 
     def test_search_contact_has_sector_updated(self, opensearch_with_collector):
         """Tests if contact has a correct sector after company update."""
         contact = ContactFactory(first_name='sector_update')
 
-        # by default company has aerospace_assembly_aircraft sector assigned
+        # company sector is randomly assigned so need to override with fixed value
         company = contact.company
         company.sector_id = Sector.renewable_energy_wind.value.id
         company.save()


### PR DESCRIPTION
### Description of change

This PR fixes a failing test after changes were made to how a company's sector was assigned in the `CompanyFactory` - this change was introduced in recent [PR 5168](https://github.com/uktrade/data-hub-api/pull/5168).

Previously, the sector defaulted to `aerospace_assembly_aircraft`, but now it is randomly assigned from an enumeration class. Rather than asserting if the sector is a specific value, the test has been amended to check if its one of the valid options.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
