### PR TITLE
Export wins endpoint permissions and validation.

### DIFF
--- a/datahub/export_win/test/factories.py
+++ b/datahub/export_win/test/factories.py
@@ -165,6 +165,7 @@ class WinFactory(factory.django.DjangoModelFactory):
     name_of_customer_confidential = False
     business_potential_id = BusinessPotentialConstant.high_export_potential.value.id
     type_id = WinTypeConstant.both.value.id
+    is_anonymous_win = False
 
     @to_many_field
     def associated_programme(self):  # noqa: D102

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -1917,15 +1917,20 @@ class TestUpdateWinView(APITestMixin):
     def test_only_users_involved_in_the_win_can_update(self, params, related_objects, status_code):
         """Test only users involved in the win can update."""
         resolved_params = params(self)
-        win = WinFactory(**resolved_params)
+        win = WinFactory(description='Not changed', **resolved_params)
         related_objects(self, win)
-
+        assert win.description == 'Not changed'
         url = reverse('api-v4:export-win:item', kwargs={'pk': win.pk})
         request_data = {
-            'description': 'Description',
+            'description': 'Changed',
         }
         response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status_code
+        win.refresh_from_db()
+        if status_code == status.HTTP_200_OK:
+            assert win.description == 'Changed'
+        else:
+            assert win.description == 'Not changed'
 
     @pytest.mark.parametrize(
         'request_data',


### PR DESCRIPTION
### Description of change

This PR ensures that:
Any user can retrieve the confirmed win. 
Only users involved in the win can edit. 
Anonymous wins cannot be retrieved.
Customer response information cannot be updated.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
