### PR TITLE
Fix/RR-1424 set advisor field to readonly

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -321,9 +321,11 @@ class DeletedWinAdmin(WinAdmin):
     actions = ('undelete',)
 
     def get_queryset(self, request):
+        """Return win queryset only for deleted win."""
         return self.model.objects.soft_deleted()
 
     def undelete(self, request, queryset):
+        """Perform undelete action in django admin"""
         for win in queryset.all():
             with reversion.create_revision():
                 win.is_deleted = False

--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -160,7 +160,6 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
         ('created_on', DateFieldListFilter),
     )
     autocomplete_fields = (
-        'adviser',
         'company',
         'company_contacts',
         'lead_officer',
@@ -168,6 +167,7 @@ class WinAdmin(BaseModelAdminMixin, VersionAdmin):
     )
     readonly_fields = (
         'id',
+        'adviser',
         'created_on',
         'modified_on',
         'total_expected_export_value',


### PR DESCRIPTION
### Description of change

This is about changing adviser field to readonly field within win

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
