### PR TITLE
Added company__name to ordering_fields

### DIFF
--- a/datahub/export_win/views.py
+++ b/datahub/export_win/views.py
@@ -125,7 +125,7 @@ class WinViewSet(CoreViewSet):
     )
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     filterset_class = ConfirmedFilterSet
-    ordering_fields = ('customer_response__responded_on', 'created_on')
+    ordering_fields = ('customer_response__responded_on', 'created_on', 'company__name')
     ordering = ('-customer_response__responded_on', '-created_on')
 
     def get_queryset(self):


### PR DESCRIPTION
### Description of change

This PR adds `'company__name'` to `WinViewSet.ordering_fields`.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
