### PR TITLE
feature/RR-1336-migrate-ew-wins

### DIFF
--- a/datahub/dataset/export_wins/test/test_views.py
+++ b/datahub/dataset/export_wins/test/test_views.py
@@ -13,6 +13,7 @@ from datahub.export_win.test.factories import (
     BreakdownFactory,
     CustomerResponseFactory,
     HVCFactory,
+    HVOProgrammesFactory,
     SupportTypeFactory,
     WinAdviserFactory,
     WinFactory,
@@ -217,6 +218,7 @@ class TestExportWinsWinDatasetView(BaseDatasetViewTest):
         win = self.factory(
             associated_programme=associated_programmes,
             type_of_support=types_of_support,
+            hvo_programme=HVOProgrammesFactory(),
         )
         CustomerResponseFactory(win=win)
 

--- a/datahub/dataset/export_wins/test/test_views.py
+++ b/datahub/dataset/export_wins/test/test_views.py
@@ -7,7 +7,16 @@ from datahub.core.test_utils import (
 )
 from datahub.dataset.core.test import BaseDatasetViewTest
 from datahub.export_win.models import HVC
-from datahub.export_win.test.factories import BreakdownFactory, HVCFactory, WinAdviserFactory
+
+from datahub.export_win.test.factories import (
+    AssociatedProgrammeFactory,
+    BreakdownFactory,
+    CustomerResponseFactory,
+    HVCFactory,
+    SupportTypeFactory,
+    WinAdviserFactory,
+    WinFactory,
+)
 
 
 pytestmark = pytest.mark.django_db
@@ -103,3 +112,120 @@ class TestExportWinsHVCDatasetView(BaseDatasetViewTest):
         response = data_flow_api_client.get(self.view_url).json()
 
         self._assert_hvc_matches_result(hvc, response['results'][0])
+
+
+class TestExportWinsWinDatasetView(BaseDatasetViewTest):
+    view_url = reverse('api-v4:dataset:export-wins-win-dataset')
+    factory = WinFactory
+
+    def _assert_win_matches_result(
+        self,
+        win,
+        associated_programmes,
+        types_of_support,
+        result,
+    ):
+        expected = {
+            'created_on': format_date_or_datetime(win.created_on),
+            'id': str(win.id),
+            'audit': win.audit,
+            'business_type': win.business_type,
+            'cdms_reference': win.cdms_reference,
+            'company_name': win.company.name,
+            'complete': win.complete,
+            'confirmation__access_to_contacts': win.customer_response.our_support.export_win_id,
+            'confirmation__access_to_information':
+                win.customer_response.access_to_information.export_win_id,
+            'confirmation__agree_with_win': win.customer_response.agree_with_win,
+            'confirmation__case_study_willing': win.customer_response.case_study_willing,
+            'confirmation__comments': win.customer_response.comments,
+            'confirmation__company_was_at_risk_of_not_exporting':
+                win.customer_response.company_was_at_risk_of_not_exporting,
+            'confirmation__created': format_date_or_datetime(
+                win.customer_response.created_on,
+            ),
+            'confirmation__developed_relationships':
+                win.customer_response.developed_relationships.export_win_id,
+            'confirmation__gained_confidence':
+                win.customer_response.gained_confidence.export_win_id,
+            'confirmation__has_enabled_expansion_into_existing_market':
+                win.customer_response.has_enabled_expansion_into_existing_market,
+            'confirmation__has_enabled_expansion_into_new_market':
+                win.customer_response.has_enabled_expansion_into_new_market,
+            'confirmation__has_explicit_export_plans':
+                win.customer_response.has_explicit_export_plans,
+            'confirmation__has_increased_exports_as_percent_of_turnover':
+                win.customer_response.has_increased_exports_as_percent_of_turnover,
+            'confirmation__improved_profile': win.customer_response.improved_profile.export_win_id,
+            'confirmation__interventions_were_prerequisite':
+                win.customer_response.interventions_were_prerequisite,
+            'confirmation__involved_state_enterprise':
+                win.customer_response.involved_state_enterprise,
+            'confirmation__name': win.customer_response.name,
+            'confirmation__other_marketing_source': win.customer_response.other_marketing_source,
+            'confirmation__our_support': win.customer_response.our_support.export_win_id,
+            'confirmation__overcame_problem': win.customer_response.overcame_problem.export_win_id,
+            'confirmation__support_improved_speed': win.customer_response.support_improved_speed,
+            'country': win.country.iso_alpha2_code,
+            'created': format_date_or_datetime(win.created_on),
+            'customer_email_address': win.customer_email_address,
+            'customer_job_title': win.customer_job_title,
+            'customer_name': win.customer_name,
+            'date': format_date_or_datetime(win.date),
+            'description': win.description,
+            'has_hvo_specialist_involvement': win.has_hvo_specialist_involvement,
+            'hvc': win.hvc.export_win_id,
+            'is_e_exported': win.is_e_exported,
+            'is_line_manager_confirmed': win.is_line_manager_confirmed,
+            'is_personally_confirmed': win.is_personally_confirmed,
+            'is_prosperity_fund_related': win.is_prosperity_fund_related,
+            'lead_officer_email_address': win.lead_officer_email_address,
+            'lead_officer_name': win.lead_officer_name,
+            'line_manager_name': win.line_manager_name,
+            'name_of_customer': win.name_of_customer,
+            'name_of_export': win.name_of_export,
+            'other_official_email_address': win.other_official_email_address,
+            'total_expected_export_value': win.total_expected_export_value,
+            'total_expected_non_export_value': win.total_expected_non_export_value,
+            'total_expected_odi_value': win.total_expected_odi_value,
+            'user__email': win.adviser.email,
+            'user__name': win.adviser.name,
+            'business_potential_display': win.business_potential.name,
+            'confirmation_last_export': win.customer_response.last_export.name,
+            'confirmation_marketing_source': win.customer_response.marketing_source.name,
+            'confirmation_portion_without_help':
+                win.customer_response.expected_portion_without_help.name,
+            'country_name': win.country.name,
+            'customer_location_display': win.customer_location.name,
+            'export_experience_display': win.export_experience.name,
+            'goods_vs_services_display': win.goods_vs_services.name,
+            'hq_team_display': win.hq_team.name,
+            'hvo_programme_display': win.hvo_programme.name,
+            'sector_display': win.sector.segment,
+            'team_type_display': win.team_type.name,
+        }
+        for i, associated_programme in enumerate(associated_programmes):
+            expected[f'associated_programme_{i+1}_display'] = associated_programme.name
+        for i, type_of_support in enumerate(types_of_support):
+            expected[f'type_of_support_{i+1}_display'] = type_of_support.name
+
+        assert result == expected
+
+    def test_success(self, data_flow_api_client):
+        associated_programmes = AssociatedProgrammeFactory.create_batch(3)
+        types_of_support = SupportTypeFactory.create_batch(2)
+        win = self.factory(
+            associated_programme=associated_programmes,
+            type_of_support=types_of_support,
+        )
+        CustomerResponseFactory(win=win)
+
+        response = data_flow_api_client.get(self.view_url).json()
+
+        assert len(response['results']) == 1
+        self._assert_win_matches_result(
+            win,
+            associated_programmes,
+            types_of_support,
+            response['results'][0],
+        )

--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -1,5 +1,5 @@
 from django.contrib.postgres.expressions import ArraySubquery
-from django.db.models import F
+from django.db.models import F, Count, Max
 from django.db.models import IntegerField, OuterRef, Value
 from django.db.models.functions import Cast, Concat
 
@@ -139,6 +139,8 @@ class ExportWinsWinDatasetView(BaseDatasetView):
                 hvo_programme_display=F('hvo_programme__name'),
                 sector_display=F('sector__segment'),
                 team_type_display=F('team_type__name'),
+                num_notifications=Count('customer_response__tokens'),
+                customer_email_date=Max('customer_response__tokens__created_on'),
             )
             .annotate(
                 company_name=F('company__name'),

--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -1,8 +1,18 @@
+from django.contrib.postgres.expressions import ArraySubquery
 from django.db.models import F
+from django.db.models import IntegerField, OuterRef, Value
+from django.db.models.functions import Cast, Concat
 
 from datahub.dataset.core.views import BaseDatasetView
 from datahub.dataset.export_wins.pagination import HVCDatasetViewCursorPagination
-from datahub.export_win.models import Breakdown, HVC, WinAdviser
+from datahub.export_win.models import (
+    AssociatedProgramme,
+    Breakdown,
+    HVC,
+    SupportType,
+    Win,
+    WinAdviser,
+)
 
 
 class ExportWinsAdvisersDatasetView(BaseDatasetView):
@@ -35,14 +45,18 @@ class ExportWinsBreakdownsDatasetView(BaseDatasetView):
     """
 
     def get_dataset(self):
-        return Breakdown.objects.select_related('win, breakdown_type').values(
-            'created_on',
-            'win__id',
-            'year',
-            'value',
-            breakdown_type=F('type__name'),
-        ).annotate(
-            id=F('legacy_id'),
+        return (
+            Breakdown.objects.select_related('win, breakdown_type')
+            .values(
+                'created_on',
+                'win__id',
+                'year',
+                'value',
+                breakdown_type=F('type__name'),
+            )
+            .annotate(
+                id=F('legacy_id'),
+            )
         )
 
 
@@ -61,3 +75,164 @@ class ExportWinsHVCDatasetView(BaseDatasetView):
             name=F('export_win_id'),
             id=F('legacy_id'),
         )
+
+
+class ExportWinsWinDatasetView(BaseDatasetView):
+    """
+    A GET API view to return export win wins.
+    """
+
+    def get_dataset(self):
+        return (
+            Win.objects.select_related(
+                'adviser',
+                'business_potential',
+                'country',
+                'customer_location',
+                'customer_response',
+                'export_experience',
+                'hvc',
+                'hvo_programme',
+                'sector',
+            )
+            .prefetch_related('associated_programme', 'type_of_support')
+            .values(
+                'created_on',
+                'id',
+                'audit',
+                'business_type',
+                'cdms_reference',
+                'complete',
+                'customer_email_address',
+                'customer_job_title',
+                'customer_name',
+                'date',
+                'description',
+                'has_hvo_specialist_involvement',
+                'is_e_exported',
+                'is_line_manager_confirmed',
+                'is_personally_confirmed',
+                'is_prosperity_fund_related',
+                'lead_officer_email_address',
+                'lead_officer_name',
+                'line_manager_name',
+                'name_of_customer',
+                'name_of_export',
+                'other_official_email_address',
+                'total_expected_export_value',
+                'total_expected_non_export_value',
+                'total_expected_odi_value',
+                created=F('created_on'),
+                business_potential_display=F('business_potential__name'),
+                confirmation_last_export=F('customer_response__last_export__name'),
+                confirmation_marketing_source=F(
+                    'customer_response__marketing_source__name',
+                ),
+                confirmation_portion_without_help=F(
+                    'customer_response__expected_portion_without_help__name',
+                ),
+                country_name=F('country__name'),
+                customer_location_display=F('customer_location__name'),
+                export_experience_display=F('export_experience__name'),
+                goods_vs_services_display=F('goods_vs_services__name'),
+                hq_team_display=F('hq_team__name'),
+                hvo_programme_display=F('hvo_programme__name'),
+                sector_display=F('sector__segment'),
+                team_type_display=F('team_type__name'),
+            )
+            .annotate(
+                company_name=F('company__name'),
+                confirmation__access_to_contacts=Cast(
+                    'customer_response__our_support__export_win_id', IntegerField(),
+                ),
+                confirmation__access_to_information=Cast(
+                    'customer_response__access_to_information__export_win_id',
+                    IntegerField(),
+                ),
+                confirmation__agree_with_win=F('customer_response__agree_with_win'),
+                confirmation__case_study_willing=F(
+                    'customer_response__case_study_willing',
+                ),
+                confirmation__comments=F('customer_response__comments'),
+                confirmation__company_was_at_risk_of_not_exporting=F(
+                    'customer_response__company_was_at_risk_of_not_exporting',
+                ),
+                confirmation__created=F('customer_response__created_on'),
+                confirmation__developed_relationships=Cast(
+                    'customer_response__developed_relationships__export_win_id',
+                    IntegerField(),
+                ),
+                confirmation__gained_confidence=Cast(
+                    'customer_response__gained_confidence__export_win_id',
+                    IntegerField(),
+                ),
+                confirmation__has_enabled_expansion_into_existing_market=F(
+                    'customer_response__has_enabled_expansion_into_existing_market',
+                ),
+                confirmation__has_enabled_expansion_into_new_market=F(
+                    'customer_response__has_enabled_expansion_into_new_market',
+                ),
+                confirmation__has_explicit_export_plans=F(
+                    'customer_response__has_explicit_export_plans',
+                ),
+                confirmation__has_increased_exports_as_percent_of_turnover=F(
+                    'customer_response__has_increased_exports_as_percent_of_turnover',
+                ),
+                confirmation__improved_profile=Cast(
+                    'customer_response__improved_profile__export_win_id', IntegerField(),
+                ),
+                confirmation__interventions_were_prerequisite=F(
+                    'customer_response__interventions_were_prerequisite',
+                ),
+                confirmation__involved_state_enterprise=F(
+                    'customer_response__involved_state_enterprise',
+                ),
+                confirmation__name=F('customer_response__name'),
+                confirmation__other_marketing_source=F(
+                    'customer_response__other_marketing_source',
+                ),
+                confirmation__our_support=Cast(
+                    'customer_response__our_support__export_win_id', IntegerField(),
+                ),
+                confirmation__overcame_problem=Cast(
+                    'customer_response__overcame_problem__export_win_id', IntegerField(),
+                ),
+                confirmation__support_improved_speed=F(
+                    'customer_response__support_improved_speed',
+                ),
+                country=F('country__iso_alpha2_code'),
+                hvc=F('hvc__export_win_id'),
+                user__email=F('adviser__email'),
+                user__name=Concat(
+                    'adviser__first_name',
+                    Value(' '),
+                    'adviser__last_name',
+                ),
+                associated_programmes=ArraySubquery(
+                    AssociatedProgramme.objects.filter(
+                        win=OuterRef('pk'),
+                    ).values('name'),
+                ),
+                types_of_support=ArraySubquery(
+                    SupportType.objects.filter(
+                        win=OuterRef('pk'),
+                    ).values('name'),
+                ),
+                # TODO 'customer_email_date': win.customer_email_date,
+                # MAPS TO Notification model in EW, we don't have this in DH
+                # TODO 'num_notifications': win.num_notifications,
+                # MAPS TO Notification model in EW, we don't have this in DH
+
+            )
+        )
+
+    def _enrich_data(self, dataset):
+        for data in dataset:
+            self._create_columns_with_index(data, 'associated_programmes', 'associated_programme')
+            self._create_columns_with_index(data, 'types_of_support', 'type_of_support')
+
+    def _create_columns_with_index(self, data, key, new_key):
+        if data.get(key) is not None:
+            for i, associated_programme in enumerate(data[key]):
+                data[f'{new_key}_{i+1}_display'] = associated_programme
+            del data[key]

--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -1,5 +1,5 @@
 from django.contrib.postgres.expressions import ArraySubquery
-from django.db.models import F, Count, Max
+from django.db.models import Count, F, Max
 from django.db.models import IntegerField, OuterRef, Value
 from django.db.models.functions import Cast, Concat
 

--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -213,18 +213,13 @@ class ExportWinsWinDatasetView(BaseDatasetView):
                 associated_programmes=ArraySubquery(
                     AssociatedProgramme.objects.filter(
                         win=OuterRef('pk'),
-                    ).values('name'),
+                    ).order_by('order').values('name'),
                 ),
                 types_of_support=ArraySubquery(
                     SupportType.objects.filter(
                         win=OuterRef('pk'),
-                    ).values('name'),
+                    ).order_by('order').values('name'),
                 ),
-                # TODO 'customer_email_date': win.customer_email_date,
-                # MAPS TO Notification model in EW, we don't have this in DH
-                # TODO 'num_notifications': win.num_notifications,
-                # MAPS TO Notification model in EW, we don't have this in DH
-
             )
         )
 

--- a/datahub/dataset/urls.py
+++ b/datahub/dataset/urls.py
@@ -20,6 +20,7 @@ from datahub.dataset.export_wins.views import (
     ExportWinsAdvisersDatasetView,
     ExportWinsBreakdownsDatasetView,
     ExportWinsHVCDatasetView,
+    ExportWinsWinDatasetView,
 )
 from datahub.dataset.interaction.views import InteractionsDatasetView
 from datahub.dataset.interaction_export_country.views import InteractionsExportCountryDatasetView
@@ -104,5 +105,10 @@ urlpatterns = [
         'export-wins-hvc-dataset',
         ExportWinsHVCDatasetView.as_view(),
         name='export-wins-hvc-dataset',
+    ),
+    path(
+        'export-wins-win-dataset',
+        ExportWinsWinDatasetView.as_view(),
+        name='export-wins-win-dataset',
     ),
 ]

--- a/datahub/export_win/test/factories.py
+++ b/datahub/export_win/test/factories.py
@@ -119,7 +119,8 @@ class HVOProgrammesFactory(factory.django.DjangoModelFactory):
 class AssociatedProgrammeFactory(factory.django.DjangoModelFactory):
     """AssociatedProgramme factory."""
 
-    name = factory.Sequence(lambda n: f'name {n}')
+    name = factory.Sequence(lambda n: f'Associated programme name {n}')
+    order = factory.Sequence(lambda n: n)
 
     class Meta:
         model = 'export_win.AssociatedProgramme'
@@ -128,7 +129,8 @@ class AssociatedProgrammeFactory(factory.django.DjangoModelFactory):
 class SupportTypeFactory(factory.django.DjangoModelFactory):
     """SupportType factory."""
 
-    name = factory.Sequence(lambda n: f'name {n}')
+    name = factory.Sequence(lambda n: f'support type name {n}')
+    order = factory.Sequence(lambda n: n)
 
     class Meta:
         model = 'export_win.SupportType'

--- a/datahub/export_win/test/factories.py
+++ b/datahub/export_win/test/factories.py
@@ -29,6 +29,7 @@ class RatingFactory(factory.django.DjangoModelFactory):
     """Rating factory."""
 
     name = factory.Sequence(lambda n: f'name {n}')
+    export_win_id = random.choice(range(0, 6, 1))
 
     class Meta:
         model = 'export_win.Rating'
@@ -109,6 +110,30 @@ class HQTeamRegionOrPostFactory(factory.django.DjangoModelFactory):
         model = 'export_win.HQTeamRegionOrPost'
 
 
+class HVOProgrammesFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = 'export_win.HVOProgrammes'
+
+
+class AssociatedProgrammeFactory(factory.django.DjangoModelFactory):
+    """AssociatedProgramme factory."""
+
+    name = factory.Sequence(lambda n: f'name {n}')
+
+    class Meta:
+        model = 'export_win.AssociatedProgramme'
+
+
+class SupportTypeFactory(factory.django.DjangoModelFactory):
+    """SupportType factory."""
+
+    name = factory.Sequence(lambda n: f'name {n}')
+
+    class Meta:
+        model = 'export_win.SupportType'
+
+
 class WinFactory(factory.django.DjangoModelFactory):
     """Win factory."""
 
@@ -137,6 +162,7 @@ class WinFactory(factory.django.DjangoModelFactory):
     name_of_customer_confidential = False
     business_potential_id = BusinessPotentialConstant.high_export_potential.value.id
     type_id = WinTypeConstant.both.value.id
+    hvo_programme = factory.SubFactory(HVOProgrammesFactory)
 
     @to_many_field
     def associated_programme(self):  # noqa: D102

--- a/datahub/export_win/test/factories.py
+++ b/datahub/export_win/test/factories.py
@@ -253,6 +253,7 @@ class BreakdownFactory(factory.django.DjangoModelFactory):
 class CustomerResponseTokenFactory(factory.django.DjangoModelFactory):
     """CustomerResponseToken factory."""
 
+    created_on = now()
     expires_on = factory.LazyFunction(lambda: datetime.utcnow() + relativedelta(days=7))
     customer_response = factory.SubFactory(CustomerResponseFactory)
     email_notification_id = factory.Faker('uuid4')  # Adjust based on your requirements

--- a/datahub/export_win/test/factories.py
+++ b/datahub/export_win/test/factories.py
@@ -162,7 +162,6 @@ class WinFactory(factory.django.DjangoModelFactory):
     name_of_customer_confidential = False
     business_potential_id = BusinessPotentialConstant.high_export_potential.value.id
     type_id = WinTypeConstant.both.value.id
-    hvo_programme = factory.SubFactory(HVOProgrammesFactory)
 
     @to_many_field
     def associated_programme(self):  # noqa: D102


### PR DESCRIPTION
### Description of change

Add an endpoint for returning the Export wins data inside datahub via a dataset to be consumed in data workspace

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
