### PR TITLE
Add option to list legacy export wins in dataset endpoint.

### DIFF
--- a/datahub/dataset/core/views.py
+++ b/datahub/dataset/core/views.py
@@ -23,11 +23,20 @@ class BaseDatasetView(HawkResponseSigningMixin, APIView):
 
     def get(self, request):
         """Endpoint which serves all records for a specific Dataset"""
+        self._get_request_params(request)
         dataset = self.get_dataset()
         paginator = self.pagination_class()
         page = paginator.paginate_queryset(dataset, request, view=self)
         self._enrich_data(page)
         return paginator.get_paginated_response(page)
+
+    def _get_request_params(self, request):
+        """
+        Hook for checking request parameters before querying dataset.
+        By default it does nothing, but subclasses can use it to modify the query set,
+        based on user parameters.
+        """
+        pass
 
     def _enrich_data(self, dataset):
         """


### PR DESCRIPTION
### Description of change

This should allow us to see how legacy wins come out from the dataset endpoint and compare with the legacy system.
It is for manual testing before switch over of the pipelines.

The output should contain legacy wins only if the URL parameter is supplied 'legacy_data=true`, otherwise the behaviour should remain unchanged.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
