### PR TITLE
Add company name mapping to company export view

### DIFF
--- a/datahub/dataset/company_export/test/test_views.py
+++ b/datahub/dataset/company_export/test/test_views.py
@@ -24,6 +24,7 @@ def get_expected_data_from_company_export(export):
         ),
         'archived_reason': export.archived_reason,
         'company_id': str(export.company_id),
+        'company_name': str(export.company.name),
         'contact_ids': [str(contact.id) for contact in export.contacts.all()] or None,
         'created_on': format_date_or_datetime(export.created_on),
         'created_by_id': export.created_by_id,

--- a/datahub/dataset/company_export/views.py
+++ b/datahub/dataset/company_export/views.py
@@ -1,3 +1,5 @@
+from django.db.models import F
+
 from datahub.company.models import CompanyExport
 from datahub.core.query_utils import get_array_agg_subquery
 from datahub.dataset.core.views import BaseFilterDatasetView
@@ -26,6 +28,7 @@ class CompanyExportDatasetView(BaseFilterDatasetView):
                 'advisor_id',
                 ordering=('advisor__date_joined',),
             ),
+            company_name=F('company__name'),
         ).values(
             'created_on',
             'modified_on',
@@ -37,6 +40,7 @@ class CompanyExportDatasetView(BaseFilterDatasetView):
             'archived_by_id',
             'id',
             'company_id',
+            'company_name',
             'title',
             'owner_id',
             'estimated_export_value_years__name',


### PR DESCRIPTION
### Description of change

The scope of this PR is to explicitly map company_name within the CompanyExport view as there seems to be issues (blank company names) with this mapping in data workspace when querying for company exports.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
