### PR TITLE
Change updated_since filter to use modified_on date

### DIFF
--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -2,7 +2,7 @@ from django.contrib.postgres.aggregates import ArrayAgg
 
 from datahub.company.models import Company
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.metadata.utils import convert_usd_to_gbp
 
@@ -70,7 +70,7 @@ class CompaniesDatasetView(BaseFilterDatasetView):
             'strategy',
         )
         updated_since = request.GET.get('updated_since')
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset
 

--- a/datahub/dataset/company_export/views.py
+++ b/datahub/dataset/company_export/views.py
@@ -3,7 +3,7 @@ from django.db.models import F
 from datahub.company.models import CompanyExport
 from datahub.core.query_utils import get_array_agg_subquery
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 from datahub.metadata.query_utils import get_sector_name_subquery
 
 
@@ -58,6 +58,6 @@ class CompanyExportDatasetView(BaseFilterDatasetView):
         )
 
         updated_since = request.GET.get('updated_since')
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset

--- a/datahub/dataset/company_export_country/views.py
+++ b/datahub/dataset/company_export_country/views.py
@@ -1,6 +1,6 @@
 from datahub.company.models import CompanyExportCountry
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 
 
 class CompanyExportCountryDatasetView(BaseFilterDatasetView):
@@ -23,6 +23,6 @@ class CompanyExportCountryDatasetView(BaseFilterDatasetView):
             'status',
         )
         updated_since = request.GET.get('updated_since')
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset

--- a/datahub/dataset/company_referral/views.py
+++ b/datahub/dataset/company_referral/views.py
@@ -1,6 +1,6 @@
 from datahub.company_referral.models import CompanyReferral
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 
 
 class CompanyReferralDatasetView(BaseFilterDatasetView):
@@ -26,6 +26,6 @@ class CompanyReferralDatasetView(BaseFilterDatasetView):
             'subject',
         )
         updated_since = request.GET.get('updated_since')
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset

--- a/datahub/dataset/contact/views.py
+++ b/datahub/dataset/contact/views.py
@@ -1,7 +1,7 @@
 from datahub.company.models.contact import Contact
 from datahub.core.query_utils import get_full_name_expression
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 
 
 class ContactsDatasetView(BaseFilterDatasetView):
@@ -44,6 +44,6 @@ class ContactsDatasetView(BaseFilterDatasetView):
         )
         updated_since = request.GET.get('updated_since')
 
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset

--- a/datahub/dataset/event/views.py
+++ b/datahub/dataset/event/views.py
@@ -5,7 +5,7 @@ from datahub.core.query_utils import (
     get_array_agg_subquery,
 )
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 from datahub.event.models import Event
 from datahub.metadata.query_utils import get_service_name_subquery
 
@@ -56,6 +56,6 @@ class EventsDatasetView(BaseFilterDatasetView):
             'related_programme_names',
         )
         updated_since = request.GET.get('updated_since')
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -6,7 +6,7 @@ from datahub.core.query_utils import (
     get_front_end_url_expression,
 )
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 from datahub.interaction.models import Interaction
 from datahub.interaction.queryset import get_base_interaction_queryset
 from datahub.metadata.query_utils import get_sector_name_subquery, get_service_name_subquery
@@ -87,6 +87,6 @@ class InteractionsDatasetView(BaseFilterDatasetView):
             'export_barrier_notes',
         )
         updated_since = request.GET.get('updated_since')
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset

--- a/datahub/dataset/interaction_export_country/views.py
+++ b/datahub/dataset/interaction_export_country/views.py
@@ -1,5 +1,5 @@
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 from datahub.interaction.models import InteractionExportCountry
 
 
@@ -22,6 +22,6 @@ class InteractionsExportCountryDatasetView(BaseFilterDatasetView):
         )
         updated_since = request.GET.get('updated_since')
 
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset

--- a/datahub/dataset/order/views.py
+++ b/datahub/dataset/order/views.py
@@ -3,7 +3,7 @@ from django.db.models.functions import Cast
 
 from datahub.core.query_utils import get_aggregate_subquery, get_string_agg_subquery
 from datahub.dataset.core.views import BaseFilterDatasetView
-from datahub.dataset.utils import filter_data_by_date
+from datahub.dataset.utils import filter_data_by_modified_date
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.omis.order.models import Order
 
@@ -52,6 +52,6 @@ class OMISDatasetView(BaseFilterDatasetView):
             'vat_cost',
         )
         updated_since = request.GET.get('updated_since')
-        filtered_queryset = filter_data_by_date(updated_since, queryset)
+        filtered_queryset = filter_data_by_modified_date(updated_since, queryset)
 
         return filtered_queryset

--- a/datahub/dataset/utils.py
+++ b/datahub/dataset/utils.py
@@ -1,9 +1,9 @@
 from datahub.dbmaintenance.utils import parse_date
 
 
-def filter_data_by_date(updated_since, queryset):
+def filter_data_by_modified_date(updated_since, queryset):
     if updated_since:
         updated_since_date = parse_date(updated_since)
         if updated_since_date:
-            queryset = queryset.filter(created_on__gt=updated_since_date)
+            queryset = queryset.filter(modified_on__gt=updated_since_date)
     return queryset


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR fixes the filtering behaviour for several datasets, in the datasets endpoint, where the API would only return records with a `created_on` date after the `updated_since_date`, which we are not sure was the intended behaviour. Instead, this has been updated to use the `modified_on` date.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
