### PR TITLE
Replace lead officer email with contact email for notifications.

### DIFF
--- a/datahub/export_win/serializers.py
+++ b/datahub/export_win/serializers.py
@@ -372,7 +372,7 @@ class PublicCustomerResponseSerializer(ModelSerializer):
             context = get_all_fields_for_lead_officer_email_receipt_no(instance)
 
         notify_export_win_email_by_rq_email(
-            instance.win.lead_officer.email,
+            instance.win.lead_officer.contact_email,
             template_id,
             context,
             update_customer_response_for_lead_officer_notification_id,

--- a/datahub/export_win/tasks.py
+++ b/datahub/export_win/tasks.py
@@ -121,7 +121,7 @@ def get_all_fields_for_lead_officer_email_receipt_no(customer_response):
     win = customer_response.win
     contact = win.company_contacts.first()
     details = {
-        'lead_officer_email': win.lead_officer.email,
+        'lead_officer_email': win.lead_officer.contact_email,
         'country_destination': win.country.name,
         'client_fullname': contact.name,
         'lead_officer_first_name': win.lead_officer.first_name,
@@ -139,7 +139,7 @@ def get_all_fields_for_lead_officer_email_receipt_yes(customer_response):
     total_export_win_value = Breakdown.objects.filter(win=win).aggregate(
         Sum('value'))['value__sum'] or 0
     details = {
-        'lead_officer_email': win.lead_officer.email,
+        'lead_officer_email': win.lead_officer.contact_email,
         'country_destination': win.country.name,
         'client_fullname': contact.name,
         'lead_officer_first_name': win.lead_officer.first_name,

--- a/datahub/export_win/test/test_tasks.py
+++ b/datahub/export_win/test/test_tasks.py
@@ -595,7 +595,7 @@ def test_get_all_fields_for_lead_officer_email_receipt_no_success():
     """
     Testing to get all fields for lead officer rejected email receipt
     """
-    assert result['lead_officer_email'] == win.lead_officer.email
+    assert result['lead_officer_email'] == win.lead_officer.contact_email
     assert result['country_destination'] == win.country.name
     assert result['client_fullname'] == contact.name
     assert result['lead_officer_first_name'] == win.lead_officer.first_name
@@ -624,7 +624,7 @@ def test_get_all_fields_for_lead_officer_email_receipt_yes_success():
     """
     Testing to get all fields for lead officer approved email receipt (with total_export_win_value)
     """
-    assert result['lead_officer_email'] == win.lead_officer.email
+    assert result['lead_officer_email'] == win.lead_officer.contact_email
     assert result['country_destination'] == win.country.name
     assert result['client_fullname'] == contact.name
     assert result['lead_officer_first_name'] == win.lead_officer.first_name


### PR DESCRIPTION
### Description of change

This gets Export win notifications to be sent to lead officer's contact email, rather than email. 

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
