### PR TITLE
Bugfix/tet 662 deleting document

### DIFF
--- a/datahub/documents/utils.py
+++ b/datahub/documents/utils.py
@@ -94,7 +94,7 @@ def perform_delete_document(document_pk):
             f'Document with ID {document_pk} is not pending deletion.',
         )
 
-    if document.uploaded_on:
+    if document.path:
         bucket_id = document.bucket_id
 
         client = get_s3_client_for_bucket(bucket_id)


### PR DESCRIPTION
### Description of change

Change the delete document functionality. Previously there was a bug, if the final api call failed when uploading the document, the document would be uploaded to s3 and an incomplete db entry would be made. If you then tried deleting this from within the service, the db entry would be deleted but the document would remain in s3. This was because there was a check on `document.uploaded_on` and only if there was an `uploaded_on` value would the code run to delete the document in s3. This `uploaded_on` field is only added to the db when the final api call is made, so if it fails the document will have been uploaded to s3 but the `uploaded_on` field will not exist on the db. Change the check to check for a property that will be in the db from the initial api call

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
