### PR TITLE
Add fields into the admin list display for upcoming task reminders

### DIFF
--- a/datahub/reminder/admin.py
+++ b/datahub/reminder/admin.py
@@ -120,6 +120,18 @@ class UpcomingTaskReminderAdmin(admin.ModelAdmin):
     """Upcoming task reminder admin."""
 
     raw_id_fields = ('adviser',)
+    list_display = (
+        'id',
+        'task',
+        'event',
+        'status',
+        'adviser',
+    )
+    list_display_links = (
+        'id',
+        'adviser',
+        'task',
+    )
 
 
 @admin.register(TaskDeletedByOthersSubscription)


### PR DESCRIPTION
### Description of change

Small additional fields to the django admin list page for upcoming task reminders.

I'm currently investigating some reminder emails not being sent out so added these to help navigate them while I continue looking.

### Checklist

* [X] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?

