### PR TITLE
Match area name for `AdministrativeArea`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -469,6 +469,7 @@ def formatted_dnb_company_area(dnb_response_uk):
     dnb_response_area = dnb_response_uk['results'][0].copy()
     dnb_response_area.update(
         address_area_abbrev_name=AdministrativeArea.texas.value.area_code,
+        address_area_name=AdministrativeArea.texas.value.name,
     )
     return format_dnb_company(dnb_response_area)
 

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -251,6 +251,7 @@ class Company(ArchivableModel, BaseModel):
     )
     address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True)
 
+    # registered_address is the official address (e.g. from companies house).
     registered_address_1 = models.CharField(max_length=MAX_LENGTH, blank=True)
     registered_address_2 = models.CharField(max_length=MAX_LENGTH, blank=True)
     registered_address_town = models.CharField(max_length=MAX_LENGTH, blank=True)

--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -40,6 +40,7 @@ def dnb_response_non_uk():
                 'address_county': '',
                 'address_postcode': '10033-1062',
                 'address_area_abbrev_name': 'NY',
+                'address_area_name': 'New York',
                 'address_country': 'US',
                 'annual_sales': 1000000.0,
                 'annual_sales_currency': 'USD',

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -181,6 +181,7 @@ def extract_address_from_dnb_company(dnb_company, prefix, ignore_when_missing=()
     area = (
         AdministrativeArea.objects.filter(
             area_code=dnb_company[f'{prefix}_area_abbrev_name'],
+            name=dnb_company[f'{prefix}_area_name'],
         ).first()
         if dnb_company.get(f'{prefix}_area_abbrev_name')
         else None


### PR DESCRIPTION
### Description of change

Previously we matched only on area codes which caused an issue where Italian companies from "Milan" with an area code of "MI" got matched to "Michigan" in America. This fix will now match on both the code and name to prevent this.

I've got a script for this to print all companies which have mismatched countries to areas. We will then be able to manually fix these or if there are thousands possibly automate it.

