### PR TITLE
Fix hvc codes in Export win dataset.

### DIFF
--- a/datahub/dataset/export_wins/test/test_views.py
+++ b/datahub/dataset/export_wins/test/test_views.py
@@ -306,7 +306,7 @@ class TestExportWinsWinDatasetView(BaseDatasetViewTest):
             'date': format_date_or_datetime(win.date),
             'description': win.description,
             'has_hvo_specialist_involvement': win.has_hvo_specialist_involvement,
-            'hvc': win.hvc.export_win_id,
+            'hvc': f'{win.hvc.campaign_id}{win.hvc.financial_year}',
             'is_e_exported': win.is_e_exported,
             'is_line_manager_confirmed': win.is_line_manager_confirmed,
             'is_personally_confirmed': win.is_personally_confirmed,

--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -351,7 +351,10 @@ class ExportWinsWinDatasetView(BaseDatasetView):
                     output_field=BooleanField(),
                 ),
                 country=F('country__iso_alpha2_code'),
-                hvc=F('hvc__export_win_id'),
+                hvc=Concat(
+                    Cast('hvc__campaign_id', CharField()),
+                    Cast('hvc__financial_year', CharField()),
+                ),
                 user__email=F('adviser__contact_email'),
                 user__name=Concat(
                     'adviser__first_name',


### PR DESCRIPTION
### Description of change

The new HVC codes don't have legacy win id, so they were not showing up correctly in the Export win dataset.
This reconstructs the id from `campaign_id` and `financial_year`.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
