### PR TITLE
Bump Django from 4.2.14 to 4.2.15

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -90,7 +90,7 @@ distlib==0.3.6
     # via virtualenv
 dj-database-url==2.2.0
     # via -r requirements.in
-django==4.2.14
+django==4.2.15
     # via
     #   -r requirements.in
     #   dj-database-url

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # Django and django related
-django==4.2.14
+django==4.2.15
 djangorestframework==3.15.2
 django-axes==6.5.1
 django-csp==3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ distlib==0.3.8
     # via virtualenv
 dj-database-url==2.2.0
     # via -r requirements.in
-django==4.2.14
+django==4.2.15
     # via
     #   -r requirements.in
     #   dj-database-url


### PR DESCRIPTION
### Description of change

Dependabot raised a PR for EMT and DnB Service to bump Django to `4.2.15` to address a [number of security vulnerabilities](https://github.com/uktrade/data-hub-api/security/dependabot). For some reason, it didn't raise one for the API (maybe it would have if we waited a little longer). So, this PR bumps Django on Dependabot's behalf.

See the [release notes](https://docs.djangoproject.com/en/4.2/releases/4.2.15/) for more information.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
