### PR TITLE
feature/rr 1353 update soft delete undelete status to history

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -121,6 +121,7 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
 
     form = WinAdminForm
     actions = ('soft_delete',)
+    list_per_page = 10
     list_display = (
         'id',
         'get_adviser',

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -252,7 +252,7 @@ class DeletedWinAdmin(WinAdmin):
                 win.is_deleted = False
                 win.modified_by = request.user
                 win.save()
-                reversion.set_comment('Undelete')
+                reversion.set_comment('Undeleted')
 
     def has_add_permission(self, request, obj=None):
         return False

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -74,7 +74,7 @@ def test_undelete():
     for win in queryset:
         versions = Version.objects.get_for_object(win)
         assert len(versions) == 1
-        assert versions[0].revision.comment == 'Undelete'
+        assert versions[0].revision.comment == 'Undeleted'
 
 
 @pytest.mark.django_db

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -1,6 +1,8 @@
 import pytest
 from django.contrib.admin.sites import site as admin_site
 from django.test import RequestFactory
+from reversion.models import Version
+
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.export_win.admin import (
@@ -45,6 +47,11 @@ def test_soft_delete():
     win2.refresh_from_db()
     assert win1.is_deleted is True
     assert win2.is_deleted is True
+
+    for win in queryset:
+        versions = Version.objects.get_for_object(win)
+        assert len(versions) == 1
+        assert versions[0].revision.comment == 'Soft deleted'
 
 
 @pytest.mark.django_db

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -64,11 +64,17 @@ def test_undelete():
     request = request_factory.get('/')
     request.user = user
     admin = DeletedWinAdmin(model=DeletedWin, admin_site=None)
-    admin.undelete(request, queryset=DeletedWin.objects.soft_deleted())
+    queryset = DeletedWin.objects.soft_deleted()
+    admin.undelete(request, queryset)
     deleted_win1.refresh_from_db()
     deleted_win2.refresh_from_db()
     assert deleted_win1.is_deleted is False
     assert deleted_win2.is_deleted is False
+
+    for win in queryset:
+        versions = Version.objects.get_for_object(win)
+        assert len(versions) == 1
+        assert versions[0].revision.comment == 'Undelete'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description of change

This is a small PR about recording soft delete and delete status activity to history and changing current default pagination for win record within the django admin to 10


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
