### PR TITLE
Require number new/safeguarded jobs and average salary at verify win stage

### DIFF
--- a/datahub/activity_stream/investment/test/test_views.py
+++ b/datahub/activity_stream/investment/test/test_views.py
@@ -92,8 +92,7 @@ def test_investment_project_with_pm_added(api_client):
     Get a list of investment project and test the returned JSON is valid as per:
     https://www.w3.org/TR/activitystreams-core/
 
-    Investment Project with PM will have fields such as totalInvestment and
-    numberNewJobs.
+    Investment Project with PM will have fields such as totalInvestment.
     """
     start = datetime.datetime(year=2012, month=7, day=12, hour=15, minute=6, second=3)
     with freeze_time(start) as frozen_datetime:
@@ -134,7 +133,6 @@ def test_investment_project_with_pm_added(api_client):
                         project.estimated_land_date,
                     ),
                     'dit:totalInvestment': project.total_investment,
-                    'dit:numberNewJobs': project.number_new_jobs,
                     'attributedTo': [
                         {
                             'id': f'dit:DataHubCompany:{project.investor_company.pk}',

--- a/datahub/investment/project/test/factories.py
+++ b/datahub/investment/project/test/factories.py
@@ -128,7 +128,6 @@ class AssignPMInvestmentProjectFactory(InvestmentProjectFactory):
     stage_id = InvestmentProjectStage.assign_pm.value.id
     client_cannot_provide_total_investment = False
     total_investment = Decimal('100.0')
-    number_new_jobs = 0
     client_considering_other_countries = False
     client_requirements = factory.Faker('text')
     site_decided = False
@@ -159,6 +158,7 @@ class VerifyWinInvestmentProjectFactory(ActiveInvestmentProjectFactory):
     client_cannot_provide_foreign_investment = False
     foreign_equity_investment = Decimal('100.0')
     government_assistance = False
+    number_new_jobs = 0
     number_safeguarded_jobs = 0
     r_and_d_budget = True
     non_fdi_r_and_d_budget = False

--- a/datahub/investment/project/test/test_validate.py
+++ b/datahub/investment/project/test/test_validate.py
@@ -142,7 +142,6 @@ def test_validate_value_fail():
     assert errors == {
         'client_cannot_provide_total_investment': 'This field is required.',
         'total_investment': 'This field is required.',
-        'number_new_jobs': 'This field is required.',
     }
 
 
@@ -152,7 +151,6 @@ def test_validate_value_instance_success():
         stage_id=constants.InvestmentProjectStage.assign_pm.value.id,
         client_cannot_provide_total_investment=False,
         total_investment=100,
-        number_new_jobs=0,
     )
     errors = validate(instance=project, fields=VALUE_FIELDS)
     assert not errors
@@ -266,7 +264,6 @@ def test_validate_verify_win_instance_failure():
         client_contacts=[ContactFactory().id, ContactFactory().id],
         client_cannot_provide_total_investment=False,
         total_investment=100,
-        number_new_jobs=10,
         client_considering_other_countries=False,
         client_requirements='client reqs',
         site_decided=False,
@@ -278,6 +275,7 @@ def test_validate_verify_win_instance_failure():
     errors = validate(instance=project)
     assert errors == {
         'government_assistance': 'This field is required.',
+        'number_new_jobs': 'This field is required.',
         'number_safeguarded_jobs': 'This field is required.',
         'r_and_d_budget': 'This field is required.',
         'non_fdi_r_and_d_budget': 'This field is required.',
@@ -288,7 +286,6 @@ def test_validate_verify_win_instance_failure():
         'address_postcode': 'This field is required.',
         'actual_uk_regions': 'This field is required.',
         'delivery_partners': 'This field is required.',
-        'average_salary': 'This field is required.',
         'client_cannot_provide_foreign_investment': 'This field is required.',
         'foreign_equity_investment': 'This field is required.',
         'actual_land_date': 'This field is required.',

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -983,7 +983,6 @@ class TestRetrieveView(APITestMixin):
         response_data = response.json()
         incomplete_fields = (
             'client_cannot_provide_total_investment',
-            'number_new_jobs',
             'total_investment',
             'client_considering_other_countries',
             'client_requirements',
@@ -1357,7 +1356,6 @@ class TestPartialUpdateView(APITestMixin):
             'client_cannot_provide_total_investment': [
                 'This field is required.',
             ],
-            'number_new_jobs': ['This field is required.'],
             'total_investment': ['This field is required.'],
             'client_considering_other_countries': ['This field is required.'],
             'client_requirements': ['This field is required.'],
@@ -1373,7 +1371,6 @@ class TestPartialUpdateView(APITestMixin):
         project = InvestmentProjectFactory(
             client_cannot_provide_total_investment=False,
             total_investment=100,
-            number_new_jobs=0,
             client_considering_other_countries=False,
             client_requirements='client reqs',
             site_decided=False,
@@ -1455,7 +1452,6 @@ class TestPartialUpdateView(APITestMixin):
             'client_cannot_provide_total_investment': [
                 'This field is required.',
             ],
-            'number_new_jobs': ['This field is required.'],
             'total_investment': ['This field is required.'],
             'client_considering_other_countries': ['This field is required.'],
             'client_requirements': ['This field is required.'],
@@ -1489,7 +1485,6 @@ class TestPartialUpdateView(APITestMixin):
             [InvestmentProjectPermission.change_associated],
         )
         project = ActiveInvestmentProjectFactory(
-            number_new_jobs=1,
             project_manager=project_manager,
         )
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
@@ -1503,6 +1498,7 @@ class TestPartialUpdateView(APITestMixin):
         response_data = response.json()
         assert response_data == {
             'government_assistance': ['This field is required.'],
+            'number_new_jobs': ['This field is required.'],
             'number_safeguarded_jobs': ['This field is required.'],
             'r_and_d_budget': ['This field is required.'],
             'non_fdi_r_and_d_budget': ['This field is required.'],
@@ -1513,7 +1509,6 @@ class TestPartialUpdateView(APITestMixin):
             'address_postcode': ['This field is required.'],
             'actual_uk_regions': ['This field is required.'],
             'delivery_partners': ['This field is required.'],
-            'average_salary': ['This field is required.'],
             'client_cannot_provide_foreign_investment': ['This field is required.'],
             'foreign_equity_investment': ['This field is required.'],
             'actual_land_date': ['This field is required.'],
@@ -1543,6 +1538,7 @@ class TestPartialUpdateView(APITestMixin):
             uk_region_locations=[random_obj_for_model(UKRegion)],
             actual_uk_regions=[random_obj_for_model(UKRegion)],
             government_assistance=False,
+            number_new_jobs=0,
             number_safeguarded_jobs=0,
             r_and_d_budget=True,
             non_fdi_r_and_d_budget=True,

--- a/datahub/investment/project/validate.py
+++ b/datahub/investment/project/validate.py
@@ -41,7 +41,6 @@ class InvestmentProjectStageValidationConfig:
         """Mapping from field name to the stage the field becomes required."""
         return {
             'client_cannot_provide_total_investment': Stage.assign_pm.value,
-            'number_new_jobs': Stage.assign_pm.value,
             'strategic_drivers': Stage.assign_pm.value,
             'client_requirements': Stage.assign_pm.value,
             'client_considering_other_countries': Stage.assign_pm.value,
@@ -49,6 +48,7 @@ class InvestmentProjectStageValidationConfig:
             'project_assurance_adviser': Stage.active.value,
             'client_cannot_provide_foreign_investment': Stage.verify_win.value,
             'government_assistance': Stage.verify_win.value,
+            'number_new_jobs': Stage.verify_win.value,
             'number_safeguarded_jobs': Stage.verify_win.value,
             'r_and_d_budget': Stage.verify_win.value,
             'non_fdi_r_and_d_budget': Stage.verify_win.value,

--- a/datahub/search/investment/test/test_signals.py
+++ b/datahub/search/investment/test/test_signals.py
@@ -352,7 +352,6 @@ def test_incomplete_fields_syncs_when_project_changes(opensearch_with_signals):
     assert result.hits.total.value == 1
     assert result.hits[0]['incomplete_fields'] == [
         'client_cannot_provide_total_investment',
-        'number_new_jobs',
         'strategic_drivers',
         'client_requirements',
         'client_considering_other_countries',
@@ -360,6 +359,7 @@ def test_incomplete_fields_syncs_when_project_changes(opensearch_with_signals):
         'project_assurance_adviser',
         'client_cannot_provide_foreign_investment',
         'government_assistance',
+        'number_new_jobs',
         'number_safeguarded_jobs',
         'r_and_d_budget',
         'non_fdi_r_and_d_budget',
@@ -378,13 +378,13 @@ def test_incomplete_fields_syncs_when_project_changes(opensearch_with_signals):
     ]
 
     project.client_cannot_provide_total_investment = False
-    project.number_new_jobs = 3
     project.client_requirements = 'things'
     project.client_considering_other_countries = True
     project.project_manager = adviser
     project.project_assurance_adviser = adviser
     project.client_cannot_provide_foreign_investment = True
     project.government_assistance = True
+    project.number_new_jobs = 3
     project.number_safeguarded_jobs = 10
     project.r_and_d_budget = True
     project.non_fdi_r_and_d_budget = True


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

Investment projects now require the `number_new_jobs`, `average_salary`, and `number_safeguarded_jobs` fields to be populated before moving to the _verify win_ stage. This PR adds this functionality.

The `average_salary` and `number_safeguarded_jobs` fields were already required at this stage. The `number_new_jobs` field was required at the _assign PM_ stage and so this rule was amended.

Please note, the `average_salary` field is only required once `number_new_jobs` is populated.

[Link to frontend PR](https://github.com/uktrade/data-hub-frontend/pull/6885)

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
