### PR TITLE
Use default pagination for company export wins endpoint.

### DIFF
--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -14,7 +14,6 @@ from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action, api_view, permission_classes
 from rest_framework.filters import OrderingFilter
 from rest_framework.generics import ListAPIView
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -529,13 +528,6 @@ class AdviserReadOnlyViewSetV1(
         return filtered_queryset
 
 
-class BigPagination(PageNumberPagination):
-    """Big pagination."""
-
-    page_size = 1000
-    page_size_query_param = 'page-size'
-
-
 class ExportWinsForCompanyView(ListAPIView):
     """
     Export Wins for Company. The view is based on the legacy view that used
@@ -549,7 +541,6 @@ class ExportWinsForCompanyView(ListAPIView):
         ),
     )
     serializer_class = DataHubLegacyExportWinSerializer
-    pagination_class = BigPagination
     http_method_names = ('get',)
     filter_backends = [DjangoFilterBackend, OrderingFilter]
     filterset_class = ConfirmedFilterSet


### PR DESCRIPTION
### Description of change

This removes custom pagination from the Company Export Wins endpoint so that it is consistent with other endpoints.
The endpoint now uses default limit offset pagination.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
