### PR TITLE
feature/RR-1363:Export win backend input validation

### DIFF
--- a/datahub/export_win/decorators.py
+++ b/datahub/export_win/decorators.py
@@ -1,0 +1,38 @@
+import functools
+import json
+from html.parser import HTMLParser
+
+from rest_framework import status
+
+from rest_framework.response import Response
+
+
+class TagChecker(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.contains_tags = False
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() in ['script', 'style']:
+            self.contains_tags = True
+
+    def handle_endtag(self, tag):
+        if tag.lower() in ['script', 'style']:
+            self.contains_tags = True
+
+
+def contains_script_or_html_tags(data):
+    tag_checker = TagChecker()
+    tag_checker.feed(data)
+    return tag_checker.contains_tags
+
+
+def validate_script_and_html_tags(view_method):
+    @functools.wraps(view_method)
+    def wrapper(self, request, *args, **kwargs):
+        data_str = json.dumps(request.data)  # Assuming request.data is already a dictionary
+        if contains_script_or_html_tags(data_str):
+            return Response({'error': 'Input contains script or HTML tags'},
+                            status=status.HTTP_400_BAD_REQUEST)
+        return view_method(self, request, *args, **kwargs)
+    return wrapper

--- a/datahub/export_win/decorators.py
+++ b/datahub/export_win/decorators.py
@@ -3,28 +3,41 @@ import json
 from html.parser import HTMLParser
 
 from rest_framework import status
-
 from rest_framework.response import Response
 
 
 class TagChecker(HTMLParser):
     def __init__(self):
         super().__init__()
-        self.contains_tags = False
+        self.contains_disallowed_content = False
+        self.disallowed_tags = ['script', 'style', 'iframe', 'embed', 'object', 'form']
+        self.disallowed_symbols = ['lt', 'gt', 'amp', 'quot', 'apos']
+        self.disallowed_characters = ['<', '>', '\\']
 
     def handle_starttag(self, tag, attrs):
-        if tag.lower() in ['script', 'style']:
-            self.contains_tags = True
+        if tag.lower() in self.disallowed_tags:
+            self.contains_disallowed_content = True
 
     def handle_endtag(self, tag):
-        if tag.lower() in ['script', 'style']:
-            self.contains_tags = True
+        if tag.lower() in self.disallowed_tags:
+            self.contains_disallowed_content = True
+
+    def handle_data(self, data):
+        if any(char in data for char in self.disallowed_characters):
+            self.contains_disallowed_content = True
+
+    def handle_entityref(self, name):
+        if name.lower() in self.disallowed_symbols:
+            self.contains_disallowed_content = True
+
+    def handle_charref(self, name):
+        self.contains_disallowed_content = True
 
 
 def contains_script_or_html_tags(data):
     tag_checker = TagChecker()
     tag_checker.feed(data)
-    return tag_checker.contains_tags
+    return tag_checker.contains_disallowed_content
 
 
 def validate_script_and_html_tags(view_method):
@@ -32,7 +45,7 @@ def validate_script_and_html_tags(view_method):
     def wrapper(self, request, *args, **kwargs):
         data_str = json.dumps(request.data)  # Assuming request.data is already a dictionary
         if contains_script_or_html_tags(data_str):
-            return Response({'error': 'Input contains script or HTML tags'},
+            return Response({'error': 'Input contains disallowed HTML or script tags or symbols'},
                             status=status.HTTP_400_BAD_REQUEST)
         return view_method(self, request, *args, **kwargs)
     return wrapper

--- a/datahub/export_win/decorators.py
+++ b/datahub/export_win/decorators.py
@@ -6,35 +6,39 @@ from rest_framework import status
 from rest_framework.response import Response
 
 
+DISALLOWED_TAGS = ['script', 'style', 'iframe', 'embed', 'object', 'form']
+DISALLOWED_SYMBOLS = ['lt', 'gt', 'amp', 'quot', 'apos']
+DISALLOWED_CHARACTERS = ['<', '>']
+
+
 class TagChecker(HTMLParser):
     def __init__(self):
         super().__init__()
         self.contains_disallowed_content = False
-        self.disallowed_tags = ['script', 'style', 'iframe', 'embed', 'object', 'form']
-        self.disallowed_symbols = ['lt', 'gt', 'amp', 'quot', 'apos']
-        self.disallowed_characters = ['<', '>', '\\']
 
     def handle_starttag(self, tag, attrs):
-        if tag.lower() in self.disallowed_tags:
+        if tag.lower() in DISALLOWED_TAGS:
             self.contains_disallowed_content = True
 
     def handle_endtag(self, tag):
-        if tag.lower() in self.disallowed_tags:
+        if tag.lower() in DISALLOWED_TAGS:
             self.contains_disallowed_content = True
 
     def handle_data(self, data):
-        if any(char in data for char in self.disallowed_characters):
+        if any(char in data for char in DISALLOWED_CHARACTERS):
             self.contains_disallowed_content = True
 
     def handle_entityref(self, name):
-        if name.lower() in self.disallowed_symbols:
+        if name.lower() in DISALLOWED_SYMBOLS:
             self.contains_disallowed_content = True
 
     def handle_charref(self, name):
         self.contains_disallowed_content = True
 
 
-def contains_script_or_html_tags(data):
+def contains_disallowed_content(data):
+    if any(char in data for char in DISALLOWED_CHARACTERS):
+        return True
     tag_checker = TagChecker()
     tag_checker.feed(data)
     return tag_checker.contains_disallowed_content
@@ -43,8 +47,8 @@ def contains_script_or_html_tags(data):
 def validate_script_and_html_tags(view_method):
     @functools.wraps(view_method)
     def wrapper(self, request, *args, **kwargs):
-        data_str = json.dumps(request.data)  # Assuming request.data is already a dictionary
-        if contains_script_or_html_tags(data_str):
+        data_str = request.data if isinstance(request.data, str) else json.dumps(request.data)
+        if contains_disallowed_content(data_str):
             return Response({'error': 'Input contains disallowed HTML or script tags or symbols'},
                             status=status.HTTP_400_BAD_REQUEST)
         return view_method(self, request, *args, **kwargs)

--- a/datahub/export_win/test/test_decorators.py
+++ b/datahub/export_win/test/test_decorators.py
@@ -20,7 +20,8 @@ class TestValidateScriptAndHtmlTags(unittest.TestCase):
         response = mock_view(None, request)
         self.assertEqual(response.status_code, 400)
         self.assertIn('error', response.data)
-        self.assertEqual(response.data['error'], 'Input contains script or HTML tags')
+        self.assertEqual(response.data['error'],
+                         'Input contains disallowed HTML or script tags or symbols')
 
     def test_input_without_html_tags(self):
         """Test the decorator with input without HTML/script tags."""

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -1212,7 +1212,7 @@ class TestCreateWinView(APITestMixin):
         assert 'error' in response_data
         error_message = response_data['error']
 
-        assert 'Input contains script or HTML tags' in error_message, \
+        assert 'Input contains disallowed HTML or script tags or symbols' in error_message, \
             'The error message should warn about script or HTML tags.'
 
         mock_export_win_serializer_notify.assert_not_called()
@@ -1885,7 +1885,7 @@ class TestUpdateWinView(APITestMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert 'error' in response_data
-        assert 'Input contains script or HTML tags' in response_data['error']
+        assert 'Input contains disallowed HTML or script tags or symbols' in response_data['error']
 
 
 class TestResendExportWinView(APITestMixin):

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -1160,6 +1160,63 @@ class TestCreateWinView(APITestMixin):
             'This field is required' in response_text,
         ])
 
+    def test_create_win_with_html_script_tags(self, mock_export_win_serializer_notify):
+        """Tests handling of HTML/script tags within submitted data."""
+        url = reverse('api-v4:export-win:collection')
+
+        # Setup basic data with HTML/script tags in potentially vulnerable fields
+        adviser = self.user
+        lead_officer = AdviserFactory()
+        company = CompanyFactory()
+        contact = ContactFactory(company=company)
+        date_won = now().date()
+        export_experience = ExportExperienceFactory()
+
+        request_data = {
+            'adviser': {'id': str(adviser.id)},
+            'lead_officer': {'id': str(lead_officer.id)},
+            'hq_team': {'id': HQTeamRegionOrPostConstant.td_events_services.value.id},
+            'team_type': {'id': TeamTypeConstant.itt.value.id},
+            'business_potential': {'id': BusinessPotentialConstant.high_export_potential.value.id},
+            'company': {'id': str(company.id)},
+            'company_contacts': [{'id': str(contact.id)}],
+            'customer_location': {'id': WinUKRegionConstant.overseas.value.id},
+            'business_type': 'The best type',
+            'description': '<script>alert("XSS");</script>',
+            'name_of_export': '<div>Unsafe HTML content</div>',
+            'date': date_won,
+            'country': CountryConstant.canada.value.id,
+            'total_expected_export_value': 1000000,
+            'total_expected_non_export_value': 1000000,
+            'total_expected_odi_value': 1000000,
+            'goods_vs_services': {'id': ExpectedValueRelationConstant.both.value.id},
+            'sector': {'id': SectorConstant.aerospace_assembly_aircraft.value.id},
+            'type_of_support': [
+                {'id': SupportTypeConstant.political_and_economic_briefing.value.id}],
+            'associated_programme': [{'id': AssociatedProgrammeConstant.afterburner.value.id}],
+            'is_personally_confirmed': False,
+            'is_line_manager_confirmed': False,
+            'name_of_customer': 'Overseas Customer<script>alert("hack");</script>',
+            'name_of_customer_confidential': True,
+            'export_experience': {'id': str(export_experience.id)},
+            'breakdowns': [{'type': {'id': BreakdownTypeConstant.export.value.id},
+                            'value': 1000, 'year': 2023}],
+        }
+        first_sent = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
+        with freeze_time(first_sent):
+            response = self.api_client.post(url, data=request_data)
+        response_data = response.json()
+
+        # Check that the system either cleansed the input or rejected the request
+        assert response.status_code == 400
+        assert 'error' in response_data
+        error_message = response_data['error']
+
+        assert 'Input contains script or HTML tags' in error_message, \
+            'The error message should warn about script or HTML tags.'
+
+        mock_export_win_serializer_notify.assert_not_called()
+
 
 class TestUpdateWinView(APITestMixin):
     """Update export win view tests."""

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -1785,9 +1785,6 @@ class TestUpdateWinView(APITestMixin):
         date_won = now().date()
         export = ExportFactory()
         export_experience = ExportExperienceFactory()
-        first_sent = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
-        with freeze_time(first_sent):
-            CustomerResponseTokenFactory(customer_response=win.customer_response)
 
         malicious_script = '<script>alert("XSS");</script>'
         request_data = {

--- a/datahub/export_win/views.py
+++ b/datahub/export_win/views.py
@@ -23,6 +23,7 @@ from datahub.core.schemas import StubSchema
 
 from datahub.core.viewsets import CoreViewSet
 from datahub.export_win import EXPORT_WINS_LEGACY_DATA_FEATURE_FLAG_NAME
+from datahub.export_win.decorators import validate_script_and_html_tags
 from datahub.export_win.models import (
     CustomerResponse,
     CustomerResponseToken,
@@ -156,10 +157,12 @@ class WinViewSet(CoreViewSet):
         )
 
     @log_bad_request
+    @validate_script_and_html_tags
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
 
     @log_bad_request
+    @validate_script_and_html_tags
     def partial_update(self, request, *args, **kwargs):
         return super().partial_update(request, *args, **kwargs)
 

--- a/datahub/export_win/views.py
+++ b/datahub/export_win/views.py
@@ -239,6 +239,11 @@ class CustomerResponseViewSet(CoreViewSet):
         context['token'] = getattr(self, 'token', None)
         return context
 
+    @validate_script_and_html_tags
+    def partial_update(self, request, *args, **kwargs):
+        """Handle PATCH requests with HTML/script tags validation."""
+        return super().partial_update(request, *args, **kwargs)
+
     def put(self, request, *args, **kwargs):
         return Response(status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
### Description of change

This PR addresses the security vulnerabilities identified in the recent penetration test by enhancing the input validation mechanisms for export win. This is a backend implementation and there will be a front end implementation coming for better user experience ( see attached documentation in [this ticket](https://uktrade.atlassian.net/jira/software/projects/RR/boards/242?selectedIssue=RR-1363) for more details) The main changes include:

1. Input Validation Enhancement - Introduced a TagChecker class to parse and detect disallowed HTML tags ('<script>', '<style>', '<iframe>', '<embed>', '<object>', '<form>'), named character references (&lt;, &gt;, &amp;, &quot;, &apos;), and specific disallowed characters (<, >,\ \).Please refer to the relevant section in the commit for detailed implementation.

2. Decorator for Validation - Implemented a validate_script_and_html_tags decorator to wrap around view functions.
This decorator ensures that any input containing disallowed HTML tags, symbols, or characters results in a 400 Bad Request response, preventing malicious content from being processed by the server. Please refer to the relevant section in the commit for detailed implementation.

3. Security Best Practices - Adopted a preventive approach by blocking dangerous input at the source, ensuring robust security against injection attacks. 

Impact:
Security Improvement: These changes mitigate the risk of XSS and other injection attacks by ensuring malicious content is blocked at the point of entry in export win.
User Experience: Users attempting to input dangerous content will receive immediate feedback, preventing potential misuse or accidental security breaches.

Testing:
you can test this by calling <datahub_env_url>/v4/export-win endpoint via postman or manual and pass following payload
`{    
    "adviser": {
      "id": "change to your own adviser id"
    },
    "lead_officer": {
      "id": "change to your own leadofficer id"
    },
    "hq_team": {
      "id": "b9afc253-5aa1-498f-b5d7-d43dad1ced82"
    },
    "team_type": {
      "id": "1f6eccf9-289a-450b-a4af-b75600ea521b"
    },
    "business_potential": {
      "id": "0e6f1d69-e9c3-4460-a74b-3881930fe3e9"
    },
    "company": {
      "id": "cf52ca4d-a6d5-4b1e-b640-ed43249b12a5"
    },
    "company_contacts": [
      {
        "id": "fc87ccb7-da02-4343-9ed4-4c17abddd1c5"
      }
    ],
    "customer_location": {
      "id": "8a4cd12a-6095-e211-a939-e4115bead28a"
    },
    "business_type": "The best type",
    "description": "Description",
    "name_of_export": "Sand",
    "date": "2024-05-05",
    "country": "5daf72a6-5d95-e211-a939-e4115bead28a",
    "total_expected_export_value": 1000000,
    "total_expected_non_export_value": 1000000,
    "total_expected_odi_value": 1000000,
    "goods_vs_services": {
      "id": "8711e3dd-3a2c-4b47-aea7-9a53c135efb6"
    },
    "sector": {
      "id": "b422c9d2-5f95-e211-a939-e4115bead28a"
    },
    "type_of_support": [
      {
        "id": "1ed7f465-1461-4d66-b4a2-8d704ea239a8"
      }
    ],
    "associated_programme": [
      {
        "id": "b6f5c31a-aa45-4ae0-89bd-2eb3ab943f76"
      }
    ],
    "is_personally_confirmed": false,
    "is_line_manager_confirmed": false,
    "name_of_customer": "Overseas Customer",
    "name_of_customer_confidential": true,
    "export_experience": {
      "id": "587928e3-cab1-45cb-ba49-0656b6d2f867"
    },
    "breakdowns": [
      {
        "type": {
          "id": "cecb1f61-abd2-4715-a0c9-b196b52671d9"
        },
        "value": 1000,
        "year": 2023
      }
    ]
  }`


https://github.com/uktrade/data-hub-api/assets/148454056/a8dc1e2e-72b3-4bf2-985b-f867a1ed2b71




### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
