### PR TITLE
add specific_programmes field to read only field in admin

### DIFF
--- a/datahub/investment/project/admin.py
+++ b/datahub/investment/project/admin.py
@@ -62,6 +62,7 @@ class InvestmentProjectAdmin(BaseModelAdminMixin, VersionAdmin):
         'financial_year_verbose',
         # Remove when migration to specific_programmes is complete
         'specific_programme',
+        'specific_programmes',
     )
     list_display = (
         'name',
@@ -73,8 +74,6 @@ class InvestmentProjectAdmin(BaseModelAdminMixin, VersionAdmin):
         'created_by',
         'modified_on',
         'modified_by',
-        # Remove when migration to specific_programmes is complete
-        'specific_programmes',
     )
 
     def financial_year_verbose(self, obj):


### PR DESCRIPTION
### Description of change

Put the new specific_programmes field to a read only field. The main purpose of this is to check that when manually running the data transfer from the specific_programme field to specific_programmes field the values has indeed been copied over.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
