### PR TITLE
Fix legacy_id migration.

### DIFF
--- a/datahub/export_win/legacy_migration.py
+++ b/datahub/export_win/legacy_migration.py
@@ -318,6 +318,7 @@ def create_breakdown_from_legacy(item):
         'type': breakdown_type,
         'year': year,
         'value': int(item['value']),
+        'legacy_id': int(item['id']),
     }
 
 
@@ -352,6 +353,7 @@ def create_win_adviser_from_legacy(item):
         'hq_team': hq_team,
         'team_type': team_type,
         'location': item['location'],
+        'legacy_id': int(item['id']),
     }
 
     adviser = _get_adviser_by_email_or_name('', item.get('name').strip())

--- a/datahub/export_win/test/test_legacy_migration.py
+++ b/datahub/export_win/test/test_legacy_migration.py
@@ -443,7 +443,7 @@ legacy_wins = {
         'next': mock_legacy_wins_page_urls['breakdowns'][1],
         'results': [
             {
-                'id': 11,
+                'id': 1,
                 'win__id': '5778b485-1060-46e2-b411-772cd0f76d79',
                 'type': 1,
                 'year': 2016,
@@ -552,7 +552,7 @@ legacy_wins = {
         'results': [
             {
                 'hq_team': 'itt:The North West International Trade Team',
-                'id': 1,
+                'id': 2,
                 'location': 'London',
                 'name': 'John Smith',
                 'team_type': 'itt',


### PR DESCRIPTION
### Description of change

The migration function was not recording the ids of legacy breakdown and win adviser records. This corrects it.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
