### PR TITLE
Add filtering and sorting to company export wins endpoint.

### DIFF
--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -69,6 +69,7 @@ from datahub.core.schemas import StubSchema
 from datahub.core.viewsets import CoreViewSet, SoftDeleteCoreViewSet
 from datahub.export_win.models import Win
 from datahub.export_win.serializers import DataHubLegacyExportWinSerializer
+from datahub.export_win.views import ConfirmedFilterSet
 from datahub.investment.project.queryset import get_slim_investment_project_queryset
 
 
@@ -550,6 +551,10 @@ class ExportWinsForCompanyView(ListAPIView):
     serializer_class = DataHubLegacyExportWinSerializer
     pagination_class = BigPagination
     http_method_names = ('get',)
+    filter_backends = [DjangoFilterBackend, OrderingFilter]
+    filterset_class = ConfirmedFilterSet
+    ordering_fields = ('customer_response__responded_on', 'created_on')
+    ordering = ('-customer_response__responded_on', '-created_on')
 
     def _get_company(self, company_pk):
         """


### PR DESCRIPTION
### Description of change

This adds filtering and sorting to company export wins endpoint.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
