### PR TITLE
Add last modified export potential field in company model

### DIFF
--- a/datahub/company/migrations/0140_last_modified_potential.py
+++ b/datahub/company/migrations/0140_last_modified_potential.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('company', '0139_auto_20231204_1601'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='company',
+            name='last_modified_potential',
+            field=models.DateTimeField(blank=True, null=True, help_text='Timestamp of the last modification for export potential.'),
+        ),
+    ]

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -351,6 +351,11 @@ class Company(ArchivableModel, BaseModel):
         choices=ExportPotentialScore.choices,
         help_text='Score that signifies export potential, imported from Data Science',
     )
+    last_modified_potential = models.DateTimeField(
+        blank=True,
+        null=True,
+        help_text='Timestamp of the last modification for export potential.',
+    )
     great_profile_status = models.CharField(
         max_length=MAX_LENGTH,
         null=True,

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -643,6 +643,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'registered_address',
             'pending_dnb_investigation',
             'export_potential',
+            'last_modified_potential',
             'great_profile_status',
             'is_global_ultimate',
             'global_ultimate_duns_number',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -428,6 +428,7 @@ class TestGetCompany(APITestMixin):
             'turnover': company.turnover,
             'turnover_gbp': convert_usd_to_gbp(company.turnover),
             'is_turnover_estimated': company.is_turnover_estimated,
+            'last_modified_potential': None,
             'website': company.website,
             'global_headquarters': {
                 'id': str(ghq.id),

--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -144,6 +144,7 @@ def base_company_dict():
         'headquarter_type': None,
         'is_number_of_employees_estimated': None,
         'is_turnover_estimated': None,
+        'last_modified_potential': None,
         'number_of_employees': None,
         'one_list_account_owner': None,
         'one_list_tier': None,


### PR DESCRIPTION
### Description of change

The scope of this PR is to include last modified potential field so we can track when the export potential was last updated.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
