### PR TITLE
Select random existing sector instead of creating new

### DIFF
--- a/datahub/investment_lead/test/factories.py
+++ b/datahub/investment_lead/test/factories.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from datahub.company.test.factories import CompanyFactory
 from datahub.core import constants
 from datahub.investment_lead.models import EYBLead
-from datahub.metadata.test.factories import SectorFactory
+from datahub.metadata.models import Sector
 
 
 factory.Faker._DEFAULT_LOCALE = 'en_GB'
@@ -31,7 +31,7 @@ class EYBLeadFactory(factory.django.DjangoModelFactory):
     triage_hashed_uuid = factory.LazyFunction(generate_hashed_uuid)
     triage_created = factory.LazyFunction(timezone.now)
     triage_modified = factory.LazyFunction(timezone.now)
-    sector = factory.SubFactory(SectorFactory)
+    sector = factory.LazyAttribute(lambda o: random.choice(list(Sector.objects.all())))
     sector_sub = factory.LazyAttribute(lambda o: f'{o.sector.segment}')
     intent = random.choices(EYBLead.IntentChoices.values, k=random.randint(1, 6))
     intent_other = ''


### PR DESCRIPTION
### Description of change

Updated EYB Lead Factory for it to select a random existing Sector instead of creating a new Sector for each EYB Lead.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
