### PR TITLE
Limit the value of breakdown year

### DIFF
--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -1,12 +1,11 @@
 import uuid
 
 from django.conf import settings
-
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
 from django.db.models import Max
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-
 from mptt.fields import TreeForeignKey
 
 from datahub.company.models import (
@@ -24,7 +23,9 @@ from datahub.metadata.models import (
     Sector,
     UKRegion,
 )
+
 from datahub.reminder.models import EmailDeliveryStatus
+
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -493,7 +494,12 @@ class Breakdown(BaseModel, BaseLegacyModel):
         related_name='breakdowns',
         on_delete=models.PROTECT,
     )
-    year = models.IntegerField()
+    year = models.IntegerField(
+        validators=[
+            MinValueValidator(1),
+            MaxValueValidator(5),
+        ],
+    )
     value = models.BigIntegerField()
 
 


### PR DESCRIPTION
### Description of change

This tiny PR relates to [RR-1444 ](https://uktrade.atlassian.net/jira/software/projects/RR/boards/242?selectedIssue=RR-1444)which is to set breakdown year to only accept value 1-5, so as to ensure that any future admin users do not enter incorrect data

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
