### PR TITLE
Added customer response base manager query filter to excludes wins being soft deleted

### DIFF
--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -46,6 +46,18 @@ class BaseExportWinSoftDeleteManager(models.Manager):
         )
 
 
+class BaseCustomerResponseSoftDeleteManager(models.Manager):
+    """Base class for Customer response soft delete manager."""
+
+    def get_queryset(self):
+        return (
+            super()
+            .get_queryset()
+            .select_related('win')
+            .exclude(win__is_deleted=True)
+        )
+
+
 class BaseExportWinOrderedConstantModel(BaseOrderedConstantModel):
     """Base class for an Export Win."""
 
@@ -632,6 +644,8 @@ class CustomerResponse(BaseModel):
         default=EmailDeliveryStatus.UNKNOWN,
     )
     lead_officer_email_sent_on = models.DateTimeField(null=True, blank=True)
+
+    objects = BaseCustomerResponseSoftDeleteManager()
 
 
 class CustomerResponseToken(models.Model):


### PR DESCRIPTION

### Description of change
This quick fix to excludes soft deleted Export wins from customer response when sending an email notification.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [X] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [X] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
