### PR TITLE
change the international telephone validator to allow hyphens in it

### DIFF
--- a/datahub/core/validators/telephone.py
+++ b/datahub/core/validators/telephone.py
@@ -21,10 +21,10 @@ class InternationalTelephoneValidator(RegexValidator):
     Validator for international telephone numbers.
 
     Validates that phone number is composed of characters found in telephone numbers -
-    0-9, a space or open / close brackets - optionally preceded with a plus sign.
+    0-9, a space, hyphens, or open / close brackets - optionally preceded with a plus sign.
     """
 
-    regex = r'^\+?[\d() ]{1,}$'
+    regex = r'^\+?[\d() -]{1,}$'
     message = 'Phone number must be composed of numeric characters.'
 
 


### PR DESCRIPTION
### Description of change
User was finding they couldn't edit a contact without getting an error. On investigation it was due to the phone number (which wasn't being changed) having hyphens in it. The validation in the api didn't allow for hyphens. However, US numbers are often displayed with hyphens. This pr changes the international telephone validator to allow hyphens to be in the number.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
