### PR TITLE
Add legacy fields win Export win serializers.

### DIFF
--- a/datahub/export_win/serializers.py
+++ b/datahub/export_win/serializers.py
@@ -6,6 +6,7 @@ from django.db import transaction
 
 from rest_framework.serializers import (
     BooleanField,
+    CharField,
     DateTimeField,
     ModelSerializer,
     SerializerMethodField,
@@ -70,11 +71,16 @@ class WinAdviserSerializer(ModelSerializer):
     team_type = NestedRelatedField(TeamType)
     hq_team = NestedRelatedField(HQTeamRegionOrPost)
 
+    # legacy field
+    name = CharField(read_only=True)
+
     class Meta:
         model = WinAdviser
         fields = (
             'id',
             'adviser',
+            # legacy field
+            'name',
             'team_type',
             'hq_team',
             'location',
@@ -163,6 +169,17 @@ class WinSerializer(ModelSerializer):
     complete = BooleanField(read_only=True)
     first_sent = DateTimeField(read_only=True)
     last_sent = DateTimeField(read_only=True)
+    migrated_on = DateTimeField(read_only=True)
+
+    # legacy fields
+    company_name = CharField(read_only=True)
+    customer_name = CharField(read_only=True)
+    customer_job_title = CharField(read_only=True)
+    customer_email_address = CharField(read_only=True)
+    lead_officer_name = CharField(read_only=True)
+    lead_officer_email_address = CharField(read_only=True)
+    adviser_name = CharField(read_only=True)
+    adviser_email_address = CharField(read_only=True)
 
     company_export = NestedRelatedField(
         CompanyExport,
@@ -175,10 +192,22 @@ class WinSerializer(ModelSerializer):
         fields = (
             'id',
             'adviser',
+            # legacy field
+            'adviser_name',
+            # legacy field
+            'adviser_email_address',
             'advisers',
             'breakdowns',
             'company',
+            # legacy field
+            'company_name',
             'company_contacts',
+            # legacy field
+            'customer_name',
+            # legacy field
+            'customer_job_title',
+            # legacy field
+            'customer_email_address',
             'complete',
             'customer_location',
             'business_type',
@@ -204,6 +233,10 @@ class WinSerializer(ModelSerializer):
             'is_personally_confirmed',
             'is_line_manager_confirmed',
             'lead_officer',
+            # legacy field
+            'lead_officer_name',
+            # legacy field
+            'lead_officer_email_address',
             'team_type',
             'hq_team',
             'business_potential',
@@ -221,6 +254,7 @@ class WinSerializer(ModelSerializer):
             'company_export',
             'first_sent',
             'last_sent',
+            'migrated_on',
         )
 
     def create(self, validated_data):

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -196,10 +196,16 @@ class TestGetWinView(APITestMixin):
                 'last_name': win.adviser.last_name,
                 'name': win.adviser.name,
             },
+            # legacy field
+            'adviser_name': win.adviser_name,
+            # legacy field
+            'adviser_email_address': win.adviser_email_address,
             'company': {
                 'id': str(win.company.id),
                 'name': win.company.name,
             },
+            # legacy field
+            'company_name': win.company_name,
             'country': {
                 'id': str(win.country.id),
                 'name': win.country.name,
@@ -217,6 +223,12 @@ class TestGetWinView(APITestMixin):
                     'email': contact.email,
                 },
             ],
+            # legacy field
+            'customer_name': win.customer_name,
+            # legacy field
+            'customer_email_address': win.customer_email_address,
+            # legacy field
+            'customer_job_title': win.customer_job_title,
             'audit': win.audit,
             'business_potential': {
                 'id': str(win.business_potential.id),
@@ -259,8 +271,13 @@ class TestGetWinView(APITestMixin):
                 'last_name': win.lead_officer.last_name,
                 'name': win.lead_officer.name,
             },
+            # legacy field
+            'lead_officer_name': win.lead_officer_name,
+            # legacy field
+            'lead_officer_email_address': win.lead_officer_email_address,
             'location': win.location,
             'modified_on': format_date_or_datetime(win.modified_on),
+            'migrated_on': format_date_or_datetime(win.migrated_on),
             'name_of_customer': win.name_of_customer,
             'name_of_customer_confidential': win.name_of_customer_confidential,
             'name_of_export': win.name_of_export,
@@ -727,7 +744,13 @@ class TestCreateWinView(APITestMixin):
                 'last_name': win.adviser.last_name,
                 'name': win.adviser.name,
             },
+            # legacy field
+            'adviser_name': win.adviser_name,
+            # legacy field
+            'adviser_email_address': win.adviser_email_address,
             'company': {'id': str(win.company_id), 'name': win.company.name},
+            # legacy field
+            'company_name': win.company_name,
             'country': {'id': str(win.country_id), 'name': win.country.name},
             'associated_programme': [
                 {
@@ -742,6 +765,12 @@ class TestCreateWinView(APITestMixin):
                     'email': contact.email,
                 },
             ],
+            # legacy field
+            'customer_name': win.customer_name,
+            # legacy field
+            'customer_email_address': win.customer_email_address,
+            # legacy field
+            'customer_job_title': win.customer_job_title,
             'audit': win.audit,
             'business_potential': {
                 'id': str(win.business_potential_id),
@@ -808,8 +837,13 @@ class TestCreateWinView(APITestMixin):
                 'last_name': win.lead_officer.last_name,
                 'name': win.lead_officer.name,
             },
+            # legacy field
+            'lead_officer_name': win.lead_officer_name,
+            # legacy field
+            'lead_officer_email_address': win.lead_officer_email_address,
             'location': win.location,
             'modified_on': format_date_or_datetime(win.modified_on),
+            'migrated_on': format_date_or_datetime(win.migrated_on),
             'name_of_customer': win.name_of_customer,
             'name_of_customer_confidential': win.name_of_customer_confidential,
             'name_of_export': win.name_of_export,
@@ -983,10 +1017,16 @@ class TestCreateWinView(APITestMixin):
                 'last_name': win.adviser.last_name,
                 'name': win.adviser.name,
             },
+            # legacy field
+            'adviser_name': win.adviser_name,
+            # legacy field
+            'adviser_email_address': win.adviser_email_address,
             'company': {
                 'id': str(win.company_id),
                 'name': win.company.name,
             },
+            # legacy field
+            'company_name': win.company_name,
             'country': {
                 'id': str(win.country_id),
                 'name': win.country.name,
@@ -1004,6 +1044,12 @@ class TestCreateWinView(APITestMixin):
                     'email': contact.email,
                 },
             ],
+            # legacy field
+            'customer_name': win.customer_name,
+            # legacy field
+            'customer_email_address': win.customer_email_address,
+            # legacy field
+            'customer_job_title': win.customer_job_title,
             'audit': win.audit,
             'business_potential': {
                 'id': str(win.business_potential_id),
@@ -1070,8 +1116,13 @@ class TestCreateWinView(APITestMixin):
                 'last_name': win.lead_officer.last_name,
                 'name': win.lead_officer.name,
             },
+            # legacy field
+            'lead_officer_name': win.lead_officer_name,
+            # legacy field
+            'lead_officer_email_address': win.lead_officer_email_address,
             'location': win.location,
             'modified_on': format_date_or_datetime(win.modified_on),
+            'migrated_on': format_date_or_datetime(win.migrated_on),
             'name_of_customer': win.name_of_customer,
             'name_of_customer_confidential': win.name_of_customer_confidential,
             'name_of_export': win.name_of_export,
@@ -1104,6 +1155,8 @@ class TestCreateWinView(APITestMixin):
                         'last_name': win_adviser.adviser.last_name,
                         'name': win_adviser.adviser.name,
                     },
+                    # legacy field
+                    'name': win_adviser.name,
                     'location': win_adviser.location,
                     'team_type': {
                         'id': str(win_adviser.team_type.id),
@@ -1376,10 +1429,16 @@ class TestUpdateWinView(APITestMixin):
                 'last_name': adviser.last_name,
                 'name': adviser.name,
             },
+            # legacy field
+            'adviser_name': win.adviser_name,
+            # legacy field
+            'adviser_email_address': win.adviser_email_address,
             'company': {
                 'id': str(company.id),
                 'name': company.name,
             },
+            # legacy field
+            'company_name': win.company_name,
             'country': {
                 'id': str(CountryConstant.canada.value.id),
                 'name': CountryConstant.canada.value.name,
@@ -1397,6 +1456,12 @@ class TestUpdateWinView(APITestMixin):
                     'email': contact.email,
                 },
             ],
+            # legacy field
+            'customer_name': win.customer_name,
+            # legacy field
+            'customer_email_address': win.customer_email_address,
+            # legacy field
+            'customer_job_title': win.customer_job_title,
             'audit': win.audit,
             'business_potential': {
                 'id': str(win.business_potential_id),
@@ -1466,8 +1531,13 @@ class TestUpdateWinView(APITestMixin):
                 'last_name': lead_officer.last_name,
                 'name': lead_officer.name,
             },
+            # legacy field
+            'lead_officer_name': win.lead_officer_name,
+            # legacy field
+            'lead_officer_email_address': win.lead_officer_email_address,
             'location': 'Park',
             'modified_on': format_date_or_datetime(win.modified_on),
+            'migrated_on': format_date_or_datetime(win.migrated_on),
             'name_of_customer': win.name_of_customer,
             'name_of_customer_confidential': win.name_of_customer_confidential,
             'name_of_export': win.name_of_export,
@@ -1500,6 +1570,8 @@ class TestUpdateWinView(APITestMixin):
                         'last_name': win_adviser.adviser.last_name,
                         'name': win_adviser.adviser.name,
                     },
+                    # legacy field
+                    'name': win_adviser.name,
                     'location': win_adviser.location,
                     'team_type': {
                         'id': str(win_adviser.team_type.id),
@@ -1590,10 +1662,16 @@ class TestUpdateWinView(APITestMixin):
                 'last_name': win.adviser.last_name,
                 'name': win.adviser.name,
             },
+            # legacy field
+            'adviser_name': win.adviser_name,
+            # legacy field
+            'adviser_email_address': win.adviser_email_address,
             'company': {
                 'id': str(win.company.id),
                 'name': win.company.name,
             },
+            # legacy field
+            'company_name': win.company_name,
             'country': {
                 'id': str(win.country.id),
                 'name': win.country.name,
@@ -1611,6 +1689,12 @@ class TestUpdateWinView(APITestMixin):
                     'email': contact.email,
                 },
             ],
+            # legacy field
+            'customer_name': win.customer_name,
+            # legacy field
+            'customer_email_address': win.customer_email_address,
+            # legacy field
+            'customer_job_title': win.customer_job_title,
             'audit': win.audit,
             'business_potential': {
                 'id': str(win.business_potential.id),
@@ -1653,8 +1737,13 @@ class TestUpdateWinView(APITestMixin):
                 'last_name': win.lead_officer.last_name,
                 'name': win.lead_officer.name,
             },
+            # legacy field
+            'lead_officer_name': win.lead_officer_name,
+            # legacy field
+            'lead_officer_email_address': win.lead_officer_email_address,
             'location': win.location,
             'modified_on': format_date_or_datetime(win.modified_on),
+            'migrated_on': format_date_or_datetime(win.migrated_on),
             'name_of_customer': win.name_of_customer,
             'name_of_customer_confidential': win.name_of_customer_confidential,
             'name_of_export': win.name_of_export,
@@ -1689,6 +1778,8 @@ class TestUpdateWinView(APITestMixin):
                         'last_name': win_adviser.adviser.last_name,
                         'name': win_adviser.adviser.name,
                     },
+                    # legacy field
+                    'name': win_adviser.name,
                     'location': win_adviser.location,
                     'team_type': {
                         'id': str(win_adviser.team_type.id),


### PR DESCRIPTION
### Description of change

This adds legacy Export win fields to serializers so that they can be displayed in the Front end.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
