### PR TITLE
Fix confirmation name and breakdown year in dataset for Export wins.

### DIFF
--- a/datahub/dataset/export_wins/test/test_views.py
+++ b/datahub/dataset/export_wins/test/test_views.py
@@ -76,7 +76,7 @@ class TestExportWinsBreakdownDatasetView(BaseDatasetViewTest):
 
     def _assert_breakdown_matches_result(self, breakdown, result):
         financial_year = get_financial_year(
-            breakdown.win.created_on + relativedelta(years=breakdown.year - 1),
+            breakdown.win.date + relativedelta(years=breakdown.year - 1),
         )
         assert result == {
             'created_on': format_date_or_datetime(breakdown.created_on),
@@ -209,7 +209,7 @@ class TestExportWinsWinDatasetView(BaseDatasetViewTest):
                 win.customer_response.interventions_were_prerequisite if has_responded else None,
             'confirmation__involved_state_enterprise':
                 win.customer_response.involved_state_enterprise if has_responded else None,
-            'confirmation__name': win.customer_response.name,
+            'confirmation__name': contact.name,
             'confirmation__other_marketing_source':
                 win.customer_response.other_marketing_source if has_responded else None,
             'confirmation__our_support':

--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -76,12 +76,12 @@ class ExportWinsBreakdownsDatasetView(BaseDatasetView):
         return (
             Breakdown.objects.select_related('win, breakdown_type')
             .annotate(
-                created_year=ExtractYear('win__created_on'),
-                created_month=ExtractMonth('win__created_on'),
+                won_year=ExtractYear('win__date'),
+                won_month=ExtractMonth('win__date'),
                 provisional_financial_year=Case(
-                    When(created_month__gte=4, then=F('created_year')),
+                    When(won_month__gte=4, then=F('won_year')),
                     default=ExpressionWrapper(
-                        F('created_year') - 1,
+                        F('won_year') - 1,
                         output_field=IntegerField(),
                     ),
                     output_field=IntegerField(),
@@ -278,7 +278,7 @@ class ExportWinsWinDatasetView(BaseDatasetView):
                     default=F('customer_response__involved_state_enterprise'),
                     output_field=BooleanField(),
                 ),
-                confirmation__name=F('customer_response__name'),
+                confirmation__name=F('customer_details__name'),
                 confirmation__other_marketing_source=F(
                     'customer_response__other_marketing_source',
                 ),

--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -605,6 +605,7 @@ class CustomerResponse(BaseModel):
         default='',
         verbose_name='Other comments or changes to the win details',
     )
+    # name is a legacy field. Should only be used when importing legacy data.
     name = models.CharField(max_length=256, verbose_name='Your name')
     marketing_source = models.ForeignKey(
         MarketingSource,


### PR DESCRIPTION
### Description of change

This changes how Breakdown year is calculated, so it is now based off the won date.

It also fixes the confirmation name - it should be loaded from contact name rather than legacy name field.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
