### PR TITLE
Increase page_size to 300 for company contacts

### DIFF
--- a/datahub/company/pagination.py
+++ b/datahub/company/pagination.py
@@ -1,0 +1,11 @@
+from rest_framework import pagination
+
+
+class ContactPageSize(pagination.PageNumberPagination):
+    """
+    The default page_size is 100, this increases it to display more
+    contacts on the frontend dropdown menu for companies with more than
+    100 contacts.
+    """
+
+    page_size = 300

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -44,6 +44,7 @@ from datahub.company.models import (
     Contact,
     Objective,
 )
+from datahub.company.pagination import ContactPageSize
 from datahub.company.queryset import (
     get_contact_queryset,
     get_export_country_queryset,
@@ -426,6 +427,7 @@ class ContactV4ViewSet(ContactViewSet):
     """Contact ViewSet v4."""
 
     serializer_class = ContactV4Serializer
+    pagination_class = ContactPageSize
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
The frontend currently only shows the first 100 company contacts on a dropdown menu. This is due to the page_size being 100. This increases the page_size so companies with >100 contacts can see all their contacts.

### Description of change

The frontend currently only shows the first 100 company contacts on a dropdown menu. This is due to the page_size being 100. This increases the page_size so companies with >100 contacts can see all their contacts.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
