### PR TITLE
Change adviser query param to match frontend

### DIFF
--- a/datahub/company_activity/serializers.py
+++ b/datahub/company_activity/serializers.py
@@ -182,7 +182,7 @@ class CompanyActivitySerializer(serializers.ModelSerializer):
 
     def get_adviser_from_post_data(self):
         """Get the adviser from post data."""
-        advisers = self.get_request_data().get('advisers')
+        advisers = self.get_request_data().get('dit_participants__adviser')
 
         if not advisers or type(advisers) is not list:
             return []

--- a/datahub/company_activity/tests/test_views.py
+++ b/datahub/company_activity/tests/test_views.py
@@ -103,7 +103,7 @@ class TestCompanyActivityViewSetV4(APITestMixin):
         response_data = response.json()
         assert len(response_data['activities']['results']) == 4
 
-        response = self.api_client.post(url, {'advisers': [str(adviser.id)]})
+        response = self.api_client.post(url, {'dit_participants__adviser': [str(adviser.id)]})
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert len(response_data['activities']['results']) == 2


### PR DESCRIPTION
### Description of change

The frontend uses a different query param to filter for advisers so update the backend. I've reused the frontend param to keep it consistent with existing endpoints.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
