### PR TITLE
Changes to `referred` investment projects

### DIFF
--- a/datahub/investment/project/migrations/0024_add_referred_to_eyb_specific_programme.py
+++ b/datahub/investment/project/migrations/0024_add_referred_to_eyb_specific_programme.py
@@ -1,0 +1,25 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def add_eyb_specific_programme(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps, PurePath(__file__).parent / '0024_add_referred_to_eyb_specific_programme.yaml'
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('investment', '0023_remove_investmentproject_specific_programme_and_more'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=add_eyb_specific_programme,
+            # for reverse_code, do nothing to avoid handling future projects with this status
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/datahub/investment/project/migrations/0024_add_referred_to_eyb_specific_programme.yaml
+++ b/datahub/investment/project/migrations/0024_add_referred_to_eyb_specific_programme.yaml
@@ -1,0 +1,3 @@
+- model: investment.specificprogramme
+  pk: 3902b516-e553-4f54-b389-0a5db87ea507
+  fields: { disabled_on: null, name: Referred to EYB }

--- a/datahub/investment/project/migrations/0025_update_projects_with_referred_status.py
+++ b/datahub/investment/project/migrations/0025_update_projects_with_referred_status.py
@@ -1,0 +1,38 @@
+from uuid import UUID
+
+from django.db import migrations, transaction
+
+
+REFERRED_TO_EYB_PROGRAMME_ID = UUID('3902b516-e553-4f54-b389-0a5db87ea507')
+REFERRED_STATUS_VALUE = 'referred'
+ONGOING_STATUS_VALUE = 'ongoing'
+
+
+def update_referred_projects_programme_and_status(apps, schema_editor):    
+    InvestmentProjectModel = apps.get_model('investment', 'InvestmentProject')
+    referred_projects = InvestmentProjectModel.objects.filter(
+        status=REFERRED_STATUS_VALUE,
+    )
+    SpecificProgrammeModel = apps.get_model('investment', 'SpecificProgramme')
+    referred_to_eyb_programme = SpecificProgrammeModel.objects.get(
+        pk=REFERRED_TO_EYB_PROGRAMME_ID
+    )
+    if referred_projects.exists():
+            # many-to-many field needs to be updated individually
+            for project in referred_projects:
+                project.specific_programmes.add(referred_to_eyb_programme)
+            # bulk update status field
+            referred_projects.update(status=ONGOING_STATUS_VALUE)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('investment', '0024_add_referred_to_eyb_specific_programme'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=update_referred_projects_programme_and_status,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/datahub/investment/project/migrations/0026_remove_referred_status_from_investment_projects.py
+++ b/datahub/investment/project/migrations/0026_remove_referred_status_from_investment_projects.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('investment', '0025_update_projects_with_referred_status'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='investmentproject',
+            name='status',
+            field=models.CharField(choices=[('ongoing', 'Ongoing'), ('delayed', 'Delayed'), ('dormant', 'Dormant'), ('lost', 'Lost'), ('abandoned', 'Abandoned'), ('won', 'Won')], default='ongoing', max_length=255),
+        ),
+    ]

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -98,7 +98,6 @@ class IProjectAbstract(models.Model):
         LOST = ('lost', 'Lost')
         ABANDONED = ('abandoned', 'Abandoned')
         WON = ('won', 'Won')
-        REFERRED = ('referred', 'Referred')
 
     class Involvement(models.TextChoices):
         UNSPECIFIED = ('unspecified', 'Unspecified')


### PR DESCRIPTION
### Description of change

Stakeholders have requested that:

- `Referred to EYB` is added as a new specific programme
- Projects that currently have `status == 'referred'` should, instead, have the new `Referred to EYB` specific programme added to their list of specific programmes and their status set as 'ongoing'.
- The `referred` status removed from the list of investment project status choices

This PR adds that functionality in a number of migrations.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
