### PR TITLE
Cls2 898 eyblead serializers views

### DIFF
--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -102,7 +102,7 @@ v4_urls = [
     path('', include((objective_urls.urls_v4, 'objective'), namespace='objective')),
     path('', include((task_urls.urls_v4, 'task'), namespace='task')),
     path(
-        '',
+        'investment-lead/',
         include((investment_lead_urls, 'investment-lead'), namespace='investment-lead'),
     ),
 ]

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -17,6 +17,7 @@ from datahub.event import urls as event_urls
 from datahub.export_win import urls as export_win_urls
 from datahub.feature_flag import urls as feature_flag_urls
 from datahub.interaction import urls as interaction_urls
+from datahub.investment_lead import urls as investment_lead_urls
 from datahub.investment.investor_profile import urls as investor_profile_urls
 from datahub.investment.opportunity import urls as opportunity_urls
 from datahub.investment.project import urls as investment_urls
@@ -100,4 +101,8 @@ v4_urls = [
     path('', include((export_win_urls.urls, 'export-win'), namespace='export-win')),
     path('', include((objective_urls.urls_v4, 'objective'), namespace='objective')),
     path('', include((task_urls.urls_v4, 'task'), namespace='task')),
+    path(
+        '',
+        include((investment_lead_urls, 'investment-lead'), namespace='investment-lead')
+    ),
 ]

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -17,11 +17,11 @@ from datahub.event import urls as event_urls
 from datahub.export_win import urls as export_win_urls
 from datahub.feature_flag import urls as feature_flag_urls
 from datahub.interaction import urls as interaction_urls
-from datahub.investment_lead import urls as investment_lead_urls
 from datahub.investment.investor_profile import urls as investor_profile_urls
 from datahub.investment.opportunity import urls as opportunity_urls
 from datahub.investment.project import urls as investment_urls
 from datahub.investment.project.proposition import urls as proposition_urls
+from datahub.investment_lead import urls as investment_lead_urls
 from datahub.metadata import urls as metadata_urls
 from datahub.omis import urls as omis_urls
 from datahub.reminder import urls as reminder_urls
@@ -103,6 +103,6 @@ v4_urls = [
     path('', include((task_urls.urls_v4, 'task'), namespace='task')),
     path(
         '',
-        include((investment_lead_urls, 'investment-lead'), namespace='investment-lead')
+        include((investment_lead_urls, 'investment-lead'), namespace='investment-lead'),
     ),
 ]

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -3,7 +3,19 @@ from rest_framework import serializers
 from datahub.investment_lead.models import EYBLead
 
 
-ALL_FIELDS = [
+ARCHIVABLE_FIELDS = [
+    'archived',
+    'archived_on',
+    'archived_reason',
+    'archived_by',
+]
+
+BASE_FIELDS = [
+    'created_on',
+    'modified_on',
+]
+
+TRIAGE_FIELDS = [
     'triage_id',
     'triage_hashed_uuid',
     'triage_created',
@@ -19,6 +31,9 @@ ALL_FIELDS = [
     'spend',
     'spend_other',
     'is_high_value',
+]
+
+USER_FIELDS = [
     'user_id',
     'user_hashed_uuid',
     'user_created',
@@ -34,6 +49,8 @@ ALL_FIELDS = [
     'landing_timeframe',
     'company_website',
 ]
+
+ALL_FIELDS = ARCHIVABLE_FIELDS + BASE_FIELDS + TRIAGE_FIELDS + USER_FIELDS
 
 UUIDS_ERROR_MESSAGE = 'Invalid serializer data: UUIDs must match.'
 

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -1,0 +1,50 @@
+from rest_framework import serializers
+
+from datahub.investment_lead.models import EYBLead
+
+
+ALL_FIELDS = [
+    'triage_id',
+    'triage_hashed_uuid',
+    'triage_created',
+    'triage_modified',
+    'sector',
+    'sector_sub',
+    'intent',
+    'intent_other',
+    'location',
+    'location_city',
+    'location_none',
+    'hiring',
+    'spend',
+    'spend_other',
+    'is_high_value',
+    'user_id',
+    'user_hashed_uuid',
+    'user_created',
+    'user_modified',
+    'company_name',
+    'company_location',
+    'full_name',
+    'role',
+    'email',
+    'telephone_number',
+    'agree_terms',
+    'agree_info_email',
+    'landing_timeframe',
+    'company_website',
+]
+
+
+class EYBLeadSerializer(serializers.ModelSerializer):
+    """Serializer for an EYB lead object"""
+
+    triage_created = serializers.DateTimeField(read_only=True)
+    triage_modified = serializers.DateTimeField(read_only=True)
+
+    user_created = serializers.DateTimeField(read_only=True)
+    user_modified = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = EYBLead
+        fields = ALL_FIELDS

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -35,6 +35,8 @@ ALL_FIELDS = [
     'company_website',
 ]
 
+UUIDS_ERROR_MESSAGE = 'Invalid serializer data: UUIDs must match.'
+
 
 class EYBLeadSerializer(serializers.ModelSerializer):
     """Serializer for an EYB lead object"""
@@ -48,3 +50,8 @@ class EYBLeadSerializer(serializers.ModelSerializer):
     class Meta:
         model = EYBLead
         fields = ALL_FIELDS
+
+    def validate(self, data):
+        if data['triage_hashed_uuid'] != data['user_hashed_uuid']:
+            raise serializers.ValidationError(UUIDS_ERROR_MESSAGE)
+        return data

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -39,11 +39,11 @@ ALL_FIELDS = [
 class EYBLeadSerializer(serializers.ModelSerializer):
     """Serializer for an EYB lead object"""
 
-    triage_created = serializers.DateTimeField(read_only=True)
-    triage_modified = serializers.DateTimeField(read_only=True)
+    triage_created = serializers.DateTimeField()
+    triage_modified = serializers.DateTimeField()
 
-    user_created = serializers.DateTimeField(read_only=True)
-    user_modified = serializers.DateTimeField(read_only=True)
+    user_created = serializers.DateTimeField()
+    user_modified = serializers.DateTimeField()
 
     class Meta:
         model = EYBLead

--- a/datahub/investment_lead/test/conftest.py
+++ b/datahub/investment_lead/test/conftest.py
@@ -1,0 +1,62 @@
+import datetime
+
+import pytest
+
+from datahub.investment_lead.models import EYBLead
+from datahub.investment_lead.test.factories import EYBLeadFactory
+
+
+@pytest.fixture
+def eyb_lead_data():
+    return {
+        # EYB Triage data
+        'triage_id': 96,
+        'triage_hashed_uuid': 'b85dabe2a4c46828424d61ec99f496d91952f9e53733898ff5f0fee89f08b635',
+        'triage_created': datetime.datetime(
+            2023, 9, 21, 7, 53, 19, 534794, tzinfo=datetime.timezone.utc,
+        ),
+        'triage_modified': datetime.datetime(
+            2023, 9, 27, 11, 32, 28, 853014, tzinfo=datetime.timezone.utc,
+        ),
+        'sector': 'FOOD_AND_DRINK',
+        'sector_sub': 'PROCESSING_AND_PRESERVING_OF_MEAT',
+        'intent': [
+            'SET_UP_NEW_PREMISES',
+            'SET_UP_A_NEW_DISTRIBUTION_CENTRE',
+            'ONWARD_SALES_AND_EXPORTS_FROM_THE_UK',
+        ],
+        'intent_other': '',
+        'location': 'NORTHERN_IRELAND',
+        'location_city': 'ARMAGH_CITY',
+        'location_none': False,
+        'hiring': '51-100',
+        'spend': '1000000-2000000',
+        'spend_other': '1234565432',
+        'is_high_value': True,
+
+        # EYB User data
+        'user_id': 90,
+        'user_hashed_uuid': 'b85dabe2a4c46828424d61ec99f496d91952f9e53733898ff5f0fee89f08b635',
+        'user_created': datetime.datetime(
+            2023, 9, 21, 7, 53, 19, 472710, tzinfo=datetime.timezone.utc,
+        ),
+        'user_modified': datetime.datetime(
+            2023, 9, 22, 8, 53, 19, 472723, tzinfo=datetime.timezone.utc,
+        ),
+        'company_name': 'Stu co',
+        'company_location': 'FR',
+        'full_name': 'John Doe',
+        'role': 'Director',
+        'email': 'foo@bar.com',
+        'telephone_number': '447923454678',
+        'agree_terms': True,
+        'agree_info_email': False,
+        'landing_timeframe': 'SIX_TO_TWELVE_MONTHS',
+        'company_website': 'http://www.google.com',
+    }
+
+
+@pytest.fixture
+def eyb_lead_db(eyb_lead_data):
+    eyb_lead_factory = EYBLeadFactory(**eyb_lead_data)
+    return EYBLead.objects.get(pk=eyb_lead_factory.pk)

--- a/datahub/investment_lead/test/conftest.py
+++ b/datahub/investment_lead/test/conftest.py
@@ -7,6 +7,16 @@ from datahub.investment_lead.test.factories import EYBLeadFactory
 
 
 @pytest.fixture
+def data_flow_api_client(hawk_api_client):
+    """Hawk API client fixture configured to use credentials with the data_flow_api scope."""
+    hawk_api_client.set_credentials(
+        'data-flow-api-id',
+        'data-flow-api-key',
+    )
+    yield hawk_api_client
+
+
+@pytest.fixture
 def eyb_lead_data():
     return {
         # EYB Triage data

--- a/datahub/investment_lead/test/conftest.py
+++ b/datahub/investment_lead/test/conftest.py
@@ -25,7 +25,7 @@ def eyb_lead_data():
             'SET_UP_A_NEW_DISTRIBUTION_CENTRE',
             'ONWARD_SALES_AND_EXPORTS_FROM_THE_UK',
         ],
-        'intent_other': '',
+        'intent_other': 'other intent',
         'location': 'NORTHERN_IRELAND',
         'location_city': 'ARMAGH_CITY',
         'location_none': False,

--- a/datahub/investment_lead/test/test_models.py
+++ b/datahub/investment_lead/test/test_models.py
@@ -1,101 +1,7 @@
-import datetime
-
 import pytest
 
 from datahub.investment_lead.models import EYBLead
-from datahub.investment_lead.test.factories import EYBLeadFactory
-
-
-@pytest.fixture
-def eyb_lead_data():
-    return {
-        # EYB Triage data
-        'triage_id': 96,
-        'triage_hashed_uuid': 'b85dabe2a4c46828424d61ec99f496d91952f9e53733898ff5f0fee89f08b635',
-        'triage_created': datetime.datetime(
-            2023, 9, 21, 7, 53, 19, 534794, tzinfo=datetime.timezone.utc,
-        ),
-        'triage_modified': datetime.datetime(
-            2023, 9, 27, 11, 32, 28, 853014, tzinfo=datetime.timezone.utc,
-        ),
-        'sector': 'FOOD_AND_DRINK',
-        'sector_sub': 'PROCESSING_AND_PRESERVING_OF_MEAT',
-        'intent': [
-            'SET_UP_NEW_PREMISES',
-            'SET_UP_A_NEW_DISTRIBUTION_CENTRE',
-            'ONWARD_SALES_AND_EXPORTS_FROM_THE_UK',
-        ],
-        'intent_other': '',
-        'location': 'NORTHERN_IRELAND',
-        'location_city': 'ARMAGH_CITY',
-        'location_none': False,
-        'hiring': '51-100',
-        'spend': '1000000-2000000',
-        'spend_other': '1234565432',
-        'is_high_value': True,
-
-        # EYB User data
-        'user_id': 90,
-        'user_hashed_uuid': 'b85dabe2a4c46828424d61ec99f496d91952f9e53733898ff5f0fee89f08b635',
-        'user_created': datetime.datetime(
-            2023, 9, 21, 7, 53, 19, 472710, tzinfo=datetime.timezone.utc,
-        ),
-        'user_modified': datetime.datetime(
-            2023, 9, 22, 8, 53, 19, 472723, tzinfo=datetime.timezone.utc,
-        ),
-        'company_name': 'Stu co',
-        'company_location': 'FR',
-        'full_name': 'John Doe',
-        'role': 'Director',
-        'email': 'foo@bar.com',
-        'telephone_number': '447923454678',
-        'agree_terms': True,
-        'agree_info_email': False,
-        'landing_timeframe': 'SIX_TO_TWELVE_MONTHS',
-        'company_website': 'http://www.google.com',
-    }
-
-
-@pytest.fixture
-def eyb_lead_db(eyb_lead_data):
-    eyb_lead_factory = EYBLeadFactory(**eyb_lead_data)
-    return EYBLead.objects.get(pk=eyb_lead_factory.pk)
-
-
-def verify_eyb_lead_data(instance: EYBLead, data: dict):
-    """Method to verify the EYBLead data against the instance created."""
-    # EYB Triage data
-    assert instance.triage_id == data['triage_id']
-    assert instance.triage_hashed_uuid == data['triage_hashed_uuid']
-    assert instance.triage_created == data['triage_created']
-    assert instance.triage_modified == data['triage_modified']
-    assert instance.sector == data['sector']
-    assert instance.sector_sub == data['sector_sub']
-    assert instance.intent == data['intent']
-    assert instance.intent_other == data['intent_other']
-    assert instance.location == data['location']
-    assert instance.location_city == data['location_city']
-    assert instance.location_none == data['location_none']
-    assert instance.hiring == data['hiring']
-    assert instance.spend == data['spend']
-    assert instance.spend_other == data['spend_other']
-    assert instance.is_high_value == data['is_high_value']
-
-    # EYB User data
-    assert instance.user_id == data['user_id']
-    assert instance.user_hashed_uuid == data['user_hashed_uuid']
-    assert instance.user_created == data['user_created']
-    assert instance.user_modified == data['user_modified']
-    assert instance.company_name == data['company_name']
-    assert instance.company_location == data['company_location']
-    assert instance.full_name == data['full_name']
-    assert instance.role == data['role']
-    assert instance.email == data['email']
-    assert instance.telephone_number == data['telephone_number']
-    assert instance.agree_terms == data['agree_terms']
-    assert instance.agree_info_email == data['agree_info_email']
-    assert instance.landing_timeframe == data['landing_timeframe']
-    assert instance.company_website == data['company_website']
+from datahub.investment_lead.test.utils import verify_eyb_lead_data
 
 
 @pytest.mark.django_db
@@ -112,4 +18,6 @@ class TestEYBLead:
         assert str(eyb_lead_db) == hashed_id
 
     def test_triage_uuid_and_user_uuid_match(self, eyb_lead_db):
+        # TODO: verify whether this will be needed in the long run
+        # we might squash the *_uuids into one
         assert eyb_lead_db.triage_hashed_uuid == eyb_lead_db.user_hashed_uuid

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -1,0 +1,17 @@
+import pytest
+
+from datahub.investment_lead.models import EYBLead
+from datahub.investment_lead.serializers import EYBLeadSerializer
+from datahub.investment_lead.test.utils import verify_eyb_lead_data
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("eyb_lead_data", "eyb_lead_db")
+class TestEYBLeadSerializer:
+    """Tests for EYBLeadSerializer."""
+
+    def test_eyb_lead_serializer(self, eyb_lead_data, eyb_lead_db):
+        eyb_object = EYBLead.objects.first()
+        eyb_object_serialized = EYBLeadSerializer(eyb_object)
+
+        verify_eyb_lead_data(eyb_object, eyb_object_serialized.data)

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -2,7 +2,6 @@ import pytest
 
 from rest_framework import serializers
 
-from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.serializers import (
     EYBLeadSerializer,
     UUIDS_ERROR_MESSAGE,
@@ -15,21 +14,18 @@ from datahub.investment_lead.test.utils import verify_eyb_lead_data
 class TestEYBLeadSerializer:
     """Tests for EYBLeadSerializer."""
 
-    def test_eyb_lead_serializer_raises_if_uuids_different(self, eyb_lead_data, eyb_lead_db):
+    def test_eyb_lead_serializer_raises_if_uuids_different(self, eyb_lead_data):
         invalid_eyb_data = eyb_lead_data.copy()
         invalid_eyb_data['triage_hashed_uuid'] = '123abc'
         invalid_eyb_data['user_hashed_uuid'] = '456def'
         eyb_serializer = EYBLeadSerializer(data=invalid_eyb_data)
 
-        with pytest.raises(serializers.ValidationError) as serial_error:
+        with pytest.raises(serializers.ValidationError):
             eyb_serializer.is_valid(raise_exception=True)
 
-        # Can this be done more elegantly?
-        error_message = str(serial_error.value.detail['non_field_errors'][0])
-        assert error_message == UUIDS_ERROR_MESSAGE
+        assert UUIDS_ERROR_MESSAGE in eyb_serializer.errors['non_field_errors']
 
-    def test_eyb_lead_serializer_as_expected(self, eyb_lead_data, eyb_lead_db):
-        eyb_object = EYBLead.objects.first()
-        eyb_object_serialized = EYBLeadSerializer(eyb_object)
-
-        verify_eyb_lead_data(eyb_object, eyb_object_serialized.data)
+    def test_eyb_lead_serializer_as_expected(self, eyb_lead_db):
+        db_instance = eyb_lead_db
+        serialized_instance = EYBLeadSerializer(eyb_lead_db)
+        verify_eyb_lead_data(db_instance, serialized_instance.data)

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -1,7 +1,12 @@
 import pytest
 
+from rest_framework import serializers
+
 from datahub.investment_lead.models import EYBLead
-from datahub.investment_lead.serializers import EYBLeadSerializer
+from datahub.investment_lead.serializers import (
+    EYBLeadSerializer,
+    UUIDS_ERROR_MESSAGE,
+)
 from datahub.investment_lead.test.utils import verify_eyb_lead_data
 
 
@@ -10,7 +15,20 @@ from datahub.investment_lead.test.utils import verify_eyb_lead_data
 class TestEYBLeadSerializer:
     """Tests for EYBLeadSerializer."""
 
-    def test_eyb_lead_serializer(self, eyb_lead_data, eyb_lead_db):
+    def test_eyb_lead_serializer_raises_if_uuids_different(self, eyb_lead_data, eyb_lead_db):
+        invalid_eyb_data = eyb_lead_data.copy()
+        invalid_eyb_data['triage_hashed_uuid'] = '123abc'
+        invalid_eyb_data['user_hashed_uuid'] = '456def'
+        eyb_serializer = EYBLeadSerializer(data=invalid_eyb_data)
+
+        with pytest.raises(serializers.ValidationError) as serial_error:
+            eyb_serializer.is_valid(raise_exception=True)
+
+        # Can this be done more elegantly?
+        error_message = str(serial_error.value.detail['non_field_errors'][0])
+        assert error_message == UUIDS_ERROR_MESSAGE
+
+    def test_eyb_lead_serializer_as_expected(self, eyb_lead_data, eyb_lead_db):
         eyb_object = EYBLead.objects.first()
         eyb_object_serialized = EYBLeadSerializer(eyb_object)
 

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -6,7 +6,7 @@ from datahub.investment_lead.test.utils import verify_eyb_lead_data
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures('eyb_lead_data', 'eyb_lead_d')
+@pytest.mark.usefixtures('eyb_lead_data', 'eyb_lead_db')
 class TestEYBLeadSerializer:
     """Tests for EYBLeadSerializer."""
 

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -6,7 +6,7 @@ from datahub.investment_lead.test.utils import verify_eyb_lead_data
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("eyb_lead_data", "eyb_lead_db")
+@pytest.mark.usefixtures('eyb_lead_data', 'eyb_lead_d')
 class TestEYBLeadSerializer:
     """Tests for EYBLeadSerializer."""
 

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -1,0 +1,30 @@
+import pytest
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+
+from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.investment_lead.models import EYBLead
+from datahub.investment_lead.test.utils import (
+    verify_eyb_lead_data
+)
+
+
+class TestDNBCompanyCreateAPI(APITestMixin):
+    """
+    EYB Lead Create view test case.
+    """
+
+    def test_post_with_no_payload(self):
+        """
+        Test that we get an Exception when no payload is sent
+        """
+        with pytest.raises(ImproperlyConfigured):
+            self.api_client.post(
+                reverse('api-v4:investment-lead:eyb-lead-create'),
+                data=None,
+            )

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -41,12 +41,13 @@ class TestEYBLeadCreateAPI(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data['location'][0] == 'This field may not be null.'
 
     def test_post_success(self, eyb_lead_data):
         """
         Test successful POST to EYB
         """
-        assert EYBLead.objects.count() == 0
+        current_count = EYBLead.objects.count()
 
         post_url = reverse('api-v4:investment-lead:create')
         response = self.api_client.post(
@@ -54,4 +55,4 @@ class TestEYBLeadCreateAPI(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert EYBLead.objects.count() == 1
+        assert EYBLead.objects.count() == current_count + 1

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -7,12 +7,12 @@ from datahub.investment_lead.models import EYBLead
 
 class TestEYBLeadCreateAPI(APITestMixin):
     """
-        EYB Lead Create view test case.
+    EYB Lead Create view test case.
     """
 
     def test_get_not_allowed(self, eyb_lead_data):
         """
-            Should return 405
+        Should return 405
         """
         post_url = reverse('api-v4:investment-lead:create')
         response = self.api_client.get(post_url)
@@ -21,9 +21,8 @@ class TestEYBLeadCreateAPI(APITestMixin):
 
     def test_post_with_no_payload(self):
         """
-            Test that we get an Exception when no payload is sent
+        Test that we get an Exception when no payload is sent
         """
-
         post_url = reverse('api-v4:investment-lead:create')
         response = self.api_client.post(post_url, data={})
 
@@ -31,9 +30,8 @@ class TestEYBLeadCreateAPI(APITestMixin):
 
     def test_post_with_incomplete_payload(self, eyb_lead_data):
         """
-            Test that we get an Exception when incomplete payload is sent
+        Test that we get an Exception when incomplete payload is sent
         """
-
         incomplete_data = eyb_lead_data.copy()
         incomplete_data['location'] = None
 
@@ -46,9 +44,8 @@ class TestEYBLeadCreateAPI(APITestMixin):
 
     def test_post_success(self, eyb_lead_data):
         """
-            Test successful POST to EYB
+        Test successful POST to EYB
         """
-
         assert EYBLead.objects.count() == 0
 
         post_url = reverse('api-v4:investment-lead:create')

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -1,3 +1,4 @@
+import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
 
@@ -10,25 +11,25 @@ class TestEYBLeadCreateAPI(APITestMixin):
     EYB Lead Create view test case.
     """
 
-    def test_get_not_allowed(self, eyb_lead_data):
+    @pytest.mark.parametrize('method', ('delete', 'patch', 'get', 'put'))
+    def test_methods_not_allowed(self, eyb_lead_data, data_flow_api_client, method):
         """
         Should return 405
         """
         post_url = reverse('api-v4:investment-lead:create')
-        response = self.api_client.get(post_url)
-
+        response = data_flow_api_client.request(method, post_url)
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
-    def test_post_with_no_payload(self):
+    def test_post_with_no_payload(self, data_flow_api_client):
         """
         Test that we get an Exception when no payload is sent
         """
         post_url = reverse('api-v4:investment-lead:create')
-        response = self.api_client.post(post_url, data={})
+        response = data_flow_api_client.post(post_url, json_={})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_post_with_incomplete_payload(self, eyb_lead_data):
+    def test_post_with_incomplete_payload(self, eyb_lead_data, data_flow_api_client):
         """
         Test that we get an Exception when incomplete payload is sent
         """
@@ -36,22 +37,22 @@ class TestEYBLeadCreateAPI(APITestMixin):
         incomplete_data['location'] = None
 
         post_url = reverse('api-v4:investment-lead:create')
-        response = self.api_client.post(
-            post_url, data=incomplete_data,
+        response = data_flow_api_client.post(
+            post_url, json_=incomplete_data,
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data['location'][0] == 'This field may not be null.'
 
-    def test_post_success(self, eyb_lead_data):
+    def test_post_success(self, eyb_lead_data, data_flow_api_client):
         """
         Test successful POST to EYB
         """
         current_count = EYBLead.objects.count()
 
         post_url = reverse('api-v4:investment-lead:create')
-        response = self.api_client.post(
-            post_url, data=eyb_lead_data,
+        response = data_flow_api_client.post(
+            post_url, json_=eyb_lead_data,
         )
 
         assert response.status_code == status.HTTP_201_CREATED

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -6,25 +6,64 @@ from django.core.exceptions import ImproperlyConfigured
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-
-from datahub.core.test_utils import APITestMixin, create_test_user
-from datahub.investment_lead.models import EYBLead
-from datahub.investment_lead.test.utils import (
-    verify_eyb_lead_data
+from datahub.core.test_utils import (
+    APITestMixin,
+    create_test_user,
 )
+from datahub.investment_lead.models import EYBLead
+from datahub.metadata.test.factories import TeamFactory
 
 
-class TestDNBCompanyCreateAPI(APITestMixin):
+class TestEYBLeadCreateAPI(APITestMixin):
     """
-    EYB Lead Create view test case.
+        EYB Lead Create view test case.
     """
+
+    def test_post_not_authorized(self):
+        """
+            Should return 403
+        """
+
+        user = create_test_user(dit_team=TeamFactory())
+        api_client = self.create_api_client(user=user)
+        post_url = reverse('api-v4:investment-lead:create')
+        response = api_client.post(post_url, data={})
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_post_with_no_payload(self):
         """
-        Test that we get an Exception when no payload is sent
+            Test that we get an Exception when no payload is sent
         """
-        with pytest.raises(ImproperlyConfigured):
-            self.api_client.post(
-                reverse('api-v4:investment-lead:eyb-lead-create'),
-                data=None,
-            )
+
+        post_url = reverse('api-v4:investment-lead:create')
+        response = self.api_client.post(post_url, data={})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_post_with_incomplete_payload(self, eyb_lead_data):
+        """
+            Test that we get an Exception when incomplete payload is sent
+        """
+
+        post_url = reverse('api-v4:investment-lead:create')
+        response = self.api_client.post(
+            post_url, data={**eyb_lead_data},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_post_success(self, eyb_lead_data):
+        """
+            Test successful POST to EYB
+        """
+
+        assert EYBLead.objects.count() == 0
+
+        post_url = reverse('api-v4:investment-lead:create')
+        response = self.api_client.post(
+            post_url, data={**eyb_lead_data},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert EYBLead.objects.count() == 1

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -1,17 +1,8 @@
-import pytest
-
-from django.conf import settings
-from django.core.exceptions import ImproperlyConfigured
-
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import (
-    APITestMixin,
-    create_test_user,
-)
+from datahub.core.test_utils import APITestMixin
 from datahub.investment_lead.models import EYBLead
-from datahub.metadata.test.factories import TeamFactory
 
 
 class TestEYBLeadCreateAPI(APITestMixin):
@@ -19,17 +10,14 @@ class TestEYBLeadCreateAPI(APITestMixin):
         EYB Lead Create view test case.
     """
 
-    def test_post_not_authorized(self):
+    def test_get_not_allowed(self, eyb_lead_data):
         """
-            Should return 403
+            Should return 405
         """
-
-        user = create_test_user(dit_team=TeamFactory())
-        api_client = self.create_api_client(user=user)
         post_url = reverse('api-v4:investment-lead:create')
-        response = api_client.post(post_url, data={})
+        response = self.api_client.get(post_url)
 
-        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     def test_post_with_no_payload(self):
         """
@@ -46,9 +34,12 @@ class TestEYBLeadCreateAPI(APITestMixin):
             Test that we get an Exception when incomplete payload is sent
         """
 
+        incomplete_data = eyb_lead_data.copy()
+        incomplete_data['location'] = None
+
         post_url = reverse('api-v4:investment-lead:create')
         response = self.api_client.post(
-            post_url, data={**eyb_lead_data},
+            post_url, data=incomplete_data,
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -62,7 +53,7 @@ class TestEYBLeadCreateAPI(APITestMixin):
 
         post_url = reverse('api-v4:investment-lead:create')
         response = self.api_client.post(
-            post_url, data={**eyb_lead_data},
+            post_url, data=eyb_lead_data,
         )
 
         assert response.status_code == status.HTTP_201_CREATED

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -4,89 +4,66 @@ from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin
 from datahub.investment_lead.models import EYBLead
+from datahub.investment_lead.test.factories import EYBLeadFactory
+
+
+EYB_CREATE_URL = reverse('api-v4:investment-lead:eyb-create')
 
 
 class TestEYBLeadCreateAPI(APITestMixin):
-    """
-    EYB Lead Create view test case.
-    """
+    """EYB Lead Create view test case."""
 
     @pytest.mark.parametrize('method', ('delete', 'patch', 'get', 'put'))
-    def test_methods_not_allowed(self, eyb_lead_data, data_flow_api_client, method):
-        """
-        Should return 405
-        """
-        post_url = reverse('api-v4:investment-lead:create')
-        response = data_flow_api_client.request(method, post_url)
+    def test_methods_not_allowed(self, data_flow_api_client, method):
+        """Tests that requests using unsupported methods return status code 405."""
+        response = data_flow_api_client.request(method, EYB_CREATE_URL)
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     def test_post_with_no_payload(self, data_flow_api_client):
-        """
-        Test that we get an Exception when no payload is sent
-        """
-        post_url = reverse('api-v4:investment-lead:create')
-        response = data_flow_api_client.post(post_url, json_={})
-
+        """Tests if an error is raised when no payload is sent."""
+        response = data_flow_api_client.post(EYB_CREATE_URL, json_={})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_post_with_incomplete_payload(self, eyb_lead_data, data_flow_api_client):
-        """
-        Test that we get an Exception when incomplete payload is sent
-        """
+        """Tests if an error is raised when an incomplete payload is sent."""
         incomplete_data = eyb_lead_data.copy()
-        incomplete_data['location'] = None
-
-        post_url = reverse('api-v4:investment-lead:create')
+        incomplete_data.pop('location', None)
         response = data_flow_api_client.post(
-            post_url, json_=incomplete_data,
+            EYB_CREATE_URL, json_=[incomplete_data],
         )
-
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data['location'][0] == 'This field may not be null.'
+
+    def test_post_with_invalid_values_in_payload(self, eyb_lead_data, data_flow_api_client):
+        """Tests if an error is raised when a payload with invalid values is sent."""
+        invalid_data = eyb_lead_data.copy()
+        invalid_data['location'] = None
+        response = data_flow_api_client.post(
+            EYB_CREATE_URL, json_=[invalid_data],
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'location' in response.data['errors'][0]['errors'].keys()
 
     def test_post_success(self, eyb_lead_data, data_flow_api_client):
-        """
-        Test successful POST to EYB
-        """
+        """Tests successful POST creates an EYB lead."""
         current_count = EYBLead.objects.count()
-
-        post_url = reverse('api-v4:investment-lead:create')
         response = data_flow_api_client.post(
-            post_url, json_=eyb_lead_data,
+            EYB_CREATE_URL, json_=[eyb_lead_data],
         )
-
         assert response.status_code == status.HTTP_201_CREATED
         assert EYBLead.objects.count() == current_count + 1
 
     def test_post_does_not_create_duplicates(self, eyb_lead_data, data_flow_api_client):
-        """
-        Test successful POST to EYB does not create duplicates
-        """
-        current_count = EYBLead.objects.count()
-        current_data = eyb_lead_data.copy()
-        post_url = reverse('api-v4:investment-lead:create')
+        """Tests successful POST does not create duplicate EYB leads."""
+        eyb_lead = EYBLeadFactory(**eyb_lead_data)
+        assert EYBLead.objects.count() == 1
 
-        # Create the first object
+        modified_eyb_lead_data = eyb_lead_data.copy()
+        modified_eyb_lead_data['location'] = 'different_location'
         response = data_flow_api_client.post(
-            post_url, json_=current_data,
+            EYB_CREATE_URL, json_=[modified_eyb_lead_data],
         )
 
         assert response.status_code == status.HTTP_201_CREATED
-        assert EYBLead.objects.count() == current_count + 1
-
-        current_obj = EYBLead.objects.first()
-        assert current_obj.location == current_data['location']
-
-        # Change the data, create the "second object"
-        current_data['location'] = 'different_location'
-        response = data_flow_api_client.post(
-            post_url, json_=current_data,
-        )
-
-        # Assert that no new object has been created but the data
-        # has succesfully been updated
-        assert response.status_code == status.HTTP_200_OK
-        assert EYBLead.objects.count() == current_count + 1
-
-        current_obj = EYBLead.objects.first()
-        assert current_obj.location == current_data['location']
+        assert EYBLead.objects.count() == 1
+        eyb_lead.refresh_from_db()
+        assert eyb_lead.location == modified_eyb_lead_data['location']

--- a/datahub/investment_lead/test/utils.py
+++ b/datahub/investment_lead/test/utils.py
@@ -1,0 +1,50 @@
+import datetime
+
+from datahub.investment_lead.models import EYBLead
+
+
+def _to_iso(dateobject):
+    if isinstance(dateobject, datetime.datetime):
+        return dateobject.astimezone().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+
+    return dateobject
+
+
+def assert_datetimes(first, second):
+    assert _to_iso(first) == _to_iso(second)
+
+
+def verify_eyb_lead_data(instance: EYBLead, data: dict):
+    """Method to verify the EYBLead data against the instance created."""
+    # EYB Triage data
+    assert instance.triage_id == data['triage_id']
+    assert instance.triage_hashed_uuid == data['triage_hashed_uuid']
+    assert_datetimes(instance.triage_created, data['triage_created'])
+    assert_datetimes(instance.triage_modified, data['triage_modified'])
+    assert instance.sector == data['sector']
+    assert instance.sector_sub == data['sector_sub']
+    assert instance.intent == data['intent']
+    assert instance.intent_other == data['intent_other']
+    assert instance.location == data['location']
+    assert instance.location_city == data['location_city']
+    assert instance.location_none == data['location_none']
+    assert instance.hiring == data['hiring']
+    assert instance.spend == data['spend']
+    assert instance.spend_other == data['spend_other']
+    assert instance.is_high_value == data['is_high_value']
+
+    # EYB User data
+    assert instance.user_id == data['user_id']
+    assert instance.user_hashed_uuid == data['user_hashed_uuid']
+    assert_datetimes(instance.user_created, data['user_created'])
+    assert_datetimes(instance.user_modified, data['user_modified'])
+    assert instance.company_name == data['company_name']
+    assert instance.company_location == data['company_location']
+    assert instance.full_name == data['full_name']
+    assert instance.role == data['role']
+    assert instance.email == data['email']
+    assert instance.telephone_number == data['telephone_number']
+    assert instance.agree_terms == data['agree_terms']
+    assert instance.agree_info_email == data['agree_info_email']
+    assert instance.landing_timeframe == data['landing_timeframe']
+    assert instance.company_website == data['company_website']

--- a/datahub/investment_lead/urls.py
+++ b/datahub/investment_lead/urls.py
@@ -1,14 +1,11 @@
 from django.urls import path
 
-from datahub.investment_lead.views import (
-    EYBLeadViewset
-)
+from datahub.investment_lead.views import EYBLeadViewset
 
 urlpatterns = [
     path(
         'investment-lead',
         EYBLeadViewset.as_view({'post': 'create'}),
-        name='create'
+        name='create',
     ),
-    
 ]

--- a/datahub/investment_lead/urls.py
+++ b/datahub/investment_lead/urls.py
@@ -1,0 +1,13 @@
+from django.urls import path
+
+from datahub.investment_lead.views import (
+    EYBLeadCreateView
+)
+
+urlpatterns = [
+    path(
+        'eyb-lead-create',
+        EYBLeadCreateView.as_view(),
+        name='eyb-lead-create',
+    ),
+]

--- a/datahub/investment_lead/urls.py
+++ b/datahub/investment_lead/urls.py
@@ -1,13 +1,14 @@
 from django.urls import path
 
 from datahub.investment_lead.views import (
-    EYBLeadCreateView
+    EYBLeadViewset
 )
 
 urlpatterns = [
     path(
-        'eyb-lead-create',
-        EYBLeadCreateView.as_view(),
-        name='eyb-lead-create',
+        'investment-lead',
+        EYBLeadViewset.as_view({'post': 'create'}),
+        name='create'
     ),
+    
 ]

--- a/datahub/investment_lead/urls.py
+++ b/datahub/investment_lead/urls.py
@@ -4,8 +4,8 @@ from datahub.investment_lead.views import EYBLeadViewset
 
 urlpatterns = [
     path(
-        'investment-lead',
+        'eyb',
         EYBLeadViewset.as_view({'post': 'create'}),
-        name='create',
+        name='eyb-create',
     ),
 ]

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -27,7 +27,7 @@ class EYBLeadViewset(
     serializer_class = EYBLeadSerializer
     queryset = EYBLead.objects.all()
 
-    authentication_classes = (PaaSIPAuthentication, HawkAuthentication, )
+    authentication_classes = (PaaSIPAuthentication, HawkAuthentication)
     permission_classes = (HawkScopePermission, )
     required_hawk_scope = HawkScope.data_flow_api
 

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -1,14 +1,11 @@
 import logging
 
-from rest_framework.response import Response
-from rest_framework.serializers import ValidationError
-from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
 
-from datahub.investment_lead.models import EYBLead
-from datahub.investment_lead.serializers import EYBLeadSerializer
 from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.viewsets import SoftDeleteCoreViewSet
+from datahub.investment_lead.models import EYBLead
+from datahub.investment_lead.serializers import EYBLeadSerializer
 
 logger = logging.getLogger(__name__)
 

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -1,5 +1,8 @@
 import logging
 
+from rest_framework import serializers, status
+from rest_framework.response import Response
+
 from config.settings.types import HawkScope
 from datahub.core.hawk_receiver import (
     HawkAuthentication,
@@ -26,3 +29,29 @@ class EYBLeadViewset(
     authentication_classes = (HawkAuthentication, )
     permission_classes = (HawkScopePermission, )
     required_hawk_scope = HawkScope.data_flow_api
+
+    def create(self, request):
+        eyb_lead_serializer = self.serializer_class(data=request.data)
+        try:
+            eyb_lead_serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError:
+            message = 'EYB data failed DH serializer validation'
+            extra_data = {
+                'eyb_lead_serializer_errors': eyb_lead_serializer.errors,
+            }
+            logger.error(message, extra=extra_data)
+            raise
+
+        # Create or update to prevent duplicates
+        eyb_lead_data = eyb_lead_serializer.validated_data
+        eyb_lead, created = EYBLead.objects.update_or_create(
+            triage_hashed_uuid=eyb_lead_data.get('triage_hashed_uuid'),
+            user_hashed_uuid=eyb_lead_data.get('user_hashed_uuid'),
+            defaults=eyb_lead_data)
+
+        status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+
+        return Response(
+            eyb_lead_serializer.to_representation(eyb_lead),
+            status=status_code,
+        )

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -1,17 +1,28 @@
 import logging
 
-from rest_framework.permissions import IsAuthenticated
-
+from config.settings.types import HawkScope
+from datahub.core.hawk_receiver import (
+    HawkAuthentication,
+    HawkResponseSigningMixin,
+    HawkScopePermission,
+)
 from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.viewsets import SoftDeleteCoreViewSet
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.serializers import EYBLeadSerializer
 
+
 logger = logging.getLogger(__name__)
 
 
-class EYBLeadViewset(ArchivableViewSetMixin, SoftDeleteCoreViewSet):
+class EYBLeadViewset(
+    ArchivableViewSetMixin,
+    SoftDeleteCoreViewSet,
+    HawkResponseSigningMixin,
+):
     serializer_class = EYBLeadSerializer
     queryset = EYBLead.objects.all()
 
-    permission_classes = (IsAuthenticated,)
+    authentication_classes = (HawkAuthentication, )
+    permission_classes = (HawkScopePermission, )
+    required_hawk_scope = HawkScope.data_flow_api

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -1,6 +1,6 @@
 import logging
 
-from rest_framework import serializers, status
+from rest_framework import status
 from rest_framework.response import Response
 
 from config.settings.types import HawkScope
@@ -31,27 +31,68 @@ class EYBLeadViewset(
     required_hawk_scope = HawkScope.data_flow_api
 
     def create(self, request):
-        eyb_lead_serializer = self.serializer_class(data=request.data)
-        try:
-            eyb_lead_serializer.is_valid(raise_exception=True)
-        except serializers.ValidationError:
-            message = 'EYB data failed DH serializer validation'
-            extra_data = {
-                'eyb_lead_serializer_errors': eyb_lead_serializer.errors,
-            }
-            logger.error(message, extra=extra_data)
-            raise
+        """POST route definition.
 
-        # Create or update to prevent duplicates
-        eyb_lead_data = eyb_lead_serializer.validated_data
-        eyb_lead, created = EYBLead.objects.update_or_create(
-            triage_hashed_uuid=eyb_lead_data.get('triage_hashed_uuid'),
-            user_hashed_uuid=eyb_lead_data.get('user_hashed_uuid'),
-            defaults=eyb_lead_data)
+        This route needs to handle both creating new and updating existing instances
+        because data is received automatically from a Data Flow pipeline.
 
-        status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
+        To reduce complexity of the pipeline, it was decided to have the separation
+        logic within the API endpoint.
+        """
+        if not isinstance(request.data, list):
+            return Response(
+                {'error': 'Expected a list of leads.'},
+                status.HTTP_400_BAD_REQUEST,
+            )
 
-        return Response(
-            eyb_lead_serializer.to_representation(eyb_lead),
-            status=status_code,
+        created_leads = []
+        updated_leads = []
+        errors = []
+
+        for index, lead_data in enumerate(request.data):
+            serializer = self.get_serializer(data=lead_data)
+            if serializer.is_valid():
+                _, created = self.perform_create(serializer)
+                if created:
+                    created_leads.append(serializer.validated_data)
+                else:
+                    updated_leads.append(serializer.validated_data)
+            else:
+                errors.append({'index': index, 'errors': serializer.errors})
+
+        response_data = {}
+        if created_leads:
+            response_data['created'] = created_leads
+        if updated_leads:
+            response_data['updated'] = updated_leads
+        if errors:
+            response_data['errors'] = errors
+
+        if not errors:
+            # All leads have been created
+            status_code = status.HTTP_201_CREATED
+        elif len(errors) == len(request.data):
+            # No leads have been created
+            status_code = status.HTTP_400_BAD_REQUEST
+        else:
+            # Some leads have been created, others failed
+            status_code = status.HTTP_207_MULTI_STATUS
+
+        return Response(response_data, status_code)
+
+    def perform_create(self, serializer):
+        """Processes a single lead.
+
+        The `triage_hashed_uuid` and `user_hashed_uuid` field should be unique for each EYBLead
+        instance. As a result, we use these to determine if a new instance is created, or an
+        existing one updated.
+
+        This overwrites the inherited BaseViewSet method.
+        """
+        validated_lead_data = serializer.validated_data
+        lead_instance, created = EYBLead.objects.update_or_create(
+            triage_hashed_uuid=validated_lead_data.get('triage_hashed_uuid'),
+            user_hashed_uuid=validated_lead_data.get('user_hashed_uuid'),
+            defaults=validated_lead_data,
         )
+        return lead_instance, created

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -1,0 +1,39 @@
+import logging
+
+from rest_framework.serializers import ValidationError
+from rest_framework.response import Response
+from rest_framework import generics
+
+from datahub.investment_lead.models import EYBLead
+from datahub.investment_lead.serializers import EYBLeadSerializer
+
+
+logger = logging.getLogger(__name__)
+
+
+class EYBLeadCreateView(generics.CreateAPIView):
+    """
+    View for creating EYB Lead from incoming EYB payloads
+    """
+
+    queryset = EYBLead.objects.all()
+
+    def post(self, request):
+        eyb_lead_serializer = EYBLeadSerializer(data=request.data)
+
+        try:
+            eyb_lead_serializer.is_valid(raise_exception=True)
+        except ValidationError:
+            message = 'EYB lead data from EYB failed DH serializer validation'
+            extra_data = {
+                'formatted_eyblead_data': eyb_lead_serializer.data,
+                'dh_eyblead_serializer_errors': eyb_lead_serializer.errors,
+            }
+            logger.error(message, extra=extra_data)
+            raise
+
+        eyb_lead = eyb_lead_serializer.save()
+
+        return Response(
+            eyb_lead_serializer.to_representation(eyb_lead),
+        )

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -78,7 +78,7 @@ class EYBLeadViewset(
         else:
             # Some leads have been created, others failed
             status_code = status.HTTP_207_MULTI_STATUS
-
+        logger.info(f'Processed {len(request.data)} EYB leads: {response_data}')
         return Response(response_data, status_code)
 
     def perform_create(self, serializer):

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.response import Response
 
 from config.settings.types import HawkScope
+from datahub.core.auth import PaaSIPAuthentication
 from datahub.core.hawk_receiver import (
     HawkAuthentication,
     HawkResponseSigningMixin,
@@ -26,7 +27,7 @@ class EYBLeadViewset(
     serializer_class = EYBLeadSerializer
     queryset = EYBLead.objects.all()
 
-    authentication_classes = (HawkAuthentication, )
+    authentication_classes = (PaaSIPAuthentication, HawkAuthentication, )
     permission_classes = (HawkScopePermission, )
     required_hawk_scope = HawkScope.data_flow_api
 

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -1,39 +1,20 @@
 import logging
 
-from rest_framework.serializers import ValidationError
 from rest_framework.response import Response
+from rest_framework.serializers import ValidationError
 from rest_framework import generics
+from rest_framework.permissions import IsAuthenticated
 
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.serializers import EYBLeadSerializer
-
+from datahub.core.mixins import ArchivableViewSetMixin
+from datahub.core.viewsets import SoftDeleteCoreViewSet
 
 logger = logging.getLogger(__name__)
 
 
-class EYBLeadCreateView(generics.CreateAPIView):
-    """
-    View for creating EYB Lead from incoming EYB payloads
-    """
-
+class EYBLeadViewset(ArchivableViewSetMixin, SoftDeleteCoreViewSet):
+    serializer_class = EYBLeadSerializer
     queryset = EYBLead.objects.all()
 
-    def post(self, request):
-        eyb_lead_serializer = EYBLeadSerializer(data=request.data)
-
-        try:
-            eyb_lead_serializer.is_valid(raise_exception=True)
-        except ValidationError:
-            message = 'EYB lead data from EYB failed DH serializer validation'
-            extra_data = {
-                'formatted_eyblead_data': eyb_lead_serializer.data,
-                'dh_eyblead_serializer_errors': eyb_lead_serializer.errors,
-            }
-            logger.error(message, extra=extra_data)
-            raise
-
-        eyb_lead = eyb_lead_serializer.save()
-
-        return Response(
-            eyb_lead_serializer.to_representation(eyb_lead),
-        )
+    permission_classes = (IsAuthenticated,)


### PR DESCRIPTION
### Description of change

**Context**: to ensure the future ability to ingest data from EYB over to Datahub, we need to correctly set up an API that allows data to be received from the EYB API, processed through a Serializer and its Views to create new EYBLead records.

JIRA ticket: https://uktrade.atlassian.net/browse/CLS2-898

#### Test Information

You should be able to send a POST request to `v4/investment-lead/eyb` with a list of leads. If you need dummy data, you can get the JSON from a serialised factory instance as follows:

```python
from datahub.investment_lead.test.factories import EYBLeadFactory
from rest_framework.renderers import JSONRenderer

eyb_lead = EYBLeadFactory()
serializer = EYBLeadSerializer(eyb_lead)
json = JSONRenderer().render(serializer.data)
json
```

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
