### PR TITLE
Add GitHub action to auto-rebase the migration branch

### DIFF
--- a/.github/workflows/update-migration-branch.yml
+++ b/.github/workflows/update-migration-branch.yml
@@ -1,0 +1,34 @@
+name: Update Migration Branch
+
+on:
+  pull_request:
+    types:
+      - closed
+
+permissions: 
+  contents: write
+
+jobs:
+  sync:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+        
+      - name: Setup Git User
+        run: |
+          git config user.name "GitHub Action"
+          git config user.email "<EMAIL>"
+      
+
+      - name: Update Migration Branch
+        run: |
+          git checkout main
+          git fetch origin
+          git checkout migration-deploy
+          git pull
+          git merge origin/main
+          git push origin migration-deploy


### PR DESCRIPTION
### Description of change

In order to keep the `migration-deploy` branch up to date we are required to rebase it against `main` every day. The current expectation is either for a developer to manually rebase the branch every morning, or for all developers to rebase the branch after merging a PR.

This isn't ideal so I have attempted to create a GitHub action to perform this process automatically. It will run each time a PR is merged into this repo's `main` branch. Once we have fully migrated the API on to the DBT Platform, this action should be removed.

You can test the action by doing the following:
- Open these two test branches in separate tabs - [chore/github-action-main](https://github.com/uktrade/data-hub-api/tree/chore/github-action-main) and [chore/github-action-mig](https://github.com/uktrade/data-hub-api/tree/chore/github-action-mig)
- Open a PR to update the README in `chore/github-action-main` and merge it
- Open the Actions tab. You should see a running action called `Update Migration Branch`
- Once this is completed, switch to `chore/github-action-mig` and refresh. You should see the changes from your PR.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
