### PR TITLE
Feature/cls2 808 add gva multiplier to investment serializer

### DIFF
--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -373,7 +373,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         GVAMultiplier,
         required=False,
         allow_null=False,
-        extra_fields=('id', 'sector_classification_gva_multiplier')
+        extra_fields=('id', 'sector_classification_gva_multiplier'),
     )
 
     # Value fields

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -369,8 +369,12 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         allow_null=True,
     )
 
-    gva_multiplier = NestedRelatedField(GVAMultiplier, required=False, allow_null=False,
-        extra_fields=('id', 'sector_classification_gva_multiplier'))
+    gva_multiplier = NestedRelatedField(
+        GVAMultiplier,
+        required=False,
+        allow_null=False,
+        extra_fields=('id', 'sector_classification_gva_multiplier')
+    )
 
     # Value fields
     fdi_value = NestedRelatedField(meta_models.FDIValue, required=False, allow_null=True)

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -19,6 +19,7 @@ from datahub.investment.project.constants import (
     ProjectManagerRequestStatus as ProjectManagerRequestStatusValue,
 )
 from datahub.investment.project.models import (
+    GVAMultiplier,
     InvestmentActivity,
     InvestmentActivityType,
     InvestmentDeliveryPartner,
@@ -93,6 +94,7 @@ CORE_FIELDS = (
     'level_of_involvement_simplified',
     'note',
     'gross_value_added',
+    'gva_multiplier',
 )
 
 VALUE_FIELDS = (
@@ -366,6 +368,9 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         required=False,
         allow_null=True,
     )
+
+    gva_multiplier = NestedRelatedField(GVAMultiplier, required=False, allow_null=False,
+        extra_fields=('id', 'sector_classification_gva_multiplier'))
 
     # Value fields
     fdi_value = NestedRelatedField(meta_models.FDIValue, required=False, allow_null=True)

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -138,6 +138,7 @@ class TestListView(APITestMixin):
             'foreign_equity_investment',
             'government_assistance',
             'gross_value_added',
+            'gva_multiplier',
             'some_new_jobs',
             'number_new_jobs',
             'will_new_jobs_last_two_years',


### PR DESCRIPTION
### Description of change
Added the GVA multiplier to the investment serialiser so that the GVA sector classification (capital/labour) is available to the frontend

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
