### PR TITLE
Rename Expo 2025 Osaka to Expo 2025, Osaka, Kansai, Japan

### DIFF
--- a/datahub/metadata/migrations/0087_update_services.py
+++ b/datahub/metadata/migrations/0087_update_services.py
@@ -1,0 +1,33 @@
+from pathlib import PurePath
+
+import mptt
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0087_update_services.yaml'
+    )
+
+
+def rebuild_tree(apps, _):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('metadata', '0086_update_services'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0087_update_services.yaml
+++ b/datahub/metadata/migrations/0087_update_services.yaml
@@ -1,0 +1,12 @@
+- model: metadata.service
+  pk: afb989d3-be68-4e0d-9827-844cb9556199
+  fields:
+    disabled_on: ~
+    order: 5253
+    segment: Expo 2025, Osaka, Kansai, Japan
+    parent:
+    contexts: ["export_service_delivery", "export_interaction", "event", "investment_interaction", "investment_project_interaction", "trade_agreement_interaction", "other_interaction", "other_service_delivery"]
+    lft: 2
+    rght: 3
+    tree_id: 19
+    level: 1


### PR DESCRIPTION
### Description of change

A user has asked for the recently added Expo 2025 Osaka service to be renamed.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
