### PR TITLE
RR-1350-Export-win-admin-audit-field-validation

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -1,5 +1,4 @@
 import reversion
-from django import forms
 
 from django.contrib import admin
 from django.contrib.admin import DateFieldListFilter
@@ -109,6 +108,8 @@ class CustomerResponseInline(BaseStackedInline):
 
 
 class WinAdminForm(ModelForm):
+    """Admin for Wins."""
+
     class Meta:
         model = Win
         fields = '__all__'
@@ -117,13 +118,6 @@ class WinAdminForm(ModelForm):
         super().__init__(*args, **kwargs)
 
         self.fields['audit'].required = True
-        instance = self.instance
-
-        initial_values = {
-            'total_expected_export_value',
-            'total_expected_non_export_value',
-            'total_expected_odi_value',
-        }
         fields_to_update = {
             'cdms_reference',
             'customer_email_address',
@@ -133,10 +127,7 @@ class WinAdminForm(ModelForm):
             'other_official_email_address',
         }
 
-        for field_name in initial_values | fields_to_update:
-            readonly = instance and instance.pk and field_name in initial_values
-            self.fields[field_name].widget = forms.TextInput(
-                attrs={'readonly': 'readonly'} if readonly else {})
+        for field_name in fields_to_update:
             self.fields[field_name].required = False
 
 
@@ -171,6 +162,9 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
         'id',
         'created_on',
         'modified_on',
+        'total_expected_export_value',
+        'total_expected_non_export_value',
+        'total_expected_odi_value',
     )
     search_fields = (
         '=id',

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -109,35 +109,35 @@ class CustomerResponseInline(BaseStackedInline):
 
 
 class WinAdminForm(ModelForm):
-    """Win admin form."""
-
     class Meta:
         model = Win
         fields = '__all__'
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+
+        self.fields['audit'].required = True
         instance = self.instance
-        if (instance and instance.pk):
-            initial_values = {
-                'total_expected_export_value',
-                'total_expected_non_export_value',
-                'total_expected_odi_value',
-            }
-            for field_name in initial_values:
-                self.fields[field_name].widget = forms.TextInput(attrs={'readonly': 'readonly'})
-            fields_to_update = [
-                'cdms_reference',
-                'customer_email_address',
-                'customer_job_title',
-                'line_manager_name',
-                'lead_officer_email_address',
-                'other_official_email_address',
-            ]
-            for field_name in fields_to_update:
-                field = self.fields.get(field_name)
-                if field:
-                    field.required = False
+
+        initial_values = {
+            'total_expected_export_value',
+            'total_expected_non_export_value',
+            'total_expected_odi_value',
+        }
+        fields_to_update = {
+            'cdms_reference',
+            'customer_email_address',
+            'customer_job_title',
+            'line_manager_name',
+            'lead_officer_email_address',
+            'other_official_email_address',
+        }
+
+        for field_name in initial_values | fields_to_update:
+            readonly = instance and instance.pk and field_name in initial_values
+            self.fields[field_name].widget = forms.TextInput(
+                attrs={'readonly': 'readonly'} if readonly else {})
+            self.fields[field_name].required = False
 
 
 @admin.register(Win)

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -196,6 +196,7 @@ class TestWinAdminForm:
         form = WinAdminForm(instance=instance_mock)
         assert form is not None
         if instance_mock.pk is not None:
+            assert form.fields['audit'].required is True
             field_attrs = form.fields['total_expected_export_value'].widget.attrs
             assert field_attrs['readonly'] == 'readonly'
             field_attrs = form.fields['total_expected_non_export_value'].widget.attrs

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -187,28 +187,23 @@ class TestWinSoftDeletedAdminForm:
 class TestWinAdminForm:
     """Test for WinAdminForm"""
 
-    def test_init_method(self):
+    def test_win_admin_form(self):
         form = WinAdminForm()
         assert form is not None
 
-    def test_init_method_with_instance_pk(self):
-        instance_mock = InstanceMock(pk=1)
-        form = WinAdminForm(instance=instance_mock)
-        assert form is not None
-        if instance_mock.pk is not None:
-            assert form.fields['audit'].required is True
-            field_attrs = form.fields['total_expected_export_value'].widget.attrs
-            assert field_attrs['readonly'] == 'readonly'
-            field_attrs = form.fields['total_expected_non_export_value'].widget.attrs
-            assert field_attrs['readonly'] == 'readonly'
-            field_attrs = form.fields['total_expected_odi_value'].widget.attrs
-            assert field_attrs['readonly'] == 'readonly'
-            assert form.fields['cdms_reference'].required is False
-            assert form.fields['customer_email_address'].required is False
-            assert form.fields['customer_job_title'].required is False
-            assert form.fields['line_manager_name'].required is False
-            assert form.fields['lead_officer_email_address'].required is False
-            assert form.fields['other_official_email_address'].required is False
+        assert form.fields['audit'].required is True
+
+        fields_to_update = {
+            'cdms_reference',
+            'customer_email_address',
+            'customer_job_title',
+            'line_manager_name',
+            'lead_officer_email_address',
+            'other_official_email_address',
+        }
+
+        for field_name in fields_to_update:
+            assert form.fields[field_name].required is False
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description of change

This is a tiny PR to set audit field to be mandatory and code refactor for read only fields

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
