### PR TITLE
Rebuild service tree after migration.

### DIFF
--- a/datahub/metadata/migrations/0084_rebuild_services.py
+++ b/datahub/metadata/migrations/0084_rebuild_services.py
@@ -1,0 +1,25 @@
+from pathlib import PurePath
+
+import mptt
+
+from django.db import migrations
+
+
+def rebuild_tree(apps, _):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0083_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
### Description of change

Previous service update migration was missing the step of rebuilding the services tree, which subsequently caused tests that depend on services to randomly fail.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
