### PR TITLE
[2 of 2] Update EYBLead serializer and viewset

### DIFF
--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -1,6 +1,12 @@
 from rest_framework import serializers
 
 from datahub.investment_lead.models import EYBLead
+from datahub.metadata.models import (
+    AdministrativeArea,
+    Country,
+    Sector,
+    UKRegion,
+)
 
 
 ARCHIVABLE_FIELDS = [
@@ -10,13 +16,13 @@ ARCHIVABLE_FIELDS = [
     'archived_by',
 ]
 
-BASE_FIELDS = [
+INVESTMENT_LEAD_BASE_FIELDS = [
     'created_on',
     'modified_on',
+    'id',
 ]
 
 TRIAGE_FIELDS = [
-    'triage_id',
     'triage_hashed_uuid',
     'triage_created',
     'triage_modified',
@@ -34,7 +40,6 @@ TRIAGE_FIELDS = [
 ]
 
 USER_FIELDS = [
-    'user_id',
     'user_hashed_uuid',
     'user_created',
     'user_modified',
@@ -50,19 +55,35 @@ USER_FIELDS = [
     'company_website',
 ]
 
-ALL_FIELDS = ARCHIVABLE_FIELDS + BASE_FIELDS + TRIAGE_FIELDS + USER_FIELDS
+COMPANY_FIELDS = [
+    'duns_number',
+    'address_1',
+    'address_2',
+    'address_town',
+    'address_county',
+    'address_area',
+    'address_country',
+    'address_postcode',
+    'company',
+]
+
+RELATED_FIELDS = [
+    'sector',
+    'location',
+    'company_location',
+    'address_area',
+    'address_country',
+    'company',
+]
+
+ALL_FIELDS = ARCHIVABLE_FIELDS + INVESTMENT_LEAD_BASE_FIELDS + \
+    TRIAGE_FIELDS + USER_FIELDS + COMPANY_FIELDS
 
 UUIDS_ERROR_MESSAGE = 'Invalid serializer data: UUIDs must match.'
 
 
-class EYBLeadSerializer(serializers.ModelSerializer):
-    """Serializer for an EYB lead object"""
-
-    triage_created = serializers.DateTimeField()
-    triage_modified = serializers.DateTimeField()
-
-    user_created = serializers.DateTimeField()
-    user_modified = serializers.DateTimeField()
+class BaseEYBLeadSerializer(serializers.ModelSerializer):
+    """Base serializer for an EYB lead object."""
 
     class Meta:
         model = EYBLead
@@ -72,3 +93,104 @@ class EYBLeadSerializer(serializers.ModelSerializer):
         if data['triage_hashed_uuid'] != data['user_hashed_uuid']:
             raise serializers.ValidationError(UUIDS_ERROR_MESSAGE)
         return data
+
+
+class CreateEYBLeadSerializer(BaseEYBLeadSerializer):
+    """Serializer for creating an EYB lead.
+
+    This serializer has been tailored to the data we expect to receive from EYB/DataFlow.
+    Most notably, this includes string representations of related model instances.
+    """
+
+    class Meta(BaseEYBLeadSerializer.Meta):
+        fields = [
+            f for f in ALL_FIELDS
+            if f not in ARCHIVABLE_FIELDS + INVESTMENT_LEAD_BASE_FIELDS + ['company']
+        ]
+
+    sector = serializers.CharField()
+    location = serializers.CharField()
+    company_location = serializers.CharField()
+    address_area = serializers.CharField()
+    address_country = serializers.CharField()
+
+    # TODO: Refactor these field validation functions as they involve 5 db hits per lead
+    def validate_sector(self, value):
+        if not Sector.objects.filter(segment=value.capitalize()).exists():
+            raise serializers.ValidationError(f'Sector "{value}" does not exist.')
+        return value
+
+    def validate_location(self, value):
+        if not UKRegion.objects.filter(name=value.title()).exists():
+            raise serializers.ValidationError(f'Location "{value}" does not exist.')
+        return value
+
+    def validate_company_location(self, value):
+        if not Country.objects.filter(iso_alpha2_code=value.upper()).exists():
+            raise serializers.ValidationError(
+                f'Country location ISO code "{value}" does not exist.',
+            )
+        return value
+
+    def validate_address_area(self, value):
+        if not AdministrativeArea.objects.filter(name=value.capitalize()).exists():
+            raise serializers.ValidationError(f'Address area "{value}" does not exist.')
+        return value
+
+    def validate_address_country(self, value):
+        if not Country.objects.filter(iso_alpha2_code=value.upper()).exists():
+            raise serializers.ValidationError(
+                f'Address country ISO code "{value}" does not exist.',
+            )
+        return value
+
+    def to_representation(self, instance):
+        """Convert model instance to built-in Python (JSON friendly) data types."""
+        related_fields = {
+            'sector': instance.sector.segment if instance.sector else None,
+            'location': instance.location.name if instance.location else None,
+            'company_location': instance.company_location.iso_alpha2_code
+            if instance.company_location else None,
+            'address_area': instance.address_area.name if instance.address_area else None,
+            'address_country': instance.address_country.iso_alpha2_code
+            if instance.address_country else None,
+        }
+        rep = super().to_representation(instance)
+        rep.update(related_fields)
+        return rep
+
+    def to_internal_value(self, data):
+        """Convert unvalidated JSON data to validated data."""
+        # Extract related field strings
+        sector_segment = data.get('sector', None)
+        location_name = data.get('location', None)
+        company_location_iso_code = data.get('company_location', None)
+        address_area_name = data.get('address_area', None)
+        address_country_iso_code = data.get('address_country', None)
+
+        validated_data = super().to_internal_value(data)
+
+        # Convert strings to model instances for related fields
+        # TODO: Investigate refactoring this logic to involve less db hits (currently 5 per lead)
+        if sector_segment:
+            validated_data['sector'] = Sector.objects.get(
+                segment=sector_segment.capitalize(),
+            )
+        if location_name:
+            validated_data['location'] = UKRegion.objects.get(
+                name=location_name.title(),
+            )
+        if company_location_iso_code:
+            validated_data['company_location'] = Country.objects.get(
+                iso_alpha2_code=company_location_iso_code.upper(),
+            )
+        if address_area_name:
+            validated_data['address_area'] = AdministrativeArea.objects.get(
+                name=address_area_name.capitalize(),
+            )
+        if address_country_iso_code:
+            validated_data['address_country'] = Country.objects.get(
+                iso_alpha2_code=address_country_iso_code.upper(),
+            )
+
+        return validated_data

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -1,17 +1,22 @@
 import pytest
+
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.core import constants
 from datahub.core.test_utils import APITestMixin
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.test.factories import EYBLeadFactory
+from datahub.investment_lead.test.utils import verify_eyb_lead_data
 
 
 EYB_CREATE_URL = reverse('api-v4:investment-lead:eyb-create')
 
+pytestmark = pytest.mark.django_db
+
 
 class TestEYBLeadCreateAPI(APITestMixin):
-    """EYB Lead Create view test case."""
+    """Test for create/update EYB lead view (via POST request)"""
 
     @pytest.mark.parametrize('method', ('delete', 'patch', 'get', 'put'))
     def test_methods_not_allowed(self, data_flow_api_client, method):
@@ -19,51 +24,56 @@ class TestEYBLeadCreateAPI(APITestMixin):
         response = data_flow_api_client.request(method, EYB_CREATE_URL)
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
-    def test_post_with_no_payload(self, data_flow_api_client):
-        """Tests if an error is raised when no payload is sent."""
-        response = data_flow_api_client.post(EYB_CREATE_URL, json_={})
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_post_with_incomplete_payload(self, eyb_lead_data, data_flow_api_client):
-        """Tests if an error is raised when an incomplete payload is sent."""
-        incomplete_data = eyb_lead_data.copy()
-        incomplete_data.pop('location', None)
-        response = data_flow_api_client.post(
-            EYB_CREATE_URL, json_=[incomplete_data],
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-    def test_post_with_invalid_values_in_payload(self, eyb_lead_data, data_flow_api_client):
-        """Tests if an error is raised when a payload with invalid values is sent."""
-        invalid_data = eyb_lead_data.copy()
-        invalid_data['location'] = None
-        response = data_flow_api_client.post(
-            EYB_CREATE_URL, json_=[invalid_data],
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert 'location' in response.data['errors'][0]['errors'].keys()
-
-    def test_post_success(self, eyb_lead_data, data_flow_api_client):
-        """Tests successful POST creates an EYB lead."""
-        current_count = EYBLead.objects.count()
-        response = data_flow_api_client.post(
-            EYB_CREATE_URL, json_=[eyb_lead_data],
-        )
+    def test_create_eyb_lead_list(self, data_flow_api_client, eyb_lead_post_data):
+        """Tests that a list of leads are processed in a single request/response cycle."""
+        response = data_flow_api_client.post(EYB_CREATE_URL, json_=[eyb_lead_post_data])
         assert response.status_code == status.HTTP_201_CREATED
-        assert EYBLead.objects.count() == current_count + 1
+        assert 'created' in response.data
 
-    def test_post_does_not_create_duplicates(self, eyb_lead_data, data_flow_api_client):
-        """Tests successful POST does not create duplicate EYB leads."""
-        eyb_lead = EYBLeadFactory(**eyb_lead_data)
+        created_lead = response.data['created'][0]
         assert EYBLead.objects.count() == 1
-
-        modified_eyb_lead_data = eyb_lead_data.copy()
-        modified_eyb_lead_data['location'] = 'different_location'
-        response = data_flow_api_client.post(
-            EYB_CREATE_URL, json_=[modified_eyb_lead_data],
+        instance = EYBLead.objects.get(
+            triage_hashed_uuid=created_lead['triage_hashed_uuid'],
+            user_hashed_uuid=created_lead['user_hashed_uuid'],
         )
+        verify_eyb_lead_data(instance, eyb_lead_post_data)
 
-        assert response.status_code == status.HTTP_201_CREATED
+    def test_create_empty_list(self, data_flow_api_client):
+        """Tests that no leads are created if an empty list is POSTed."""
+        response = data_flow_api_client.post(EYB_CREATE_URL, json_=[])
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.data['error'] == 'Expected a list of leads.'
+
+    def test_create_invalid_list(self, data_flow_api_client, eyb_lead_post_data):
+        """Tests that no leads are created if a list containing invalid data is POSTed."""
+        invalid_post_data = eyb_lead_post_data.copy()
+        invalid_post_data['sector'] = None
+        response = data_flow_api_client.post(EYB_CREATE_URL, json_=[invalid_post_data])
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'errors' in response.data
+
+    def test_updating_existing_lead(self, data_flow_api_client, eyb_lead_post_data):
+        """Tests that an existing lead is updated and does not create a duplicate."""
+        existing_lead = EYBLeadFactory(
+            triage_hashed_uuid=eyb_lead_post_data['triage_hashed_uuid'],
+            user_hashed_uuid=eyb_lead_post_data['user_hashed_uuid'],
+            location_id=constants.UKRegion.wales.value.id,
+        )
         assert EYBLead.objects.count() == 1
-        eyb_lead.refresh_from_db()
-        assert eyb_lead.location == modified_eyb_lead_data['location']
+        assert existing_lead.location.name == constants.UKRegion.wales.value.name
+
+        modified_post_data = eyb_lead_post_data.copy()
+        modified_post_data['location'] = constants.UKRegion.south_west.value.name
+        response = data_flow_api_client.post(EYB_CREATE_URL, json_=[modified_post_data])
+        assert response.status_code == status.HTTP_201_CREATED
+        assert 'updated' in response.data
+
+        updated_lead = response.data['updated'][0]
+        assert EYBLead.objects.count() == 1
+        instance = EYBLead.objects.get(
+            triage_hashed_uuid=updated_lead['triage_hashed_uuid'],
+            user_hashed_uuid=updated_lead['user_hashed_uuid'],
+        )
+        assert instance.triage_hashed_uuid == eyb_lead_post_data['triage_hashed_uuid']
+        assert instance.user_hashed_uuid == eyb_lead_post_data['user_hashed_uuid']
+        assert instance.location.name == constants.UKRegion.south_west.value.name


### PR DESCRIPTION
### Description of change

This PR is 2 of 2 (see the first here: #5618) of modifications to the EYBLead model, serializer and viewset. This PR updates the serializer and viewset to enable the creation of leads via POST requests. The modifications include ensuring string representations of related fields (e.g. a sector's name) are translated to model instances.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
