### PR TITLE
Improve export wins dataset endpoints.

### DIFF
--- a/datahub/dataset/export_wins/utils.py
+++ b/datahub/dataset/export_wins/utils.py
@@ -6,10 +6,17 @@ def use_nulls_on_empty_string_fields(data):
             data[column] = None
 
 
-def create_columns_with_index(data, key, new_key):
-    if data.get(key) is not None:
-        for i, value in enumerate(data[key]):
-            data[f'{new_key}_{i+1}_display'] = value
+def create_columns_with_index(data, key, new_key, max_items=5):
+    num_items = len(data.get(key, []))
+
+    for i in range(max(num_items, max_items)):
+        if i < num_items:
+            value = data[key][i]
+        else:
+            value = None
+        data[f'{new_key}_{i+1}_display'] = value
+
+    if key in data:
         del data[key]
 
 


### PR DESCRIPTION
### Description of change

This changes `customer_email_date` to return when earliest notification was sent to customer.

Adds missing `associated_programmes_x` and `type_of_support_x` when values don't exist, to align with legacy system.

Adds `win_id` filter so that the data from the endpoint can be compared with legacy system much easier

Adds `legacy_data` filter to breakdowns endpoint.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
