### PR TITLE
Add default sorting to Win view.

### DIFF
--- a/datahub/export_win/views.py
+++ b/datahub/export_win/views.py
@@ -12,6 +12,7 @@ from django_filters.rest_framework import (
 
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import AllowAny
 from rest_framework.views import Response
 
@@ -93,8 +94,10 @@ class WinViewSet(CoreViewSet):
         first_sent=Min('customer_response__tokens__created_on'),
         last_sent=Max('customer_response__tokens__created_on'),
     )
-    filter_backends = [DjangoFilterBackend]
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
     filterset_class = ConfirmedFilterSet
+    ordering_fields = ('customer_response__responded_on', 'created_on')
+    ordering = ('-customer_response__responded_on', '-created_on')
 
     def perform_create(self, serializer):
         """


### PR DESCRIPTION
### Description of change

This adds default sorting to Wins view so that the Wins are sorted by responded_on and created_on in descending order.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
