### PR TITLE
Prefetch inside serializers instead of view

### DIFF
--- a/datahub/company_activity/serializers.py
+++ b/datahub/company_activity/serializers.py
@@ -66,8 +66,13 @@ class CompanyActivitySerializer(serializers.ModelSerializer):
 
         Also applies any filters from the query_params to the related models.
         """
-        sortby = self.get_sortby_from_post_data()
-        interactions = company.interactions.all().order_by(sortby)
+        interactions = company.interactions.all().prefetch_related(
+            'contacts',
+            'service',
+            'dit_participants__adviser',
+            'dit_participants__team',
+            'communication_channel',
+        )
 
         advisers = self.get_adviser_from_post_data()
 
@@ -88,7 +93,8 @@ class CompanyActivitySerializer(serializers.ModelSerializer):
                 date__gte=date_after,
             )
 
-        return interactions
+        sortby = self.get_sortby_from_post_data()
+        return interactions.order_by(sortby)
 
     def get_request_data(self):
         """Get the post request parameter data"""

--- a/datahub/company_activity/views.py
+++ b/datahub/company_activity/views.py
@@ -15,14 +15,7 @@ class CompanyActivityViewSetV4(CoreViewSet):
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     http_method_names = ['post']
     serializer_class = CompanyActivitySerializer
-    queryset = Company.objects.prefetch_related(
-        'interactions',
-        'interactions__contacts',
-        'interactions__service',
-        'interactions__dit_participants__adviser',
-        'interactions__dit_participants__team',
-        'interactions__communication_channel',
-    )
+    queryset = Company.objects.all()
 
     def retrieve(self, request, *args, **kwargs):
         if request.data:


### PR DESCRIPTION
### Description of change

The prefetch on the viewset was not pulling through as the query was executing inside the serializer. Locally this goes from 100 DB queries (would increase for the total interactions for a company) to 15, regardless of the number of interactions.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?

