### PR TITLE
Feature/RR-1353 Add version comment when win record created and updated

### DIFF
--- a/datahub/export_win/serializers.py
+++ b/datahub/export_win/serializers.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import reversion
 from django.conf import settings
 from django.db import transaction
 
@@ -230,7 +231,7 @@ class WinSerializer(ModelSerializer):
         type_of_support = validated_data.pop('type_of_support')
         associated_programme = validated_data.pop('associated_programme')
         team_members = validated_data.pop('team_members', [])
-        with transaction.atomic():
+        with transaction.atomic(), reversion.create_revision():
             win = Win.objects.create(**validated_data)
 
             for breakdown in breakdowns:
@@ -264,7 +265,7 @@ class WinSerializer(ModelSerializer):
                     update_customer_response_token_for_email_notification_id,
                     token.id,
                 )
-
+            reversion.set_comment('Win created')
         return win
 
     def update(self, instance, validated_data):
@@ -275,7 +276,7 @@ class WinSerializer(ModelSerializer):
         type_of_support = validated_data.pop('type_of_support', None)
         associated_programme = validated_data.pop('associated_programme', None)
         team_members = validated_data.pop('team_members', None)
-        with transaction.atomic():
+        with transaction.atomic(), reversion.create_revision():
             for attr, value in validated_data.items():
                 setattr(instance, attr, value)
             instance.save()
@@ -298,6 +299,7 @@ class WinSerializer(ModelSerializer):
                 instance.associated_programme.set(associated_programme)
             if team_members is not None:
                 instance.team_members.set(team_members)
+            reversion.set_comment('Win updated')
         return instance
 
 

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -790,6 +790,11 @@ class TestCreateWinView(APITestMixin):
             'last_sent': format_date_or_datetime(first_sent),
             'company_export': None,
         }
+        # check version created
+        assert Version.objects.get_for_object(win).count() == 1
+        version = Version.objects.get_for_object(win).first()
+        assert version.revision.user == self.user
+        assert version.revision.comment == 'Win created'
 
         assert response_data == expected_response_data
         assert CustomerResponseToken.objects.filter(
@@ -1088,6 +1093,7 @@ class TestCreateWinView(APITestMixin):
         assert Version.objects.get_for_object(win).count() == 1
         version = Version.objects.get_for_object(win).first()
         assert version.revision.user == self.user
+        assert version.revision.comment == 'Win created'
 
         assert CustomerResponseToken.objects.filter(
             customer_response_id=win.customer_response.id,
@@ -1403,6 +1409,7 @@ class TestUpdateWinView(APITestMixin):
         assert Version.objects.get_for_object(win).count() == 1
         version = Version.objects.get_for_object(win).first()
         assert version.revision.user == self.user
+        assert version.revision.comment == 'Win updated'
 
     def test_doesnt_update_related_fields_when_not_supplied(self):
         """Tests related fields don't get updated when not supplied."""
@@ -1615,6 +1622,7 @@ class TestUpdateWinView(APITestMixin):
         assert Version.objects.get_for_object(win).count() == 1
         version = Version.objects.get_for_object(win).first()
         assert version.revision.user == self.user
+        assert version.revision.comment == 'Win updated'
 
 
 class TestResendExportWinView(APITestMixin):


### PR DESCRIPTION
### Description of change

This PR intends to add version comments when win record is created and updated via serializers. 

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
