### PR TITLE
Output financial year for Win breakdown dataset.

### DIFF
--- a/datahub/dataset/export_wins/test/test_views.py
+++ b/datahub/dataset/export_wins/test/test_views.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 
 import pytest
+from dateutil.relativedelta import relativedelta
 
 from django.urls import reverse
 
@@ -9,6 +10,7 @@ from freezegun import freeze_time
 from datahub.core.test_utils import (
     format_date_or_datetime,
 )
+from datahub.core.utils import get_financial_year
 from datahub.dataset.core.test import BaseDatasetViewTest
 from datahub.export_win.constants import EXPORT_WINS_LEGACY_ID_START_VALUE
 from datahub.export_win.models import HVC
@@ -71,11 +73,14 @@ class TestExportWinsBreakdownDatasetView(BaseDatasetViewTest):
     factory = BreakdownFactory
 
     def _assert_breakdown_matches_result(self, breakdown, result):
+        financial_year = get_financial_year(
+            breakdown.win.created_on + relativedelta(years=breakdown.year - 1),
+        )
         assert result == {
             'created_on': format_date_or_datetime(breakdown.created_on),
             'id': breakdown.legacy_id,
             'win__id': str(breakdown.win.id),
-            'year': breakdown.year,
+            'year': financial_year,
             'value': breakdown.value,
             'breakdown_type': breakdown.type.name,
         }

--- a/datahub/export_win/test/factories.py
+++ b/datahub/export_win/test/factories.py
@@ -239,7 +239,8 @@ class BreakdownFactory(factory.django.DjangoModelFactory):
     """Breakdown factory."""
 
     win = factory.SubFactory(WinFactory)
-    year = factory.fuzzy.FuzzyInteger(2022, 2050, 1)
+    # currently we store relative year to Win created date
+    year = factory.fuzzy.FuzzyInteger(1, 5, 1)
     value = factory.fuzzy.FuzzyInteger(1000, 100000, 10)
 
     class Meta:


### PR DESCRIPTION
### Description of change

This replaces relative year in Breakdowns with actual financial year based on related Win created date.

Pseudo code:
Financial Year = get_financial_year(win.created_on) + (breakdown.year - 1)

Financial year is assumed from 1 April to 31 March.

Example:
If Win was created on 02/2024 and breakdown year is 1, then financial year is 2023
If Win was created on 04/2024 and breakdown year is 1, then financial year is 2024
If Win was created on 02/2024 and breakdown year is 2, then financial year is 2024



### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
