### PR TITLE
Fix flakey export-wins test

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -254,7 +254,9 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
 
     def get_contact_names(self, obj):
         """Return a comma separated list of company contact names."""
-        return ', '.join(contact.name for contact in obj.company_contacts.all())
+        return ', '.join(
+            contact.name for contact in obj.company_contacts.all().order_by('last_name')
+        )
     get_contact_names.short_description = 'Contact name'
 
     def get_actions(self, request):


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

On occasion, CircleCI workflows were failing with the following error:

```
FAILED datahub/export_win/test/test_admin.py::test_get_contact_names - AssertionError: assert 'Jane Smith, John Doe' == 'John Doe, Jane Smith'
  
  - John Doe, Jane Smith
  + Jane Smith, John Doe
```

This PR fixes this _flakiness_ by ordering the contact queryset by `last_name`.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
