### PR TITLE
Fix lead officer email for anonymous wins.

### DIFF
--- a/datahub/export_win/constants.py
+++ b/datahub/export_win/constants.py
@@ -2,6 +2,8 @@ from enum import Enum
 
 from datahub.core.constants import Constant
 
+ANONYMOUS = 'anonymous'
+
 EMAIL_MAX_DAYS_TO_RESPONSE_THRESHOLD = 7
 EMAIL_MAX_WEEKS_AUTO_RESEND_THRESHOLD = 3
 EMAIL_MAX_TOKEN_ISSUED_WITHIN_RESPONSE_THRESHOLD = 4

--- a/datahub/export_win/test/test_tasks.py
+++ b/datahub/export_win/test/test_tasks.py
@@ -735,6 +735,25 @@ def test_get_all_fields_for_lead_officer_email_receipt_no_success():
     )
 
 
+def test_get_all_fields_for_lead_officer_email_receipt_no_success_anonymous():
+    win = WinFactory(company=None)
+    customer_response = CustomerResponseFactory(win=win)
+
+    result = get_all_fields_for_lead_officer_email_receipt_no(
+        customer_response,
+    )
+    """
+    Testing to get all fields for lead officer rejected email receipt
+    """
+    assert result['lead_officer_email'] == win.lead_officer.contact_email
+    assert result['country_destination'] == win.country.name
+    assert result['client_fullname'] == 'anonymous'
+    assert result['lead_officer_first_name'] == win.lead_officer.first_name
+    assert result['goods_services'] == win.goods_vs_services.name
+    assert result['client_company_name'] == 'anonymous'
+    assert result['url'] == settings.DATAHUB_FRONTEND_BASE_URL
+
+
 def test_get_all_fields_for_lead_officer_email_receipt_yes_success():
     win = WinFactory()
     contact = ContactFactory(company=win.company)
@@ -765,3 +784,30 @@ def test_get_all_fields_for_lead_officer_email_receipt_yes_success():
         company_id=win.company.id,
         uuid=win.id,
     )
+
+
+def test_get_all_fields_for_lead_officer_email_receipt_yes_success_anonymous():
+    win = WinFactory(company=None)
+    customer_response = CustomerResponseFactory(win=win)
+
+    num_breakdowns = 5
+    breakdown_value = 10000
+
+    BreakdownFactory.create_batch(num_breakdowns, win=win, value=breakdown_value)
+
+    result = get_all_fields_for_lead_officer_email_receipt_yes(
+        customer_response,
+    )
+    expected_total_export_win_value = num_breakdowns * breakdown_value
+
+    """
+    Testing to get all fields for lead officer approved email receipt (with total_export_win_value)
+    """
+    assert result['lead_officer_email'] == win.lead_officer.contact_email
+    assert result['country_destination'] == win.country.name
+    assert result['client_fullname'] == 'anonymous'
+    assert result['lead_officer_first_name'] == win.lead_officer.first_name
+    assert result['total_export_win_value'] == expected_total_export_win_value
+    assert result['goods_services'] == win.goods_vs_services.name
+    assert result['client_company_name'] == 'anonymous'
+    assert result['url'] == settings.DATAHUB_FRONTEND_BASE_URL


### PR DESCRIPTION
### Description of change

Anonymous wins typically have company and company contact missing and that caused review endpoint to fail when customer was submitting the review form, as lead officer template expected company and company contact to be present.

If this data is missing then it is being replaced with "anonymous" and the URL is replaced with link to the front page since these wins cannot be viewed in Data Hub front end.


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
