### PR TITLE
[Refactor GVA 2/3] Update GVA multiplier and value calculation

### DIFF
--- a/datahub/activity_stream/investment/test/test_views.py
+++ b/datahub/activity_stream/investment/test/test_views.py
@@ -252,6 +252,7 @@ def test_investment_project_added_with_gva(api_client):
             foreign_equity_investment=10000,
             sector_id=constants.Sector.aerospace_assembly_aircraft.value.id,
             investment_type_id=constants.InvestmentType.fdi.value.id,
+            business_activities=[],
         )
         frozen_datetime.tick(datetime.timedelta(seconds=1, microseconds=1))
         response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
@@ -289,7 +290,7 @@ def test_investment_project_added_with_gva(api_client):
                         project.estimated_land_date,
                     ),
                     'dit:foreignEquityInvestment': 10000.0,
-                    'dit:grossValueAdded': 519835140.0,
+                    'dit:grossValueAdded': 2097.0,
                     'attributedTo': [
                         {
                             'id': f'dit:DataHubCompany:{project.investor_company.pk}',

--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -107,6 +107,10 @@ class Sector(Enum):
         'Aerospace : Manufacturing and assembly : Aircraft',
         'b422c9d2-5f95-e211-a939-e4115bead28a',
     )
+    consumer_and_retail = Constant(
+        'Consumer and retail',
+        '355f977b-8ac3-e211-a646-e4115bead28a',
+    )
     defence_air = Constant(
         'Defence : Air',
         '03dbd3fb-24e4-421e-bcc1-1dfcd63b2eeb',

--- a/datahub/investment/project/gva_utils.py
+++ b/datahub/investment/project/gva_utils.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
 from logging import getLogger
 
@@ -6,32 +5,31 @@ from django.utils.functional import cached_property
 
 from datahub.core.constants import (
     InvestmentBusinessActivity as InvestmentBusinessActivityConstant,
+)
+from datahub.core.constants import (
     InvestmentType as InvestmentTypeConstant,
+    Sector as SectorConstant,
 )
-from datahub.core.utils import get_financial_year
-from datahub.investment.project.constants import (
-    FDISICGrouping as FDI_SICGroupingConstant,
-)
-from datahub.investment.project.models import GVAMultiplier, InvestmentSector
+from datahub.investment.project.models import GVAMultiplier
 
 logger = getLogger(__name__)
 
 
 class GrossValueAddedCalculator:
-    """
-    Gross Value Added (GVA) Calculator.
+    """Gross Value Added (GVA) Calculator.
 
     This calculates the Gross Value Added for an investment project.
 
     A project must meet the following criteria to be able to generate its GVA:
 
     - Must be an FDI project
-    - Must have either a sector set or a business activity of retail
+    - Must have either a sector set or a business activity of retail or sales
     - Must have a value for foreign equity investment
+    - Must have a value for number of new jobs
 
     Using the sector/business activity a GVA multiplier for financial year associated with
-    the sector is retrieved. This multiplier is then multiplied by the
-    foreign equity investment amount.
+    the sector is retrieved. This multiplier is then multiplied by the foreign
+    equity investment amount or number of jobs depending on the sector classification.
     """
 
     def __init__(self, investment_project):
@@ -46,18 +44,42 @@ class GrossValueAddedCalculator:
     @cached_property
     def gross_value_added(self):
         """Calculates the Gross Value Added (GVA) for an investment project."""
-        if not self.investment_project.foreign_equity_investment or not self.gva_multiplier:
+        if self.gva_multiplier is None:
             return None
-        return Decimal(
-            self.gva_multiplier.multiplier * self.investment_project.foreign_equity_investment,
-        ).quantize(
-            Decimal('1.'),
-            rounding=ROUND_HALF_UP,
-        )
+        if (
+            self.gva_multiplier.sector_classification_gva_multiplier
+            == GVAMultiplier.SectorClassificationChoices.CAPITAL
+        ):
+            if self.investment_project.foreign_equity_investment is None:
+                return None
+            return Decimal(
+                self.gva_multiplier.multiplier
+                * self.investment_project.foreign_equity_investment,
+            ).quantize(
+                Decimal('1.'),
+                rounding=ROUND_HALF_UP,
+            )
+        if (
+            self.gva_multiplier.sector_classification_gva_multiplier
+            == GVAMultiplier.SectorClassificationChoices.LABOUR
+        ):
+            if self.investment_project.number_new_jobs is None:
+                return None
+            return Decimal(
+                self.gva_multiplier.multiplier
+                * self.investment_project.number_new_jobs,
+            ).quantize(
+                Decimal('1.'),
+                rounding=ROUND_HALF_UP,
+            )
+        return None
 
     def _get_gva_multiplier_for_investment_project(self):
         """:returns a GVA multiplier for an investment project."""
-        if str(self.investment_project.investment_type_id) != InvestmentTypeConstant.fdi.value.id:
+        if (
+            str(self.investment_project.investment_type_id)
+            != InvestmentTypeConstant.fdi.value.id
+        ):
             return None
 
         if self._has_business_activity_of_retail_or_sales():
@@ -69,8 +91,7 @@ class GrossValueAddedCalculator:
             return None
 
     def _has_business_activity_of_retail_or_sales(self):
-        """
-        :returns True or False. Checks if an investment project has either a
+        """:returns True or False. Checks if an investment project has either a
         business activity of retail or sales.
         """
         return self.investment_project.business_activities.filter(
@@ -82,94 +103,39 @@ class GrossValueAddedCalculator:
 
     def _get_retail_gva_multiplier(self):
         """:returns the GVA Multiplier for a retail investment project."""
-        return self._get_gva_multiplier(FDI_SICGroupingConstant.retail.value.id)
+        return self._get_gva_multiplier(SectorConstant.consumer_and_retail.value.id)
 
     def _get_sector_gva_multiplier(self):
-        """:returns the GVA Multiplier for the a sector if one found else returns None."""
-        fdi_sic_grouping = self._get_fdi_sic_grouping_for_sector()
-        if not fdi_sic_grouping:
-            return None
-        return self._get_gva_multiplier(fdi_sic_grouping.id)
+        """:returns the GVA Multiplier for a sector."""
+        return self._get_gva_multiplier(self.investment_project.sector.id)
 
-    def _get_fdi_sic_grouping_for_sector(self):
-        """:returns the FDI SIC Grouping for a DIT Sector if one found else returns None."""
-        root_sector = self.investment_project.sector.get_root()
-        investment_sector = self._get_investment_sector(root_sector)
-        if not investment_sector:
-            return None
-        return investment_sector.fdi_sic_grouping
+    def _get_gva_multiplier(self, sector_id):
+        """:returns a GVA Multiplier or None.
 
-    def _get_gva_multiplier(self, fdi_sic_grouping_id):
-        """
-        :returns a GVA Multiplier or None.
+        Retrieves all the GVA multipliers for a sector in descending order.
+        Returns the first instance (i.e. latest GVA multiplier) if there is one.
 
-        Firstly retrieves all the GVA Multipliers for a FDI SIC Grouping. Then checks
-        if there is a multiplier for the given financial year. If one is not found
-        then returns the GVA Multiplier for the last year there is an entry for.
-
-        GVA multipliers will be reviewed each year to ensure they continue to be accurate with
-        a changing economy. If the GVA values have not been updated, the latest year's information
-        should continue to be used as it represents the most accurate data available
-
-        If there are no entries returns None.
+        If there are no multipliers for a given sector, returns None.
 
         """
-        gva_multipliers_for_grouping = GVAMultiplier.objects.filter(
-            fdi_sic_grouping_id=fdi_sic_grouping_id,
+        gva_multipliers_for_sector = GVAMultiplier.objects.filter(
+            sector_id=sector_id,
         ).order_by(
             '-financial_year',
         )
-
-        financial_year = self._get_gva_multiplier_financial_year()
-        try:
-            return gva_multipliers_for_grouping.get(
-                financial_year=financial_year,
-            )
-        except GVAMultiplier.DoesNotExist:
-            if gva_multipliers_for_grouping.filter(
-                financial_year__gt=financial_year,
-            ).exists():
-                logger.exception(
-                    f'Unable to find a GVA Multiplier for financial year {financial_year} '
-                    f'fdi sic grouping id {fdi_sic_grouping_id}',
-                )
-            return gva_multipliers_for_grouping.first()
-
-    def _get_investment_sector(self, root_sector):
-        """:returns the investment sector for a root DIT sector if one found else returns None."""
-        try:
-            return root_sector.investmentsector
-        except InvestmentSector.DoesNotExist:
+        if gva_multipliers_for_sector.first() is None:
             logger.warning(
-                f'Unable to find InvestmentSector for DIT Sector {root_sector}',
+                f'Unable to find GVA multiplier for sector {sector_id}',
             )
-            return None
-
-    def _get_gva_multiplier_financial_year(self):
-        """
-        :returns the financial year that should be used for the investment project.
-
-        If the investment project does not have an actual land date return the current
-        financial year. If the actual land date is less than or equal to 2019 return 2019
-        this is because there is no multiplier data prior to the 2019 financial year.
-
-        Due to the multiplier data being for a financial year for all investment projects
-        with actual land date greater than 2019 return the financial year that the project landed.
-        """
-        if not self.investment_project.actual_land_date:
-            return get_financial_year(
-                datetime.today(),
-            )
-
-        return max(
-            get_financial_year(self.investment_project.actual_land_date),
-            2019,
-        )
+        return gva_multipliers_for_sector.first()
 
 
 def set_gross_value_added_for_investment_project(investment_project):
     """Sets the Gross Value Added data for investment project."""
     calculate_gross_value_added = GrossValueAddedCalculator(investment_project)
-    investment_project.gva_multiplier = calculate_gross_value_added.gva_multiplier
+    if calculate_gross_value_added.gva_multiplier is not None:
+        investment_project.gva_multiplier_id = calculate_gross_value_added.gva_multiplier.id
+    else:
+        investment_project.gva_multiplier = None
     investment_project.gross_value_added = calculate_gross_value_added.gross_value_added
     return investment_project

--- a/datahub/investment/project/test/management/commands/test_refresh_gross_value_added_values.py
+++ b/datahub/investment/project/test/management/commands/test_refresh_gross_value_added_values.py
@@ -45,7 +45,7 @@ class TestRefreshGrossValueAddedCommand:
                 '51983.514030000',
                 1000,
                 200,
-                '51983514',  # will be 10396703
+                '10396703',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
@@ -56,7 +56,7 @@ class TestRefreshGrossValueAddedCommand:
                 '51983.514030000',
                 1000,
                 200,
-                '51983514',  # will be 10396703
+                '10396703',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
@@ -65,7 +65,7 @@ class TestRefreshGrossValueAddedCommand:
                 '51983.514030000',
                 1000,
                 200,
-                '51983514',  # will be 10396703
+                '10396703',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
@@ -80,10 +80,10 @@ class TestRefreshGrossValueAddedCommand:
                 InvestmentTypeConstant.fdi.value.id,
                 SectorConstant.aerospace_assembly_aircraft.value.id,
                 [],
-                '0.206470876',  # will be 0.209650945
+                '0.209650945',
                 1000,
                 200,
-                '206',  # will be 210
+                '210',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
@@ -95,7 +95,7 @@ class TestRefreshGrossValueAddedCommand:
                 '51983.514030000',
                 1000,
                 200,
-                '51983514',  # will be 10396703
+                '10396703',
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
@@ -107,7 +107,7 @@ class TestRefreshGrossValueAddedCommand:
                 '51983.514030000',
                 None,
                 200,
-                None,  # will be 10396703
+                '10396703',
             ),
             (
                 InvestmentTypeConstant.commitment_to_invest.value.id,
@@ -137,10 +137,10 @@ class TestRefreshGrossValueAddedCommand:
         investment_type,
         sector,
         business_activities,
-        multiplier_value,
+        multiplier_value: str | None,
         foreign_equity_investment,
         number_new_jobs,
-        gross_value_added,
+        gross_value_added: str | None,
     ):
         """Test populating Gross value added data."""
         caplog.set_level(logging.INFO)

--- a/datahub/investment/project/test/test_admin.py
+++ b/datahub/investment/project/test/test_admin.py
@@ -301,8 +301,7 @@ class TestInvestmentProjectAdmin(AdminTestMixin):
         response = self.client.post(url, data, follow=True)
         assert response.status_code == 200
         investment_project = InvestmentProject.objects.get(pk=investment_project_pk)
-        assert investment_project.gross_value_added == Decimal('20647')  # will be 20965
+        assert investment_project.gross_value_added == Decimal('20965')
 
         # GVA Multiplier - Aircraft - 2022
-        # will be 0.209650945
-        assert investment_project.gva_multiplier.multiplier == Decimal('0.206470876')
+        assert investment_project.gva_multiplier.multiplier == Decimal('0.209650945')

--- a/datahub/investment/project/test/test_gva_utils.py
+++ b/datahub/investment/project/test/test_gva_utils.py
@@ -3,7 +3,6 @@ from decimal import Decimal
 from unittest import mock
 
 import pytest
-from freezegun import freeze_time
 
 from datahub.core.constants import (
     InvestmentBusinessActivity as InvestmentBusinessActivityConstant,
@@ -17,6 +16,7 @@ from datahub.investment.project.test.factories import (
     GVAMultiplierFactory,
     InvestmentProjectFactory,
 )
+from datahub.metadata.models import Sector
 from datahub.metadata.test.factories import SectorFactory
 
 
@@ -33,53 +33,75 @@ class TestGrossValueAddedCalculator:
     """Test for Gross Value Added Calculator."""
 
     @pytest.mark.parametrize(
-        'investment_type,sector,business_activities,expected_multiplier_value',
-        (
+        'investment_type,sector,business_activities',
+        [
+            # Non-FDI investment type
+            (
+                InvestmentTypeConstant.non_fdi.value.id,
+                SectorConstant.renewable_energy_wind.value.id,
+                [],
+            ),
+            # When sector is empty
             (
                 InvestmentTypeConstant.fdi.value.id,
                 None,
                 [],
-                None,
             ),
-            (
-                InvestmentTypeConstant.fdi.value.id,
-                None,
-                [
-                    InvestmentBusinessActivityConstant.retail.value.id,
-                ],
-                Decimal('51983.514030000'),
-            ),
-            (
-                InvestmentTypeConstant.fdi.value.id,
-                None,
-                [
-                    InvestmentBusinessActivityConstant.sales.value.id,
-                ],
-                Decimal('51983.514030000'),
-            ),
-            (
-                InvestmentTypeConstant.fdi.value.id,
-                SectorConstant.renewable_energy_wind.value.id,
-                [
-                    InvestmentBusinessActivityConstant.retail.value.id,
-                    InvestmentBusinessActivityConstant.sales.value.id,
-                    InvestmentBusinessActivityConstant.other.value.id,
+        ],
+    )
+    def test_get_gva_multiplier_returns_none_when_expected(
+        self,
+        investment_type,
+        sector,
+        business_activities,
+    ):
+        """Test _get_gva_multiplier_for_investment_project returns none when:
+        a) investment type is non-FDI,
+        b) investment project sector is empty.
+        """
+        project = InvestmentProjectFactory(
+            sector_id=sector,
+            business_activities=business_activities,
+            investment_type_id=investment_type,
+        )
+        assert project.gva_multiplier is None
 
+    @pytest.mark.parametrize(
+        'investment_type,sector,business_activities,expected_multiplier_value',
+        [
+            #  FDI investment project with retail business activity
+            (
+                InvestmentTypeConstant.fdi.value.id,
+                None,
+                [
+                    InvestmentBusinessActivityConstant.retail.value.id,
                 ],
                 Decimal('51983.514030000'),
             ),
+            #  FDI investment project with sales business activity
+            (
+                InvestmentTypeConstant.fdi.value.id,
+                None,
+                [
+                    InvestmentBusinessActivityConstant.sales.value.id,
+                ],
+                Decimal('51983.514030000'),
+            ),
+            #  FDI investment project with sector and no business activities
             (
                 InvestmentTypeConstant.fdi.value.id,
                 SectorConstant.renewable_energy_wind.value.id,
                 [],
                 Decimal('0.093757195'),
             ),
+            #  FDI investment project with sector and no business activities
             (
                 InvestmentTypeConstant.fdi.value.id,
                 SectorConstant.aerospace_assembly_aircraft.value.id,
                 [],
-                Decimal('0.206470876'),  # will be 0.209650945
+                Decimal('0.209650945'),
             ),
+            #  FDI investment project with sector and retail business activities
             (
                 InvestmentTypeConstant.fdi.value.id,
                 SectorConstant.renewable_energy_wind.value.id,
@@ -89,174 +111,300 @@ class TestGrossValueAddedCalculator:
                 ],
                 Decimal('51983.514030000'),
             ),
-            (
-                InvestmentTypeConstant.commitment_to_invest.value.id,
-                SectorConstant.renewable_energy_wind.value.id,
-                [],
-                None,
-            ),
-            (
-                InvestmentTypeConstant.non_fdi.value.id,
-                None,
-                [
-                    InvestmentBusinessActivityConstant.retail.value.id,
-                ],
-                None,
-            ),
-        ),
+        ],
     )
-    def test_set_gva_multiplier(
+    def test_get_gva_multiplier_returns_value_when_expected(
         self,
         investment_type,
         sector,
         business_activities,
-        expected_multiplier_value,
+        expected_multiplier_value: Decimal,
     ):
-        """Test the GVA Multiplier correctly gets set on an investment project."""
+        """Test _get_gva_multiplier_for_investment_project returns value when:
+        a) investment type is FDI,
+        b) business activities are retail or sales,
+        c) investment project has a sector.
+        """
         project = InvestmentProjectFactory(
             sector_id=sector,
             business_activities=business_activities,
             investment_type_id=investment_type,
         )
-        if not expected_multiplier_value:
-            assert not project.gva_multiplier
-        else:
-            assert project.gva_multiplier.multiplier == Decimal(expected_multiplier_value)
+        assert project.gva_multiplier.multiplier == expected_multiplier_value
 
-    def test_no_investment_sector_linking_sector_to_fdi_sic_grouping_returns_none(self):
+    def test_multiple_gva_multipliers_for_sector_returns_most_recent_multiplier(self):
         """
-        Tests that when there is no link between a dit sector and an
-        fdi sic grouping None is returned.
+        Test when multiple GVA multipliers are present for a sector, it returns the
+        most recent multiplier.
         """
-        new_sector = SectorFactory(parent=None)
-        project = InvestmentProjectFactory(
-            sector_id=new_sector.id,
-            investment_type_id=InvestmentTypeConstant.fdi.value.id,
-            business_activities=[],
-        )
-        assert project.gva_multiplier is None
-
-    @freeze_time('2050-01-01 01:01:01')
-    def test_no_gva_multiplier_for_financial_year_returns_latest_year(self):
-        """
-        Test when a GVA Multiplier is not present for the financial year 2050.
-        """
+        sector_id = SectorConstant.renewable_energy_wind.value.id
+        fdi_sic_grouping_id = FDISICGroupingConstant.electric.value.id
         GVAMultiplierFactory(
-            multiplier=Decimal('0.5'),
+            financial_year=2030,
+            sector_id=sector_id,
+            fdi_sic_grouping_id=fdi_sic_grouping_id,
+        )
+        GVAMultiplierFactory(
             financial_year=2040,
-            fdi_sic_grouping_id=FDISICGroupingConstant.electric.value.id,
+            sector_id=sector_id,
+            fdi_sic_grouping_id=fdi_sic_grouping_id,
         )
         project = InvestmentProjectFactory(
-            sector_id=SectorConstant.renewable_energy_wind.value.id,
+            sector_id=sector_id,
             business_activities=[],
             investment_type_id=InvestmentTypeConstant.fdi.value.id,
-            foreign_equity_investment=1000,
+            foreign_equity_investment=DEFAULT_FOREIGN_EQUITY_INVESTMENT,
         )
         assert project.gva_multiplier.financial_year == 2040
 
-    def test_no_gva_multiplier_for_financial_year_logs_if_later_multiplier_available(
-        self,
-        caplog,
-    ):
+    def test_no_gva_multiplier_found_for_sector_returns_none(self, caplog):
         """
-        Test when a GVA Multiplier is not present for the financial year 2050 but one is
-        present for 2052. Checks a log is added to the exception log to flag
-        that data is missing for that year.
+        Test when a GVA Multiplier is not present for the given sector.
+        Checks an exception is added to the log to flag that data is missing.
         """
         caplog.set_level('WARNING')
-
-        GVAMultiplierFactory(
-            multiplier=Decimal('0.5'),
-            financial_year=2052,
-            fdi_sic_grouping_id=FDISICGroupingConstant.electric.value.id,
-        )
-        GVAMultiplierFactory(
-            multiplier=Decimal('0.5'),
-            financial_year=2049,
-            fdi_sic_grouping_id=FDISICGroupingConstant.electric.value.id,
-        )
-
+        sector = SectorFactory()
         project = InvestmentProjectFactory(
-            sector_id=SectorConstant.renewable_energy_wind.value.id,
+            sector_id=sector.id,
             business_activities=[],
             investment_type_id=InvestmentTypeConstant.fdi.value.id,
-            foreign_equity_investment=1000,
+            foreign_equity_investment=DEFAULT_FOREIGN_EQUITY_INVESTMENT,
             actual_land_date=date(2050, 5, 1),
+
         )
-        assert project.gva_multiplier.financial_year == 2052
+        assert project.gva_multiplier is None
         assert caplog.messages[0] == (
-            'Unable to find a GVA Multiplier for financial year 2050'
-            f' fdi sic grouping id {FDISICGroupingConstant.electric.value.id}'
+            f'Unable to find GVA multiplier for sector {sector.id}'
         )
 
+    def test_no_investment_project_sector_returns_none(self):
+        """
+        Tests when an investment project has no sector that the GVA multiplier returned is none.
+        """
+        project = InvestmentProjectFactory(
+            business_activities=[],
+            investment_type_id=InvestmentTypeConstant.fdi.value.id,
+            sector_id=None,
+        )
+        assert project.gva_multiplier is None
+
     @pytest.mark.parametrize(
-        'foreign_equity_investment,multiplier_value,expected_gross_value_added',
-        (
-            (1, 1, '1'),
-            (None, 1, None),
-            (100000, 0.0581, '5810'),
-            (130000000, 0.4537, '58981000'),
-            (10000000, 0.0621, '621000'),
-            (111000, 0.0621, '6893'),
-            (9999999999999999999, 0.9999, '9999000000000000000'),
-            (9999999999999999999, 9.999999, '99999990000000008192'),
-            (296000, 0.0581, '17198'),
-            (7002180, 0.0386, '270284'),
-            (287732, 0.3939, '113338'),
-            (1800000, 0.0264, '47520'),
-            (28000, 0.021, '588'),
-            (8907560, 0.9526, '8485342'),
-            (16717, 0.0853, '1426'),
-            (1166000, 0.042700, '49788'),
-            (15, 0.5, '8'),
-            (17, 0.5, '9'),
-        ),
+        'sector_classification, foreign_equity_investment, number_new_jobs',
+        [
+            (
+                CAPITAL,
+                None,  # No foreign equity investment
+                DEFAULT_NUMBER_NEW_JOBS,
+            ),
+            (
+                CAPITAL,
+                None,  # No foreign equity investment
+                None,  # No number of new jobs
+            ),
+            (
+                LABOUR,
+                DEFAULT_FOREIGN_EQUITY_INVESTMENT,
+                None,  # No number of new jobs
+            ),
+            (
+                LABOUR,
+                None,  # No foreign equity investment
+                None,  # No number of new jobs
+            ),
+        ],
     )
-    def test_calculate_gva(
+    def test_gva_calculation_based_on_sector_classification_when_expected_gva_is_none(
         self,
+        sector_classification,
         foreign_equity_investment,
-        multiplier_value,
-        expected_gross_value_added,
+        number_new_jobs,
     ):
-        """Test calculate GVA."""
-        gva_multiplier = GVAMultiplierFactory(
-            multiplier=multiplier_value,
-            financial_year=1980,
+        """
+        Tests that GVA value is set to None when:
+        a) sector is capital intensive, there is no foreign equity investment value,
+        and there is a value for number of new jobs;
+        b) sector is capital intensive, there is no foreign equity investment value,
+        and there is no value for number of new jobs;
+        c) sector is labour intensive, there is a foreign equity investment value,
+        and there is no value for number of new jobs;
+        d) sector is labour intensive, there is no foreign equity investment value,
+        and there is no value for number of new jobs;
+        """
+        sector = SectorFactory()
+        GVAMultiplierFactory(
+            multiplier=DEFAULT_MULTIPLIER,
+            sector_id=sector.id,
+            sector_classification_gva_multiplier=sector_classification,
         )
-
-        with mock.patch(
-            'datahub.investment.project.gva_utils.GrossValueAddedCalculator._get_gva_multiplier',
-        ) as mock_get_multiplier:
-            mock_get_multiplier.return_value = gva_multiplier
-            project = InvestmentProjectFactory(
-                foreign_equity_investment=foreign_equity_investment,
-                investment_type_id=InvestmentTypeConstant.fdi.value.id,
-                sector_id=SectorConstant.renewable_energy_wind.value.id,
-            )
-
-        if not expected_gross_value_added:
-            assert not project.gross_value_added
-        else:
-            assert project.gross_value_added == Decimal(expected_gross_value_added)
+        project = InvestmentProjectFactory(
+            business_activities=[],
+            foreign_equity_investment=foreign_equity_investment,
+            investment_type_id=InvestmentTypeConstant.fdi.value.id,
+            number_new_jobs=number_new_jobs,
+            sector_id=sector.id,
+        )
+        assert project.gross_value_added is None
 
     @pytest.mark.parametrize(
-        'actual_land_date,expected_financial_year',
-        (
-            (None, 2029),
-            (date(1980, 1, 1), 2019),
-            (date(2018, 1, 1), 2019),
-            (date(2019, 3, 1), 2019),
-            (date(2019, 8, 1), 2019),
-            (date(2025, 3, 1), 2024),
-            (date(2025, 4, 1), 2025),
-            (date(2025, 3, 31), 2024),
-            (date(2035, 1, 1), 2034),
-            (date(2035, 4, 1), 2035),
-        ),
+        'sector_classification, foreign_equity_investment, number_new_jobs, expected_gva_value',
+        [
+            (
+                CAPITAL,
+                DEFAULT_FOREIGN_EQUITY_INVESTMENT,
+                None,  # No number of new jobs
+                Decimal(DEFAULT_MULTIPLIER * DEFAULT_FOREIGN_EQUITY_INVESTMENT),
+            ),
+            (
+                LABOUR,
+                None,  # No foreign equity investment
+                DEFAULT_NUMBER_NEW_JOBS,
+                Decimal(DEFAULT_MULTIPLIER * DEFAULT_NUMBER_NEW_JOBS),
+            ),
+        ],
     )
-    @freeze_time('2030-01-01 01:00:00')
-    def test_get_gva_multiplier_financial_year(self, actual_land_date, expected_financial_year):
-        """Test for getting the financial that should be used for a given investment project."""
-        investment_project = InvestmentProjectFactory(actual_land_date=actual_land_date)
-        gva = GrossValueAddedCalculator(investment_project=investment_project)
-        assert gva._get_gva_multiplier_financial_year() == expected_financial_year
+    def test_gva_calculation_based_on_sector_classification_when_expected_gva_is_not_none(
+        self,
+        sector_classification,
+        foreign_equity_investment,
+        number_new_jobs,
+        expected_gva_value: Decimal,
+    ):
+        """
+        Tests that the correct gva value is set when:
+        a) Sector classification is capital, there is foreign equity investment,
+        and there is no value for number of new jobs
+        b) Sector classification is labour, there is no foreign equity investment,
+        value and there is a value for number of new jobs
+        """
+        sector = SectorFactory()
+        GVAMultiplierFactory(
+            multiplier=DEFAULT_MULTIPLIER,
+            sector_id=sector.id,
+            sector_classification_gva_multiplier=sector_classification,
+        )
+        project = InvestmentProjectFactory(
+            business_activities=[],
+            foreign_equity_investment=foreign_equity_investment,
+            investment_type_id=InvestmentTypeConstant.fdi.value.id,
+            number_new_jobs=number_new_jobs,
+            sector_id=sector.id,
+        )
+        assert project.gross_value_added == expected_gva_value
+
+    def test_no_gva_multiplier_returns_none(self):
+        """
+        Tests if a project's GVA multiplier is none, that it returns a GVA value of none.
+        """
+        project = InvestmentProjectFactory()
+        project.gva_multiplier = None
+        assert project.gross_value_added is None
+
+    @pytest.mark.parametrize(
+        'sector_classification, multiplier_value, foreign_equity_investment, number_new_jobs',
+        [
+            (CAPITAL, Decimal('0.5'), None, 200),  # Capital intensive, no FEI
+            (LABOUR, Decimal('0.5'), 1200, None),  # Labour intensive, no jobs
+            (CAPITAL, None, 100000, 50),  # Capital intensive, no GVA multiplier
+            (LABOUR, None, 130000000, 1000),  # Labour intensive, no GVA multiplier
+            ('another', Decimal('0.5'), 1200, 200),  # Neither labour or capital intensive
+        ],
+    )
+    def test_calculate_gva_when_expected_gva_value_is_none(
+        self,
+        sector_classification,
+        multiplier_value: Decimal | None,
+        foreign_equity_investment,
+        number_new_jobs,
+    ):
+        """
+        Test various scenarios for correct GVA calculation when gva value is expected to be none
+        """
+        sector = SectorFactory()
+        if multiplier_value is None:
+            # avoids violating GVAMultiplier's not-null constraint
+            gva_multiplier = None
+        else:
+            gva_multiplier = GVAMultiplierFactory(
+                multiplier=multiplier_value,
+                sector_id=sector.id,
+                sector_classification_gva_multiplier=sector_classification,
+            )
+        project = InvestmentProjectFactory(
+            business_activities=[],
+            foreign_equity_investment=foreign_equity_investment,
+            investment_type_id=InvestmentTypeConstant.fdi.value.id,
+            number_new_jobs=number_new_jobs,
+            sector_id=sector.id,
+        )
+        with mock.patch(
+            'datahub.investment.project.gva_utils.GrossValueAddedCalculator._get_gva_multiplier_for_investment_project',  # noqa
+            return_value=gva_multiplier,
+        ):
+            calculated_gva_value = GrossValueAddedCalculator(project).gross_value_added
+            assert calculated_gva_value is None
+
+    @pytest.mark.parametrize(
+        'sector_classification, multiplier_value, foreign_equity_investment, number_new_jobs, expected_gva_value',  # noqa
+        [
+            (CAPITAL, Decimal('0.5'), 1200, 200, 600),  # Capital intensive
+            (LABOUR, Decimal('0.5'), 1200, 200, 100),   # Labour intensive
+            # Capital intensive, large investment
+            (CAPITAL, Decimal('0.07'), 5000000, 100, 350000),
+            # Labour intensive, moderate number of jobs
+            (LABOUR, Decimal('0.15'), 2000000, 500, 75),
+            (CAPITAL, Decimal('0.1'), 0, 100, 0),  # Capital intensive, zero investment
+            (LABOUR, Decimal('0.05'), 1000000, 0, 0),  # Labour intensive, zero jobs
+            # Capital intensive, very large investment
+            (CAPITAL, Decimal('1.0'), 999999999999991, 1000, 999999999999991),
+            # Labour intensive, minimal jobs; expected value is 0 due to rounding
+            (LABOUR, Decimal('0.25'), 150000, 1, 0),
+        ],
+    )
+    def test_calculate_gva_when_expected_gva_value_is_not_none(
+        self,
+        sector_classification,
+        multiplier_value,
+        foreign_equity_investment,
+        number_new_jobs,
+        expected_gva_value: Decimal | None,
+    ):
+        """
+        Test various scenarios for correct calculation when GVA value is expected not to be none.
+        """
+        sector = SectorFactory()
+        if multiplier_value is None:
+            # avoids violating GVAMultiplier's not-null constraint
+            gva_multiplier = None
+        else:
+            gva_multiplier = GVAMultiplierFactory(
+                multiplier=multiplier_value,
+                sector_id=sector.id,
+                sector_classification_gva_multiplier=sector_classification,
+            )
+        project = InvestmentProjectFactory(
+            business_activities=[],
+            foreign_equity_investment=foreign_equity_investment,
+            investment_type_id=InvestmentTypeConstant.fdi.value.id,
+            number_new_jobs=number_new_jobs,
+            sector_id=sector.id,
+        )
+        with mock.patch(
+            'datahub.investment.project.gva_utils.GrossValueAddedCalculator._get_gva_multiplier_for_investment_project',  # noqa
+            return_value=gva_multiplier,
+        ):
+            calculated_gva_value = GrossValueAddedCalculator(project).gross_value_added
+            assert calculated_gva_value == expected_gva_value
+
+    def test_presence_of_gva_multipliers_for_each_sector(self):
+        """
+        Tests that all sectors have an associated GVA multiplier.
+        """
+        sector_ids = [
+            sector.id for sector
+            in Sector.objects.all()
+            if not sector.disabled_on
+        ]
+        gva_multiplier_sector_ids = [
+            gva_multiplier.sector_id for gva_multiplier in GVAMultiplier.objects.all()
+        ]
+        assert set(sector_ids) == set(gva_multiplier_sector_ids)

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -543,7 +543,7 @@ class TestCreateView(APITestMixin):
         # GVA Multiplier for Consumer and retail - 2022
         # As sector is labour intensive value = multuplier * number of jobs
         assert response_data['number_new_jobs'] == request_data['number_new_jobs']
-        assert response_data['gross_value_added'] == '51983514'  # will be 10396703
+        assert response_data['gross_value_added'] == '10396703'
 
         assert response_data['country_investment_originates_from']['id'] == str(
             investor_company.address_country.id,
@@ -1148,15 +1148,15 @@ class TestPartialUpdateView(APITestMixin):
     @pytest.mark.parametrize(
         'foreign_equity_investment,expected_gross_value_added,expected_multiplier_value',
         (
-            (20000, '4129', '0.206470876'),  # will be 4193, 0.209650945
-            (None, None, '0.206470876'),  # will be 0.209650945
+            (20000, '4193', '0.209650945'),
+            (None, None, '0.209650945'),
         ),
     )
     def test_change_foreign_equity_investment_updates_gross_value_added(
         self,
         foreign_equity_investment,
-        expected_gross_value_added,
-        expected_multiplier_value,
+        expected_gross_value_added: str | None,
+        expected_multiplier_value: str | None,
     ):
         """Test that updating the foreign equity investment updated gross value added."""
         project = InvestmentProjectFactory(
@@ -1167,7 +1167,7 @@ class TestPartialUpdateView(APITestMixin):
             business_activities=[],
         )
         # GVA Multiplier - Aircraft - 2022 - 0.209650945
-        assert project.gross_value_added == 2065  # will be 2097
+        assert project.gross_value_added == 2097
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
         request_data = {
@@ -1193,10 +1193,10 @@ class TestPartialUpdateView(APITestMixin):
         'business_activity,expected_gross_value_added',
         (
             # GVA Multiplier for Consumer and retail - 2022 - 51983.51403
-            (constants.InvestmentBusinessActivity.retail.value.id, '51983514'),  # will be 1039670
-            (constants.InvestmentBusinessActivity.sales.value.id, '51983514'),  # will be 1039670
+            (constants.InvestmentBusinessActivity.retail.value.id, '1039670'),
+            (constants.InvestmentBusinessActivity.sales.value.id, '1039670'),
             # No change - GVA Multiplier for Aircraft - 2022 - 0.209650945
-            (constants.InvestmentBusinessActivity.other.value.id, '206'),  # will be 210
+            (constants.InvestmentBusinessActivity.other.value.id, '210'),
         ),
     )
     def test_change_business_activity_to_retail_updated_gross_value_added(
@@ -1214,7 +1214,7 @@ class TestPartialUpdateView(APITestMixin):
             number_new_jobs=20,
         )
         # GVA Multiplier - Aircraft - 2022 - 0.209650945
-        assert project.gross_value_added == 206  # will be 210
+        assert project.gross_value_added == 210
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
         request_data = {

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -219,7 +219,7 @@ class TestSearch(APITestMixin):
                 {
                     'gross_value_added_end': 99999999999999,
                 },
-                ['20647'],
+                ['20965'],
                 ['abc defg'],
             ),
             (
@@ -227,7 +227,7 @@ class TestSearch(APITestMixin):
                     'gross_value_added_start': 20000,
                     'gross_value_added_end': 21000,
                 },
-                ['20647'],
+                ['20965'],
                 ['abc defg'],
             ),
             (


### PR DESCRIPTION
### Description of change

This PR is **2 of 3** that refactors how gross value added (GVA) is calculated for investment projects to conform with the new specification.

- [PR 1/3](https://github.com/uktrade/data-hub-api/pull/5275)
- [PR 3/3](https://github.com/uktrade/data-hub-api/pull/5277)

### Functionality Changes

In this PR, the majority of the changes have been made to functionality within `gva_utils.py` which controls how GVA multipliers are linked to investment projects, and how a project's GVA value is calculated.

### Tests

The remaining changes are to the rest of the tests, which now use the latest multipliers, values, and business logic (which is outlined in the excerpt in [PR 1/3](https://github.com/uktrade/data-hub-api/pull/5275)).

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
