### PR TITLE
Add archived filter to contacts endpoint.

### DIFF
--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -1308,6 +1308,38 @@ class ContactListBase(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert {res['email'] for res in response.data['results']} == expected
 
+    @pytest.mark.parametrize(
+        'contacts,filter_,expected',
+        (
+            (
+                (True, False),
+                True,
+                {True},
+            ),
+            (
+                (True, False),
+                False,
+                {False},
+            ),
+            (
+                (True, False),
+                None,
+                {True, False},
+            ),
+        ),
+    )
+    def test_filter_by_archived(self, contacts, filter_, expected):
+        """Test getting contacts by archived"""
+        ContactFactory.create_batch(len(contacts), archived=factory.Iterator(contacts))
+
+        response = self.api_client.get(
+            reverse(f'{self.endpoint_namespace}:contact:list'),
+            data={'archived': filter_} if filter_ is not None else {},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {res['archived'] for res in response.data['results']} == expected
+
 
 class TestContactListV3(ContactListBase):
     """Tests for v3 list contacts endpoint"""

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -403,7 +403,7 @@ class ContactViewSet(ArchivableViewSetMixin, CoreViewSet):
         DjangoFilterBackend,
         OrderingFilter,
     )
-    filterset_fields = ['company_id', 'email']
+    filterset_fields = ['company_id', 'email', 'archived']
     ordering = ('-created_on',)
 
     def get_serializer_class(self):


### PR DESCRIPTION
### Description of change

This adds `archived` filter to contact endpoints.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
