### PR TITLE
Fix differences in download and frontend when investment project manually deleted using django admin

### DIFF
--- a/datahub/search/investment/test/test_signals.py
+++ b/datahub/search/investment/test/test_signals.py
@@ -95,6 +95,22 @@ def test_investment_project_auto_updates_to_opensearch(opensearch_with_signals):
     assert result.hits.total.value == 1
 
 
+def test_investment_project_delete_from_opensearch(opensearch_with_signals):
+    """
+    Test that when an investment project is deleted from the db it also
+    calls delete document to delete from OpenSearch
+    """
+    project = InvestmentProjectFactory()
+
+    opensearch_with_signals.indices.refresh()
+    assert search_investment_project_by_id(project.pk)
+
+    with mock.patch('datahub.search.investment.signals.delete_document') as mock_delete_document:
+        project.delete()
+        opensearch_with_signals.indices.refresh()
+        assert mock_delete_document.called
+
+
 @pytest.fixture
 def team_member():
     """Team member fixture"""


### PR DESCRIPTION
### Description of change

Add a post_delete signal when deleting an investment project, so that opensearch gets updated

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
