### PR TITLE
Update company factories calls so that they use existing objects when…

### DIFF
--- a/data_generator.py
+++ b/data_generator.py
@@ -82,7 +82,7 @@ with DisableSignals():
     # In February 2024 there were 18,000 advisers, 500,000 companies, and 950,000 contacts.
     # Alter number of adivsers below to create larger or smaller data set.
     # Generate Advisers
-    print('Generating advisers')
+    print('Generating advisers')  # noqa
     for index in range(10):
         AdviserFactory(dit_team=random.choice(teams))
         if index % 10 == 0:
@@ -92,7 +92,7 @@ with DisableSignals():
     print(f'Generated {advisers.count} advisers')  # noqa
 
     # # Generate base companies
-    print('\nGenerating Companies')
+    print('\nGenerating Companies')  # noqa
     for index, adviser in enumerate(advisers):
         CompanyFactory.create_batch(
             random.randint(0, 25),
@@ -102,7 +102,7 @@ with DisableSignals():
         if index % 10 == 0:
             print('.', end='')  # noqa        
 
-    print('\nGenerating Company variations')
+    print('\nGenerating Company variations')  # noqa
     companies = Company.objects.all()
     # The ratios of the below types of companies do not reflect the live database.
     # Generate different type of companies

--- a/data_generator.py
+++ b/data_generator.py
@@ -89,7 +89,7 @@ with DisableSignals():
             print('.', end='')  # noqa        
     advisers = Advisor.objects.all()
 
-    print(f'Generated {len(advisers)} advisers')  # noqa
+    print(f'Generated {advisers.count} advisers')  # noqa
 
     # # Generate base companies
     print('\nGenerating Companies')
@@ -117,19 +117,19 @@ with DisableSignals():
             random.randint(0, 1),
             created_by=adviser,
             modified_by=random.choice(advisers),
-        ),
+        )
         ArchivedCompanyFactory.create_batch(
             random.randint(0, 1),
             created_by=adviser,
             modified_by=adviser,
-        ),
+        )
         DuplicateCompanyFactory.create_batch(
             random.randint(0, 1),
             created_by=adviser,
             modified_by=adviser,
             transferred_by=random.choice(advisers),
-            transferred_to=random.choice(companies)
-        ),
+            transferred_to=random.choice(companies),
+        )
 
         # Show a sign of life every now and then
         if index % 10 == 0:

--- a/data_generator.py
+++ b/data_generator.py
@@ -26,8 +26,11 @@ from datahub.company.models.adviser import Advisor
 from datahub.company.models.company import Company
 from datahub.company.test.factories import (
     AdviserFactory,
+    ArchivedCompanyFactory,
     # ArchivedCompanyFactory,
     CompanyFactory,
+    CompanyWithAreaFactory,
+    DuplicateCompanyFactory,
     # CompanyWithAreaFactory,
     # ContactFactory,
     SubsidiaryFactory,
@@ -86,8 +89,9 @@ with DisableSignals():
             print('.', end='')  # noqa        
     advisers = Advisor.objects.all()
 
-    # print(f'Generated {len(advisers)} advisers')  # noqa
-    # Generate base companies
+    print(f'Generated {len(advisers)} advisers')  # noqa
+
+    # # Generate base companies
     print('\nGenerating Companies')
     for index, adviser in enumerate(advisers):
         CompanyFactory.create_batch(
@@ -109,20 +113,24 @@ with DisableSignals():
             modified_by=random.choice(advisers),
             global_headquarters=random.choice(companies),
         )
-        # companies.extend(
-        #     CompanyWithAreaFactory.create_batch(
-        #         random.randint(0, 1),
-        #         created_by=adviser,
-        #         modified_by=adviser,
-        #     ),
-        # )
-        # companies.extend(
-        #     ArchivedCompanyFactory.create_batch(
-        #         random.randint(0, 1),
-        #         created_by=adviser,
-        #         modified_by=adviser,
-        #     ),
-        # )
+        CompanyWithAreaFactory.create_batch(
+            random.randint(0, 1),
+            created_by=adviser,
+            modified_by=random.choice(advisers),
+        ),
+        ArchivedCompanyFactory.create_batch(
+            random.randint(0, 1),
+            created_by=adviser,
+            modified_by=adviser,
+        ),
+        DuplicateCompanyFactory.create_batch(
+            random.randint(0, 1),
+            created_by=adviser,
+            modified_by=adviser,
+            transferred_by=random.choice(advisers),
+            transferred_to=random.choice(companies)
+        ),
+
         # Show a sign of life every now and then
         if index % 10 == 0:
             print('.', end='')  # noqa


### PR DESCRIPTION
### Description of change

Updated the existing company factory calls in the data_generator.py script to use existing objects (e.g. advisers and companies) where possible.
Added the DuplicateCompanyFactory call.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
