### PR TITLE
feature/RR 1355 export win managing contributing advisor

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -64,7 +64,7 @@ class AdvisorInline(BaseTabularInline):
     autocomplete_fields = (
         'adviser',
     )
-
+    can_delete = True
     model = WinAdviser
     form = AdvisorInlineForm
     fields = ('id', 'adviser', 'team_type', 'hq_team', 'location')

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -1,11 +1,10 @@
-from django.urls import reverse
 import reversion
-
 from django.contrib import admin
 from django.contrib.admin import DateFieldListFilter
 from django.db.models import Value
 from django.db.models.functions import Concat
 from django.forms import ModelForm
+from django.urls import reverse
 from reversion.admin import VersionAdmin
 
 from datahub.core.admin import BaseModelAdminMixin, EXPORT_WIN_GROUP_NAME

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -369,6 +369,10 @@ class WinAdviserAdmin(BaseModelAdminMixin):
         'adviser',
     )
 
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        return queryset.filter(win__is_deleted=False)
+
     def has_change_permission(self, request, obj=None):
         return False
 

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -393,4 +393,4 @@ class WinAdviserAdmin(BaseModelAdminMixin):
 
     get_adviser_name.short_description = 'Name'
 
-    WinAdviser._meta.verbose_name_plural = 'Team Members'
+    WinAdviser._meta.verbose_name_plural = 'Advisors'

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -1,3 +1,4 @@
+from django.urls import reverse
 import reversion
 
 from django.contrib import admin
@@ -370,14 +371,25 @@ class WinAdviserAdmin(BaseModelAdminMixin):
     )
 
     def get_queryset(self, request):
+        """Return winadviser queryset only for undeleted win."""
         queryset = super().get_queryset(request)
         return queryset.filter(win__is_deleted=False)
 
+    def get_adviser_name(self, obj):
+        """Return adviser name."""
+        return obj.adviser.name
+
+    def delete_view(self, request, object_id, extra_context=None):
+        """
+        Redirect to the winadviser list view after successful deletion.
+        """
+        response = super().delete_view(request, object_id, extra_context=extra_context)
+        if response.status_code == 302:  # Redirect status code
+            response['Location'] = reverse('admin:export_win_winadviser_changelist')
+        return response
+
     def has_change_permission(self, request, obj=None):
         return False
-
-    def get_adviser_name(self, obj):
-        return obj.adviser.name
 
     get_adviser_name.short_description = 'Name'
 

--- a/datahub/export_win/test/test_admin.py
+++ b/datahub/export_win/test/test_admin.py
@@ -14,9 +14,11 @@ from datahub.export_win.admin import (
     CustomerResponseInlineForm,
     DeletedWinAdmin, WinAdmin,
     WinAdminForm,
+    WinAdviserAdmin,
     WinSoftDeletedAdminForm)
-from datahub.export_win.models import DeletedWin, Win
-from datahub.export_win.test.factories import CustomerResponseFactory, WinFactory
+from datahub.export_win.models import DeletedWin, Win, WinAdviser
+from datahub.export_win.test.factories import (
+    CustomerResponseFactory, WinAdviserFactory, WinFactory)
 
 
 @pytest.fixture
@@ -172,6 +174,32 @@ def test_has_view_permission():
 
     request.user = superuser
     assert admin.has_view_permission(request) is True
+
+
+@pytest.mark.django_db
+def test_get_queryset():
+    """
+    Test to get winadviser
+    And only show winadviser where win is not deleted
+    """
+    deleted_win1 = WinFactory(is_deleted=False)
+    deleted_win2 = WinFactory(is_deleted=True)
+    win_adviser1 = WinAdviserFactory(win=deleted_win1)
+    win_adviser2 = WinAdviserFactory(win=deleted_win2)
+
+    win_adviser_admin = WinAdviserAdmin(model=WinAdviser, admin_site=AdminSite())
+    queryset = win_adviser_admin.get_queryset(request=None)
+    assert win_adviser1 in queryset
+    assert win_adviser2 not in queryset
+
+
+@pytest.mark.django_db
+def test_get_adviser_name():
+    """Test for get adviser name"""
+    adviser = AdviserFactory(first_name='John', last_name='Smith')
+    win_adviser = WinAdviserFactory(adviser=adviser)
+    admin_instance = WinAdviserAdmin(model=WinAdviser, admin_site=AdminSite())
+    assert admin_instance.get_adviser_name(win_adviser) == 'John Smith'
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
### Description of change
This PR is to:
- allow contributing advisors deletion from win admin form in the django admin
- reinstate Advisor menu as team member will be covered in RR-1357 seperately
- redirect users to contributing advisor list view page after deleting advisor
- list only contributing advisor from undeleted win or active win


### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
