### PR TITLE
Add event related programme to search endpoint

### DIFF
--- a/datahub/search/event/serializers.py
+++ b/datahub/search/event/serializers.py
@@ -37,6 +37,7 @@ class SearchEventQuerySerializer(EntitySearchQuerySerializer):
     name = serializers.CharField(required=False)
     organiser = SingleOrListField(child=StringUUIDField(), required=False)
     organiser_name = serializers.CharField(required=False)
+    related_programmes = SingleOrListField(child=StringUUIDField(), required=False)
     start_date_after = RelaxedDateTimeField(required=False)
     start_date_before = RelaxedDateTimeField(required=False)
     teams = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/event/views.py
+++ b/datahub/search/event/views.py
@@ -21,6 +21,7 @@ class SearchEventAPIViewMixin:
         'name',
         'organiser',
         'organiser_name',
+        'related_programmes',
         'start_date_after',
         'start_date_before',
         'teams',
@@ -32,6 +33,7 @@ class SearchEventAPIViewMixin:
         'event_type': 'event_type.id',
         'lead_team': 'lead_team.id',
         'organiser': 'organiser.id',
+        'related_programmes': 'related_programmes.id',
         'teams': 'teams.id',
         'uk_region': 'uk_region.id',
     }


### PR DESCRIPTION
### Description of change

The `related_programmes` field for events has been added to the search endpoint. This is needed for an upcoming migration ticket.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
