### PR TITLE
Fix complete field in Export win dataset.

### DIFF
--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -207,6 +207,7 @@ class ExportWinsWinDatasetView(BaseDatasetView):
                     output_field=JSONField(),
                 ),
                 temp_cdms_reference=F('cdms_reference'),
+                temp_complete=F('complete'),
             )
             .prefetch_related('associated_programme', 'type_of_support')
             .values(
@@ -214,7 +215,6 @@ class ExportWinsWinDatasetView(BaseDatasetView):
                 'id',
                 'audit',
                 'business_type',
-                'complete',
                 'date',
                 'description',
                 'has_hvo_specialist_involvement',
@@ -250,6 +250,18 @@ class ExportWinsWinDatasetView(BaseDatasetView):
                 customer_email_date=Max('customer_response__tokens__created_on'),
             )
             .annotate(
+                complete=Case(
+                    When(
+                        migrated_on__isnull=True,
+                        then=Case(
+                            When(num_notifications__gt=0, then=True),
+                            default=False,
+                            output_field=BooleanField(),
+                        ),
+                    ),
+                    default=F('temp_complete'),
+                    output_field=BooleanField(),
+                ),
                 company_name=F('company__name'),
                 confirmation__access_to_contacts=Case(
                     When(customer_response__responded_on__isnull=True, then=None),


### PR DESCRIPTION
### Description of change

This fixes the `complete` field that indicates if email was sent to the customer.

For legacy record (when `migrated_on` is not None), it will come from `win.complete`, otherwise it will be True if `num_notifications` is greater than 0, otherwise it will be False.

 
### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
