### PR TITLE
feature/RR-1355-wins-admin-screen

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -343,3 +343,29 @@ class DeletedWinAdmin(WinAdmin):
 
     def has_change_permission(self, request, obj=None):
         return False
+
+
+@admin.register(WinAdviser)
+class WinAdviserAdmin(BaseModelAdminMixin):
+    """Admin for Win Adviser."""
+
+    list_display = ('win', 'adviser', 'team_type', 'hq_team', 'location')
+    search_fields = ('win__id',)
+
+    fieldsets = (
+        ('Overview', {'fields': (
+            'id',
+            'win',
+            'adviser',
+            'team_type',
+            'hq_team',
+            'location',
+        )}),
+        ('Legacy Fields', {'fields': (
+            'name',
+            'legacy_id',
+        )}),
+    )
+
+    def has_change_permission(self, request, obj=None):
+        return False

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -367,5 +367,9 @@ class WinAdviserAdmin(BaseModelAdminMixin):
         )}),
     )
 
+    autocomplete_fields = (
+        'adviser',
+    )
+
     def has_change_permission(self, request, obj=None):
         return False

--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -421,11 +421,11 @@ class Win(BaseModel):
         super().save(*args, **kwargs)
 
     def __str__(self):
-        return "Export win {}: {} <{}> - {}".format(
+        return 'Export win {}: {} <{}> - {}'.format(
             self.pk,
             self.adviser,
             self.adviser.email,
-            self.created_on.strftime("%Y-%m-%d %H:%M:%S") if self.created_on else '',
+            self.created_on.strftime('%Y-%m-%d %H:%M:%S') if self.created_on else '',
         )
 
 

--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -420,6 +420,14 @@ class Win(BaseModel):
         self.total_expected_odi_value = calc_total['total_odi_value']
         super().save(*args, **kwargs)
 
+    def __str__(self):
+        return "Export win {}: {} <{}> - {}".format(
+            self.pk,
+            self.adviser,
+            self.adviser.email,
+            self.created_on.strftime("%Y-%m-%d %H:%M:%S") if self.created_on else '',
+        )
+
 
 class Breakdown(BaseModel, BaseLegacyModel):
     """Win breakdown."""
@@ -461,6 +469,9 @@ class WinAdviser(BaseModel, BaseLegacyModel):
     )
     # Legacy fields
     name = models.CharField(max_length=128)
+
+    class Meta:
+        verbose_name = 'Adviser'
 
 
 @reversion.register_base_model()

--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -413,20 +413,16 @@ class Win(BaseModel):
 
     objects = BaseExportWinSoftDeleteManager()
 
+    def __str__(self):
+        return (f'Export win {self.pk}: {self.adviser} <{self.adviser.email}> - '
+                f'{self.created_on.strftime("%Y-%m-%d %H:%M:%S") if self.created_on else ""}')
+
     def save(self, *args, **kwargs):
         calc_total = _calculate_totals_for_export_win(self)
         self.total_expected_export_value = calc_total['total_export_value']
         self.total_expected_non_export_value = calc_total['total_non_export_value']
         self.total_expected_odi_value = calc_total['total_odi_value']
         super().save(*args, **kwargs)
-
-    def __str__(self):
-        return 'Export win {win_id}: {adviser} <{adviser_email}> - {created}'.format(
-            win_id=self.pk,
-            adviser=self.adviser,
-            adviser_email=self.adviser.email,
-            created=self.created_on.strftime('%Y-%m-%d %H:%M:%S') if self.created_on else '',
-        )
 
 
 class Breakdown(BaseModel, BaseLegacyModel):

--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -421,11 +421,11 @@ class Win(BaseModel):
         super().save(*args, **kwargs)
 
     def __str__(self):
-        return 'Export win {}: {} <{}> - {}'.format(
-            self.pk,
-            self.adviser,
-            self.adviser.email,
-            self.created_on.strftime('%Y-%m-%d %H:%M:%S') if self.created_on else '',
+        return 'Export win {win_id}: {adviser} <{adviser_email}> - {created}'.format(
+            win_id=self.pk,
+            adviser=self.adviser,
+            adviser_email=self.adviser.email,
+            created=self.created_on.strftime('%Y-%m-%d %H:%M:%S') if self.created_on else '',
         )
 
 

--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -469,6 +469,9 @@ class WinAdviser(BaseModel, BaseLegacyModel):
     class Meta:
         verbose_name = 'Adviser'
 
+    def __str__(self):
+        return f'Name: {self.adviser}, Team {self.team_type} - {self.hq_team}'
+
 
 @reversion.register_base_model()
 class CustomerResponse(BaseModel):

--- a/datahub/export_win/test/factories.py
+++ b/datahub/export_win/test/factories.py
@@ -139,6 +139,7 @@ class SupportTypeFactory(factory.django.DjangoModelFactory):
 class WinFactory(factory.django.DjangoModelFactory):
     """Win factory."""
 
+    created_on = factory.LazyFunction(now)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SelfAttribute('created_by')
     date = factory.Faker('date_object')

--- a/datahub/export_win/test/test_models.py
+++ b/datahub/export_win/test/test_models.py
@@ -94,24 +94,36 @@ class TestBreakdownModel(BaseLegacyModelTests):
     model_class = Breakdown
 
 
-def test_win_save(win_factory):
-    win = win_factory
-    calc_total = _calculate_totals_for_export_win(win)
-    win.save()
-    assert win.total_expected_export_value == calc_total['total_export_value']
-    assert win.total_expected_non_export_value == calc_total['total_non_export_value']
-    assert win.total_expected_odi_value == calc_total['total_odi_value']
+class TestWinModel():
 
+    def test_win_save(self, win_factory):
+        win = win_factory
+        calc_total = _calculate_totals_for_export_win(win)
+        win.save()
+        assert win.total_expected_export_value == calc_total['total_export_value']
+        assert win.total_expected_non_export_value == calc_total['total_non_export_value']
+        assert win.total_expected_odi_value == calc_total['total_odi_value']
 
-def test_update_total_values(adviser_factory, win_factory, breakdown_factory):
-    win = win_factory
-    breakdown = breakdown_factory
-    calc_total = _calculate_totals_for_export_win(win)
-    expected_export_value = calc_total['total_export_value']
-    expected_non_export_value = calc_total['total_non_export_value']
-    expected_odi_value = calc_total['total_odi_value']
-    update_total_values(sender=adviser_factory, instance=breakdown)
-    win.refresh_from_db()
-    assert win.total_expected_export_value == expected_export_value
-    assert win.total_expected_non_export_value == expected_non_export_value
-    assert win.total_expected_odi_value == expected_odi_value
+    def test_update_total_values(self, adviser_factory, win_factory, breakdown_factory):
+        win = win_factory
+        breakdown = breakdown_factory
+        calc_total = _calculate_totals_for_export_win(win)
+        expected_export_value = calc_total['total_export_value']
+        expected_non_export_value = calc_total['total_non_export_value']
+        expected_odi_value = calc_total['total_odi_value']
+        update_total_values(sender=adviser_factory, instance=breakdown)
+        win.refresh_from_db()
+        assert win.total_expected_export_value == expected_export_value
+        assert win.total_expected_non_export_value == expected_non_export_value
+        assert win.total_expected_odi_value == expected_odi_value
+
+    def test_str_representation_with_created_on(self, win_factory):
+        win = win_factory
+        assert str(win) == (f'Export win {win.pk}: {win.adviser} <{win.adviser.email}> - '
+                            f'{win.created_on.strftime("%Y-%m-%d %H:%M:%S")}')
+
+    def test_str_representation_without_created_on(self):
+        win = WinFactory(created_on=None)
+        win.created_on = None
+
+        assert str(win) == f'Export win {win.pk}: {win.adviser} <{win.adviser.email}> - '

--- a/datahub/export_win/test/test_models.py
+++ b/datahub/export_win/test/test_models.py
@@ -87,6 +87,14 @@ class TestWinAdviserModel(BaseLegacyModelTests):
     factory = WinAdviserFactory
     model_class = WinAdviser
 
+    def test_str_representation(self):
+        win_adviser = self.factory()
+
+        assert (
+            str(win_adviser)
+            == f'Name: {win_adviser.adviser}, Team {win_adviser.team_type} - {win_adviser.hq_team}'
+        )
+
 
 class TestBreakdownModel(BaseLegacyModelTests):
 


### PR DESCRIPTION
### Description of change

- Add a new admin page for the `WinAdviser` model
- Update the display name of the `Win` model to match what is displayed in the export wins system (`Export win <Win ID>: <adviser name> <adviser email> - <date stamp> <time stamp>`)
- Update the display name of the `WinAdviser` model to match what is displayed in the export wins system (`Name <adviser name>, Team <team_type> - <hq_team>`)

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
