### PR TITLE
Fix customer email date in Export win dataset

### DIFF
--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -9,7 +9,7 @@ from django.db.models import (
     F,
     Func,
     IntegerField,
-    Max,
+    Min,
     OuterRef,
     Subquery,
     Value,
@@ -247,7 +247,7 @@ class ExportWinsWinDatasetView(BaseDatasetView):
                 sector_display=F('sector_name'),
                 team_type_display=F('team_type__name'),
                 num_notifications=Count('customer_response__tokens'),
-                customer_email_date=Max('customer_response__tokens__created_on'),
+                customer_email_date=Min('customer_response__tokens__created_on'),
             )
             .annotate(
                 complete=Case(


### PR DESCRIPTION
### Description of change

This fixes the customer email date so it shows the date customer email was sent the first time rather than last.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
