### PR TITLE
Fix adviser name in Export wins dataset.

### DIFF
--- a/datahub/dataset/export_wins/test/test_views.py
+++ b/datahub/dataset/export_wins/test/test_views.py
@@ -42,7 +42,7 @@ class TestExportWinsAdvisersDatasetView(BaseDatasetViewTest):
             'created_on': format_date_or_datetime(win_adviser.created_on),
             'id': win_adviser.legacy_id,
             'location': win_adviser.location,
-            'name': win_adviser.name,
+            'name': win_adviser.adviser.name,
             'win__id': str(win_adviser.win.id),
             'hq_team_display': win_adviser.hq_team.name,
             'team_type_display': win_adviser.team_type.name,
@@ -52,7 +52,7 @@ class TestExportWinsAdvisersDatasetView(BaseDatasetViewTest):
 
     def test_success(self, data_flow_api_client):
 
-        win_adviser = self.factory(location='Somewhere', name='bob')
+        win_adviser = self.factory(location='Somewhere')
 
         response = data_flow_api_client.get(self.view_url).json()
 

--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -50,17 +50,17 @@ class ExportWinsAdvisersDatasetView(BaseDatasetView):
 
     def get_dataset(self):
         return (
-            WinAdviser.objects.select_related('win, hq_team, team_type')
+            WinAdviser.objects.select_related('win', 'adviser', 'hq_team', 'team_type')
             .values(
                 'created_on',
                 'win__id',
                 'location',
-                'name',
                 hq_team_display=F('hq_team__name'),
                 team_type_display=F('team_type__name'),
             )
             .annotate(
                 id=F('legacy_id'),
+                name=Concat(F('adviser__first_name'), Value(' '), F('adviser__last_name')),
                 hq_team=F('hq_team__export_win_id'),
                 team_type=F('team_type__export_win_id'),
             )


### PR DESCRIPTION
### Description of change

This fixes the Export win adviser dataset endpoint, so that the adviser name doesn't come from the legacy field.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
