### PR TITLE
Reinstate normal codeowners and dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: weekly
     time: "00:00"
     timezone: Europe/London
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 10
   ignore:
   - dependency-name: flake8-bugbear # TET-129
     versions:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-# * @uktrade/datahub
-* @cgsunkel @marijnkampf @p3dr0migue1 @DeanElliott96 @bau123
+* @uktrade/datahub


### PR DESCRIPTION
### Description of change

Reinstate the codeowners to prevent PRs from being blocked

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
