### PR TITLE
Adapt GVA formular to exclude FDI retention projects

### DIFF
--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -401,6 +401,10 @@ class FDIType(Enum):
         'Creation of new site or activity',
         'f8447013-cfdc-4f35-a146-6619665388b3',
     )
+    retention = Constant(
+        'Retention',
+        '0657168e-8a58-4f37-914f-ec541556fc28',
+    )
 
 
 class FDIValue(Enum):

--- a/datahub/investment/project/gva_utils.py
+++ b/datahub/investment/project/gva_utils.py
@@ -4,11 +4,12 @@ from logging import getLogger
 from django.utils.functional import cached_property
 
 from datahub.core.constants import (
-    InvestmentBusinessActivity as InvestmentBusinessActivityConstant,
-)
-from datahub.core.constants import (
+    FDIType as FDITypeConstant,
     InvestmentType as InvestmentTypeConstant,
     Sector as SectorConstant,
+)
+from datahub.core.constants import (
+    InvestmentBusinessActivity as InvestmentBusinessActivityConstant,
 )
 from datahub.investment.project.models import GVAMultiplier
 
@@ -80,6 +81,9 @@ class GrossValueAddedCalculator:
             str(self.investment_project.investment_type_id)
             != InvestmentTypeConstant.fdi.value.id
         ):
+            return None
+
+        if str(self.investment_project.fdi_type_id) == FDITypeConstant.retention.value.id:
             return None
 
         if self._has_business_activity_of_retail_or_sales():


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR modifies how Gross Value Added (GVA) is calculated for an investment project. Now, projects with an FDI type of `retention` will return a GVA multiplier of None, and thus, have no GVA.

See ticket `CLS2-788` for more information.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
