### PR TITLE
Only add administrative areas for country and area matches

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -397,6 +397,7 @@ def dnb_response_uk():
             {
                 'address_country': 'GB',
                 'address_county': '',
+                'address_area_name': None,
                 'address_line_1': 'Unit 10, Ockham Drive',
                 'address_line_2': '',
                 'address_postcode': 'UB6 0F2',
@@ -467,10 +468,21 @@ def formatted_dnb_company_area(dnb_response_uk):
     Get formatted DNB company data.
     """
     dnb_response_area = dnb_response_uk['results'][0].copy()
-    dnb_response_area.update(
-        address_area_abbrev_name=AdministrativeArea.texas.value.area_code,
-        address_area_name=AdministrativeArea.texas.value.name,
-    )
+    return format_dnb_company(dnb_response_area)
+
+
+@pytest.fixture
+def formatted_dnb_company_area_non_uk(dnb_response_non_uk):
+    """
+    Get formatted DNB company data.
+    """
+    dnb_response_area = dnb_response_non_uk['results'][0].copy()
+
+    administrative_areas = [area.value.name for area in AdministrativeArea]
+    if dnb_response_area['address_area_name'] in administrative_areas:
+        dnb_response_area.update(
+            address_area_name=dnb_response_area['address_area_name'],
+        )
     return format_dnb_company(dnb_response_area)
 
 

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -178,14 +178,15 @@ def extract_address_from_dnb_company(dnb_company, prefix, ignore_when_missing=()
         if dnb_company.get(f'{prefix}_country')
         else None
     )
-    area = (
-        AdministrativeArea.objects.filter(
-            area_code=dnb_company[f'{prefix}_area_abbrev_name'],
-            name=dnb_company[f'{prefix}_area_name'],
-        ).first()
-        if dnb_company.get(f'{prefix}_area_abbrev_name')
-        else None
-    )
+
+    area = None
+    if country and dnb_company.get(f'{prefix}_area_name'):
+        area = (
+            AdministrativeArea.objects.filter(
+                name=dnb_company[f'{prefix}_area_name'],
+                country_id=country.id,
+            ).first()
+        )
 
     extracted_address = {
         'line_1': dnb_company.get(f'{prefix}_line_1') or '',


### PR DESCRIPTION
### Description of change

Some `AdministrativeArea`s do not have an abbreviated name associated with them, so we must match by country and name. For example, Tamil Nadu in India does not have an abbreviated name associated for us however from DNB it has an abbreviated name of "TN" which would have been matched to "Tennesse" in data-hub. My previously update would have not matched an `AdministrativeArea` here as it has no abbreviated name even though we have Tamil Nadu in our database. This update now checks by country and name instead of abbreviated name and name.

There are 3106 companies with the wrong `AdministrativeArea` associated with them, I'm currently writing a script to update them all.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?

