### PR TITLE
Add Retrieve and List views for EYB leads

### DIFF
--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
 
-from datahub.core.serializers import NestedRelatedField
+from datahub.core.serializers import (
+    AddressSerializer,
+    NestedRelatedField,
+)
 from datahub.investment_lead.models import EYBLead
 from datahub.metadata.models import (
     AdministrativeArea,
@@ -75,6 +78,16 @@ RELATED_FIELDS = [
     'address_area',
     'address_country',
     'company',
+]
+
+ADDRESS_FIELDS = [
+    'address_1',
+    'address_2',
+    'address_town',
+    'address_county',
+    'address_area',
+    'address_country',
+    'address_postcode',
 ]
 
 ALL_FIELDS = ARCHIVABLE_FIELDS + INVESTMENT_LEAD_BASE_FIELDS + \
@@ -199,8 +212,16 @@ class CreateEYBLeadSerializer(BaseEYBLeadSerializer):
 
 class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
 
+    class Meta(BaseEYBLeadSerializer.Meta):
+        fields = [
+            f for f in ALL_FIELDS
+            if f not in ADDRESS_FIELDS
+        ] + ['address']
+
     sector = NestedRelatedField(Sector)
     location = NestedRelatedField(UKRegion)
     company_location = NestedRelatedField(Country)
-    address_area = NestedRelatedField(AdministrativeArea)
-    address_country = NestedRelatedField(Country)
+    address = AddressSerializer(
+        source_model=EYBLead,
+        address_source_prefix='address',
+    )

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from datahub.core.serializers import NestedRelatedField
 from datahub.investment_lead.models import EYBLead
 from datahub.metadata.models import (
     AdministrativeArea,
@@ -194,3 +195,12 @@ class CreateEYBLeadSerializer(BaseEYBLeadSerializer):
             )
 
         return validated_data
+
+
+class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
+
+    sector = NestedRelatedField(Sector)
+    location = NestedRelatedField(UKRegion)
+    company_location = NestedRelatedField(Country)
+    address_area = NestedRelatedField(AdministrativeArea)
+    address_country = NestedRelatedField(Country)

--- a/datahub/investment_lead/test/conftest.py
+++ b/datahub/investment_lead/test/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from datahub.core import constants
-
+from datahub.core.test_utils import create_test_user
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.test.factories import EYBLeadFactory
 from datahub.metadata.models import (
@@ -12,6 +12,11 @@ from datahub.metadata.models import (
 )
 
 DATETIME_STRING = '2024-09-04T08:02:30.123456Z'
+
+
+@pytest.fixture
+def test_user_with_view_permissions():
+    return create_test_user(permission_codenames=['view_eyblead'])
 
 
 @pytest.fixture

--- a/datahub/investment_lead/test/test_models.py
+++ b/datahub/investment_lead/test/test_models.py
@@ -13,7 +13,7 @@ class TestEYBLead:
     ):
         assert EYBLead.objects.all().exists()
         verify_eyb_lead_data(
-            eyb_lead_instance_from_db, eyb_lead_factory_data, is_factory_data=True,
+            eyb_lead_instance_from_db, eyb_lead_factory_data, data_type='factory',
         )
 
     def test_str(self, eyb_lead_instance_from_db):

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -4,6 +4,7 @@ from datahub.core import constants
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.serializers import (
     CreateEYBLeadSerializer,
+    RetrieveEYBLeadSerializer,
     UUIDS_ERROR_MESSAGE,
 )
 from datahub.investment_lead.test.utils import verify_eyb_lead_data
@@ -38,7 +39,7 @@ class TestCreateEYBLeadSerializer:
         instance = serializer.save()
         assert isinstance(instance, EYBLead)
         assert EYBLead.objects.count() == 1
-        verify_eyb_lead_data(instance, serializer.validated_data, is_factory_data=False)
+        verify_eyb_lead_data(instance, serializer.validated_data, data_type='factory')
 
     def test_create_invalid_eyb_lead(self, eyb_lead_post_data):
         eyb_lead_post_data['spend'] = 'Invalid spend choice'
@@ -90,3 +91,17 @@ class TestCreateEYBLeadSerializer:
         assert validated_data['company_location'].pk == canada_country.pk
         assert validated_data['address_area'].pk == alberta_area.pk
         assert validated_data['address_country'].pk == canada_country.pk
+
+
+class TestRetrieveEYBLeadSerializer:
+    """Tests for RetrieveEYBLeadSerializer"""
+
+    def test_retrieve_eyb_lead(self, eyb_lead_instance_from_db):
+        serializer = RetrieveEYBLeadSerializer(eyb_lead_instance_from_db)
+        verify_eyb_lead_data(eyb_lead_instance_from_db, serializer.data, data_type='nested')
+
+    def test_serialize_queryset(self, eyb_lead_instance_from_db):
+        queryset = EYBLead.objects.all()
+        serializer = RetrieveEYBLeadSerializer(queryset, many=True)
+        assert len(serializer.data) == 1
+        verify_eyb_lead_data(eyb_lead_instance_from_db, serializer.data[0], data_type='nested')

--- a/datahub/investment_lead/test/test_utils.py
+++ b/datahub/investment_lead/test/test_utils.py
@@ -1,0 +1,13 @@
+import pytest
+
+from datahub.investment_lead.test.factories import EYBLeadFactory
+from datahub.investment_lead.test.utils import verify_eyb_lead_data
+
+
+@pytest.mark.django_db
+def test_verify_eyb_lead_data_raises_error_when_invalid_argument_is_passed(
+    eyb_lead_factory_data,
+):
+    instance = EYBLeadFactory(**eyb_lead_factory_data)
+    with pytest.raises(ValueError):
+        verify_eyb_lead_data(instance, eyb_lead_factory_data, 'invalid_data_type')

--- a/datahub/investment_lead/test/utils.py
+++ b/datahub/investment_lead/test/utils.py
@@ -64,11 +64,20 @@ def verify_eyb_lead_data(
 
     # Company fields
     assert instance.duns_number == data['duns_number']
-    assert instance.address_1 == data['address_1']
-    assert instance.address_2 == data['address_2']
-    assert instance.address_town == data['address_town']
-    assert instance.address_county == data['address_county']
-    assert instance.address_postcode == data['address_postcode']
+
+    # Address fields
+    if data_type != 'nested':
+        assert instance.address_1 == data['address_1']
+        assert instance.address_2 == data['address_2']
+        assert instance.address_town == data['address_town']
+        assert instance.address_county == data['address_county']
+        assert instance.address_postcode == data['address_postcode']
+    else:
+        assert instance.address_1 == data['address']['line_1']
+        assert instance.address_2 == data['address']['line_2']
+        assert instance.address_town == data['address']['town']
+        assert instance.address_county == data['address']['county']
+        assert instance.address_postcode == data['address']['postcode']
 
     # Related fields
     if data_type == 'post':
@@ -87,7 +96,7 @@ def verify_eyb_lead_data(
         assert str(instance.sector.id) == data['sector']['id']
         assert str(instance.location.id) == data['location']['id']
         assert str(instance.company_location.id) == data['company_location']['id']
-        assert str(instance.address_area.id) == data['address_area']['id']
-        assert str(instance.address_country.id) == data['address_country']['id']
+        assert str(instance.address_area.id) == data['address']['area']['id']
+        assert str(instance.address_country.id) == data['address']['country']['id']
     else:
         raise ValueError(f'Invalid value "{data_type}" for argument data_type')

--- a/datahub/investment_lead/urls.py
+++ b/datahub/investment_lead/urls.py
@@ -1,11 +1,26 @@
 from django.urls import path
 
-from datahub.investment_lead.views import EYBLeadViewset
+from datahub.investment_lead.views import EYBLeadViewSet
+
+
+eyb_lead_collection = EYBLeadViewSet.as_view({
+    'post': 'create',
+    'get': 'list',
+})
+
+eyb_lead_item = EYBLeadViewSet.as_view({
+    'get': 'retrieve',
+})
 
 urlpatterns = [
     path(
         'eyb',
-        EYBLeadViewset.as_view({'post': 'create'}),
-        name='eyb-create',
+        eyb_lead_collection,
+        name='eyb-lead-collection',
+    ),
+    path(
+        'eyb/<uuid:pk>',
+        eyb_lead_item,
+        name='eyb-lead-item',
     ),
 ]

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -60,7 +60,7 @@ class EYBLeadViewSet(HawkResponseSigningMixin, SoftDeleteCoreViewSet):
         errors = []
 
         for index, lead_data in enumerate(request.data):
-            serializer = CreateEYBLeadSerializer(data=lead_data)
+            serializer = self.get_serializer(data=lead_data)
             if serializer.is_valid():
                 instance, created = self.perform_create_or_update(serializer)
                 if created:

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -10,26 +10,35 @@ from datahub.core.hawk_receiver import (
     HawkResponseSigningMixin,
     HawkScopePermission,
 )
-from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.viewsets import SoftDeleteCoreViewSet
 from datahub.investment_lead.models import EYBLead
-from datahub.investment_lead.serializers import CreateEYBLeadSerializer
+from datahub.investment_lead.serializers import (
+    CreateEYBLeadSerializer,
+    RetrieveEYBLeadSerializer,
+)
 
 
 logger = logging.getLogger(__name__)
 
 
-class EYBLeadViewset(
-    ArchivableViewSetMixin,
-    SoftDeleteCoreViewSet,
-    HawkResponseSigningMixin,
-):
-    serializer_class = CreateEYBLeadSerializer
-    queryset = EYBLead.objects.all()
-
-    authentication_classes = (PaaSIPAuthentication, HawkAuthentication)
-    permission_classes = (HawkScopePermission, )
+class EYBLeadViewSet(HawkResponseSigningMixin, SoftDeleteCoreViewSet):
+    queryset = EYBLead.objects.filter(archived=False)
     required_hawk_scope = HawkScope.data_flow_api
+
+    def get_authenticators(self):
+        if self.request.method == 'POST':
+            return [PaaSIPAuthentication(), HawkAuthentication()]
+        return super().get_authenticators()
+
+    def get_permissions(self):
+        if self.request.method == 'POST':
+            return [HawkScopePermission()]
+        return super().get_permissions()
+
+    def get_serializer_class(self):
+        if self.request.method == 'POST':
+            return CreateEYBLeadSerializer
+        return RetrieveEYBLeadSerializer
 
     def create(self, request):
         """POST route definition.
@@ -51,7 +60,7 @@ class EYBLeadViewset(
         errors = []
 
         for index, lead_data in enumerate(request.data):
-            serializer = self.get_serializer(data=lead_data)
+            serializer = CreateEYBLeadSerializer(data=lead_data)
             if serializer.is_valid():
                 instance, created = self.perform_create_or_update(serializer)
                 if created:


### PR DESCRIPTION
### Description of change

This PR adds a retrieve and list view for EYB leads. In addition to the method, these views differ from the create view because these actions will be performed via the frontend and thus authenticated by SSO and user permissions instead.

### Test Instructions

After populating the database with some `EYBLead` instances

```
python manage.py shell
```
```python
from datahub.investment_lead.test.factories import EYBLeadFactory

EYBLeadFactory.create_batch(10)
```

you should be able to:
- Send a GET request to `v4/investment-lead/eyb` and retrieve a list of instances
- Send a GET request to `v4/investment-lead/eyb/<eyb-lead-pk>` and retrieve the specified instance

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
