### PR TITLE
Add export experience field to public Export Wins endpoint.

### DIFF
--- a/datahub/export_win/serializers.py
+++ b/datahub/export_win/serializers.py
@@ -306,6 +306,7 @@ class LimitedExportWinSerializer(ModelSerializer):
 
     country = NestedRelatedField(Country)
     goods_vs_services = NestedRelatedField(ExpectedValueRelation)
+    export_experience = NestedRelatedField(ExportExperience)
     lead_officer = NestedAdviserField()
     breakdowns = BreakdownSerializer(many=True)
 
@@ -315,6 +316,7 @@ class LimitedExportWinSerializer(ModelSerializer):
             'date',
             'country',
             'goods_vs_services',
+            'export_experience',
             'lead_officer',
             'breakdowns',
             'description',

--- a/datahub/export_win/test/test_customer_response_views.py
+++ b/datahub/export_win/test/test_customer_response_views.py
@@ -90,6 +90,10 @@ class TestGetCustomerResponseView(APITestMixin):
                     'id': str(win.goods_vs_services.id),
                     'name': win.goods_vs_services.name,
                 },
+                'export_experience': {
+                    'id': str(win.export_experience.id),
+                    'name': win.export_experience.name,
+                },
                 'lead_officer': {
                     'id': str(win.lead_officer.id),
                     'name': win.lead_officer.name,
@@ -306,6 +310,10 @@ class TestUpdateCustomerResponseView(APITestMixin):
                 'goods_vs_services': {
                     'id': str(win.goods_vs_services.id),
                     'name': win.goods_vs_services.name,
+                },
+                'export_experience': {
+                    'id': str(win.export_experience.id),
+                    'name': win.export_experience.name,
                 },
                 'lead_officer': {
                     'id': str(win.lead_officer.id),


### PR DESCRIPTION
### Description of change

This adds `export_experience` field to public facing Export Wins endpoint.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
