### PR TITLE
Allow interactions to be filtered by contact ID

### DIFF
--- a/datahub/search/company/test/test_opensearch.py
+++ b/datahub/search/company/test/test_opensearch.py
@@ -450,6 +450,7 @@ def test_get_basic_search_query():
                                 'company_number',
                                 'contact.name',
                                 'contact.name.trigram',
+                                'contacts.id',
                                 'contacts.name',
                                 'contacts.name.trigram',
                                 'country.trigram',

--- a/datahub/search/contact/test/test_opensearch.py
+++ b/datahub/search/contact/test/test_opensearch.py
@@ -320,6 +320,7 @@ def test_get_basic_search_query():
                                 'company_number',
                                 'contact.name',
                                 'contact.name.trigram',
+                                'contacts.id',
                                 'contacts.name',
                                 'contacts.name.trigram',
                                 'country.trigram',

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -11,7 +11,7 @@ from datahub.search.models import BaseSearchModel
 def _contact_field():
     return Object(
         properties={
-            'id': Keyword(index=False),
+            'id': Keyword(),
             'first_name': Text(index=False),
             'last_name': Text(index=False),
             'name': Text(
@@ -139,6 +139,7 @@ class Interaction(BaseSearchModel):
         'company.name.trigram',
         'companies.name',
         'companies.name.trigram',
+        'contacts.id',
         'contacts.name',  # to find 2-letter words
         'contacts.name.trigram',
         'event.name',

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -29,6 +29,7 @@ class SearchInteractionQuerySerializer(EntitySearchQuerySerializer):
     service = SingleOrListField(child=StringUUIDField(), required=False)
     sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     was_policy_feedback_provided = serializers.BooleanField(required=False)
+    contacts = SingleOrListField(child=StringUUIDField(), required=False)
 
     DEFAULT_ORDERING = SearchOrdering('date', SortDirection.desc)
 

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -49,6 +49,7 @@ class SearchInteractionAPIViewMixin:
         'sector_descends',
         'service',
         'was_policy_feedback_provided',
+        'contacts',
     )
     REMAP_FIELDS = {
         'company': 'company.id',
@@ -60,6 +61,7 @@ class SearchInteractionAPIViewMixin:
         'policy_areas': 'policy_areas.id',
         'policy_issue_types': 'policy_issue_types.id',
         'service': 'service.id',
+        'contacts': 'contacts.id',
     }
 
     COMPOSITE_FILTERS = {

--- a/datahub/search/investment/test/test_opensearch.py
+++ b/datahub/search/investment/test/test_opensearch.py
@@ -742,6 +742,7 @@ def test_get_basic_search_query():
                                 'company_number',
                                 'contact.name',
                                 'contact.name.trigram',
+                                'contacts.id',
                                 'contacts.name',
                                 'contacts.name.trigram',
                                 'country.trigram',


### PR DESCRIPTION
### Description of change

As part of an upcoming piece of work we need to return a list of interactions for a specific contact. This is now possible.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
