### PR TITLE
DPM-118 dbt platform deploy configuration

### DIFF
--- a/.copilot/config.yml
+++ b/.copilot/config.yml
@@ -1,0 +1,4 @@
+repository: public.ecr.aws/data-hub-api
+builder:
+  name: paketobuildpacks/builder-jammy-full
+  version: 0.3.339

--- a/.copilot/config.yml
+++ b/.copilot/config.yml
@@ -1,4 +1,4 @@
-repository: public.ecr.aws/data-hub-api
+repository: data-hub-api
 builder:
   name: paketobuildpacks/builder-jammy-full
   version: 0.3.339

--- a/.copilot/image_build_run.sh
+++ b/.copilot/image_build_run.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Exit early if something goes wrong
+set -e
+
+# Add commands below to run inside the container after all the other buildpacks have been applied
+export ADMIN_OAUTH2_ENABLED="True"
+export ADMIN_OAUTH2_BASE_URL=""
+export ADMIN_OAUTH2_TOKEN_FETCH_PATH="/o/token/"
+export ADMIN_OAUTH2_USER_PROFILE_PATH="/o/v1/user/me/"
+export ADMIN_OAUTH2_AUTH_PATH="/o/authorize/"
+export ADMIN_OAUTH2_CLIENT_ID="client-id"
+export ADMIN_OAUTH2_CLIENT_SECRET="client-secret"
+export ADMIN_OAUTH2_LOGOUT_PATH="/o/logout"
+export ACTIVITY_STREAM_ACCESS_KEY_ID="some-id"
+export ACTIVITY_STREAM_SECRET_ACCESS_KEY="some-secret"
+export DATABASE_URL="postgresql://postgres:datahub@postgres/datahub"
+export DEBUG="True"
+export DJANGO_SECRET_KEY="changeme"
+export DJANGO_SETTINGS_MODULE="config.settings.local"
+export ES_INDEX_PREFIX="test_index"
+export ES5_URL="http://localhost:9200"
+export OPENSEARCH_URL="http://localhost:9200"
+export OPENSEARCH_INDEX_PREFIX="test_index"
+export PAAS_IP_ALLOWLIST="1.2.3.4"
+export AWS_DEFAULT_REGION="eu-west-2"
+export AWS_ACCESS_KEY_ID="foo"
+export AWS_SECRET_ACCESS_KEY="bar"
+export DEFAULT_BUCKET="baz"
+export SSO_ENABLED="True"
+export STAFF_SSO_BASE_URL="http://sso.invalid/"
+export STAFF_SSO_AUTH_TOKEN="sso-token"
+export DIT_EMAIL_DOMAINS="trade.gov.uk,digital.trade.gov.uk"
+export DATA_HUB_FRONTEND_ACCESS_KEY_ID="frontend-key-id"
+export DATA_HUB_FRONTEND_SECRET_ACCESS_KEY="frontend-key"
+export ES_APM_ENABLED="False"
+export ES_APM_SERVICE_NAME="datahub"
+export ES_APM_SECRET_TOKEN=""
+export ES_APM_SERVER_URL="http://localhost:8200"
+export ES_APM_ENVIRONMENT="circleci"
+export REDIS_BASE_URL="redis://localhost:6379"
+
+python manage.py collectstatic  --noinput

--- a/.copilot/phases/build.sh
+++ b/.copilot/phases/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Exit early if something goes wrong
+set -e
+
+# Add commands below to run as part of the build phase

--- a/.copilot/phases/install.sh
+++ b/.copilot/phases/install.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Exit early if something goes wrong
+set -e
+
+# Add commands below to run as part of the install phase

--- a/.copilot/phases/post_build.sh
+++ b/.copilot/phases/post_build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Exit early if something goes wrong
+set -e
+
+# Add commands below to run as part of the post_build phase

--- a/.copilot/phases/pre_build.sh
+++ b/.copilot/phases/pre_build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Exit early if something goes wrong
+set -e
+
+# Add commands below to run as part of the pre_build phase

--- a/web.sh
+++ b/web.sh
@@ -13,5 +13,11 @@ if [ -z "$SKIP_OPENSEARCH_MAPPING_MIGRATIONS" ] && [ "${CF_INSTANCE_INDEX:-0}" =
   ./manage.py migrate_search
 fi
 
-python manage.py collectstatic  --noinput
-python app.py
+if [ -n "${COPILOT_ENVIRONMENT_NAME}" ]; then
+  echo "Running in DBT Platform"
+  python app.py
+else
+  echo "Running in Cloud Foundry"
+  python manage.py collectstatic  --noinput
+  python app.py
+fi


### PR DESCRIPTION
### Description of change

Adds the DBT Platform build configuration files.

### Checklist

* [x] Has this branch been rebased on top of the current `migration-deploy` branch?
* 🤷 Is the CircleCI build passing?

### General points

- add the build configuration files under `.copilot`
- alter the web entrypoint script to only run collect static on GOVUK PaaS
