### PR TITLE
Fix business potential returned by company export wins endpoint.

### DIFF
--- a/datahub/company/test/test_company_exportwins_views.py
+++ b/datahub/company/test/test_company_exportwins_views.py
@@ -173,7 +173,7 @@ class TestGetCompanyExportWins(APITestMixin):
                     'created': format_date_or_datetime(win.created_on),
                     'country': win.country.iso_alpha2_code,
                     'sector': win.sector.name,
-                    'business_potential': win.business_potential.export_win_id,
+                    'business_potential': win.business_potential.name,
                     'business_type': win.business_type,
                     'name_of_export': win.name_of_export,
                     # this field is intentionally duplicated to match legacy system output

--- a/datahub/export_win/serializers.py
+++ b/datahub/export_win/serializers.py
@@ -579,7 +579,7 @@ class DataHubLegacyExportWinSerializer(ModelSerializer):
     def get_business_potential(self, win):
         """Return human readable name for business type."""
         if win.business_potential:
-            return win.business_potential.export_win_id
+            return win.business_potential.name
         return None
 
     def get_response(self, win):


### PR DESCRIPTION
### Description of change

This returns business potential name instead of business potential legacy export wins id.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
