### PR TITLE
feature/RR-1334-exclude-legacy-hvc

### DIFF
--- a/datahub/dataset/export_wins/test/test_views.py
+++ b/datahub/dataset/export_wins/test/test_views.py
@@ -126,8 +126,8 @@ class TestExportWinsHVCDatasetView(BaseDatasetViewTest):
         hvc.save()
 
         legacy_hvc = HVC.objects.filter(legacy_id=1).first()
-
-        response = data_flow_api_client.get(f'{self.view_url}?exclude_legacy=false&page_size=10000').json()
+        url = f'{self.view_url}?exclude_legacy=false&page_size=10000'
+        response = data_flow_api_client.get(url).json()
 
         legacy_ids = [result['id'] for result in response['results']]
 


### PR DESCRIPTION
### Description of change

Add the ability to exclude the existing HVC items from the datahub dataset response. This is needed to avoid duplication in the data flow pipelines as the export wins API also returns these values.

Calling this url will `/v4/dataset/export-wins-hvc-dataset?exclude_legacy=true` only return HVC items added directly into datahub, and exclude the items added from EW

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
