### PR TITLE
Add `notes` field to interaction export

### DIFF
--- a/datahub/search/interaction/test/test_views.py
+++ b/datahub/search/interaction/test/test_views.py
@@ -1082,6 +1082,7 @@ class TestInteractionExportView(APITestMixin):
                     separator='; ',
                 ),
                 'Policy feedback notes': interaction.policy_feedback_notes,
+                'Notes': interaction.notes,
             }
             for interaction in sorted_interactions
         ]
@@ -1228,6 +1229,7 @@ class TestInteractionExportView(APITestMixin):
                     separator='; ',
                 ),
                 'Policy feedback notes': interaction.policy_feedback_notes,
+                'Notes': interaction.notes,
                 'advisers': _format_expected_advisers(interaction),
                 'adviser_emails': _format_expected_adviser_emails(interaction),
                 'tag_1': '',

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -143,6 +143,7 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
         'policy_issue_type_names': 'Policy issue types',
         'policy_area_names': 'Policy areas',
         'policy_feedback_notes': 'Policy feedback notes',
+        'notes': 'Notes',
     }
 
 
@@ -256,6 +257,7 @@ class SearchInteractionPolicyFeedbackExportAPIView(
         'policy_issue_type_names': 'Policy issue types',
         'policy_area_names': 'Policy areas',
         'policy_feedback_notes': 'Policy feedback notes',
+        'notes': 'Notes',
         'adviser_names': 'advisers',
         'adviser_emails': 'adviser_emails',
         'tag_1': 'tag_1',


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

Users have requested the `Interaction.notes` field be included in the interaction export because at the moment, the notes are only visible when clicking into an interaction on Data Hub.

This PR adds the field to the API view, and subsequently the exported CSV.

<img width="634" alt="image" src="https://github.com/uktrade/data-hub-api/assets/47334342/e0b2b117-1162-480c-9a91-bc90f3617110">

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
