### PR TITLE
Add company referrals to the activity endpoint

### DIFF
--- a/datahub/company_activity/tests/test_views.py
+++ b/datahub/company_activity/tests/test_views.py
@@ -5,6 +5,7 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
+    CompanyReferralInteractionFactory,
     InteractionDITParticipantFactory,
 )
 
@@ -48,6 +49,7 @@ class TestCompanyActivityViewSetV4(APITestMixin):
         assert activtiy['id'] == str(interaction.id)
         assert activtiy['subject'] == interaction.subject
         assert activtiy['kind'] == interaction.kind
+        assert activtiy['activity_source'] == 'interaction'
         assert (
             activtiy['communication_channel']['name']
             == interaction.communication_channel.name
@@ -87,20 +89,30 @@ class TestCompanyActivityViewSetV4(APITestMixin):
             companies=[],
         )
         CompanyInteractionFactory(company=company, companies=[])
+        referral = CompanyReferralInteractionFactory(
+            company=company,
+            dit_participants=[InteractionDITParticipantFactory(adviser=adviser)],
+            companies=[],
+        )
+        CompanyReferralInteractionFactory(company=company, companies=[])
 
         url = reverse('api-v4:company-activity:activity', kwargs={'pk': company.pk})
 
         response = self.api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
-        assert len(response_data['activities']['results']) == 2
+        assert len(response_data['activities']['results']) == 4
 
         response = self.api_client.post(url, {'advisers': [str(adviser.id)]})
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
-        assert len(response_data['activities']['results']) == 1
+        assert len(response_data['activities']['results']) == 2
 
-        assert response_data['activities']['results'][0]['id'] == str(interaction.id)
+        returned_ids = [
+            response.get('id') for response in response_data['activities']['results']
+        ]
+        assert str(interaction.id) in returned_ids
+        assert str(referral.id) in returned_ids
 
     def test_endpoint__can_handle_incorrect_advisor_id_param(self):
         """Test activity endpoint can handle an advisor id param that isn't a valid uuid"""
@@ -138,6 +150,12 @@ class TestCompanyActivityViewSetV4(APITestMixin):
             dit_participants=[InteractionDITParticipantFactory(adviser=adviser)],
             date='2023-01-01',
         )
+        referral_before = CompanyReferralInteractionFactory(
+            company=company,
+            companies=[],
+            company_referral__completed_on='2023-01-01',
+            dit_participants=[InteractionDITParticipantFactory(adviser=adviser)],
+        )
         interaction_after = CompanyInteractionFactory(
             company=company,
             companies=[],
@@ -155,7 +173,7 @@ class TestCompanyActivityViewSetV4(APITestMixin):
 
         response = self.api_client.post(url)
         response_data = response.json()
-        assert len(response_data['activities']['results']) == 3
+        assert len(response_data['activities']['results']) == 4
 
         payload = {
             'date_after': '2024-01-01',
@@ -173,10 +191,13 @@ class TestCompanyActivityViewSetV4(APITestMixin):
         }
         response = self.api_client.post(url, data=payload)
         response_data = response.json()
-        assert len(response_data['activities']['results']) == 2
-        returned_ids = [a.get('id') for a in response_data['activities']['results']]
+        assert len(response_data['activities']['results']) == 3
+        returned_ids = [
+            response.get('id') for response in response_data['activities']['results']
+        ]
         assert str(interaction_before.id) in returned_ids
         assert str(interaction_between.id) in returned_ids
+        assert str(referral_before.id) in returned_ids
 
         payload = {
             'date_before': '2023-12-30',
@@ -232,10 +253,10 @@ class TestCompanyActivityViewSetV4(APITestMixin):
             companies=[],
             date='2023-08-09',
         )
-        interaction_3 = CompanyInteractionFactory(
+        referral = CompanyReferralInteractionFactory(
             company=company,
             companies=[],
-            date='2023-08-08',
+            company_referral__completed_on='2023-08-08',
         )
 
         url = reverse(
@@ -250,9 +271,11 @@ class TestCompanyActivityViewSetV4(APITestMixin):
         assert response_data['activities']['count'] == 3
         assert len(response_data['activities']['results']) == 2
 
-        returned_ids = [a.get('id') for a in response_data['activities']['results']]
+        returned_ids = [
+            response.get('id') for response in response_data['activities']['results']
+        ]
         assert str(interaction_2.id) in returned_ids
-        assert str(interaction_3.id) in returned_ids
+        assert str(referral.id) in returned_ids
 
     def test_endpoint__sorting(self):
         """Test activity endpoint sorts correctly based on request param"""
@@ -267,10 +290,10 @@ class TestCompanyActivityViewSetV4(APITestMixin):
             companies=[],
             date='2023-08-09',
         )
-        interaction_3 = CompanyInteractionFactory(
+        referral = CompanyReferralInteractionFactory(
             company=company,
             companies=[],
-            date='2023-08-08',
+            company_referral__completed_on='2023-08-08',
         )
 
         url = reverse(
@@ -285,11 +308,13 @@ class TestCompanyActivityViewSetV4(APITestMixin):
         response = self.api_client.post(url, data=payload)
         response_data = response.json()
 
-        returned_ids = [a.get('id') for a in response_data['activities']['results']]
+        returned_ids = [
+            response.get('id') for response in response_data['activities']['results']
+        ]
         assert returned_ids == [
             str(interaction_1.id),
             str(interaction_2.id),
-            str(interaction_3.id),
+            str(referral.id),
         ]
 
         payload = {
@@ -299,9 +324,63 @@ class TestCompanyActivityViewSetV4(APITestMixin):
         response = self.api_client.post(url, data=payload)
         response_data = response.json()
 
-        returned_ids = [a.get('id') for a in response_data['activities']['results']]
+        returned_ids = [
+            response.get('id') for response in response_data['activities']['results']
+        ]
         assert returned_ids == [
-            str(interaction_3.id),
+            str(referral.id),
             str(interaction_2.id),
             str(interaction_1.id),
         ]
+
+    def test_endpoint__has_company_referrals(self):
+        """Test activity endpoint returns referral interactions for given company"""
+        company = CompanyFactory()
+        interaction = CompanyReferralInteractionFactory(company=company, companies=[])
+        CompanyReferralInteractionFactory(company=company, companies=[])
+
+        url = reverse('api-v4:company-activity:activity', kwargs={'pk': company.pk})
+        response = self.api_client.post(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert len(response_data['activities']['results']) == 2
+
+        activtiy = [
+            activity
+            for activity in response_data['activities']['results']
+            if activity['id'] == str(interaction.id)
+        ][0]
+
+        assert activtiy['id'] == str(interaction.id)
+        assert activtiy['activity_source'] == 'referral'
+        assert (
+            activtiy['company_referral']['recipient']['name']
+            == interaction.company_referral.recipient.name
+        )
+        assert (
+            activtiy['company_referral']['status']
+            == interaction.company_referral.status
+        )
+        assert (
+            activtiy['company_referral']['subject']
+            == interaction.company_referral.subject
+        )
+        assert (
+            activtiy['company_referral']['notes'] == interaction.company_referral.notes
+        )
+
+    def test_endpoint__has_referrals_for_given_company_only(self):
+        """Test activity endpoint returns referrals for given company only"""
+        company = CompanyFactory()
+        interaction = CompanyReferralInteractionFactory(company=company, companies=[])
+        CompanyReferralInteractionFactory(companies=[])
+
+        url = reverse('api-v4:company-activity:activity', kwargs={'pk': company.pk})
+        response = self.api_client.post(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert len(response_data['activities']['results']) == 1
+
+        assert response_data['activities']['results'][0]['id'] == str(interaction.id)

--- a/datahub/company_activity/tests/test_views.py
+++ b/datahub/company_activity/tests/test_views.py
@@ -256,7 +256,7 @@ class TestCompanyActivityViewSetV4(APITestMixin):
         referral = CompanyReferralInteractionFactory(
             company=company,
             companies=[],
-            company_referral__completed_on='2023-08-08',
+            date='2023-08-08',
         )
 
         url = reverse(
@@ -293,7 +293,7 @@ class TestCompanyActivityViewSetV4(APITestMixin):
         referral = CompanyReferralInteractionFactory(
             company=company,
             companies=[],
-            company_referral__completed_on='2023-08-08',
+            date='2023-08-08',
         )
 
         url = reverse(


### PR DESCRIPTION
### Description of change

Referrals are part of interactions once marked as complete. This PR splits the referrals from interactions so they can be filtered independently on their own dates.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
