### PR TITLE
feature/RR-1358-custom-export-wins-admin-search

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -179,6 +179,7 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
         'lead_officer_adviser_name',
         'company__name',
         'country__name',
+        'contact_name',
         'sector__segment',
         'customer_response__responded_on',
         'created_on',
@@ -275,14 +276,18 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
         return False
 
     def get_search_results(self, request, queryset, search_term):
-        queryset = queryset.annotate(
-            adviser_name=Concat(
-                'adviser__first_name', Value(' '), 'adviser__last_name',
-            ),
-            lead_officer_adviser_name=Concat(
-                'lead_officer__first_name', Value(' '), 'lead_officer__last_name',
-            ),
-        )
+        if search_term:
+            queryset = queryset.annotate(
+                adviser_name=Concat(
+                    'adviser__first_name', Value(' '), 'adviser__last_name',
+                ),
+                lead_officer_adviser_name=Concat(
+                    'lead_officer__first_name', Value(' '), 'lead_officer__last_name',
+                ),
+                contact_name=Concat(
+                    'company_contacts__first_name', Value(' '), 'company_contacts__last_name',
+                ),
+            )
 
         return super().get_search_results(
             request,

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -276,16 +276,12 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
         return False
 
     def get_search_results(self, request, queryset, search_term):
-
         queryset = queryset.annotate(
             adviser_name=Concat(
                 'adviser__first_name', Value(' '), 'adviser__last_name',
             ),
             lead_officer_adviser_name=Concat(
                 'lead_officer__first_name', Value(' '), 'lead_officer__last_name',
-            ),
-            contact_name=Concat(
-                'company_contacts__first_name', Value(' '), 'company_contacts__last_name',
             ),
         )
 

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -173,9 +173,9 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
         'modified_on',
     )
     search_fields = (
-        'id',
+        '=id',
         'adviser_name',
-        'company__pk',
+        '=company__pk',
         'lead_officer_adviser_name',
         'company__name',
         'country__name',

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -3,6 +3,8 @@ from django import forms
 
 from django.contrib import admin
 from django.contrib.admin import DateFieldListFilter
+from django.db.models import Value
+from django.db.models.functions import Concat
 from django.forms import ModelForm
 from reversion.admin import VersionAdmin
 
@@ -172,9 +174,12 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
     )
     search_fields = (
         'id',
+        'adviser_name',
         'company__pk',
+        'lead_officer_adviser_name',
         'company__name',
         'country__name',
+        'contact_name',
         'sector__segment',
         'customer_response__responded_on',
         'created_on',
@@ -269,6 +274,26 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def get_search_results(self, request, queryset, search_term):
+
+        queryset = queryset.annotate(
+            adviser_name=Concat(
+                'adviser__first_name', Value(' '), 'adviser__last_name',
+            ),
+            lead_officer_adviser_name=Concat(
+                'lead_officer__first_name', Value(' '), 'lead_officer__last_name',
+            ),
+            contact_name=Concat(
+                'company_contacts__first_name', Value(' '), 'company_contacts__last_name',
+            ),
+        )
+
+        return super().get_search_results(
+            request,
+            queryset,
+            search_term,
+        )
 
 
 class WinSoftDeletedAdminForm(ModelForm):

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -179,7 +179,6 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
         'lead_officer_adviser_name',
         'company__name',
         'country__name',
-        'contact_name',
         'sector__segment',
         'customer_response__responded_on',
         'created_on',

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -1,5 +1,6 @@
-from unittest.mock import Mock
 import pytest
+
+from unittest.mock import Mock
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Group

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -302,7 +302,5 @@ class TestWinAdminSearchResults:
         admin = WinAdmin(Win, None)
         results = admin.get_search_results(Mock(), Win.objects.all(), 'John Doe')[0]
 
-        print(results)
-
         assert len(results) == 1
         assert results[0].id == win1.id

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -258,6 +258,17 @@ class TestCustomerResponseInlineForm:
 
 @pytest.mark.django_db
 class TestWinAdminSearchResults:
+
+    def test_admin_search_no_filters(self):
+        win1 = WinFactory()
+        contacts = ContactFactory.create_batch(4)
+        win1.company_contacts.set(contacts)
+
+        admin = WinAdmin(Win, None)
+        results = admin.get_search_results(Mock(), Win.objects.all(), '')[0]
+
+        assert len(results) == 1
+
     def test_admin_search_on_adviser_name(self):
         adviser = AdviserFactory(first_name='FIRST', last_name='LAST')
         win1 = WinFactory(adviser=adviser)
@@ -274,20 +285,6 @@ class TestWinAdminSearchResults:
         WinFactory.create_batch(3)
         admin = WinAdmin(Win, None)
         results = admin.get_search_results(Mock(), Win.objects.all(), 'LEAD OFFICER')[0]
-
-        assert len(results) == 1
-        assert results[0].id == win1.id
-
-    def test_admin_search_on_contact_name(self):
-        contact1 = ContactFactory(first_name='John', last_name='Doe')
-        contact2 = ContactFactory(first_name='Jane', last_name='Smith')
-
-        win1 = WinFactory()
-        win1.company_contacts.add(contact1, contact2)
-
-        WinFactory.create_batch(3)
-        admin = WinAdmin(Win, None)
-        results = admin.get_search_results(Mock(), Win.objects.all(), 'John Doe')[0]
 
         assert len(results) == 1
         assert results[0].id == win1.id

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -1,6 +1,6 @@
-import pytest
-
 from unittest.mock import Mock
+
+import pytest
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Group

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -264,11 +264,12 @@ class TestWinAdminSearchResults:
         win1 = WinFactory()
         contacts = ContactFactory.create_batch(4)
         win1.company_contacts.set(contacts)
+        WinFactory()
 
         admin = WinAdmin(Win, None)
         results = admin.get_search_results(Mock(), Win.objects.all(), '')[0]
 
-        assert len(results) == 1
+        assert len(results) == 2
 
     def test_admin_search_on_adviser_name(self):
         adviser = AdviserFactory(first_name='FIRST', last_name='LAST')
@@ -286,6 +287,22 @@ class TestWinAdminSearchResults:
         WinFactory.create_batch(3)
         admin = WinAdmin(Win, None)
         results = admin.get_search_results(Mock(), Win.objects.all(), 'LEAD OFFICER')[0]
+
+        assert len(results) == 1
+        assert results[0].id == win1.id
+
+    def test_admin_search_on_contact_name(self):
+        contact1 = ContactFactory(first_name='John', last_name='Doe')
+        contact2 = ContactFactory(first_name='Jane', last_name='Smith')
+
+        win1 = WinFactory()
+        win1.company_contacts.add(contact1, contact2)
+
+        WinFactory.create_batch(3)
+        admin = WinAdmin(Win, None)
+        results = admin.get_search_results(Mock(), Win.objects.all(), 'John Doe')[0]
+
+        print(results)
 
         assert len(results) == 1
         assert results[0].id == win1.id

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -2262,6 +2262,41 @@
     created_on: "2024-03-27T11:00:00Z"
     modified_on: "2024-03-27T11:00:00Z"
 
+- model: export_win.Win
+  pk: 2343d010-1436-4cb3-851a-4c87276d4953
+  fields:
+    adviser: 95a99736-5402-11eb-ae93-0242ac130002
+    lead_officer: e83a608e-84a4-11e6-ae22-56b6b6499611
+    hq_team: b9afc253-5aa1-498f-b5d7-d43dad1ced82
+    team_type: 1f6eccf9-289a-450b-a4af-b75600ea521b
+    business_potential: 0e6f1d69-e9c3-4460-a74b-3881930fe3e9
+    company: a73efeba-8499-11e6-ae22-56b6b6499611
+    company_contacts: [9b1138ab-ec7b-497f-b8c3-27fed21694ef]
+    customer_location: 256a5a92-44a6-473e-adcb-6f9ec4d17c62
+    business_type: "The best type"
+    description: "Description"
+    name_of_export: "Sand"
+    date: "2024-05-05"
+    country: 81756b9a-5d95-e211-a939-e4115bead28a
+    total_expected_export_value: 158778
+    total_expected_non_export_value: 525478
+    total_expected_odi_value: 88987
+    goods_vs_services: 8711e3dd-3a2c-4b47-aea7-9a53c135efb6
+    sector: b422c9d2-5f95-e211-a939-e4115bead28a
+    type_of_support: [1ed7f465-1461-4d66-b4a2-8d704ea239a8]
+    associated_programme: [b6f5c31a-aa45-4ae0-89bd-2eb3ab943f76]
+    is_personally_confirmed: False
+    is_line_manager_confirmed: False
+    name_of_customer: "Overseas Customer"
+    name_of_customer_confidential: True
+    export_experience: 587928e3-cab1-45cb-ba49-0656b6d2f867    
+    lead_officer_name: "Dave"
+    line_manager_name: "Dave"
+    company_name: "Test company name"
+    cdms_reference: "1234"
+    created_on: "2024-03-27T11:00:00Z"
+    modified_on: "2024-03-27T11:00:00Z"
+
 - model: export_win.Breakdown
   pk: ab38d245-331e-49e9-96a1-904a984bf477
   fields:


### PR DESCRIPTION
### Description of change

Some of the fields that the export wins admin users want to search on are written as python properties that combine multiple fields, however the admin searching functionality can only search on model fields that are stored in the DB. This change annotates the default queryset with some Concat functions that are run as SQL queries

Added an extra export win into the test data

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
