### PR TITLE
Migration command to update interactions adviser

### DIFF
--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -32,7 +32,9 @@ from datahub.export_win.test.factories import (
 )
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
+    InteractionDITParticipantFactory,
     InteractionExportCountryFactory,
+
 )
 from datahub.investment.investor_profile.test.factories import LargeCapitalInvestorProfileFactory
 from datahub.investment.opportunity.test.factories import LargeCapitalOpportunityFactory
@@ -63,6 +65,7 @@ MAPPINGS = {
     'company_list.PipelineItem': PipelineItemFactory,
     'company_referral.CompanyReferral': CompanyReferralFactory,
     'event.Event': EventFactory,
+    'interaction.InteractionDITParticipant': InteractionDITParticipantFactory,
     'interaction.Interaction': CompanyInteractionFactory,
     'interaction.InteractionExportCountry': InteractionExportCountryFactory,
     'investment.InvestmentProject': InvestmentProjectFactory,
@@ -104,7 +107,6 @@ def test_with_one_model(model_label, model_factory):
     with reversion.create_revision():
         objs = model_factory.create_batch(2)
 
-    # check created versions/revisions
     assert Version.objects.get_for_model(model).count() == 2
     assert Revision.objects.count() == 1
 
@@ -133,7 +135,16 @@ def test_with_all_models(caplog):
     objs = []
     for model_factory in MAPPINGS.values():
         with reversion.create_revision():
-            obj = model_factory.create_batch(2)  # keep only one
+
+            # This prevents CompanyInteractionFactory from creating an
+            # InteractionDITParticipantFactory which has a revision.
+            # Deleting the CompanyInteraction also deletes the InteractionDITParticipant
+            # causing two revsions instead of the expected one for this test.
+            if model_factory == CompanyInteractionFactory:
+                obj = model_factory.create_batch(2, dit_participants=[])
+            else:
+                obj = model_factory.create_batch(2)  # keep only one
+
             objs.append(obj[0])
 
     total_versions = Version.objects.count()

--- a/datahub/dbmaintenance/management/commands/update_interactions_to_new_adviser.py
+++ b/datahub/dbmaintenance/management/commands/update_interactions_to_new_adviser.py
@@ -1,0 +1,96 @@
+from logging import getLogger
+
+import reversion
+
+
+from django.core.management import BaseCommand
+
+from datahub.interaction.models import InteractionDITParticipant
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Command to update an interaction to new adviser
+
+    Example of executing this command locally:
+        python manage.py update_interactions_to_new_adviser <old_adviser_id> <new_adviser_id>
+
+    NOTE: Does not update the team of the new adviser.
+    """
+
+    help = 'Updates all the interaction associated with <old_adviser_id> to <new_adviser_id>'
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            help='Simulate the command by querying for changed data but not saving changes.',
+        )
+        parser.add_argument(
+            'old_adviser_id',
+            type=str,
+            help='Old adviser id whose interaction are to be moved from',
+        )
+        parser.add_argument(
+            'new_adviser_id',
+            type=str,
+            help='New adviser id whose interaction are to be moved to',
+        )
+
+    def handle(self, *args, **options):
+        simulate = options['simulate']
+
+        # Old adviser for interactions to be moved from.
+        old_adviser_id = options.get('old_adviser_id')
+
+        # New adviser for interactions to be moved to.
+        new_adviser_id = options.get('new_adviser_id')
+
+        # Get all interactions associated with the new adviser so we can remove them
+        # from the interactions associated with the old adviser. This is to prevent
+        # updating the old adviser to the new adviser on interactions the new adviser
+        # is already an adviser for. There is a unique together contraint on the model
+        # to prevent the duplicate advisers on the same interactions. For example, inactive
+        # John Doe's interactions being moved to an active John Doe's interactions. Both
+        # inactive and active John Doe's may have been added to the same interaction
+        # already so updating the inactive John interactions to the active John
+        # interactions would cause a unique together constraint error.
+        interaction_ids_with_new_adviser = InteractionDITParticipant.objects.filter(
+            adviser_id=new_adviser_id,
+        ).values_list('interaction_id', flat=True)
+
+        interaction_participants = InteractionDITParticipant.objects.filter(
+            adviser_id=old_adviser_id,
+        ).exclude(interaction_id__in=interaction_ids_with_new_adviser)
+
+        if not interaction_participants:
+            logger.warning('No interactions to update.')
+            return
+
+        interaction_participants_count = interaction_participants.count()
+        logger.info(
+            f'{interaction_participants_count} interaction participants to update.',
+        )
+
+        # Update the adviser to the new adviser.
+        for interaction_participant in interaction_participants:
+            if simulate:
+                logger.info(
+                    f'Moving participant interaction: {interaction_participant.id} from '
+                    f'current adviser: {interaction_participant.adviser_id} to '
+                    f'new adviser: {new_adviser_id}',
+                )
+                return
+
+            interaction_participant.adviser_id = new_adviser_id
+
+            # Cannot bulk_update as doesn't trigger signals for reversion.
+            with reversion.create_revision():
+                interaction_participant.save()
+                reversion.set_comment(
+                    f'Updated interactions: {interaction_participants_count} to have new adviser '
+                    f'id {new_adviser_id}',
+                )

--- a/datahub/dbmaintenance/test/commands/test_update_interactions_to_new_adviser.py
+++ b/datahub/dbmaintenance/test/commands/test_update_interactions_to_new_adviser.py
@@ -1,0 +1,132 @@
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.interaction.test.factories import AdviserFactory
+from datahub.interaction.test.factories import CompaniesInteractionFactory
+from datahub.interaction.test.factories import InteractionDITParticipantFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run__fake_uuids(caplog):
+    """
+    Test that the command:
+
+    - ignores rows with unmatched adviser UUIDs
+    """
+    caplog.set_level('INFO')
+
+    fake_old_adviser_uuid = '00000000-1234-0000-0000-000000000000'
+    fake_new_adviser_uuid = '00000000-4321-4321-0000-000000000000'
+
+    call_command(
+        'update_interactions_to_new_adviser',
+        fake_old_adviser_uuid,
+        fake_new_adviser_uuid,
+    )
+
+    assert 'No interactions to update.' in caplog.text
+
+
+@pytest.mark.parametrize(
+    'simulate',
+    (
+        (True),
+        (False),
+    ),
+)
+def test_run__update_interaction_participant(simulate):
+    """
+    Test that the command:
+    - updates records only if simulate=False is passed
+    - does not update records if simulate=True is passed
+    - updates interaction participants to new adviser
+    """
+    participant_interaction = InteractionDITParticipantFactory()
+    new_adviser = AdviserFactory()
+
+    if simulate:
+        call_command(
+            'update_interactions_to_new_adviser',
+            participant_interaction.adviser_id,
+            new_adviser.id,
+            '--simulate',
+        )
+    else:
+        call_command(
+            'update_interactions_to_new_adviser',
+            participant_interaction.adviser_id,
+            new_adviser.id,
+        )
+
+    participant_interaction.refresh_from_db()
+
+    if simulate:
+        # No changes expected
+        assert participant_interaction.adviser_id == participant_interaction.adviser_id
+    else:
+        # Change expected
+        assert participant_interaction.adviser_id == new_adviser.id
+
+
+def test_run__no_update_for_advisers_with_same_interaction(caplog):
+    """
+    Test that the command:
+
+    - does not update advisers which have the same interaction as this breaks
+        the unique_together constraint.
+    """
+    caplog.set_level('INFO')
+
+    # Old adviser with same interaction id as new adviser
+    same_interaction = CompaniesInteractionFactory()
+    old_adviser = AdviserFactory()
+    interaction_with_old_adviser = InteractionDITParticipantFactory(
+        adviser=old_adviser, interaction=same_interaction,
+    )
+    new_adviser = AdviserFactory()
+    interaction_with_new_adviser = InteractionDITParticipantFactory(
+        adviser=new_adviser, interaction=same_interaction,
+    )
+
+    call_command('update_interactions_to_new_adviser', old_adviser.id, new_adviser.id)
+
+    interaction_with_old_adviser.refresh_from_db()
+    interaction_with_new_adviser.refresh_from_db()
+
+    # No changes expected as would fail unique constraint
+    assert 'No interactions to update.' in caplog.text
+    assert (
+        interaction_with_new_adviser.adviser_id
+        == interaction_with_new_adviser.adviser_id
+    )
+    assert (
+        interaction_with_old_adviser.adviser_id
+        == interaction_with_old_adviser.adviser_id
+    )
+
+
+def test_audit_log():
+    """Test that reversion revisions are created."""
+    interaction_participant = InteractionDITParticipantFactory.create_batch(2)
+    adviser = AdviserFactory()
+
+    interaction_participant_1 = interaction_participant[0]
+    interaction_participant_2 = interaction_participant[1]
+
+    call_command(
+        'update_interactions_to_new_adviser',
+        interaction_participant_2.adviser_id,
+        adviser.id,
+    )
+
+    versions = Version.objects.get_for_object(interaction_participant_1)
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(interaction_participant_2)
+    assert versions.count() == 1
+    assert (
+        versions[0].revision.get_comment()
+        == f'Updated interactions: 1 to have new adviser id {adviser.id}'
+    )

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -89,6 +89,7 @@ class PolicyIssueType(BaseOrderedConstantModel):
     """
 
 
+@reversion.register_base_model()
 class InteractionDITParticipant(models.Model):
     """
     Many-to-many model between an interaction and an adviser (called a DIT participant).

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -230,7 +230,10 @@ class EventServiceDeliveryFactory(InteractionFactoryBase):
 class InteractionDITParticipantFactory(factory.django.DjangoModelFactory):
     """Factory for a DIT participant in an interaction."""
 
-    interaction = factory.SubFactory(CompanyInteractionFactory)
+    interaction = factory.SubFactory(CompanyInteractionFactory,
+                                     dit_participants=[],
+                                     contacts=[],
+                                     )
     adviser = factory.SubFactory(AdviserFactory)
     team = factory.SelfAttribute('adviser.dit_team')
 


### PR DESCRIPTION
Change interaction records with incorrect adviser
<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
