### PR TITLE
Fix legacy Export win migration and add missing associated programmes.

### DIFF
--- a/datahub/export_win/constants.py
+++ b/datahub/export_win/constants.py
@@ -20,3 +20,4 @@ class TeamType(Enum):
     itt = Constant('International Trade Team', '1f6eccf9-289a-450b-a4af-b75600ea521b')
     post = Constant('Overseas Post', '6e798633-83da-4597-8e9a-9bb033ca06a4')
     tcp = Constant('Trade Challenge Partners (TCP)', 'f7006548-9ef0-4c4e-bc60-1b7ca40ff75b')
+    trade = Constant('Export Support Services', '24823128-f9e6-4877-a12f-4995f8b525d8')

--- a/datahub/export_win/migrations/0046_fix_hq_team_migration.py
+++ b/datahub/export_win/migrations/0046_fix_hq_team_migration.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+from pathlib import PurePath
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+def load_team_types(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0046_fix_hq_team_migration.yaml'
+    )
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('export_win', '0045_alter_breakdown_year'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_team_types, migrations.RunPython.noop),
+    ]

--- a/datahub/export_win/migrations/0046_fix_hq_team_migration.yaml
+++ b/datahub/export_win/migrations/0046_fix_hq_team_migration.yaml
@@ -1,0 +1,12 @@
+- model: export_win.teamtype
+  pk: 24823128-f9e6-4877-a12f-4995f8b525d8
+  fields:
+    disabled_on: null
+    name: 'Export Support Services'
+    export_win_id: trade
+    order: 900
+- model: export_win.hqteamregionorpost
+  pk: 37ed1910-e369-4311-a062-77a6d2951a96
+  fields:
+    export_win_id: 'trade:1'
+    team_type_id: 24823128-f9e6-4877-a12f-4995f8b525d8

--- a/datahub/export_win/migrations/0047_add_associated_programmes.py
+++ b/datahub/export_win/migrations/0047_add_associated_programmes.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+from pathlib import PurePath
+import uuid
+
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_associated_programmes(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0047_add_associated_programmes.yaml'
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('export_win', '0046_fix_hq_team_migration'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_associated_programmes, migrations.RunPython.noop),
+    ]

--- a/datahub/export_win/migrations/0047_add_associated_programmes.yaml
+++ b/datahub/export_win/migrations/0047_add_associated_programmes.yaml
@@ -1,0 +1,26 @@
+- model: export_win.associatedprogramme
+  pk: 4da1d272-6200-4785-af8c-263f3324c205
+  fields:
+    disabled_on: null
+    name: "Northern Ireland Investment Summit 2023"
+    export_win_id: "114"
+    order:  705
+- model: export_win.associatedprogramme
+  pk: 5a3307a0-757b-4789-a86f-272f17dfb798
+  fields:
+    disabled_on: null
+    name: "International Trade Week 2023"
+    export_win_id: "115"
+    order:  625
+- model: export_win.associatedprogramme
+  pk: 78e86747-5bf9-4ee6-ac82-e92e133ed991
+  fields:
+    disabled_on: null
+    name: "Women's International Network (WIN Programme)"
+    export_win_id: "116"
+    order:  865
+- model: export_win.associatedprogramme
+  pk: c4a0744d-1f54-41d8-aa46-29951e0fa913
+  fields:
+    export_win_id: "117"
+    order: 505

--- a/datahub/export_win/test/test_views.py
+++ b/datahub/export_win/test/test_views.py
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.django_db
     (
         (
             TeamTypeConstant.team.value.id,
-            74,
+            73,
         ),
         (
             TeamTypeConstant.investment.value.id,
@@ -43,6 +43,10 @@ pytestmark = pytest.mark.django_db
         (
             TeamTypeConstant.tcp.value.id,
             73,
+        ),
+        (
+            TeamTypeConstant.trade.value.id,
+            1,
         ),
     ),
 )


### PR DESCRIPTION
### Description of change

This fixes the HQ team that was added to wrong team type and had a duplicate legacy_win_id that didn't match the legacy system.

It also adds a few missing associated programmes and corrects their ordering.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
