### PR TITLE
Updated for syncing to process latest modified first and output…

### DIFF
--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -342,6 +342,12 @@ class MockQuerySet:
             raise MultipleObjectsReturned()
 
         return matches[0]
+    
+    def order_by(self, *fields):
+        """
+        Mock order_by note: no actual ordering takes place.
+        """
+        return self.values_list(self, *fields)
 
     def filter(self, pk__in=()):
         """

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -342,7 +342,7 @@ class MockQuerySet:
             raise MultipleObjectsReturned()
 
         return matches[0]
-    
+
     def order_by(self, *fields):
         """
         Mock order_by note: no actual ordering takes place.

--- a/datahub/search/bulk_sync.py
+++ b/datahub/search/bulk_sync.py
@@ -25,7 +25,9 @@ def sync_app(search_app, batch_size=None, post_batch_callback=None):
 
     # We know pk exists but some models don't have modified_on, so handle this.
     try:
-        it = search_app.queryset.order_by('-modified_on').values_list('pk', flat=True).iterator(chunk_size=batch_size)
+        it = search_app.queryset.order_by('-modified_on').values_list('pk', flat=True).iterator(
+            chunk_size=batch_size,
+        )
         has_modified_on = True
     except FieldError:
         it = search_app.queryset.values_list('pk', flat=True).iterator(chunk_size=batch_size)

--- a/datahub/search/bulk_sync.py
+++ b/datahub/search/bulk_sync.py
@@ -1,5 +1,7 @@
 from logging import getLogger
 
+from django.core.exceptions import FieldError
+
 from datahub.core.utils import slice_iterable_into_chunks
 from datahub.search.opensearch import bulk
 
@@ -20,7 +22,15 @@ def sync_app(search_app, batch_size=None, post_batch_callback=None):
     num_source_rows_processed = 0
     num_objects_synced = 0
     total_rows = search_app.queryset.count()
-    it = search_app.queryset.values_list('pk', flat=True).iterator(chunk_size=batch_size)
+
+    # We know pk exists but some models don't have modified_on, so handle this.
+    try:
+        it = search_app.queryset.order_by('-modified_on').values_list('pk', flat=True).iterator(chunk_size=batch_size)
+        has_modified_on = True
+    except FieldError:
+        it = search_app.queryset.values_list('pk', flat=True).iterator(chunk_size=batch_size)
+        has_modified_on = False
+
     batches = slice_iterable_into_chunks(it, batch_size)
     for batch in batches:
         objs = search_app.queryset.filter(pk__in=batch)
@@ -43,10 +53,15 @@ def sync_app(search_app, batch_size=None, post_batch_callback=None):
         num_objects_synced += num_actions
 
         if emit_progress:
-            logger.info(
+            log_message = (
                 f'{model_name} rows processed: {num_source_rows_processed}/{total_rows} '
-                f'{num_source_rows_processed*100//total_rows}%',
+                f'{num_source_rows_processed*100//total_rows}%'
             )
+
+            if has_modified_on:
+                log_message = f'{log_message} modified_on: {objs.last().modified_on}'
+
+            logger.info(log_message)
 
     logger.info(f'{model_name} rows processed: {num_source_rows_processed}/{total_rows} 100%.')
     if num_source_rows_processed != num_objects_synced:

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -7,9 +7,9 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core.test_utils import MockQuerySet
 from datahub.interaction.models import Interaction
 from datahub.interaction.test.factories import InteractionFactoryBase
+from datahub.search.adviser import AdviserSearchApp
 from datahub.search.bulk_sync import sync_app, sync_objects
 from datahub.search.company import CompanySearchApp
-from datahub.search.adviser import AdviserSearchApp
 from datahub.search.interaction import InteractionSearchApp
 from datahub.search.signals import disable_search_signal_receivers
 from datahub.search.test.utils import create_mock_search_app
@@ -97,8 +97,9 @@ def test_sync_app_uses_latest_data(monkeypatch, opensearch):
     )
     assert fetched_company['_source']['name'] == 'new name'
 
+
 @pytest.mark.django_db
-@patch("datahub.search.bulk_sync.PROGRESS_INTERVAL", 1)
+@patch('datahub.search.bulk_sync.PROGRESS_INTERVAL', 1)
 @disable_search_signal_receivers(Interaction)
 def test_sync_app_log_messages__logs__modified_on(caplog):
     """Test with model with modified_on (interaction)."""
@@ -110,11 +111,14 @@ def test_sync_app_log_messages__logs__modified_on(caplog):
 
     # Assert 'modified_on' is shown for fields which have it.
     assert 'Processing Interaction records, using batch size 1' in caplog.text
-    assert f'Interaction rows processed: 1/2 50% modified_on: {interactions[1].modified_on}' in caplog.text
-    assert f'Interaction rows processed: 2/2 100% modified_on: {interactions[0].modified_on}' in caplog.text
+    assert f'Interaction rows processed: 1/2 50% modified_on: {interactions[1].modified_on}' \
+        in caplog.text
+    assert f'Interaction rows processed: 2/2 100% modified_on: {interactions[0].modified_on}' \
+        in caplog.text
+
 
 @pytest.mark.django_db
-@patch("datahub.search.bulk_sync.PROGRESS_INTERVAL", 1)
+@patch('datahub.search.bulk_sync.PROGRESS_INTERVAL', 1)
 @disable_search_signal_receivers(Advisor)
 def test_sync_app_log_messages__does_not_log__modified_on(caplog):
     """Test with model without modified_on field (adviser)."""
@@ -127,5 +131,5 @@ def test_sync_app_log_messages__does_not_log__modified_on(caplog):
     # Assert 'modified_on' is NOT shown for fields which don't have it.
     assert 'Processing Adviser records, using batch size 1' in caplog.text
     assert 'Adviser rows processed: 1/2 50%'
-    assert f'modified_on:' not in caplog.text
+    assert 'modified_on:' not in caplog.text
     assert 'Adviser rows processed: 2/2 100%'

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -1,12 +1,16 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
-from datahub.company.models import Company
-from datahub.company.test.factories import CompanyFactory
+from datahub.company.models import Advisor, Company
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core.test_utils import MockQuerySet
+from datahub.interaction.models import Interaction
+from datahub.interaction.test.factories import InteractionFactoryBase
 from datahub.search.bulk_sync import sync_app, sync_objects
 from datahub.search.company import CompanySearchApp
+from datahub.search.adviser import AdviserSearchApp
+from datahub.search.interaction import InteractionSearchApp
 from datahub.search.signals import disable_search_signal_receivers
 from datahub.search.test.utils import create_mock_search_app
 
@@ -92,3 +96,36 @@ def test_sync_app_uses_latest_data(monkeypatch, opensearch):
         id=company.pk,
     )
     assert fetched_company['_source']['name'] == 'new name'
+
+@pytest.mark.django_db
+@patch("datahub.search.bulk_sync.PROGRESS_INTERVAL", 1)
+@disable_search_signal_receivers(Interaction)
+def test_sync_app_log_messages__logs__modified_on(caplog):
+    """Test with model with modified_on (interaction)."""
+    interactions = InteractionFactoryBase.create_batch(2)
+
+    caplog.set_level('INFO')
+
+    sync_app(InteractionSearchApp, batch_size=1)
+
+    # Assert 'modified_on' is shown for fields which have it.
+    assert 'Processing Interaction records, using batch size 1' in caplog.text
+    assert f'Interaction rows processed: 1/2 50% modified_on: {interactions[1].modified_on}' in caplog.text
+    assert f'Interaction rows processed: 2/2 100% modified_on: {interactions[0].modified_on}' in caplog.text
+
+@pytest.mark.django_db
+@patch("datahub.search.bulk_sync.PROGRESS_INTERVAL", 1)
+@disable_search_signal_receivers(Advisor)
+def test_sync_app_log_messages__does_not_log__modified_on(caplog):
+    """Test with model without modified_on field (adviser)."""
+    AdviserFactory.create_batch(2)
+
+    caplog.set_level('INFO')
+
+    sync_app(AdviserSearchApp, batch_size=1)
+
+    # Assert 'modified_on' is NOT shown for fields which don't have it.
+    assert 'Processing Adviser records, using batch size 1' in caplog.text
+    assert 'Adviser rows processed: 1/2 50%'
+    assert f'modified_on:' not in caplog.text
+    assert 'Adviser rows processed: 2/2 100%'


### PR DESCRIPTION
…modified_on in logs.

### Description of change

Currently a complete update will take approximately 7 hours to update. This modifies `sync_search` to run for changed / new records first and outputs the modified on date with the progress indicator so we are able to tell when the changed records between the initial data copy and the final live copy have completed.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
