### PR TITLE
Send a Task deleted reminder when archived/deleted

### DIFF
--- a/datahub/task/emails.py
+++ b/datahub/task/emails.py
@@ -168,3 +168,23 @@ class TaskAmendedByOthersEmailTemplate(EmailTemplate):
             self.task_due_date,
             self.adviser_amending_task,
         ]
+
+
+class TaskDeletedByOthersEmailTemplate(EmailTemplate):
+    UTM_CAMPAIGN = 'task_deleted'
+
+    def __init__(self, task: Task):
+        super().__init__(task)
+
+    @property
+    def subject(self):
+        return 'Task deleted'
+
+    @property
+    def fields_to_include(self):
+        return [
+            self.investment_project,
+            self.company_name,
+            self.task_due_date,
+            self.adviser_amending_task,
+        ]

--- a/datahub/task/signals.py
+++ b/datahub/task/signals.py
@@ -4,8 +4,7 @@ from django.dispatch import receiver
 from datahub.task.models import Task
 from datahub.task.tasks import (
     schedule_advisers_added_to_task,
-    schedule_notify_advisers_task_amended_by_others,
-    schedule_notify_advisers_task_completed,
+    schedule_notify_advisers_task_archived_completed_or_amended,
 )
 
 
@@ -46,5 +45,8 @@ def save_task(sender, instance, created, **kwargs):
     # any m2m changes are triggered by the m2m signal
     adviser_ids_pre_m2m_change = list(instance.advisers.all().values_list('id', flat=True))
 
-    schedule_notify_advisers_task_completed(instance, created)
-    schedule_notify_advisers_task_amended_by_others(instance, created, adviser_ids_pre_m2m_change)
+    schedule_notify_advisers_task_archived_completed_or_amended(
+        instance,
+        created,
+        adviser_ids_pre_m2m_change,
+    )

--- a/datahub/task/tasks.py
+++ b/datahub/task/tasks.py
@@ -393,16 +393,6 @@ def notify_adviser_archived_completed_or_amended_task(
     """
     if created:
         return
-    if not task.archived and task.status is not Task.Status.COMPLETE:
-        notify_advisers_of_task(
-            task,
-            adviser_ids_pre_m2m_change,
-            TaskAmendedByOthersReminder,
-            TaskAmendedByOthersSubscription,
-            TaskAmendedByOthersEmailTemplate,
-            update_task_amended_by_others_email_status,
-        )
-        return
 
     if task.archived:
         notify_advisers_of_task(
@@ -413,7 +403,9 @@ def notify_adviser_archived_completed_or_amended_task(
             TaskDeletedByOthersEmailTemplate,
             update_task_completed_email_status,
         )
-    else:
+        return
+
+    if Task.Status.COMPLETE:
         notify_advisers_of_task(
             task,
             None,
@@ -422,6 +414,17 @@ def notify_adviser_archived_completed_or_amended_task(
             TaskCompletedEmailTemplate,
             update_task_completed_email_status,
         )
+        return
+
+    notify_advisers_of_task(
+        task,
+        adviser_ids_pre_m2m_change,
+        TaskAmendedByOthersReminder,
+        TaskAmendedByOthersSubscription,
+        TaskAmendedByOthersEmailTemplate,
+        update_task_amended_by_others_email_status,
+    )
+    return
 
 
 def notify_advisers_of_task(

--- a/datahub/task/tasks.py
+++ b/datahub/task/tasks.py
@@ -405,7 +405,7 @@ def notify_adviser_archived_completed_or_amended_task(
         )
         return
 
-    if Task.Status.COMPLETE:
+    if task.status is Task.Status.COMPLETE:
         notify_advisers_of_task(
             task,
             None,

--- a/datahub/task/tasks.py
+++ b/datahub/task/tasks.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+from django.apps import apps
 from django.conf import settings
 from django.utils import timezone
 from django_pglocks import advisory_lock
@@ -16,6 +17,8 @@ from datahub.reminder.models import (
     TaskAssignedToMeFromOthersSubscription,
     TaskCompletedReminder,
     TaskCompletedSubscription,
+    TaskDeletedByOthersReminder,
+    TaskDeletedByOthersSubscription,
     TaskOverdueReminder,
     TaskOverdueSubscription,
     UpcomingTaskReminder,
@@ -26,6 +29,7 @@ from datahub.task.emails import (
     TaskAmendedByOthersEmailTemplate,
     TaskAssignedToOthersEmailTemplate,
     TaskCompletedEmailTemplate,
+    TaskDeletedByOthersEmailTemplate,
     TaskOverdueEmailTemplate,
     UpcomingTaskEmailTemplate,
 )
@@ -41,6 +45,7 @@ def schedule_advisers_added_to_task(task, adviser_ids):
         schedule_create_task_assigned_to_me_from_others_subscription_task(task, adviser_id)
         schedule_create_task_overdue_subscription_task(adviser_id)
         schedule_create_task_completed_subscription_task(adviser_id)
+        schedule_create_task_archived_subscription_task(adviser_id)
         schedule_create_task_amended_by_others_subscription_task(adviser_id)
 
 
@@ -299,6 +304,18 @@ def update_task_completed_email_status(email_notification_id, reminder_ids):
     )
 
 
+def update_task_deleted_email_status(email_notification_id, reminder_ids):
+    reminders = TaskDeletedByOthersReminder.all_objects.filter(id__in=reminder_ids)
+    for reminder in reminders:
+        reminder.email_notification_id = email_notification_id
+        reminder.save()
+
+    logger.info(
+        'Task update_task_deleted_email_status completed, setting '
+        f'email_notification_id to {email_notification_id} for reminder_ids {reminder_ids}',
+    )
+
+
 def schedule_create_task_completed_subscription_task(adviser_id):
     job = job_scheduler(
         queue_name=LONG_RUNNING_QUEUE,
@@ -312,7 +329,7 @@ def schedule_create_task_completed_subscription_task(adviser_id):
 
 def create_task_completed_subscription(adviser_id):
     """
-    Creates a task reminder subscription for an adviser if the adviser doesn't have
+    Creates a task completed subscription for an adviser if the adviser doesn't have
     a subscription already.
     """
     if not TaskCompletedSubscription.objects.filter(
@@ -324,40 +341,135 @@ def create_task_completed_subscription(adviser_id):
         )
 
 
-def notify_adviser_completed_task(task, created):
+def schedule_create_task_archived_subscription_task(adviser_id):
+    job = job_scheduler(
+        queue_name=LONG_RUNNING_QUEUE,
+        function=create_task_deleted_by_others_subscription,
+        function_args=(adviser_id,),
+    )
+    logger.info(
+        f'Task {job.id} create_task_archived_subscription',
+    )
+
+
+def create_task_deleted_by_others_subscription(adviser_id):
     """
-    Send a notification to all advisers, excluding the adviser who marked the task as completed,
-    when task completed. Do not send a notification when task is deleted (archived).
+    Creates a task deleted/archived by others subscription for an adviser if the adviser doesn't
+    have a subscription already.
+    """
+    if not TaskDeletedByOthersSubscription.objects.filter(
+        adviser_id=adviser_id,
+    ).first():
+        TaskDeletedByOthersSubscription.objects.create(
+            adviser_id=adviser_id,
+            email_reminders_enabled=True,
+        )
+
+
+def notify_adviser_archived_completed_or_amended_task(
+    task,
+    created,
+    adviser_ids_pre_m2m_change=None,
+):
+    """
+    Send a notification to all advisers, excluding the adviser who ammended,
+    archived/deleted or completed the task.
+    After a task status has been set to completed:
+    - it can no longer be edited
+    - it can be archived/deleted
+    - The TaskCompletedReminder should be send.
+    After a task has been archived/deleted:
+    - it can no longer be edited (including changing the status)
+    - it **can** be undeleted/unarchived
+    - The TaskDeletedByOthersReminder should be send.
+    - No other notifications should be send once a Task has been archived/deleted.
+
+    task: Task
+    created: true or false depending on whether the task has been created or updated.
+    adviser_ids_pre_m2m_change: values of adviser ids that have been updated before the
+    m2m_change. Used for amended by others only.
     """
     if created:
         return
+    if not task.archived and task.status is not Task.Status.COMPLETE:
+        notify_advisers_of_task(
+            task,
+            adviser_ids_pre_m2m_change,
+            TaskAmendedByOthersReminder,
+            TaskAmendedByOthersSubscription,
+            TaskAmendedByOthersEmailTemplate,
+            update_task_amended_by_others_email_status,
+        )
+        return
 
     if task.archived:
-        return
+        notify_advisers_of_task(
+            task,
+            None,
+            TaskDeletedByOthersReminder,
+            TaskDeletedByOthersSubscription,
+            TaskDeletedByOthersEmailTemplate,
+            update_task_completed_email_status,
+        )
+    else:
+        notify_advisers_of_task(
+            task,
+            None,
+            TaskCompletedReminder,
+            TaskCompletedSubscription,
+            TaskCompletedEmailTemplate,
+            update_task_completed_email_status,
+        )
 
-    if task.status is not Task.Status.COMPLETE:
-        return
 
-    advisers_to_notify = task.advisers.exclude(id=task.modified_by.id)
+def notify_advisers_of_task(
+    task,
+    adviser_ids_pre_m2m_change,
+    reminder_class,
+    subscription_class,
+    email_template_class,
+    update_task_function,
+):
+    """_summary_
+    For all advisers of the task, excluding the adviser who performed this action:
+        - Create a reminder
+        - Send an email notification provided the adviser has a subscription setup.
+
+    Args:
+        task (_type_): Task to notify advisers for.
+        reminder_class (BaseReminder): Reminder class to be used.
+        subscription_class (BaseSubscription): Subscription class to be used.
+        email_template_class (EmailTemplate): Email Template class to be used.
+    """
+    if adviser_ids_pre_m2m_change is None:
+        advisers_to_notify = task.advisers.exclude(
+            id=task.modified_by.id,
+        )
+    else:
+        advisers_to_notify = task.advisers.filter(id__in=adviser_ids_pre_m2m_change).exclude(
+            id=task.modified_by.id,
+        )
 
     if not advisers_to_notify.exists():
         return
 
     for adviser in advisers_to_notify:
-        existing_reminder = TaskCompletedReminder.objects.filter(
+        existing_reminder = apps.get_model('reminder', reminder_class.__name__).objects.filter(
             task=task,
             adviser=adviser,
         ).first()
         if existing_reminder:
             continue
-
-        reminder = TaskCompletedReminder.objects.create(
+        reminder = apps.get_model('reminder', reminder_class.__name__).objects.create(
             adviser=adviser,
-            event=f'{task} completed by {task.modified_by.name}',
+            event=f'{task} {reminder_class.__name__} by {task.modified_by.name}',
             task=task,
         )
 
-        adviser_subscription = TaskCompletedSubscription.objects.filter(
+        adviser_subscription = apps.get_model(
+            'reminder',
+            subscription_class.__name__,
+        ).objects.filter(
             adviser=adviser,
         ).first()
         if not adviser_subscription:
@@ -368,25 +480,29 @@ def notify_adviser_completed_task(task, created):
                 adviser=adviser,
                 task=task,
                 reminder=reminder,
-                update_task=update_task_completed_email_status,
-                email_template_class=TaskCompletedEmailTemplate,
+                update_task=update_task_function,
+                email_template_class=email_template_class,
             )
         else:
             logger.info(
-                f'No email for TaskCompletedReminder with id {reminder.id} sent to adviser '
+                f'No email for {reminder_class.__name__} with id {reminder.id} sent to adviser '
                 f'{adviser.id} for task {task.id}, as email reminders are turned off in their '
                 'subscription',
             )
 
 
-def schedule_notify_advisers_task_completed(task, created):
+def schedule_notify_advisers_task_archived_completed_or_amended(
+    task,
+    created,
+    adviser_ids_pre_m2m_change,
+):
     job = job_scheduler(
         queue_name=LONG_RUNNING_QUEUE,
-        function=notify_adviser_completed_task,
-        function_args=(task, created),
+        function=notify_adviser_archived_completed_or_amended_task,
+        function_args=(task, created, adviser_ids_pre_m2m_change),
     )
     logger.info(
-        f'Task {job.id} schedule_notify_advisers_task_completed',
+        f'Task {job.id} schedule_notify_advisers_task_archived_completed_or_amended',
     )
 
 
@@ -416,55 +532,6 @@ def create_task_amended_by_others_subscription(adviser_id):
         )
 
 
-def notify_adviser_task_amended_by_others(
-    task,
-    created,
-    adviser_ids_pre_m2m_change,
-):
-    """
-    Send a notification to all advisers, excluding the adviser who marked the task as completed,
-    when task is amended. Do not send a notification when the task status is set to Complete or
-    marked as deleted (archived).
-    """
-    if created:
-        return
-
-    if task.archived:
-        return
-
-    if task.status is Task.Status.COMPLETE:
-        return
-
-    advisers_to_notify = task.advisers.filter(id__in=adviser_ids_pre_m2m_change).exclude(
-        id=task.modified_by.id,
-    )
-
-    if not advisers_to_notify.exists():
-        return
-
-    for adviser in advisers_to_notify:
-        reminder = TaskAmendedByOthersReminder.objects.create(
-            adviser=adviser,
-            event=f'{task} amended by {task.modified_by.name}',
-            task=task,
-        )
-
-        adviser_subscription = TaskAmendedByOthersSubscription.objects.filter(
-            adviser=adviser,
-        ).first()
-        if not adviser_subscription:
-            return
-
-        if adviser_subscription.email_reminders_enabled:
-            send_task_email(
-                adviser=adviser,
-                task=task,
-                reminder=reminder,
-                update_task=update_task_amended_by_others_email_status,
-                email_template_class=TaskAmendedByOthersEmailTemplate,
-            )
-
-
 def schedule_create_task_amended_by_others_subscription_task(adviser_id):
     job = job_scheduler(
         queue_name=LONG_RUNNING_QUEUE,
@@ -473,25 +540,6 @@ def schedule_create_task_amended_by_others_subscription_task(adviser_id):
     )
     logger.info(
         f'Task {job.id} create_task_amended_by_others_subscription',
-    )
-
-
-def schedule_notify_advisers_task_amended_by_others(
-    task,
-    created,
-    adviser_ids_pre_m2m_change,
-):
-    job = job_scheduler(
-        queue_name=LONG_RUNNING_QUEUE,
-        function=notify_adviser_task_amended_by_others,
-        function_args=(
-            task,
-            created,
-            adviser_ids_pre_m2m_change,
-        ),
-    )
-    logger.info(
-        f'Task {job.id} notify_adviser_task_amended_by_others',
     )
 
 

--- a/datahub/task/tasks.py
+++ b/datahub/task/tasks.py
@@ -372,7 +372,7 @@ def notify_adviser_archived_completed_or_amended_task(
     adviser_ids_pre_m2m_change=None,
 ):
     """
-    Send a notification to all advisers, excluding the adviser who ammended,
+    Send a notification to all advisers, excluding the adviser who amended,
     archived/deleted or completed the task.
     After a task status has been set to completed:
     - it can no longer be edited
@@ -383,6 +383,8 @@ def notify_adviser_archived_completed_or_amended_task(
     - it **can** be undeleted/unarchived
     - The TaskDeletedByOthersReminder should be send.
     - No other notifications should be send once a Task has been archived/deleted.
+    After a task has been amended:
+    - The TaskAmmendedByOthersReminder should be send.
 
     task: Task
     created: true or false depending on whether the task has been created or updated.

--- a/datahub/task/test/test_signals.py
+++ b/datahub/task/test/test_signals.py
@@ -68,22 +68,23 @@ class TestTaskAdviserChangedSubscriptions:
 
 
 class TestTaskAdviserCompletedSubscriptions:
-    @patch('datahub.task.signals.schedule_notify_advisers_task_completed')
+    @patch('datahub.task.signals.schedule_notify_advisers_task_archived_completed_or_amended')
     def test_creating_and_updating_task_triggers_notify_adviser_completed_scheduled_task(
         self,
-        schedule_notify_advisers_task_completed,
+        schedule_notify_advisers_task_archived_completed_or_amended,
     ):
         """
         Note: only the triggering of the schedule is tested not the processing of it.
         """
-        task = TaskFactory(advisers=[AdviserFactory()])
+        adviser = AdviserFactory()
+        task = TaskFactory(advisers=[adviser])
         task.save()
 
-        schedule_notify_advisers_task_completed.assert_has_calls(
+        schedule_notify_advisers_task_archived_completed_or_amended.assert_has_calls(
             [
-                call(task, True),
-                call(task, False),
-                call(task, False),
+                call(task, True, []),
+                call(task, False, [adviser.id]),
+                call(task, False, [adviser.id]),
             ],
             any_order=True,
         )
@@ -97,8 +98,7 @@ class TestTaskAdviserCompletedSubscriptions:
         Calling with adviser completed should result in sending of TaskCompletedReminder
         """
         adviser = AdviserFactory()
-        task = TaskFactory(advisers=[adviser])
-        task.status = Task.Status.COMPLETE
+        task = TaskFactory(advisers=[adviser], status=Task.Status.COMPLETE)
         task.save()
 
         send_task_email.assert_any_call(
@@ -111,15 +111,15 @@ class TestTaskAdviserCompletedSubscriptions:
 
 
 class TestTaskAmededByOthersSubscriptions:
-    @patch('datahub.task.signals.schedule_notify_advisers_task_amended_by_others')
+    @patch('datahub.task.signals.schedule_notify_advisers_task_archived_completed_or_amended')
     def test_creating_task_triggers_notify_advisers_task_amended_by_others_scheduled_task(
         self,
-        schedule_notify_advisers_task_amended_by_others,
+        schedule_notify_advisers_task_archived_completed_or_amended,
     ):
         adviser = AdviserFactory()
         task = TaskFactory(advisers=[adviser])
 
-        schedule_notify_advisers_task_amended_by_others.assert_has_calls(
+        schedule_notify_advisers_task_archived_completed_or_amended.assert_has_calls(
             [
                 call(task, True, []),
                 call(task, False, [adviser.id]),
@@ -127,16 +127,16 @@ class TestTaskAmededByOthersSubscriptions:
             any_order=True,
         )
 
-    @patch('datahub.task.signals.schedule_notify_advisers_task_amended_by_others')
+    @patch('datahub.task.signals.schedule_notify_advisers_task_archived_completed_or_amended')
     def test_modifying_task_triggers_notify_advisers_task_amended_by_others_scheduled_task(
         self,
-        schedule_notify_advisers_task_amended_by_others,
+        schedule_notify_advisers_task_archived_completed_or_amended,
     ):
         adviser = AdviserFactory()
         task = TaskFactory(advisers=[adviser])
         task.save()
 
-        schedule_notify_advisers_task_amended_by_others.assert_has_calls(
+        schedule_notify_advisers_task_archived_completed_or_amended.assert_has_calls(
             [
                 call(task, True, []),
                 call(task, False, [adviser.id]),

--- a/datahub/task/test/test_tasks.py
+++ b/datahub/task/test/test_tasks.py
@@ -20,6 +20,7 @@ from datahub.reminder.models import (
     TaskAssignedToMeFromOthersSubscription,
     TaskCompletedReminder,
     TaskCompletedSubscription,
+    TaskDeletedByOthersReminder,
     TaskOverdueReminder,
     TaskOverdueSubscription,
     UpcomingTaskReminder,
@@ -29,6 +30,7 @@ from datahub.reminder.test.factories import (
     TaskAmendedByOthersReminderFactory,
     TaskAssignedToMeFromOthersReminderFactory,
     TaskCompletedReminderFactory,
+    TaskDeletedByOthersReminderFactory,
     TaskOverdueReminderFactory,
     UpcomingTaskReminderFactory,
 )
@@ -59,6 +61,7 @@ from datahub.task.tasks import (
     update_task_amended_by_others_email_status,
     update_task_assigned_to_me_from_others_email_status,
     update_task_completed_email_status,
+    update_task_deleted_email_status,
     update_task_overdue_reminder_email_status,
     update_task_reminder_email_status,
 )
@@ -690,6 +693,33 @@ class TestTasksAssignedToMeFromOthers:
         TaskAssignedToMeFromOthersReminderFactory.create_batch(2, task_id=task2.id)
 
         linked_reminders = TaskAssignedToMeFromOthersReminder.objects.filter(
+            email_notification_id=notification_id,
+        )
+        assert linked_reminders.count() == (reminder_number)
+
+    def test_update_task_deleted_email_status(
+        self,
+    ):
+        """
+        Test it updates reminder data with the connected email notification information.
+        """
+        task = TaskFactory()
+        reminder_number = 3
+        notification_id = str(uuid4())
+        reminders = TaskDeletedByOthersReminderFactory.create_batch(
+            reminder_number,
+            task_id=task.id,
+        )
+
+        update_task_deleted_email_status(
+            notification_id,
+            [reminder.id for reminder in reminders],
+        )
+
+        task2 = TaskFactory()
+        TaskDeletedByOthersReminderFactory.create_batch(2, task_id=task2.id)
+
+        linked_reminders = TaskDeletedByOthersReminder.objects.filter(
             email_notification_id=notification_id,
         )
         assert linked_reminders.count() == (reminder_number)


### PR DESCRIPTION
### Description of change

Send a Task deleted reminder when archived/deleted.
Refactor of sending reminders.

Send a notification to all advisers, excluding the adviser who amended, archived/deleted or completed the task.
- After a task status has been set to completed:
  - it can no longer be edited
  - it can be archived/deleted
  - The TaskCompletedReminder should be send.
- After a task has been archived/deleted:
  - it can no longer be edited (including changing the status)
  - it **can** be undeleted/unarchived
  - The TaskDeletedByOthersReminder should be send.
  - No other notifications should be send once a Task has been archived/deleted.
- After a task has been amended:
  - The TaskAmmendedByOthersReminder should be send.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
