### PR TITLE
Ignore orphaned WinAdvisers in legacy Export wins migration.

### DIFF
--- a/datahub/export_win/legacy_migration.py
+++ b/datahub/export_win/legacy_migration.py
@@ -347,11 +347,17 @@ def update_legacy_win_totals():
 
 
 def create_win_adviser_from_legacy(item):
+    try:
+        win = Win.objects.all_wins().get(id=item['win__id'])
+    except Win.DoesNotExist:
+        logger.warning(f"Legacy Win {item['win__id']} does not exist.")
+        return None
+
     hq_team = HQTeamRegionOrPost.objects.get(export_win_id=item['hq_team'])
     team_type = TeamType.objects.get(export_win_id=item['team_type'])
 
     adviser_data = {
-        'win_id': item['win__id'],
+        'win': win,
         'hq_team': hq_team,
         'team_type': team_type,
         'location': item['location'],

--- a/datahub/export_win/test/test_legacy_migration.py
+++ b/datahub/export_win/test/test_legacy_migration.py
@@ -558,6 +558,14 @@ legacy_wins = {
                 'team_type': 'itt',
                 'win__id': '02ce5d82-5294-477a-ab9a-94782e7b2794',
             },
+            {  # For orphaned win adviser
+                'hq_team': 'itt:The North West International Trade Team',
+                'id': 3,
+                'location': 'London',
+                'name': 'John Smith',
+                'team_type': 'itt',
+                'win__id': 'a43f0333-f95e-4762-a258-0e9f4ed42b1c',
+            },
         ],
     },
 }


### PR DESCRIPTION
### Description of change

This lets the legacy Export win migration continue if it encounters orphaned Win adviser.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
