### PR TITLE
Handle duplicate adviser and contact record for legacy win migration.

### DIFF
--- a/datahub/export_win/test/test_legacy_migration.py
+++ b/datahub/export_win/test/test_legacy_migration.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -273,7 +273,7 @@ legacy_wins = {
             'is_prosperity_fund_related': True,
             'lead_officer_email_address': '',
             'lead_officer_name': 'Lead officer name',
-            'line_manager_name': 'line manager name',
+            'line_manager_name': 'line manager',
             'name_of_customer': '',
             'name_of_export': '',
             'other_official_email_address': '',
@@ -423,19 +423,43 @@ def test_legacy_migration(mock_legacy_wins_pages):
     jane_doe = AdviserFactory(
         first_name='Jane',
         last_name='Doe',
+        is_active=True,
     )
     john_smith = AdviserFactory(
         first_name='John',
         last_name='Smith',
+        is_active=True,
+    )
+    AdviserFactory(
+        first_name='John',
+        last_name='Smith',
+        is_active=False,
+    )
+    line_manager = AdviserFactory(
+        first_name='line',
+        last_name='manager',
     )
     adviser = AdviserFactory(
         contact_email='user.email@trade.gov.uk',
+        is_active=True,
     )
-    contact = ContactFactory(
-        company=company,
-        first_name='John',
-        last_name='Doe',
+    AdviserFactory(
+        contact_email='user.email@trade.gov.uk',
+        is_active=False,
     )
+    current_date = datetime.utcnow()
+    with freeze_time(current_date):
+        contact = ContactFactory(
+            company=company,
+            first_name='John',
+            last_name='Doe',
+        )
+    with freeze_time(current_date - timedelta(days=1)):
+        ContactFactory(
+            company=company,
+            first_name='John',
+            last_name='Doe',
+        )
 
     current_date = datetime.now(tz=timezone.utc)
 
@@ -525,3 +549,4 @@ def test_legacy_migration(mock_legacy_wins_pages):
     assert win_4.customer_response.name == ''
     assert win_4.customer_response.comments == ''
     assert win_4.customer_response.other_marketing_source == ''
+    assert win_4.line_manager == line_manager


### PR DESCRIPTION
### Description of change

This update handles cases when there are duplicate adviser and contact records in Data Hub for legacy export wins migration.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
