### PR TITLE
Disabled customer response - responded on field in order lockdown date stamp

### DIFF
--- a/datahub/export_win/admin.py
+++ b/datahub/export_win/admin.py
@@ -101,6 +101,11 @@ class CustomerResponseInlineForm(ModelForm):
         self.fields['name'].required = not is_instance_and_pk_exist
         self.fields['id'].widget.attrs['readonly'] = is_instance_and_pk_exist
 
+        # Disabled responded on form field so that it will lock down to users.
+        # Even if a user tampers field values, it will be  ignored in favour
+        # to initial form value, rather than using readonly attrs.
+        self.fields['responded_on'].widget.attrs['disabled'] = True
+
 
 class CustomerResponseInline(BaseStackedInline):
     """Customer response in line."""


### PR DESCRIPTION
### Description of change
Currently, Export Win admin team has an access to modify a customer date response. As requested, it must be lockdown in order not to tamper the date stamp of customer response date.
 
<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [X] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [X] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
