### PR TITLE
Feature/add new endpoint for activity

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -326,6 +326,7 @@ SEARCH_APPS = [
     'datahub.search.event.EventSearchApp',
     'datahub.search.export_country_history.ExportCountryHistoryApp',
     'datahub.search.interaction.InteractionSearchApp',
+    'datahub.search.activity.InteractionActivitySearchApp',
     'datahub.search.investment.InvestmentSearchApp',
     'datahub.search.omis.OrderSearchApp',
     'datahub.search.large_investor_profile.LargeInvestorProfileSearchApp',

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -20,6 +20,7 @@ INSTALLED_APPS += [
 SEARCH_APPS += [
     'datahub.search.test.search_support.simplemodel.SimpleModelSearchApp',
     'datahub.search.test.search_support.relatedmodel.RelatedModelSearchApp',
+    'datahub.search.test.search_support.searchappwithsamemodel.RelatedModelWithSameSearchModelApp',
 ]
 
 # Note that the prefix used for indexes created during tests is set dynamically in

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -20,7 +20,7 @@ INSTALLED_APPS += [
 SEARCH_APPS += [
     'datahub.search.test.search_support.simplemodel.SimpleModelSearchApp',
     'datahub.search.test.search_support.relatedmodel.RelatedModelSearchApp',
-    'datahub.search.test.search_support.searchappwithsamemodel.RelatedModelWithSameSearchModelApp',
+    'datahub.search.test.search_support.searchappwithsamemodel.RelatedModelWithSameDBModelApp',
 ]
 
 # Note that the prefix used for indexes created during tests is set dynamically in

--- a/datahub/search/activity/__init__.py
+++ b/datahub/search/activity/__init__.py
@@ -1,0 +1,3 @@
+from datahub.search.interaction.apps import InteractionSearchApp
+
+__all__ = ('InteractionSearchApp',)

--- a/datahub/search/activity/__init__.py
+++ b/datahub/search/activity/__init__.py
@@ -1,3 +1,3 @@
-from datahub.search.interaction.apps import InteractionSearchApp
+from datahub.search.activity.apps import InteractionActivitySearchApp
 
-__all__ = ('InteractionSearchApp',)
+__all__ = ('InteractionActivitySearchApp',)

--- a/datahub/search/activity/apps.py
+++ b/datahub/search/activity/apps.py
@@ -6,7 +6,7 @@ from datahub.interaction.models import (
     InteractionExportCountry,
     InteractionPermission,
 )
-from datahub.search.activity.models import Interaction
+from datahub.search.activity.models import Activity
 from datahub.search.apps import SearchApp
 
 
@@ -14,7 +14,7 @@ class InteractionActivitySearchApp(SearchApp):
     """SearchApp for interactions."""
 
     name = 'activity'
-    search_model = Interaction
+    search_model = Activity
     view_permissions = (f'interaction.{InteractionPermission.view_all}',)
     export_permission = f'interaction.{InteractionPermission.export}'
     queryset = DBInteraction.objects.select_related(

--- a/datahub/search/activity/apps.py
+++ b/datahub/search/activity/apps.py
@@ -13,7 +13,7 @@ from datahub.search.apps import SearchApp
 class InteractionActivitySearchApp(SearchApp):
     """SearchApp for interactions."""
 
-    name = 'interaction'
+    name = 'activity'
     search_model = Interaction
     view_permissions = (f'interaction.{InteractionPermission.view_all}',)
     export_permission = f'interaction.{InteractionPermission.export}'

--- a/datahub/search/activity/apps.py
+++ b/datahub/search/activity/apps.py
@@ -6,11 +6,11 @@ from datahub.interaction.models import (
     InteractionExportCountry,
     InteractionPermission,
 )
-from datahub.search.apps import SearchApp
 from datahub.search.activity.models import Interaction
+from datahub.search.apps import SearchApp
 
 
-class InteractionSearchApp(SearchApp):
+class InteractionActivitySearchApp(SearchApp):
     """SearchApp for interactions."""
 
     name = 'interaction'

--- a/datahub/search/activity/apps.py
+++ b/datahub/search/activity/apps.py
@@ -1,0 +1,48 @@
+from django.db.models import Prefetch
+
+from datahub.interaction.models import (
+    Interaction as DBInteraction,
+    InteractionDITParticipant,
+    InteractionExportCountry,
+    InteractionPermission,
+)
+from datahub.search.apps import SearchApp
+from datahub.search.activity.models import Interaction
+
+
+class InteractionSearchApp(SearchApp):
+    """SearchApp for interactions."""
+
+    name = 'interaction'
+    search_model = Interaction
+    view_permissions = (f'interaction.{InteractionPermission.view_all}',)
+    export_permission = f'interaction.{InteractionPermission.export}'
+    queryset = DBInteraction.objects.select_related(
+        'company',
+        'company__sector',
+        'company__sector__parent',
+        'company__sector__parent__parent',
+        'company__one_list_tier',
+        'company__global_headquarters__one_list_tier',
+        'communication_channel',
+        'investment_project',
+        'investment_project__sector',
+        'investment_project__sector__parent',
+        'investment_project__sector__parent__parent',
+        'service',
+        'service_delivery_status',
+        'event',
+    ).prefetch_related(
+        'contacts',
+        'companies',
+        'policy_areas',
+        'policy_issue_types',
+        Prefetch(
+            'dit_participants',
+            queryset=InteractionDITParticipant.objects.select_related('adviser', 'team'),
+        ),
+        Prefetch(
+            'export_countries',
+            queryset=InteractionExportCountry.objects.select_related('country'),
+        ),
+    )

--- a/datahub/search/activity/models.py
+++ b/datahub/search/activity/models.py
@@ -70,7 +70,7 @@ class _DITParticipant(InnerDoc):
     team = Object(IDNameTrigram)
 
 
-class Interaction(BaseSearchModel):
+class Activity(BaseSearchModel):
     """OpenSearch representation of Interaction model."""
 
     id = Keyword()

--- a/datahub/search/activity/models.py
+++ b/datahub/search/activity/models.py
@@ -1,0 +1,156 @@
+from operator import attrgetter
+
+from opensearch_dsl import Boolean, Date, Double, InnerDoc, Keyword, Object, Text
+
+from datahub.search import dict_utils, fields
+from datahub.search.fields import TrigramText
+from datahub.search.inner_docs import IDNameTrigram, Person
+from datahub.search.models import BaseSearchModel
+
+
+def _contact_field():
+    return Object(
+        properties={
+            'id': Keyword(),
+            'first_name': Text(index=False),
+            'last_name': Text(index=False),
+            'name': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+        },
+    )
+
+
+def _dit_participant_list(dit_participant_manager):
+    return [
+        {
+            'adviser': dict_utils.contact_or_adviser_dict(dit_participant.adviser),
+            'team': dict_utils.id_name_dict(dit_participant.team),
+        }
+        for dit_participant in dit_participant_manager.all()
+    ]
+
+
+def _export_country_field():
+    return Object(
+        properties={
+            'id': Keyword(index=False),
+            'country': Object(
+                properties={
+                    'id': Keyword(),
+                    'name': Text(index=False),
+                },
+            ),
+            'status': Text(index=False),
+        },
+    )
+
+
+def _export_countries_list(export_countries):
+    return [
+        {
+            'country': dict_utils.id_name_dict(export_country.country),
+            'status': export_country.status,
+        }
+        for export_country in export_countries.all()
+    ]
+
+
+def _companies_list(companies):
+    return [
+        dict_utils.company_dict(company)
+        for company in companies.all()
+    ]
+
+
+class _DITParticipant(InnerDoc):
+    adviser = Object(Person)
+    team = Object(IDNameTrigram)
+
+
+class Interaction(BaseSearchModel):
+    """OpenSearch representation of Interaction model."""
+
+    id = Keyword()
+    company = fields.company_field()
+    companies = fields.company_field()
+    company_sector = fields.sector_field()
+    company_one_list_group_tier = fields.id_unindexed_name_field()
+    communication_channel = fields.id_unindexed_name_field()
+    contacts = _contact_field()
+    created_on = Date()
+    date = Date()
+    dit_participants = Object(_DITParticipant)
+    event = fields.id_name_partial_field()
+    investment_project = fields.id_unindexed_name_field()
+    investment_project_sector = fields.sector_field()
+    is_event = Boolean(index=False)
+    grant_amount_offered = Double(index=False)
+    kind = Keyword()
+    modified_on = Date()
+    net_company_receipt = Double(index=False)
+    notes = fields.Text(index=False)
+    policy_areas = fields.id_unindexed_name_field()
+    policy_issue_types = fields.id_unindexed_name_field()
+    service = fields.id_name_partial_field()
+    service_delivery_status = fields.id_unindexed_name_field()
+    subject = Text(
+        fields={
+            'english': fields.EnglishText(),
+            'keyword': fields.NormalizedKeyword(),
+            'trigram': fields.TrigramText(),
+        },
+    )
+    was_policy_feedback_provided = Boolean()
+    were_countries_discussed = Boolean()
+    export_countries = _export_country_field()
+
+    MAPPINGS = {
+        'company': dict_utils.company_dict,
+        'companies': _companies_list,
+        'communication_channel': dict_utils.id_name_dict,
+        'contacts': dict_utils.contact_or_adviser_list_of_dicts,
+        'dit_participants': _dit_participant_list,
+        'export_countries': _export_countries_list,
+        'event': dict_utils.id_name_dict,
+        'investment_project': dict_utils.id_name_dict,
+        'policy_areas': dict_utils.id_name_list_of_dicts,
+        'policy_issue_types': dict_utils.id_name_list_of_dicts,
+        'service': dict_utils.id_name_dict,
+        'service_delivery_status': dict_utils.id_name_dict,
+    }
+
+    COMPUTED_MAPPINGS = {
+        'company_sector': dict_utils.computed_nested_sector_dict('company.sector'),
+        'company_one_list_group_tier': lambda obj: dict_utils.id_name_dict(
+            obj.company.get_one_list_group_tier() if obj.company else None,
+        ),
+        'investment_project_sector': dict_utils.computed_nested_sector_dict(
+            'investment_project.sector',
+        ),
+        'is_event': attrgetter('is_event'),
+    }
+
+    SEARCH_FIELDS = (
+        'id',
+        'company.name',
+        'company.name.trigram',
+        'companies.name',
+        'companies.name.trigram',
+        'contacts.id',
+        'contacts.name',  # to find 2-letter words
+        'contacts.name.trigram',
+        'event.name',
+        'event.name.trigram',
+        'service.name',
+        'service.name.trigram',
+        'subject',
+        'subject.trigram',
+        'subject.english',
+        'dit_participants.adviser.name',
+        'dit_participants.adviser.name.trigram',
+        'dit_participants.team.name',
+        'dit_participants.team.name.trigram',
+    )

--- a/datahub/search/activity/serializers.py
+++ b/datahub/search/activity/serializers.py
@@ -1,0 +1,40 @@
+from rest_framework import serializers
+
+from datahub.core.serializers import RelaxedDateTimeField
+from datahub.search.serializers import (
+    EntitySearchQuerySerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
+from datahub.search.utils import SearchOrdering, SortDirection
+
+
+class SearchInteractionQuerySerializer(EntitySearchQuerySerializer):
+    """Serialiser used to validate interaction search POST bodies."""
+
+    kind = SingleOrListField(child=serializers.CharField(), required=False)
+    company = SingleOrListField(child=StringUUIDField(), required=False)
+    subject = serializers.CharField(required=False)
+    company_name = serializers.CharField(required=False)
+    company_one_list_group_tier = SingleOrListField(child=StringUUIDField(), required=False)
+    date_after = RelaxedDateTimeField(required=False)
+    date_before = RelaxedDateTimeField(required=False)
+    created_on_exists = serializers.BooleanField(required=False)
+    dit_participants__adviser = SingleOrListField(child=StringUUIDField(), required=False)
+    dit_participants__team = SingleOrListField(child=StringUUIDField(), required=False)
+    communication_channel = SingleOrListField(child=StringUUIDField(), required=False)
+    investment_project = SingleOrListField(child=StringUUIDField(), required=False)
+    policy_areas = SingleOrListField(child=StringUUIDField(), required=False)
+    policy_issue_types = SingleOrListField(child=StringUUIDField(), required=False)
+    service = SingleOrListField(child=StringUUIDField(), required=False)
+    sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
+    was_policy_feedback_provided = serializers.BooleanField(required=False)
+    contacts = SingleOrListField(child=StringUUIDField(), required=False)
+
+    DEFAULT_ORDERING = SearchOrdering('date', SortDirection.desc)
+
+    SORT_BY_FIELDS = (
+        'company.name',
+        'date',
+        'subject',
+    )

--- a/datahub/search/activity/signals.py
+++ b/datahub/search/activity/signals.py
@@ -1,0 +1,52 @@
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save
+
+from datahub.company.models import Company as DBCompany, Contact as DBContact
+from datahub.interaction.models import (
+    Interaction as DBInteraction,
+    InteractionDITParticipant as DBInteractionDITParticipant,
+)
+from datahub.investment.project.models import InvestmentProject as DBInvestmentProject
+from datahub.search.deletion import delete_document
+from datahub.search.activity import InteractionSearchApp
+from datahub.search.activity.models import Interaction as SearchInteraction
+from datahub.search.signals import SignalReceiver
+from datahub.search.sync_object import sync_object_async, sync_related_objects_async
+
+
+def sync_interaction_to_opensearch(instance):
+    """Sync interaction to the OpenSearch."""
+    transaction.on_commit(
+        lambda: sync_object_async(InteractionSearchApp, instance.pk),
+    )
+
+
+def sync_participant_to_opensearch(dit_participant):
+    """Sync a DIT participant's interaction to OpenSearch."""
+    transaction.on_commit(
+        lambda: sync_object_async(InteractionSearchApp, dit_participant.interaction_id),
+    )
+
+
+def remove_interaction_from_opensearch(instance):
+    """Remove interaction from es."""
+    transaction.on_commit(
+        lambda pk=instance.pk: delete_document(SearchInteraction, pk),
+    )
+
+
+def sync_related_interactions_to_opensearch(instance):
+    """Sync related interactions."""
+    transaction.on_commit(
+        lambda: sync_related_objects_async(instance, 'interactions'),
+    )
+
+
+receivers = (
+    SignalReceiver(post_save, DBInteraction, sync_interaction_to_opensearch),
+    SignalReceiver(post_save, DBInteractionDITParticipant, sync_participant_to_opensearch),
+    SignalReceiver(post_save, DBCompany, sync_related_interactions_to_opensearch),
+    SignalReceiver(post_save, DBContact, sync_related_interactions_to_opensearch),
+    SignalReceiver(post_save, DBInvestmentProject, sync_related_interactions_to_opensearch),
+    SignalReceiver(post_delete, DBInteraction, remove_interaction_from_opensearch),
+)

--- a/datahub/search/activity/signals.py
+++ b/datahub/search/activity/signals.py
@@ -7,9 +7,9 @@ from datahub.interaction.models import (
     InteractionDITParticipant as DBInteractionDITParticipant,
 )
 from datahub.investment.project.models import InvestmentProject as DBInvestmentProject
-from datahub.search.deletion import delete_document
-from datahub.search.activity import InteractionSearchApp
+from datahub.search.activity import InteractionActivitySearchApp
 from datahub.search.activity.models import Interaction as SearchInteraction
+from datahub.search.deletion import delete_document
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async, sync_related_objects_async
 
@@ -17,14 +17,14 @@ from datahub.search.sync_object import sync_object_async, sync_related_objects_a
 def sync_interaction_to_opensearch(instance):
     """Sync interaction to the OpenSearch."""
     transaction.on_commit(
-        lambda: sync_object_async(InteractionSearchApp, instance.pk),
+        lambda: sync_object_async(InteractionActivitySearchApp, instance.pk),
     )
 
 
 def sync_participant_to_opensearch(dit_participant):
     """Sync a DIT participant's interaction to OpenSearch."""
     transaction.on_commit(
-        lambda: sync_object_async(InteractionSearchApp, dit_participant.interaction_id),
+        lambda: sync_object_async(InteractionActivitySearchApp, dit_participant.interaction_id),
     )
 
 

--- a/datahub/search/activity/signals.py
+++ b/datahub/search/activity/signals.py
@@ -8,7 +8,7 @@ from datahub.interaction.models import (
 )
 from datahub.investment.project.models import InvestmentProject as DBInvestmentProject
 from datahub.search.activity import InteractionActivitySearchApp
-from datahub.search.activity.models import Interaction as SearchInteraction
+from datahub.search.activity.models import Activity as SearchActivity
 from datahub.search.deletion import delete_document
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async, sync_related_objects_async
@@ -31,14 +31,14 @@ def sync_participant_to_opensearch(dit_participant):
 def remove_interaction_from_opensearch(instance):
     """Remove interaction from es."""
     transaction.on_commit(
-        lambda pk=instance.pk: delete_document(SearchInteraction, pk),
+        lambda pk=instance.pk: delete_document(SearchActivity, pk),
     )
 
 
 def sync_related_interactions_to_opensearch(instance):
     """Sync related interactions."""
     transaction.on_commit(
-        lambda: sync_related_objects_async(instance, 'interactions'),
+        lambda: sync_related_objects_async(instance, 'interactions', None, 'activity'),
     )
 
 

--- a/datahub/search/activity/test/test_models.py
+++ b/datahub/search/activity/test/test_models.py
@@ -10,7 +10,7 @@ from datahub.interaction.test.factories import (
     ServiceDeliveryFactory,
 )
 from datahub.search.activity import InteractionActivitySearchApp
-from datahub.search.activity.models import Interaction
+from datahub.search.activity.models import Activity
 
 pytestmark = pytest.mark.django_db
 
@@ -28,7 +28,7 @@ def test_interaction_to_dict(opensearch, factory_cls):
     """Test converting an interaction to a dict."""
     interaction = factory_cls()
 
-    result = Interaction.db_object_to_dict(interaction)
+    result = Activity.db_object_to_dict(interaction)
     result['contacts'].sort(key=itemgetter('id'))
     result['companies'].sort(key=itemgetter('id'))
     result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
@@ -147,7 +147,7 @@ def test_service_delivery_to_dict(opensearch):
     """Test converting an interaction to a dict."""
     interaction = ServiceDeliveryFactory()
 
-    result = Interaction.db_object_to_dict(interaction)
+    result = Activity.db_object_to_dict(interaction)
     result['contacts'].sort(key=itemgetter('id'))
     result['companies'].sort(key=itemgetter('id'))
     result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
@@ -235,6 +235,6 @@ def test_interactions_to_documents(opensearch):
     """Test converting 2 orders to OpenSearch documents."""
     interactions = CompanyInteractionFactory.create_batch(2)
 
-    result = Interaction.db_objects_to_documents(interactions)
+    result = Activity.db_objects_to_documents(interactions)
 
     assert {item['_id'] for item in result} == {item.pk for item in interactions}

--- a/datahub/search/activity/test/test_models.py
+++ b/datahub/search/activity/test/test_models.py
@@ -9,7 +9,7 @@ from datahub.interaction.test.factories import (
     InvestmentProjectInteractionFactory,
     ServiceDeliveryFactory,
 )
-from datahub.search.activity import InteractionSearchApp
+from datahub.search.activity import InteractionActivitySearchApp
 from datahub.search.activity.models import Interaction
 
 pytestmark = pytest.mark.django_db
@@ -37,7 +37,7 @@ def test_interaction_to_dict(opensearch, factory_cls):
     result['policy_issue_types'].sort(key=itemgetter('id'))
 
     assert result == {
-        '_document_type': InteractionSearchApp.name,
+        '_document_type': InteractionActivitySearchApp.name,
         'id': interaction.pk,
         'kind': interaction.kind,
         'date': interaction.date,
@@ -153,7 +153,7 @@ def test_service_delivery_to_dict(opensearch):
     result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
 
     assert result == {
-        '_document_type': InteractionSearchApp.name,
+        '_document_type': InteractionActivitySearchApp.name,
         'id': interaction.pk,
         'kind': interaction.kind,
         'date': interaction.date,

--- a/datahub/search/activity/test/test_models.py
+++ b/datahub/search/activity/test/test_models.py
@@ -1,0 +1,240 @@
+from operator import attrgetter, itemgetter
+
+import pytest
+
+from datahub.interaction.test.factories import (
+    CompanyInteractionFactory,
+    CompanyInteractionFactoryWithPolicyFeedback,
+    ExportCountriesInteractionFactory,
+    InvestmentProjectInteractionFactory,
+    ServiceDeliveryFactory,
+)
+from datahub.search.activity import InteractionSearchApp
+from datahub.search.activity.models import Interaction
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    'factory_cls',
+    (
+        CompanyInteractionFactory,
+        InvestmentProjectInteractionFactory,
+        CompanyInteractionFactoryWithPolicyFeedback,
+        ExportCountriesInteractionFactory,
+    ),
+)
+def test_interaction_to_dict(opensearch, factory_cls):
+    """Test converting an interaction to a dict."""
+    interaction = factory_cls()
+
+    result = Interaction.db_object_to_dict(interaction)
+    result['contacts'].sort(key=itemgetter('id'))
+    result['companies'].sort(key=itemgetter('id'))
+    result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
+    result['export_countries'].sort(key=lambda export_country: export_country['country']['id'])
+    result['policy_areas'].sort(key=itemgetter('id'))
+    result['policy_issue_types'].sort(key=itemgetter('id'))
+
+    assert result == {
+        '_document_type': InteractionSearchApp.name,
+        'id': interaction.pk,
+        'kind': interaction.kind,
+        'date': interaction.date,
+        'company': {
+            'id': str(interaction.company.pk),
+            'name': interaction.company.name,
+            'trading_names': interaction.company.trading_names,
+        } if interaction.company else None,
+        'companies': [
+            {
+                'id': str(company.pk),
+                'name': company.name,
+                'trading_names': company.trading_names,
+            } for company in sorted(interaction.companies.all(), key=attrgetter('id'))
+        ],
+        'company_sector': {
+            'id': str(interaction.company.sector.pk),
+            'name': interaction.company.sector.name,
+            'ancestors': [{
+                'id': str(ancestor.pk),
+            } for ancestor in interaction.company.sector.get_ancestors()],
+        } if interaction.company else None,
+        'company_one_list_group_tier': {
+            'id': str(interaction.company.get_one_list_group_tier().pk),
+            'name': interaction.company.get_one_list_group_tier().name,
+        } if interaction.company and interaction.company.get_one_list_group_tier() else None,
+        'contacts': [
+            {
+                'id': str(obj.pk),
+                'first_name': obj.first_name,
+                'name': obj.name,
+                'last_name': obj.last_name,
+            }
+            for obj in sorted(interaction.contacts.all(), key=attrgetter('id'))
+        ],
+        'is_event': interaction.is_event,
+        'event': None,
+        'service': {
+            'id': str(interaction.service.pk),
+            'name': interaction.service.name,
+        },
+        'subject': interaction.subject,
+        'dit_participants': [
+            {
+                'adviser': {
+                    'id': str(dit_participant.adviser.pk),
+                    'first_name': dit_participant.adviser.first_name,
+                    'name': dit_participant.adviser.name,
+                    'last_name': dit_participant.adviser.last_name,
+                },
+                'team': {
+                    'id': str(dit_participant.team.pk),
+                    'name': dit_participant.team.name,
+                },
+            }
+            for dit_participant in interaction.dit_participants.order_by('adviser__pk')
+        ],
+        'notes': interaction.notes,
+        'communication_channel': {
+            'id': str(interaction.communication_channel.pk),
+            'name': interaction.communication_channel.name,
+        },
+        'investment_project': {
+            'id': str(interaction.investment_project.pk),
+            'name': interaction.investment_project.name,
+        } if interaction.investment_project else None,
+        'investment_project_sector': {
+            'id': str(interaction.investment_project.sector.pk),
+            'name': interaction.investment_project.sector.name,
+            'ancestors': [{
+                'id': str(ancestor.pk),
+            } for ancestor in interaction.investment_project.sector.get_ancestors()],
+        } if interaction.investment_project else None,
+        'policy_areas': [
+            {
+                'id': str(obj.pk),
+                'name': obj.name,
+            } for obj in sorted(interaction.policy_areas.all(), key=attrgetter('id'))
+        ],
+        'policy_issue_types': [
+            {
+                'id': str(obj.pk),
+                'name': obj.name,
+            } for obj in sorted(interaction.policy_issue_types.all(), key=attrgetter('id'))
+        ],
+        'service_delivery_status': None,
+        'grant_amount_offered': None,
+        'net_company_receipt': None,
+        'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
+        'export_countries': [
+            {
+                'country': {
+                    'id': str(export_country.country.pk),
+                    'name': export_country.country.name,
+                },
+                'status': export_country.status,
+            }
+            for export_country in interaction.export_countries.order_by('country__pk')
+        ],
+        'were_countries_discussed': interaction.were_countries_discussed,
+        'created_on': interaction.created_on,
+        'modified_on': interaction.modified_on,
+    }
+
+
+def test_service_delivery_to_dict(opensearch):
+    """Test converting an interaction to a dict."""
+    interaction = ServiceDeliveryFactory()
+
+    result = Interaction.db_object_to_dict(interaction)
+    result['contacts'].sort(key=itemgetter('id'))
+    result['companies'].sort(key=itemgetter('id'))
+    result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
+
+    assert result == {
+        '_document_type': InteractionSearchApp.name,
+        'id': interaction.pk,
+        'kind': interaction.kind,
+        'date': interaction.date,
+        'company': {
+            'id': str(interaction.company.pk),
+            'name': interaction.company.name,
+            'trading_names': interaction.company.trading_names,
+        },
+        'companies': [
+            {
+                'id': str(company.pk),
+                'name': company.name,
+                'trading_names': company.trading_names,
+            } for company in sorted(interaction.companies.all(), key=attrgetter('id'))
+        ],
+        'company_sector': {
+            'id': str(interaction.company.sector.pk),
+            'name': interaction.company.sector.name,
+            'ancestors': [{
+                'id': str(ancestor.pk),
+            } for ancestor in interaction.company.sector.get_ancestors()],
+        },
+        'company_one_list_group_tier': {
+            'id': interaction.company.get_one_list_group_tier().pk,
+            'name': interaction.company.get_one_list_group_tier().name,
+        } if interaction.company.get_one_list_group_tier() else None,
+        'contacts': [
+            {
+                'id': str(obj.pk),
+                'first_name': obj.first_name,
+                'name': obj.name,
+                'last_name': obj.last_name,
+            }
+            for obj in sorted(interaction.contacts.all(), key=attrgetter('id'))
+        ],
+        'is_event': interaction.is_event,
+        'event': None,
+        'service': {
+            'id': str(interaction.service.pk),
+            'name': interaction.service.name,
+        },
+        'subject': interaction.subject,
+        'dit_participants': [
+            {
+                'adviser': {
+                    'id': str(dit_participant.adviser.pk),
+                    'first_name': dit_participant.adviser.first_name,
+                    'name': dit_participant.adviser.name,
+                    'last_name': dit_participant.adviser.last_name,
+                },
+                'team': {
+                    'id': str(dit_participant.team.pk),
+                    'name': dit_participant.team.name,
+                },
+            }
+            for dit_participant in interaction.dit_participants.order_by('adviser__pk')
+        ],
+        'notes': interaction.notes,
+        'communication_channel': None,
+        'investment_project': None,
+        'investment_project_sector': None,
+        'policy_areas': [],
+        'policy_issue_types': [],
+        'service_delivery_status': {
+            'id': str(interaction.service_delivery_status.pk),
+            'name': interaction.service_delivery_status.name,
+        },
+        'grant_amount_offered': interaction.grant_amount_offered,
+        'net_company_receipt': interaction.net_company_receipt,
+        'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
+        'export_countries': [],
+        'were_countries_discussed': None,
+        'created_on': interaction.created_on,
+        'modified_on': interaction.modified_on,
+    }
+
+
+def test_interactions_to_documents(opensearch):
+    """Test converting 2 orders to OpenSearch documents."""
+    interactions = CompanyInteractionFactory.create_batch(2)
+
+    result = Interaction.db_objects_to_documents(interactions)
+
+    assert {item['_id'] for item in result} == {item.pk for item in interactions}

--- a/datahub/search/activity/test/test_signals.py
+++ b/datahub/search/activity/test/test_signals.py
@@ -6,7 +6,7 @@ from datahub.interaction.test.factories import (
     InteractionDITParticipantFactory,
     InvestmentProjectInteractionFactory,
 )
-from datahub.search.activity.apps import InteractionSearchApp
+from datahub.search.activity.apps import InteractionActivitySearchApp
 
 pytestmark = pytest.mark.django_db
 
@@ -17,7 +17,7 @@ def test_new_interaction_synced(opensearch_with_signals):
     opensearch_with_signals.indices.refresh()
 
     assert opensearch_with_signals.get(
-        index=InteractionSearchApp.search_model.get_write_index(),
+        index=InteractionActivitySearchApp.search_model.get_write_index(),
         id=interaction.pk,
     )
 
@@ -31,7 +31,7 @@ def test_updated_interaction_synced(opensearch_with_signals):
     opensearch_with_signals.indices.refresh()
 
     result = opensearch_with_signals.get(
-        index=InteractionSearchApp.search_model.get_write_index(),
+        index=InteractionActivitySearchApp.search_model.get_write_index(),
         id=interaction.pk,
     )
     assert result['_source']['subject'] == new_subject
@@ -46,7 +46,7 @@ def test_deleted_interaction_deleted_from_opensearch(opensearch_with_signals):
     opensearch_with_signals.indices.refresh()
 
     assert opensearch_with_signals.get(
-        index=InteractionSearchApp.search_model.get_write_index(),
+        index=InteractionActivitySearchApp.search_model.get_write_index(),
         id=interaction.pk,
     )
 
@@ -56,7 +56,7 @@ def test_deleted_interaction_deleted_from_opensearch(opensearch_with_signals):
 
     with pytest.raises(NotFoundError):
         assert opensearch_with_signals.get(
-            index=InteractionSearchApp.search_model.get_write_index(),
+            index=InteractionActivitySearchApp.search_model.get_write_index(),
             id=interaction_id,
         ) is None
 
@@ -67,7 +67,7 @@ def test_interaction_synced_when_dit_participant_added(opensearch_with_signals):
     opensearch_with_signals.indices.refresh()
 
     doc = opensearch_with_signals.get(
-        index=InteractionSearchApp.search_model.get_read_alias(),
+        index=InteractionActivitySearchApp.search_model.get_read_alias(),
         id=interaction.pk,
     )
     assert doc['_source']['dit_participants'] == []
@@ -76,7 +76,7 @@ def test_interaction_synced_when_dit_participant_added(opensearch_with_signals):
     opensearch_with_signals.indices.refresh()
 
     updated_doc = opensearch_with_signals.get(
-        index=InteractionSearchApp.search_model.get_read_alias(),
+        index=InteractionActivitySearchApp.search_model.get_read_alias(),
         id=interaction.pk,
     )
     actual_dit_participants = updated_doc['_source']['dit_participants']
@@ -96,7 +96,7 @@ def test_updating_company_name_updates_interaction(opensearch_with_signals):
     opensearch_with_signals.indices.refresh()
 
     result = opensearch_with_signals.get(
-        index=InteractionSearchApp.search_model.get_write_index(),
+        index=InteractionActivitySearchApp.search_model.get_write_index(),
         id=interaction.pk,
     )
     assert result['_source']['company']['name'] == new_company_name
@@ -117,7 +117,7 @@ def test_updating_contact_name_updates_interaction(opensearch_with_signals):
     opensearch_with_signals.indices.refresh()
 
     result = opensearch_with_signals.get(
-        index=InteractionSearchApp.search_model.get_write_index(),
+        index=InteractionActivitySearchApp.search_model.get_write_index(),
         id=interaction.pk,
     )
     assert result['_source']['contacts'][0] == {
@@ -140,7 +140,7 @@ def test_updating_project_name_updates_interaction(opensearch_with_signals):
     opensearch_with_signals.indices.refresh()
 
     result = opensearch_with_signals.get(
-        index=InteractionSearchApp.search_model.get_write_index(),
+        index=InteractionActivitySearchApp.search_model.get_write_index(),
         id=interaction.pk,
     )
     assert result['_source']['investment_project']['name'] == new_project_name

--- a/datahub/search/activity/test/test_signals.py
+++ b/datahub/search/activity/test/test_signals.py
@@ -1,0 +1,146 @@
+import pytest
+from opensearchpy.exceptions import NotFoundError
+
+from datahub.interaction.test.factories import (
+    CompanyInteractionFactory,
+    InteractionDITParticipantFactory,
+    InvestmentProjectInteractionFactory,
+)
+from datahub.search.activity.apps import InteractionSearchApp
+
+pytestmark = pytest.mark.django_db
+
+
+def test_new_interaction_synced(opensearch_with_signals):
+    """Test that new interactions are synced to OpenSearch."""
+    interaction = CompanyInteractionFactory()
+    opensearch_with_signals.indices.refresh()
+
+    assert opensearch_with_signals.get(
+        index=InteractionSearchApp.search_model.get_write_index(),
+        id=interaction.pk,
+    )
+
+
+def test_updated_interaction_synced(opensearch_with_signals):
+    """Test that when an interaction is updated it is synced to OpenSearch."""
+    interaction = CompanyInteractionFactory()
+    new_subject = 'pluto'
+    interaction.subject = new_subject
+    interaction.save()
+    opensearch_with_signals.indices.refresh()
+
+    result = opensearch_with_signals.get(
+        index=InteractionSearchApp.search_model.get_write_index(),
+        id=interaction.pk,
+    )
+    assert result['_source']['subject'] == new_subject
+
+
+def test_deleted_interaction_deleted_from_opensearch(opensearch_with_signals):
+    """
+    Test that when an interaction is deleted from db it is also
+    deleted from OpenSearch.
+    """
+    interaction = InvestmentProjectInteractionFactory()
+    opensearch_with_signals.indices.refresh()
+
+    assert opensearch_with_signals.get(
+        index=InteractionSearchApp.search_model.get_write_index(),
+        id=interaction.pk,
+    )
+
+    interaction_id = interaction.pk
+    interaction.delete()
+    opensearch_with_signals.indices.refresh()
+
+    with pytest.raises(NotFoundError):
+        assert opensearch_with_signals.get(
+            index=InteractionSearchApp.search_model.get_write_index(),
+            id=interaction_id,
+        ) is None
+
+
+def test_interaction_synced_when_dit_participant_added(opensearch_with_signals):
+    """Test that interactions are synced to OpenSearch if their DIT participants change."""
+    interaction = CompanyInteractionFactory(dit_participants=[])
+    opensearch_with_signals.indices.refresh()
+
+    doc = opensearch_with_signals.get(
+        index=InteractionSearchApp.search_model.get_read_alias(),
+        id=interaction.pk,
+    )
+    assert doc['_source']['dit_participants'] == []
+
+    dit_participant = InteractionDITParticipantFactory(interaction=interaction)
+    opensearch_with_signals.indices.refresh()
+
+    updated_doc = opensearch_with_signals.get(
+        index=InteractionSearchApp.search_model.get_read_alias(),
+        id=interaction.pk,
+    )
+    actual_dit_participants = updated_doc['_source']['dit_participants']
+    assert len(actual_dit_participants) == 1
+    assert actual_dit_participants[0]['adviser']['id'] == str(dit_participant.adviser.pk)
+    assert actual_dit_participants[0]['team']['id'] == str(dit_participant.team.pk)
+
+
+def test_updating_company_name_updates_interaction(opensearch_with_signals):
+    """
+    Test that when a company name is updated, the company's interactions are synced to OpenSearch.
+    """
+    interaction = CompanyInteractionFactory()
+    new_company_name = 'exogenous'
+    interaction.company.name = new_company_name
+    interaction.company.save()
+    opensearch_with_signals.indices.refresh()
+
+    result = opensearch_with_signals.get(
+        index=InteractionSearchApp.search_model.get_write_index(),
+        id=interaction.pk,
+    )
+    assert result['_source']['company']['name'] == new_company_name
+
+
+def test_updating_contact_name_updates_interaction(opensearch_with_signals):
+    """
+    Test that when a contact's name is updated, the contact's interactions are
+    synced to OpenSearch.
+    """
+    interaction = CompanyInteractionFactory()
+    new_first_name = 'Jamie'
+    new_last_name = 'Bloggs'
+    contact = interaction.contacts.first()
+    contact.first_name = new_first_name
+    contact.last_name = new_last_name
+    contact.save()
+    opensearch_with_signals.indices.refresh()
+
+    result = opensearch_with_signals.get(
+        index=InteractionSearchApp.search_model.get_write_index(),
+        id=interaction.pk,
+    )
+    assert result['_source']['contacts'][0] == {
+        'id': str(contact.pk),
+        'first_name': new_first_name,
+        'last_name': new_last_name,
+        'name': f'{new_first_name} {new_last_name}',
+    }
+
+
+def test_updating_project_name_updates_interaction(opensearch_with_signals):
+    """
+    Test that when an investment project's name is updated, the project's interactions are
+    synced to OpenSearch.
+    """
+    interaction = InvestmentProjectInteractionFactory()
+    new_project_name = 'helios'
+    interaction.investment_project.name = new_project_name
+    interaction.investment_project.save()
+    opensearch_with_signals.indices.refresh()
+
+    result = opensearch_with_signals.get(
+        index=InteractionSearchApp.search_model.get_write_index(),
+        id=interaction.pk,
+    )
+    assert result['_source']['investment_project']['name'] == new_project_name

--- a/datahub/search/activity/test/test_views.py
+++ b/datahub/search/activity/test/test_views.py
@@ -1,10 +1,11 @@
+import random
+
 from cgi import parse_header
 from collections import Counter
 from csv import DictReader
 from datetime import datetime, timezone
 from io import StringIO
 from operator import attrgetter, itemgetter
-from random import choice
 from uuid import UUID
 
 import factory
@@ -495,7 +496,9 @@ class TestInteractionEntitySearchView(APITestMixin):
         """
         Test that we can filter by one list tier group.
         """
-        one_list_tier = OneListTier.objects.all().order_by('?')[0]
+        one_list_tier = OneListTier.objects.all()[
+            random.randint(0, OneListTier.objects.count() - 1)
+        ]
         company_1 = CompanyFactory(
             name='Global HQ Ltd',
             one_list_tier=one_list_tier,
@@ -620,7 +623,7 @@ class TestInteractionEntitySearchView(APITestMixin):
 
         opensearch_with_collector.flush_and_refresh()
 
-        interaction = choice(interactions)
+        interaction = random.choice(interactions)
         dit_participant = interaction.dit_participants.order_by('?').first()
 
         url = reverse('api-v3:search:interaction')
@@ -1056,7 +1059,7 @@ class TestInteractionExportView(APITestMixin):
                 'Company': get_attr_or_none(interaction, 'company.name'),
                 'Company link':
                     f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
-                    f'/{interaction.company.pk}',
+                    f'/{interaction.company_id}',
                 'Company country': get_attr_or_none(
                     interaction,
                     'company.address_country.name',

--- a/datahub/search/activity/test/test_views.py
+++ b/datahub/search/activity/test/test_views.py
@@ -46,7 +46,7 @@ from datahub.interaction.test.factories import (
 from datahub.investment.project.test.factories import ActiveInvestmentProjectFactory
 from datahub.metadata.models import Sector
 from datahub.metadata.test.factories import TeamFactory
-from datahub.search.activity import InteractionSearchApp
+from datahub.search.activity import InteractionActivitySearchApp
 from datahub.search.activity.views import (
     SearchInteractionExportAPIView,
     SearchInteractionPolicyFeedbackExportAPIView,
@@ -56,7 +56,7 @@ from datahub.search.activity.views import (
 pytestmark = [
     pytest.mark.django_db,
     # Index objects for this search app only
-    pytest.mark.opensearch_collector_apps.with_args(InteractionSearchApp),
+    pytest.mark.opensearch_collector_apps.with_args(InteractionActivitySearchApp),
 ]
 
 

--- a/datahub/search/activity/test/test_views.py
+++ b/datahub/search/activity/test/test_views.py
@@ -1,0 +1,1444 @@
+from cgi import parse_header
+from collections import Counter
+from csv import DictReader
+from datetime import datetime, timezone
+from io import StringIO
+from operator import attrgetter, itemgetter
+from random import choice
+from uuid import UUID
+
+import factory
+import pytest
+from dateutil.parser import parse as dateutil_parse
+from django.conf import settings
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.models import OneListTier
+from datahub.company.test.factories import CompanyFactory, ContactFactory, SubsidiaryFactory
+from datahub.core import constants
+from datahub.core.query_utils import get_bracketed_concat_expression, get_full_name_expression
+from datahub.core.test_utils import (
+    APITestMixin,
+    create_test_user,
+    format_csv_data,
+    get_attr_or_none,
+    join_attr_values,
+    random_obj_for_queryset,
+)
+from datahub.core.utils import join_truthy_strings
+from datahub.interaction.models import (
+    CommunicationChannel,
+    Interaction,
+    InteractionPermission,
+    PolicyArea,
+    PolicyIssueType,
+)
+from datahub.interaction.test.factories import (
+    CompanyInteractionFactory,
+    CompanyInteractionFactoryWithPolicyFeedback,
+    EventServiceDeliveryFactory,
+    InteractionDITParticipantFactory,
+    InvestmentProjectInteractionFactory,
+    ServiceDeliveryFactory,
+)
+from datahub.investment.project.test.factories import ActiveInvestmentProjectFactory
+from datahub.metadata.models import Sector
+from datahub.metadata.test.factories import TeamFactory
+from datahub.search.activity import InteractionSearchApp
+from datahub.search.activity.views import (
+    SearchInteractionExportAPIView,
+    SearchInteractionPolicyFeedbackExportAPIView,
+)
+
+
+pytestmark = [
+    pytest.mark.django_db,
+    # Index objects for this search app only
+    pytest.mark.opensearch_collector_apps.with_args(InteractionSearchApp),
+]
+
+
+@pytest.fixture
+def interactions(opensearch_with_collector):
+    """Sets up data for the tests."""
+    data = []
+    with freeze_time('2017-01-01 13:00:00'):
+        company_1 = CompanyFactory(name='ABC Trading Ltd')
+        company_2 = CompanyFactory(name='Little Puddle Ltd')
+        data.extend([
+            CompanyInteractionFactory(
+                subject='Exports meeting',
+                date=dateutil_parse('2017-10-30T00:00:00Z'),
+                company=company_1,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Lee', last_name='Danger'),
+                    ContactFactory(company=company_1, first_name='Francis', last_name='Brady'),
+                    ContactFactory(company=company_1, first_name='Zanger Za', last_name='Qa'),
+                ],
+                dit_participants__adviser__first_name='Angela',
+                dit_participants__adviser__last_name='Lawson',
+            ),
+            CompanyInteractionFactory(
+                subject='a coffee',
+                date=dateutil_parse('2017-04-05T00:00:00Z'),
+                company=company_2,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Try', last_name='Slanger'),
+                ],
+                dit_participants__adviser__first_name='Zed',
+                dit_participants__adviser__last_name='Zeddy',
+            ),
+            CompanyInteractionFactory(
+                subject='Email about exhibition',
+                date=dateutil_parse('2016-09-02T00:00:00Z'),
+                company=company_2,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Caroline', last_name='Green'),
+                ],
+                dit_participants__adviser__first_name='Prime',
+                dit_participants__adviser__last_name='Zeddy',
+            ),
+            CompanyInteractionFactory(
+                subject='talking about cats',
+                date=dateutil_parse('2018-02-01T00:00:00Z'),
+                company=company_2,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Full', last_name='Bridge'),
+                ],
+                dit_participants__adviser__first_name='Low',
+                dit_participants__adviser__last_name='Tremon',
+            ),
+            CompanyInteractionFactory(
+                subject='Event at HQ',
+                date=dateutil_parse('2018-01-01T00:00:00Z'),
+                company=company_2,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Diane', last_name='Pree'),
+                ],
+                dit_participants__adviser__first_name='Trevor',
+                dit_participants__adviser__last_name='Saleman',
+            ),
+        ])
+
+    opensearch_with_collector.flush_and_refresh()
+
+    yield data
+
+
+class TestInteractionEntitySearchView(APITestMixin):
+    """Tests interaction search views."""
+
+    def test_interaction_search_no_permissions(self):
+        """Should return 403"""
+        user = create_test_user(dit_team=TeamFactory())
+        api_client = self.create_api_client(user=user)
+        url = reverse('api-v3:search:interaction')
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_get_all(self, interactions):
+        """
+        Tests that all interactions are returned with an empty POST body.
+        """
+        url = reverse('api-v3:search:interaction')
+
+        response = self.api_client.post(url, {})
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(interactions)
+        expected_ids = Counter(str(interaction.id) for interaction in interactions)
+        assert Counter([item['id'] for item in response_data['results']]) == expected_ids
+
+    def test_limit(self, interactions):
+        """Tests that results can be limited."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'limit': 1,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert len(response_data['results']) == 1
+
+    def test_offset(self, interactions):
+        """Tests that results can be offset."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'offset': 1,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert len(response_data['results']) == 4
+
+    def test_default_sort(self, opensearch_with_collector):
+        """Tests default sorting of results by date (descending)."""
+        url = reverse('api-v3:search:interaction')
+
+        dates = (
+            datetime(2017, 2, 4, 13, 15, 0, tzinfo=timezone.utc),
+            datetime(2017, 1, 4, 11, 23, 10, tzinfo=timezone.utc),
+            datetime(2017, 9, 29, 3, 25, 15, tzinfo=timezone.utc),
+            datetime(2017, 7, 5, 11, 44, 33, tzinfo=timezone.utc),
+            datetime(2017, 2, 1, 18, 15, 1, tzinfo=timezone.utc),
+        )
+        CompanyInteractionFactory.create_batch(
+            len(dates),
+            date=factory.Iterator(dates),
+        )
+        opensearch_with_collector.flush_and_refresh()
+
+        response = self.api_client.post(url, {})
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+
+        sorted_dates = sorted(dates, reverse=True)
+        expected_dates = [d.isoformat() for d in sorted_dates]
+        assert response_data['count'] == len(dates)
+        assert [item['date'] for item in response_data['results']] == expected_dates
+
+    def test_sort_by_subject_asc(self, interactions):
+        """Tests sorting of results by subject (ascending)."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'sortby': 'subject:asc',
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(interactions)
+        subjects = (interaction.subject for interaction in interactions)
+        expected_subjects = list(sorted(subjects, key=lambda s: s.lower()))
+        assert [item['subject'] for item in response_data['results']] == expected_subjects
+
+    def test_sort_by_subject_desc(self, interactions):
+        """Tests sorting of results by subject (ascending)."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'sortby': 'subject:desc',
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(interactions)
+        subjects = (interaction.subject for interaction in interactions)
+        expected_subjects = list(sorted(subjects, key=lambda s: s.lower(), reverse=True))
+        assert [item['subject'] for item in response_data['results']] == expected_subjects
+
+    @pytest.mark.parametrize(
+        'sortby,error',
+        (
+            ('date:backwards', '"backwards" is not a valid sort direction.'),
+            ('gyratory:asc', '"gyratory" is not a valid choice for the sort field.'),
+        ),
+    )
+    def test_sort_by_invalid_field(self, opensearch_with_collector, sortby, error):
+        """Tests attempting to sort by an invalid field and direction."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'sortby': sortby,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data == {
+            'sortby': [error],
+        }
+
+    @pytest.mark.parametrize(
+        'term',
+        (
+            'exports',
+            'meeting',
+            'exports meeting',
+            'danger',
+            'dan',
+            'dang',
+            'FRANCIS',
+            'angela',
+            'angel',
+            'ngel',
+            'ela',
+            'za',
+            'QA',
+        ),
+    )
+    def test_search_original_query(self, interactions, term):
+        """Tests searching across fields for a particular interaction."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'original_query': term,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        interaction = interactions[0]
+        assert response_data['count'] == 1
+        results = response_data['results']
+
+        for result in results:
+            result['contacts'].sort(key=itemgetter('id'))
+            result['companies'].sort(key=itemgetter('id'))
+            result['dit_participants'].sort(
+                key=lambda dit_participant: dit_participant['adviser']['id'],
+            )
+
+        assert results == [{
+            'id': str(interaction.pk),
+            'kind': interaction.kind,
+            'date': interaction.date.isoformat(),
+            'company': {
+                'id': str(interaction.company.pk),
+                'name': interaction.company.name,
+                'trading_names': interaction.company.trading_names,
+            },
+            'companies': [{
+                'id': str(company.pk),
+                'name': company.name,
+                'trading_names': company.trading_names,
+            } for company in sorted(interaction.companies.all(), key=attrgetter('id'))],
+            'company_sector': {
+                'id': str(interaction.company.sector.pk),
+                'name': interaction.company.sector.name,
+                'ancestors': [{
+                    'id': str(ancestor.pk),
+                } for ancestor in interaction.company.sector.get_ancestors()],
+            },
+            'company_one_list_group_tier': {
+                'id': interaction.company.get_one_list_group_tier().pk,
+                'name': interaction.company.get_one_list_group_tier().name,
+            } if interaction.company.get_one_list_group_tier() else None,
+            'contacts': [
+                {
+                    'id': str(contact.pk),
+                    'first_name': contact.first_name,
+                    'name': contact.name,
+                    'last_name': contact.last_name,
+                }
+                for contact in sorted(interaction.contacts.all(), key=attrgetter('id'))
+            ],
+            'is_event': None,
+            'event': None,
+            'service': {
+                'id': str(interaction.service.pk),
+                'name': interaction.service.name,
+            },
+            'subject': interaction.subject,
+            'dit_participants': [
+                {
+                    'adviser': {
+                        'id': str(dit_participant.adviser.pk),
+                        'first_name': dit_participant.adviser.first_name,
+                        'name': dit_participant.adviser.name,
+                        'last_name': dit_participant.adviser.last_name,
+                    },
+                    'team': {
+                        'id': str(dit_participant.team.pk),
+                        'name': dit_participant.team.name,
+                    },
+                }
+                for dit_participant in interaction.dit_participants.order_by('adviser__pk')
+            ],
+            'notes': interaction.notes,
+            'communication_channel': {
+                'id': str(interaction.communication_channel.pk),
+                'name': interaction.communication_channel.name,
+            },
+            'investment_project': None,
+            'investment_project_sector': None,
+            'policy_areas': [],
+            'policy_issue_types': [],
+            'service_delivery_status': None,
+            'grant_amount_offered': None,
+            'net_company_receipt': None,
+            'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
+            'created_on': interaction.created_on.isoformat(),
+            'modified_on': interaction.modified_on.isoformat(),
+        }]
+
+    def test_filter_by_kind(self, opensearch_with_collector):
+        """Tests filtering interaction by kind."""
+        CompanyInteractionFactory.create_batch(10)
+        service_deliveries = ServiceDeliveryFactory.create_batch(10)
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            'kind': Interaction.Kind.SERVICE_DELIVERY,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+
+        assert response_data['count'] == 10
+
+        results = response_data['results']
+        service_delivery_ids = {str(interaction.id) for interaction in service_deliveries}
+        assert {result['id'] for result in results} == service_delivery_ids
+
+    def test_filter_by_company_id(self, opensearch_with_collector):
+        """Tests filtering interaction by company id."""
+        companies = CompanyFactory.create_batch(10)
+        CompanyInteractionFactory.create_batch(
+            len(companies),
+            company=factory.Iterator(companies),
+        )
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            'company': companies[5].id,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+
+        assert response_data['count'] == 1
+
+        results = response_data['results']
+        assert results[0]['company']['id'] == str(companies[5].id)
+
+    @pytest.mark.parametrize(
+        'name_term,matched_company_name',
+        (
+            # name
+            ('whiskers', 'whiskers and tabby'),
+            ('whi', 'whiskers and tabby'),
+            ('his', 'whiskers and tabby'),
+            ('ers', 'whiskers and tabby'),
+            ('1a', '1a'),
+
+            # trading names
+            ('maine coon egyptian mau', 'whiskers and tabby'),
+            ('maine', 'whiskers and tabby'),
+            ('mau', 'whiskers and tabby'),
+            ('ine oon', 'whiskers and tabby'),
+            ('ine mau', 'whiskers and tabby'),
+            ('3a', '1a'),
+
+            # non-matches
+            ('whi lorem', None),
+            ('wh', None),
+            ('whe', None),
+            ('tiger', None),
+            ('panda', None),
+            ('moine', None),
+        ),
+    )
+    def test_filter_by_company_name(
+        self, opensearch_with_collector, name_term, matched_company_name,
+    ):
+        """Tests filtering interaction by company name."""
+        matching_company1 = CompanyFactory(
+            name='whiskers and tabby',
+            trading_names=['Maine Coon', 'Egyptian Mau'],
+        )
+        matching_company2 = CompanyFactory(
+            name='1a',
+            trading_names=['3a', '4a'],
+        )
+        non_matching_company = CompanyFactory(
+            name='Pluto and pippo',
+            trading_names=['eniam nooc', 'naitpyge uam'],
+        )
+        CompanyInteractionFactory(company=matching_company1)
+        CompanyInteractionFactory(company=matching_company2)
+        CompanyInteractionFactory(company=non_matching_company)
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': '',
+                'company_name': name_term,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        match = Interaction.objects.filter(company__name=matched_company_name).first()
+        if match:
+            assert response.data['count'] == 1
+            assert len(response.data['results']) == 1
+            assert response.data['results'][0]['id'] == str(match.id)
+        else:
+            assert response.data['count'] == 0
+            assert len(response.data['results']) == 0
+
+    def test_filter_by_one_list_tier_group(
+        self,
+        opensearch_with_collector,
+    ):
+        """
+        Test that we can filter by one list tier group.
+        """
+        one_list_tier = OneListTier.objects.all().order_by('?')[0]
+        company_1 = CompanyFactory(
+            name='Global HQ Ltd',
+            one_list_tier=one_list_tier,
+        )
+        company_2 = CompanyFactory(
+            name='Regional Subsidiary Ltd',
+            global_headquarters=company_1,
+        )
+        CompanyInteractionFactory(
+            subject='Global HQ chat',
+            company=company_1,
+        )
+        CompanyInteractionFactory(
+            subject='Regional Subsidiary chat',
+            company=company_2,
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'company_one_list_group_tier': one_list_tier.id,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+        assert len(response.data['results']) == 2
+        matched_interaction_subjects = {result['subject'] for result in response.data['results']}
+
+        assert matched_interaction_subjects == {'Global HQ chat', 'Regional Subsidiary chat'}
+        assert all(
+            result['company_one_list_group_tier']['name'] == one_list_tier.name
+            for result in response.data['results']
+        )
+
+    def test_filter_by_multiple_one_list_tier_groups(
+        self,
+        opensearch_with_collector,
+    ):
+        """
+        Test that we can filter by multiple one list tier groups.
+        """
+        one_list_tiers = list(OneListTier.objects.all().order_by('?')[0:2])
+        company_1 = CompanyFactory(
+            name='Global HQ Ltd',
+            one_list_tier=one_list_tiers[0],
+        )
+        company_2 = CompanyFactory(
+            name='Other Company',
+            one_list_tier=one_list_tiers[1],
+        )
+        CompanyInteractionFactory(
+            subject='Global HQ chat',
+            company=company_1,
+        )
+        CompanyInteractionFactory(
+            subject='Other Company chat',
+            company=company_2,
+        )
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'company_one_list_group_tier': [tier.id for tier in one_list_tiers],
+            },
+        )
+
+        expected_interaction_subjects = {
+            'Global HQ chat',
+            'Other Company chat',
+        }
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+        assert len(response.data['results']) == 2
+        matched_interaction_subjects = {result['subject'] for result in response.data['results']}
+
+        assert matched_interaction_subjects == expected_interaction_subjects
+
+    @pytest.mark.parametrize(
+        'created_on_exists',
+        (True, False),
+    )
+    def test_filter_by_created_on_exists(self, opensearch_with_collector, created_on_exists):
+        """Tests filtering interaction by created_on exists."""
+        CompanyInteractionFactory.create_batch(3)
+        no_created_on = CompanyInteractionFactory.create_batch(3)
+        for interaction in no_created_on:
+            interaction.created_on = None
+            interaction.save()
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            'created_on_exists': created_on_exists,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        results = response_data['results']
+        assert response_data['count'] == 3
+        assert all(
+            (not result['created_on'] is None) == created_on_exists
+            for result in results
+        )
+
+    @pytest.mark.parametrize('dit_participant_field', ('adviser', 'team'))
+    def test_filter_by_dit_participant(self, opensearch_with_collector, dit_participant_field):
+        """Test filtering interaction by DIT participant adviser and team IDs."""
+        interactions = CompanyInteractionFactory.create_batch(10, dit_participants=[])
+        for interaction in interactions:
+            InteractionDITParticipantFactory.create_batch(2, interaction=interaction)
+
+        opensearch_with_collector.flush_and_refresh()
+
+        interaction = choice(interactions)
+        dit_participant = interaction.dit_participants.order_by('?').first()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            f'dit_participants__{dit_participant_field}':
+                getattr(dit_participant, dit_participant_field).id,
+        }
+        response = self.api_client.post(url, request_data)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == 1
+
+        results = response_data['results']
+        assert len(results) == 1
+        assert results[0]['id'] == str(interaction.pk)
+
+    def test_filter_by_communication_channel(self, opensearch_with_collector):
+        """Tests filtering interaction by interaction type."""
+        communication_channels = list(CommunicationChannel.objects.order_by('?')[:2])
+        CompanyInteractionFactory.create_batch(
+            5,
+            communication_channel=communication_channels[0],
+        )
+        CompanyInteractionFactory.create_batch(
+            5,
+            communication_channel=communication_channels[1],
+        )
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            'original_query': '',
+            'communication_channel': communication_channels[1].pk,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+
+        assert response_data['count'] == 5
+
+        results = response_data['results']
+        result_ids = {result['communication_channel']['id'] for result in results}
+        assert result_ids == {str(communication_channels[1].pk)}
+
+    @pytest.mark.parametrize(
+        'field,field_model',
+        (
+            ('policy_areas', PolicyArea),
+            ('policy_issue_types', PolicyIssueType),
+        ),
+    )
+    def test_filter_by_policy_fields(self, opensearch_with_collector, field, field_model):
+        """
+        Tests filtering interactions by:
+        - policy area
+        - policy issue type
+        """
+        values = list(field_model.objects.order_by('?')[:2])
+        expected_field_value = values[0]
+        other_field_value = values[1]
+
+        factory_values = [
+            [expected_field_value, other_field_value],
+            [expected_field_value, other_field_value],
+            [expected_field_value],
+            [expected_field_value],
+            [expected_field_value],
+        ]
+
+        expected_interactions = CompanyInteractionFactoryWithPolicyFeedback.create_batch(
+            5,
+            **{field: factory.Iterator(factory_values)},
+        )
+
+        # Unrelated interactions
+        CompanyInteractionFactoryWithPolicyFeedback.create_batch(
+            6,
+            **{field: [other_field_value]},
+        )
+        CompanyInteractionFactory.create_batch(6)
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            'original_query': '',
+            field: expected_field_value.pk,
+        }
+        response = self.api_client.post(url, request_data)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        results = response_data['results']
+        expected_ids = {str(interaction.pk) for interaction in expected_interactions}
+
+        assert response_data['count'] == 5
+        assert Counter(
+            value['id']
+            for result in results
+            for value in result[field]
+        ) == {
+            str(expected_field_value.pk): 5,
+            # two interactions had both values
+            str(other_field_value.pk): 2,
+        }
+        assert {result['id'] for result in results} == expected_ids
+
+    def test_filter_by_service(self, opensearch_with_collector):
+        """Tests filtering interaction by service."""
+        CompanyInteractionFactory.create_batch(
+            5,
+            service_id=constants.Service.inbound_referral.value.id,
+        )
+        service_id = constants.Service.account_management.value.id
+        CompanyInteractionFactory.create_batch(
+            5,
+            service_id=service_id,
+        )
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            'service': service_id,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+
+        assert response_data['count'] == 5
+
+        results = response_data['results']
+        result_ids = {result['service']['id'] for result in results}
+        assert result_ids == {str(service_id)}
+
+    @pytest.mark.parametrize('was_policy_feedback_provided', (False, True))
+    def test_filter_by_was_policy_feedback_provided(
+        self,
+        opensearch_with_collector,
+        was_policy_feedback_provided,
+    ):
+        """Test filtering interactions by was_policy_feedback_provided."""
+        interactions_without_policy_feedback = CompanyInteractionFactory.create_batch(5)
+        interactions_with_policy_feedback = (
+            CompanyInteractionFactoryWithPolicyFeedback.create_batch(5)
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            'was_policy_feedback_provided': was_policy_feedback_provided,
+        }
+        response = self.api_client.post(url, data=request_data)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        expected_interactions = (
+            interactions_with_policy_feedback if was_policy_feedback_provided
+            else interactions_without_policy_feedback
+        )
+        assert response_data['count'] == len(expected_interactions)
+
+        results = response_data['results']
+        result_ids = {result['id'] for result in results}
+        assert result_ids == {str(interaction.pk) for interaction in expected_interactions}
+
+    @pytest.mark.parametrize(
+        'data,results',
+        (
+            (
+                {
+                    'date_after': '2017-12-01',
+                },
+                {
+                    'talking about cats',
+                    'Event at HQ',
+                },
+            ),
+            (
+                {
+                    'date_after': '2017-12-01',
+                    'date_before': '2018-01-02',
+                },
+                {
+                    'Event at HQ',
+                },
+            ),
+            (
+                {
+                    'date_before': '2017-01-01',
+                },
+                {
+                    'Email about exhibition',
+                },
+            ),
+        ),
+    )
+    def test_filter_by_date(self, interactions, data, results):
+        """Tests filtering interaction by date."""
+        url = reverse('api-v3:search:interaction')
+        response = self.api_client.post(url, data)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        names = {result['subject'] for result in response_data['results']}
+        assert names == results
+
+    @pytest.mark.parametrize(
+        'sector_level',
+        (0, 1, 2),
+    )
+    def test_sector_descends_filter_for_company_interaction(
+            self,
+            hierarchical_sectors,
+            opensearch_with_collector,
+            sector_level,
+    ):
+        """Test the sector_descends filter with company interactions."""
+        num_sectors = len(hierarchical_sectors)
+        sectors_ids = [sector.pk for sector in hierarchical_sectors]
+
+        companies = CompanyFactory.create_batch(
+            num_sectors,
+            sector_id=factory.Iterator(sectors_ids),
+        )
+        company_interactions = CompanyInteractionFactory.create_batch(
+            3,
+            company=factory.Iterator(companies),
+        )
+
+        other_companies = CompanyFactory.create_batch(
+            3,
+            sector=factory.LazyFunction(lambda: random_obj_for_queryset(
+                Sector.objects.exclude(pk__in=sectors_ids),
+            )),
+        )
+        CompanyInteractionFactory.create_batch(
+            3,
+            company=factory.Iterator(other_companies),
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        body = {
+            'sector_descends': hierarchical_sectors[sector_level].pk,
+        }
+        response = self.api_client.post(url, body)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == num_sectors - sector_level
+
+        actual_ids = {UUID(interaction['id']) for interaction in response_data['results']}
+        expected_ids = {interaction.pk for interaction in company_interactions[sector_level:]}
+        assert actual_ids == expected_ids
+
+    @pytest.mark.parametrize(
+        'sector_level',
+        (0, 1, 2),
+    )
+    def test_sector_descends_filter_for_investment_project_interaction(
+            self,
+            hierarchical_sectors,
+            opensearch_with_collector,
+            sector_level,
+    ):
+        """Test the sector_descends filter with investment project interactions."""
+        num_sectors = len(hierarchical_sectors)
+        sectors_ids = [sector.pk for sector in hierarchical_sectors]
+
+        projects = ActiveInvestmentProjectFactory.create_batch(
+            num_sectors,
+            sector_id=factory.Iterator(sectors_ids),
+        )
+        investment_project_interactions = InvestmentProjectInteractionFactory.create_batch(
+            3,
+            investment_project=factory.Iterator(projects),
+        )
+
+        other_projects = ActiveInvestmentProjectFactory.create_batch(
+            3,
+            sector=factory.LazyFunction(lambda: random_obj_for_queryset(
+                Sector.objects.exclude(pk__in=sectors_ids),
+            )),
+        )
+        InvestmentProjectInteractionFactory.create_batch(
+            3,
+            investment_project=factory.Iterator(other_projects),
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        url = reverse('api-v3:search:interaction')
+        body = {
+            'sector_descends': hierarchical_sectors[sector_level].pk,
+        }
+        response = self.api_client.post(url, body)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == num_sectors - sector_level
+
+        actual_ids = {UUID(interaction['id']) for interaction in response_data['results']}
+        expected_ids = {
+            interaction.pk for interaction in investment_project_interactions[sector_level:]
+        }
+        assert actual_ids == expected_ids
+
+
+class TestInteractionExportView(APITestMixin):
+    """Tests the interaction export view."""
+
+    @pytest.mark.parametrize(
+        'permissions',
+        (
+            (),
+            (InteractionPermission.view_all,),
+            (InteractionPermission.export,),
+        ),
+    )
+    def test_user_without_permission_cannot_export(self, opensearch_with_collector, permissions):
+        """Test that a user without the correct permissions cannot export data."""
+        user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
+        api_client = self.create_api_client(user=user)
+
+        url = reverse('api-v3:search:interaction-export')
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        'request_sortby,orm_ordering',
+        (
+            (None, '-date'),
+            ('date', 'date'),
+            ('company.name', 'company__name'),
+        ),
+    )
+    def test_interaction_export(
+        self,
+        opensearch_with_collector,
+        request_sortby,
+        orm_ordering,
+    ):
+        """
+        Test export of interaction search results with a policy feedback user.
+
+        Checks that all interaction kinds except for policy feedback are included in the export.
+        """
+        # Faker generates job titles containing commas which complicates comparisons,
+        # so all contact job titles are explicitly set
+        company = CompanyFactory()
+        interaction = CompanyInteractionFactory(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Engineer'),
+                ContactFactory(company=company, job_title=None),
+                ContactFactory(company=company, job_title=''),
+            ],
+        )
+        InteractionDITParticipantFactory.create_batch(2, interaction=interaction)
+        InteractionDITParticipantFactory(interaction=interaction, team=None)
+        InteractionDITParticipantFactory(
+            interaction=interaction,
+            adviser=None,
+            team=factory.SubFactory(TeamFactory),
+        )
+        EventServiceDeliveryFactory(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Managing director'),
+            ],
+        )
+        InvestmentProjectInteractionFactory(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Exports manager'),
+            ],
+        )
+        ServiceDeliveryFactory(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Sales director'),
+            ],
+        )
+        CompanyInteractionFactoryWithPolicyFeedback(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Business development manager'),
+            ],
+            policy_areas=PolicyArea.objects.order_by('?')[:2],
+            policy_issue_types=PolicyIssueType.objects.order_by('?')[:2],
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        data = {}
+        if request_sortby:
+            data['sortby'] = request_sortby
+
+        url = reverse('api-v3:search:interaction-export')
+
+        with freeze_time('2018-01-01 11:12:13'):
+            response = self.api_client.post(url, data=data)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})
+        assert parse_header(response.get('Content-Disposition')) == (
+            'attachment', {'filename': 'Data Hub - Interactions - 2018-01-01-11-12-13.csv'},
+        )
+        sorted_interactions = Interaction.objects.order_by(
+            orm_ordering,
+            'pk',
+        )
+        reader = DictReader(StringIO(response.getvalue().decode('utf-8-sig')))
+
+        assert reader.fieldnames == list(SearchInteractionExportAPIView.field_titles.values())
+
+        expected_row_data = [
+            {
+                'Date': interaction.date,
+                'Type': interaction.get_kind_display(),
+                'Service': get_attr_or_none(interaction, 'service.name'),
+                'Subject': interaction.subject,
+                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["interaction"]}'
+                        f'/{interaction.pk}',
+                'Company': get_attr_or_none(interaction, 'company.name'),
+                'Company link':
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
+                    f'/{interaction.company.pk}',
+                'Company country': get_attr_or_none(
+                    interaction,
+                    'company.address_country.name',
+                ),
+                'Company UK region': get_attr_or_none(interaction, 'company.uk_region.name'),
+                'Company sector': get_attr_or_none(interaction, 'company.sector.name'),
+                'Contacts': _format_expected_contacts(interaction),
+                'Advisers': _format_expected_advisers(interaction),
+                'Event': get_attr_or_none(interaction, 'event.name'),
+                'Communication channel':
+                    get_attr_or_none(interaction, 'communication_channel.name'),
+                'Service delivery status': get_attr_or_none(
+                    interaction,
+                    'service_delivery_status.name',
+                ),
+                'Net company receipt': interaction.net_company_receipt,
+                'Policy issue types': join_attr_values(
+                    interaction.policy_issue_types.order_by('name'),
+                ),
+                'Policy areas': join_attr_values(
+                    interaction.policy_areas.order_by('name'),
+                    separator='; ',
+                ),
+                'Policy feedback notes': interaction.policy_feedback_notes,
+                'Notes': interaction.notes,
+            }
+            for interaction in sorted_interactions
+        ]
+
+        # DictReader uses OrderedDicts, we convert them to normal dicts to get better errors
+        # when the assertion fails
+        actual_row_data = [dict(item) for item in reader]
+
+        assert actual_row_data == format_csv_data(expected_row_data)
+
+    @pytest.mark.parametrize(
+        'request_sortby,orm_ordering',
+        (
+            (None, '-date'),
+            ('date', 'date'),
+            ('company.name', 'company__name'),
+        ),
+    )
+    def test_policy_feedback_export(
+        self,
+        opensearch_with_collector,
+        request_sortby,
+        orm_ordering,
+    ):
+        """
+        Test export of interaction policy feedback
+        """
+        # Faker generates job titles containing commas which complicates comparisons,
+        # so all contact job titles are explicitly set
+        company = SubsidiaryFactory()
+        interaction = CompanyInteractionFactory(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Engineer'),
+                ContactFactory(company=company, job_title=None),
+                ContactFactory(company=company, job_title=''),
+            ],
+        )
+        InteractionDITParticipantFactory.create_batch(2, interaction=interaction)
+        InteractionDITParticipantFactory(interaction=interaction, team=None)
+        InteractionDITParticipantFactory(
+            interaction=interaction,
+            adviser=None,
+            team=factory.SubFactory(TeamFactory),
+        )
+        EventServiceDeliveryFactory(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Managing director'),
+            ],
+        )
+        InvestmentProjectInteractionFactory(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Exports manager'),
+            ],
+        )
+        ServiceDeliveryFactory(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Sales director'),
+            ],
+        )
+        CompanyInteractionFactoryWithPolicyFeedback(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Business development manager'),
+            ],
+            policy_areas=PolicyArea.objects.order_by('?')[:2],
+            policy_issue_types=PolicyIssueType.objects.order_by('?')[:2],
+        )
+
+        opensearch_with_collector.flush_and_refresh()
+
+        data = {}
+        if request_sortby:
+            data['sortby'] = request_sortby
+
+        url = reverse('api-v3:search:interaction-policy-feedback')
+
+        with freeze_time('2018-01-01 11:12:13'):
+            response = self.api_client.post(url, data=data)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})
+        assert parse_header(response.get('Content-Disposition')) == (
+            'attachment', {'filename': 'Data Hub - Interactions - 2018-01-01-11-12-13.csv'},
+        )
+        sorted_interactions = Interaction.objects.order_by(
+            orm_ordering,
+            'pk',
+        )
+        reader = DictReader(StringIO(response.getvalue().decode('utf-8-sig')))
+
+        assert reader.fieldnames == list(
+            SearchInteractionPolicyFeedbackExportAPIView.field_titles.values(),
+        )
+
+        expected_row_data = [
+            {
+                'Date': interaction.date,
+                'Created date': interaction.created_on,
+                'Modified date': interaction.modified_on,
+                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["interaction"]}'
+                        f'/{interaction.pk}',
+                'Service': get_attr_or_none(interaction, 'service.name'),
+                'Subject': interaction.subject,
+                'Company': get_attr_or_none(interaction, 'company.name'),
+                'Parent': get_attr_or_none(
+                    interaction,
+                    'company.global_headquarters.name',
+                ),
+                'Parent country': get_attr_or_none(
+                    interaction,
+                    'company.global_headquarters.address_country.name',
+                ),
+                'Company country': get_attr_or_none(
+                    interaction,
+                    'company.address_country.name',
+                ),
+                'Company UK region': get_attr_or_none(interaction, 'company.uk_region.name'),
+                'One List Tier': get_attr_or_none(interaction, 'company.one_list_tier.name'),
+                'Company sector': get_attr_or_none(interaction, 'company.sector.name'),
+                'Company sector cluster': get_attr_or_none(
+                    interaction,
+                    'company.sector.sector_cluster.name',
+                ),
+                'turnover': get_attr_or_none(interaction, 'company.turnover'),
+                'number_of_employees': get_attr_or_none(
+                    interaction,
+                    'company.number_of_employees',
+                ),
+                'team_names': _format_expected_team_names(interaction),
+                'team_countries': _format_expected_team_countries(interaction),
+                'kind_name': interaction.get_kind_display(),
+                'Communication channel':
+                    get_attr_or_none(interaction, 'communication_channel.name'),
+                'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
+                'Policy issue types': join_attr_values(
+                    interaction.policy_issue_types.order_by('name'),
+                ),
+                'Policy areas': join_attr_values(
+                    interaction.policy_areas.order_by('name'),
+                    separator='; ',
+                ),
+                'Policy feedback notes': interaction.policy_feedback_notes,
+                'Notes': interaction.notes,
+                'advisers': _format_expected_advisers(interaction),
+                'adviser_emails': _format_expected_adviser_emails(interaction),
+                'tag_1': '',
+                'probability_score_tag_1': '',
+                'tag_2': '',
+                'probability_score_tag_2': '',
+                'tag_3': '',
+                'probability_score_tag_3': '',
+                'tag_4': '',
+                'probability_score_tag_4': '',
+                'tag_5': '',
+                'probability_score_tag_5': '',
+
+                'Contacts': _format_expected_contacts(interaction),
+                'Event': get_attr_or_none(interaction, 'event.name'),
+                'Service delivery status': get_attr_or_none(
+                    interaction,
+                    'service_delivery_status.name',
+                ),
+                'Net company receipt': interaction.net_company_receipt,
+            }
+            for interaction in sorted_interactions
+        ]
+
+        # DictReader uses OrderedDicts, we convert them to normal dicts to get better errors
+        # when the assertion fails
+        actual_row_data = [dict(item) for item in reader]
+
+        assert actual_row_data == format_csv_data(expected_row_data)
+
+
+class TestInteractionBasicSearch(APITestMixin):
+    """Tests searching for interactions via basic (global) search."""
+
+    @pytest.mark.parametrize(
+        'term',
+        (
+            'exports',
+            'meeting',
+            'exports meeting',
+            'danger',
+            'dan',
+            'dang',
+            'FRANCIS',
+            'angela',
+            'angel',
+            'ngel',
+            'ela',
+            'za',
+            'QA',
+        ),
+    )
+    def test_search(self, interactions, term):
+        """Tests searching for various search terms."""
+        url = reverse('api-v3:search:basic')
+
+        request_data = {
+            'term': term,
+            'entity': 'interaction',
+        }
+        response = self.api_client.get(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        interaction = interactions[0]
+        assert response_data['count'] >= 1
+        results = response_data['results']
+
+        for result in results:
+            result['contacts'].sort(key=itemgetter('id'))
+            result['companies'].sort(key=itemgetter('id'))
+            result['dit_participants'].sort(
+                key=lambda dit_participant: dit_participant['adviser']['id'],
+            )
+
+        assert results[0] == {
+            'id': str(interaction.pk),
+            'kind': interaction.kind,
+            'date': interaction.date.isoformat(),
+            'company': {
+                'id': str(interaction.company.pk),
+                'name': interaction.company.name,
+                'trading_names': interaction.company.trading_names,
+            },
+            'companies': [
+                {
+                    'id': str(company.pk),
+                    'name': company.name,
+                    'trading_names': company.trading_names,
+                } for company in sorted(interaction.companies.all(), key=attrgetter('id'))
+            ],
+            'company_one_list_group_tier': {
+                'id': interaction.company.get_one_list_group_tier().pk,
+                'name': interaction.company.get_one_list_group_tier().name,
+            } if interaction.company.get_one_list_group_tier() else None,
+            'company_sector': {
+                'id': str(interaction.company.sector.pk),
+                'name': interaction.company.sector.name,
+                'ancestors': [{
+                    'id': str(ancestor.pk),
+                } for ancestor in interaction.company.sector.get_ancestors()],
+            },
+            'contacts': [
+                {
+                    'id': str(contact.pk),
+                    'first_name': contact.first_name,
+                    'name': contact.name,
+                    'last_name': contact.last_name,
+                }
+                for contact in sorted(interaction.contacts.all(), key=attrgetter('id'))
+            ],
+            'is_event': None,
+            'event': None,
+            'service': {
+                'id': str(interaction.service.pk),
+                'name': interaction.service.name,
+            },
+            'subject': interaction.subject,
+            'dit_participants': [
+                {
+                    'adviser': {
+                        'id': str(dit_participant.adviser.pk),
+                        'first_name': dit_participant.adviser.first_name,
+                        'name': dit_participant.adviser.name,
+                        'last_name': dit_participant.adviser.last_name,
+                    },
+                    'team': {
+                        'id': str(dit_participant.team.pk),
+                        'name': dit_participant.team.name,
+                    },
+                }
+                for dit_participant in interaction.dit_participants.order_by('adviser__pk')
+            ],
+            'notes': interaction.notes,
+            'communication_channel': {
+                'id': str(interaction.communication_channel.pk),
+                'name': interaction.communication_channel.name,
+            },
+            'investment_project': None,
+            'investment_project_sector': None,
+            'policy_areas': [],
+            'policy_issue_types': [],
+            'service_delivery_status': None,
+            'grant_amount_offered': None,
+            'net_company_receipt': None,
+            'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
+            'created_on': interaction.created_on.isoformat(),
+            'modified_on': interaction.modified_on.isoformat(),
+        }
+
+
+def _format_expected_contacts(interaction):
+    queryset = interaction.contacts.order_by(
+        get_full_name_expression(bracketed_field_name='job_title'),
+    )
+
+    return ', '.join(
+        _format_expected_contact_name(contact) for contact in queryset
+    )
+
+
+def _format_expected_contact_name(contact):
+    if contact.job_title:
+        return f'{contact.name} ({contact.job_title})'
+
+    return f'{contact.name}'
+
+
+def _format_expected_team_names(interaction):
+    queryset = interaction.dit_participants.order_by(
+        'team__name',
+    )
+    return ', '.join(
+        dit_participant.team.name for dit_participant in queryset if dit_participant.team
+    )
+
+
+def _format_expected_team_countries(interaction):
+    queryset = interaction.dit_participants.order_by(
+        'team__name',
+    )
+
+    return ', '.join(
+        dit_participant.team.country.name for dit_participant in queryset if dit_participant.team
+    )
+
+
+def _format_expected_advisers(interaction):
+    queryset = interaction.dit_participants.order_by(
+        get_bracketed_concat_expression(
+            'adviser__first_name',
+            'adviser__last_name',
+            expression_to_bracket='team__name',
+        ),
+    )
+
+    return ', '.join(
+        _format_expected_adviser_name(dit_participant) for dit_participant in queryset
+    )
+
+
+def _format_expected_adviser_emails(interaction):
+    queryset = interaction.dit_participants.order_by('adviser__email')
+
+    return ', '.join(
+        dit_participant.adviser.email for dit_participant in queryset if dit_participant.adviser
+    )
+
+
+def _format_expected_adviser_name(dit_participant):
+    adviser_name = dit_participant.adviser.name if dit_participant.adviser else ''
+    team_name = f'({dit_participant.team.name})' if dit_participant.team else ''
+    return join_truthy_strings(adviser_name, team_name)

--- a/datahub/search/activity/views.py
+++ b/datahub/search/activity/views.py
@@ -15,7 +15,7 @@ from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.metadata.query_utils import get_service_name_subquery
 from datahub.search.activity import InteractionActivitySearchApp
 from datahub.search.activity.serializers import SearchInteractionQuerySerializer
-from datahub.search.views import register_v3_view, SearchAPIView, SearchExportAPIView
+from datahub.search.views import register_v4_view, SearchAPIView, SearchExportAPIView
 
 
 class SearchInteractionAPIViewMixin:
@@ -84,12 +84,12 @@ class SearchInteractionAPIViewMixin:
     }
 
 
-@register_v3_view()
+@register_v4_view()
 class SearchInteractionAPIView(SearchInteractionAPIViewMixin, SearchAPIView):
     """Filtered interaction search view."""
 
 
-@register_v3_view(sub_path='export')
+@register_v4_view(sub_path='export')
 class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExportAPIView):
     """Filtered interaction search export view."""
 
@@ -149,7 +149,7 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
     }
 
 
-@register_v3_view(sub_path='policy-feedback')
+@register_v4_view(sub_path='policy-feedback')
 class SearchInteractionPolicyFeedbackExportAPIView(
     SearchInteractionAPIViewMixin,
     SearchExportAPIView,

--- a/datahub/search/activity/views.py
+++ b/datahub/search/activity/views.py
@@ -1,0 +1,279 @@
+from django.db.models import CharField, OuterRef, Prefetch, Value
+from django.db.models.functions import Cast
+
+from datahub.company.models import Contact
+from datahub.core.query_utils import (
+    get_bracketed_concat_expression,
+    get_choices_as_case_expression,
+    get_front_end_url_expression,
+    get_full_name_expression,
+    get_string_agg_subquery,
+)
+from datahub.interaction.models import Interaction as DBInteraction, InteractionDITParticipant
+from datahub.metadata.models import Sector
+from datahub.metadata.query_utils import get_sector_name_subquery
+from datahub.metadata.query_utils import get_service_name_subquery
+from datahub.search.activity import InteractionSearchApp
+from datahub.search.activity.serializers import SearchInteractionQuerySerializer
+from datahub.search.views import register_v3_view, SearchAPIView, SearchExportAPIView
+
+
+class SearchInteractionAPIViewMixin:
+    """Defines common settings."""
+
+    search_app = InteractionSearchApp
+    serializer_class = SearchInteractionQuerySerializer
+    es_sort_by_remappings = {
+        'company.name': 'company.name.keyword',
+        'subject': 'subject.keyword',
+    }
+    fields_to_exclude = (
+        'export_countries',
+        'were_countries_discussed',
+    )
+    FILTER_FIELDS = (
+        'kind',
+        'company',
+        'subject',
+        'company_name',
+        'company_one_list_group_tier',
+        'created_on_exists',
+        'dit_participants__adviser',
+        'dit_participants__team',
+        'date_after',
+        'date_before',
+        'communication_channel',
+        'investment_project',
+        'policy_areas',
+        'policy_issue_types',
+        'sector_descends',
+        'service',
+        'was_policy_feedback_provided',
+        'contacts',
+    )
+    REMAP_FIELDS = {
+        'company': 'company.id',
+        'company_one_list_group_tier': 'company_one_list_group_tier.id',
+        'dit_participants__adviser': 'dit_participants.adviser.id',
+        'dit_participants__team': 'dit_participants.team.id',
+        'communication_channel': 'communication_channel.id',
+        'investment_project': 'investment_project.id',
+        'policy_areas': 'policy_areas.id',
+        'policy_issue_types': 'policy_issue_types.id',
+        'service': 'service.id',
+        'contacts': 'contacts.id',
+    }
+
+    COMPOSITE_FILTERS = {
+        'company_name': [
+            'company.name',
+            'company.name.trigram',
+            'company.trading_names',  # to find 2-letter words
+            'company.trading_names.trigram',
+        ],
+        'sector_descends': [
+            'company_sector.id',
+            'company_sector.ancestors.id',
+            'investment_project_sector.id',
+            'investment_project_sector.ancestors.id',
+        ],
+        'subject': [
+            'subject',  # to find 2-letter words
+            'subject.trigram',
+        ],
+    }
+
+
+@register_v3_view()
+class SearchInteractionAPIView(SearchInteractionAPIViewMixin, SearchAPIView):
+    """Filtered interaction search view."""
+
+
+@register_v3_view(sub_path='export')
+class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExportAPIView):
+    """Filtered interaction search export view."""
+
+    queryset = DBInteraction.objects.annotate(
+        company_link=get_front_end_url_expression('company', 'company__pk'),
+        company_sector_name=get_sector_name_subquery('company__sector'),
+        contact_names=get_string_agg_subquery(
+            DBInteraction,
+            get_full_name_expression(
+                person_field_name='contacts',
+                bracketed_field_name='job_title',
+            ),
+        ),
+        adviser_names=get_string_agg_subquery(
+            DBInteraction,
+            get_bracketed_concat_expression(
+                'dit_participants__adviser__first_name',
+                'dit_participants__adviser__last_name',
+                expression_to_bracket='dit_participants__team__name',
+            ),
+        ),
+        link=get_front_end_url_expression('interaction', 'pk'),
+        kind_name=get_choices_as_case_expression(DBInteraction, 'kind'),
+        policy_issue_type_names=get_string_agg_subquery(
+            DBInteraction,
+            Cast('policy_issue_types__name', CharField()),
+        ),
+        policy_area_names=get_string_agg_subquery(
+            DBInteraction,
+            Cast('policy_areas__name', CharField()),
+            # Some policy areas contain commas, so we use a semicolon to delimit multiple values
+            delimiter='; ',
+        ),
+        service_name=get_service_name_subquery('service'),
+    )
+    field_titles = {
+        'date': 'Date',
+        'kind_name': 'Type',
+        'service_name': 'Service',
+        'subject': 'Subject',
+        'link': 'Link',
+        'company__name': 'Company',
+        'company_link': 'Company link',
+        'company__address_country__name': 'Company country',
+        'company__uk_region__name': 'Company UK region',
+        'company_sector_name': 'Company sector',
+        'contact_names': 'Contacts',
+        'adviser_names': 'Advisers',
+        'event__name': 'Event',
+        'communication_channel__name': 'Communication channel',
+        'service_delivery_status__name': 'Service delivery status',
+        'net_company_receipt': 'Net company receipt',
+        'policy_issue_type_names': 'Policy issue types',
+        'policy_area_names': 'Policy areas',
+        'policy_feedback_notes': 'Policy feedback notes',
+        'notes': 'Notes',
+    }
+
+
+@register_v3_view(sub_path='policy-feedback')
+class SearchInteractionPolicyFeedbackExportAPIView(
+    SearchInteractionAPIViewMixin,
+    SearchExportAPIView,
+):
+    """Filtered interaction policy feedback search export view."""
+
+    queryset = DBInteraction.objects.select_related(
+        'company',
+        'company__global_headquarters',
+        'company__sector',
+    ).prefetch_related(
+        Prefetch('contacts', queryset=Contact.objects.order_by('pk')),
+        'policy_areas',
+        'policy_issue_types',
+        Prefetch(
+            'dit_participants',
+            queryset=(
+                InteractionDITParticipant.objects.order_by('pk').select_related('adviser', 'team')
+            ),
+        ),
+    ).annotate(
+        company_link=get_front_end_url_expression('company', 'company__pk'),
+        company_sector_name=get_sector_name_subquery('company__sector'),
+        company_sector_cluster=Sector.objects.filter(
+            parent_id__isnull=True,
+            tree_id=OuterRef('company__sector__tree_id'),
+        ).values('sector_cluster__name'),
+        contact_names=get_string_agg_subquery(
+            DBInteraction,
+            get_full_name_expression(
+                person_field_name='contacts',
+                bracketed_field_name='job_title',
+            ),
+        ),
+        created_by_name=get_full_name_expression(
+            person_field_name='created_by',
+        ),
+        adviser_names=get_string_agg_subquery(
+            DBInteraction,
+            get_bracketed_concat_expression(
+                'dit_participants__adviser__first_name',
+                'dit_participants__adviser__last_name',
+                expression_to_bracket='dit_participants__team__name',
+            ),
+        ),
+        adviser_emails=get_string_agg_subquery(
+            DBInteraction,
+            'dit_participants__adviser__email',
+        ),
+        team_names=get_string_agg_subquery(
+            DBInteraction,
+            Cast('dit_participants__team__name', CharField()),
+        ),
+        team_countries=get_string_agg_subquery(
+            DBInteraction,
+            Cast('dit_participants__team__country__name', CharField()),
+        ),
+        link=get_front_end_url_expression('interaction', 'pk'),
+        kind_name=get_choices_as_case_expression(DBInteraction, 'kind'),
+        policy_issue_type_names=get_string_agg_subquery(
+            DBInteraction,
+            Cast('policy_issue_types__name', CharField()),
+        ),
+        policy_area_names=get_string_agg_subquery(
+            DBInteraction,
+            Cast('policy_areas__name', CharField()),
+            # Some policy areas contain commas, so we use a semicolon to delimit multiple values
+            delimiter='; ',
+        ),
+        service_name=get_service_name_subquery('service'),
+        # Placeholder values
+        tags_prediction=Value('', CharField()),
+        tag_1=Value('', CharField()),
+        probability_score_tag_1=Value('', CharField()),
+        tag_2=Value('', CharField()),
+        probability_score_tag_2=Value('', CharField()),
+        tag_3=Value('', CharField()),
+        probability_score_tag_3=Value('', CharField()),
+        tag_4=Value('', CharField()),
+        probability_score_tag_4=Value('', CharField()),
+        tag_5=Value('', CharField()),
+        probability_score_tag_5=Value('', CharField()),
+    )
+
+    field_titles = {
+        'date': 'Date',
+        'created_on': 'Created date',
+        'modified_on': 'Modified date',
+        'link': 'Link',
+        'service_name': 'Service',
+        'subject': 'Subject',
+        'company__name': 'Company',
+        'company__global_headquarters__name': 'Parent',
+        'company__global_headquarters__address_country__name': 'Parent country',
+        'company__address_country__name': 'Company country',
+        'company__uk_region__name': 'Company UK region',
+        'company__one_list_tier__name': 'One List Tier',
+        'company_sector_name': 'Company sector',
+        'company_sector_cluster': 'Company sector cluster',
+        'company__turnover': 'turnover',
+        'company__number_of_employees': 'number_of_employees',
+        'team_names': 'team_names',
+        'team_countries': 'team_countries',
+        'kind_name': 'kind_name',
+        'communication_channel__name': 'Communication channel',
+        'was_policy_feedback_provided': 'was_policy_feedback_provided',
+        'policy_issue_type_names': 'Policy issue types',
+        'policy_area_names': 'Policy areas',
+        'policy_feedback_notes': 'Policy feedback notes',
+        'notes': 'Notes',
+        'adviser_names': 'advisers',
+        'adviser_emails': 'adviser_emails',
+        'tag_1': 'tag_1',
+        'probability_score_tag_1': 'probability_score_tag_1',
+        'tag_2': 'tag_2',
+        'probability_score_tag_2': 'probability_score_tag_2',
+        'tag_3': 'tag_3',
+        'probability_score_tag_3': 'probability_score_tag_3',
+        'tag_4': 'tag_4',
+        'probability_score_tag_4': 'probability_score_tag_4',
+        'tag_5': 'tag_5',
+        'probability_score_tag_5': 'probability_score_tag_5',
+        'contact_names': 'Contacts',
+        'event__name': 'Event',
+        'service_delivery_status__name': 'Service delivery status',
+        'net_company_receipt': 'Net company receipt',
+    }

--- a/datahub/search/activity/views.py
+++ b/datahub/search/activity/views.py
@@ -13,7 +13,7 @@ from datahub.interaction.models import Interaction as DBInteraction, Interaction
 from datahub.metadata.models import Sector
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.metadata.query_utils import get_service_name_subquery
-from datahub.search.activity import InteractionSearchApp
+from datahub.search.activity import InteractionActivitySearchApp
 from datahub.search.activity.serializers import SearchInteractionQuerySerializer
 from datahub.search.views import register_v3_view, SearchAPIView, SearchExportAPIView
 
@@ -21,7 +21,7 @@ from datahub.search.views import register_v3_view, SearchAPIView, SearchExportAP
 class SearchInteractionAPIViewMixin:
     """Defines common settings."""
 
-    search_app = InteractionSearchApp
+    search_app = InteractionActivitySearchApp
     serializer_class = SearchInteractionQuerySerializer
     es_sort_by_remappings = {
         'company.name': 'company.name.keyword',

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -98,6 +98,10 @@ def get_global_search_apps_as_mapping():
 
 def get_search_app(app_name):
     """Gets a single search app (by name)."""
+    search_app = _load_search_apps()[app_name]
+    if not search_app:
+        raise LookupError(f'Search app with name {app_name} not found.')
+
     return _load_search_apps()[app_name]
 
 

--- a/datahub/search/interaction/signals.py
+++ b/datahub/search/interaction/signals.py
@@ -38,7 +38,7 @@ def remove_interaction_from_opensearch(instance):
 def sync_related_interactions_to_opensearch(instance):
     """Sync related interactions."""
     transaction.on_commit(
-        lambda: sync_related_objects_async(instance, 'interactions'),
+        lambda: sync_related_objects_async(instance, 'interactions', None, 'interaction'),
     )
 
 

--- a/datahub/search/sync_object.py
+++ b/datahub/search/sync_object.py
@@ -62,7 +62,12 @@ def sync_object_async(search_app, pk):
     )
 
 
-def sync_related_objects_async(related_obj, related_obj_field_name, related_obj_filter=None):
+def sync_related_objects_async(
+        related_obj,
+        related_obj_field_name,
+        related_obj_filter=None,
+        search_app_name=None,
+):
     """
     Syncs objects related to another object via a specified field.
 
@@ -73,8 +78,18 @@ def sync_related_objects_async(related_obj, related_obj_field_name, related_obj_
 
     This function is normally used by signal receivers to copy new or updated related objects to
     OpenSearch.
+
+    :param search_app_name: str - Syncs to the given search app if given, used when there are
+        multiple search apps for the same DB model as get_search_apps returns the first search app
+        associated with a DB model.
     """
     kwargs = {'related_obj_filter': related_obj_filter} if related_obj_filter else {}
+
+    # Specify the search app to update, used when there are multiple search apps for
+    # the same DB model.
+    if search_app_name:
+        kwargs['search_app_name'] = search_app_name
+
     job = job_scheduler(
         function=sync_related_objects_task,
         function_args=(

--- a/datahub/search/test/search_support/searchappwithsamemodel/__init__.py
+++ b/datahub/search/test/search_support/searchappwithsamemodel/__init__.py
@@ -1,0 +1,5 @@
+from datahub.search.test.search_support.searchappwithsamemodel.apps import (
+    RelatedModelWithSameDBModelApp,
+)
+
+__all__ = ('RelatedModelWithSameDBModelApp', )

--- a/datahub/search/test/search_support/searchappwithsamemodel/apps.py
+++ b/datahub/search/test/search_support/searchappwithsamemodel/apps.py
@@ -1,0 +1,18 @@
+from datahub.search.apps import SearchApp
+from datahub.search.test.search_support.models import RelatedModel as DBRelatedModel
+from datahub.search.test.search_support.searchappwithsamemodel.models import (
+    SearchAppWithSameDBModel,
+)
+
+
+class RelatedModelWithSameDBModelApp(SearchApp):
+    """
+    SearchApp which contains the same DB model.
+    """
+
+    name = 'related_search_with_same_model'
+    search_model = SearchAppWithSameDBModel
+    queryset = DBRelatedModel.objects
+    view_permissions = [
+        'search_support.view_related_search_with_same_model',
+    ]

--- a/datahub/search/test/search_support/searchappwithsamemodel/models.py
+++ b/datahub/search/test/search_support/searchappwithsamemodel/models.py
@@ -1,0 +1,18 @@
+from opensearch_dsl import Keyword
+
+from datahub.search import dict_utils
+from datahub.search import fields
+from datahub.search.models import BaseSearchModel
+
+
+class SearchAppWithSameDBModel(BaseSearchModel):
+    """OpenSearch representation of SimpleModel model."""
+
+    id = Keyword()
+    simpleton = fields.id_name_field()
+
+    MAPPINGS = {
+        'simpleton': dict_utils.id_name_dict,
+    }
+
+    SEARCH_FIELDS = ('simpleton.name',)

--- a/datahub/search/test/search_support/searchappwithsamemodel/signals.py
+++ b/datahub/search/test/search_support/searchappwithsamemodel/signals.py
@@ -1,0 +1,29 @@
+from django.db.models.signals import post_save
+
+from datahub.search.signals import SignalReceiver
+from datahub.search.test.search_support.models import (
+    RelatedModel as DBRelatedModel,
+    SimpleModel as DBSimpleModel,
+)
+
+
+def _dummy_callback(instance):
+    """
+    Function called post-save and deliberately empty.
+    It can be used to check if/when it's called.
+    """
+
+
+def dummy_callback(*args, **kwargs):
+    """
+    Forward calls to _dummy_callback.
+
+    This is so that tests can patch _dummy_callback to check if it has been called.
+    """
+    _dummy_callback(*args, **kwargs)
+
+
+receivers = (
+    SignalReceiver(post_save, DBSimpleModel, dummy_callback),
+    SignalReceiver(post_save, DBRelatedModel, dummy_callback),
+)

--- a/datahub/search/test/test_tasks.py
+++ b/datahub/search/test/test_tasks.py
@@ -14,7 +14,7 @@ from datahub.search.tasks import (
 from datahub.search.test.search_support.models import RelatedModel, SimpleModel
 from datahub.search.test.search_support.relatedmodel import RelatedModelSearchApp
 from datahub.search.test.search_support.searchappwithsamemodel import (
-    RelatedModelWithSameSearchModelApp,
+    RelatedModelWithSameDBModelApp,
 )
 from datahub.search.test.search_support.simplemodel import SimpleModelSearchApp
 from datahub.search.test.utils import create_mock_search_app, doc_exists
@@ -107,9 +107,9 @@ def test_sync_related_objects_task_syncs_for_given_search_app(related_obj_filter
     opensearch.indices.refresh()
 
     # Updates only the search app specified by name 'related_search_with_same_model'
-    assert doc_exists(opensearch, RelatedModelWithSameSearchModelApp, relation_1.pk)
-    assert doc_exists(opensearch, RelatedModelWithSameSearchModelApp, relation_2.pk)
-    assert not doc_exists(opensearch, RelatedModelWithSameSearchModelApp, unrelated_obj.pk)
+    assert doc_exists(opensearch, RelatedModelWithSameDBModelApp, relation_1.pk)
+    assert doc_exists(opensearch, RelatedModelWithSameDBModelApp, relation_2.pk)
+    assert not doc_exists(opensearch, RelatedModelWithSameDBModelApp, unrelated_obj.pk)
 
     # Doesn't update the other search app not specified
     assert not doc_exists(opensearch, RelatedModelSearchApp, relation_1.pk)


### PR DESCRIPTION
### Description of change

Beginning of work for new endpoint which will show data from several integrations (aventri, maxemail etc).

To start this is mostly a copy paste of the current interactions search endpoint which will be extended from for further integrations with the other services.

Also fixed an issue where the sync command only updates the first search index associated with the given model instance. This is an issue here as we now have two search endpoints for interactions. I've updated the sync to accept a parameter to specify the search app you want to update to prevent this.

Ticket: https://uktrade.atlassian.net/browse/TET-819

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?