### PR TITLE
Remove year from International Trade Week

### DIFF
--- a/datahub/event/migrations/0028_update_event_programme.py
+++ b/datahub/event/migrations/0028_update_event_programme.py
@@ -1,0 +1,20 @@
+from pathlib import PurePath
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def update_event_programmes(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps, PurePath(__file__).parent / "0028_update_event_programme.yaml"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('event', '0027_update_event_programme'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_event_programmes, migrations.RunPython.noop),
+    ]

--- a/datahub/event/migrations/0028_update_event_programme.yaml
+++ b/datahub/event/migrations/0028_update_event_programme.yaml
@@ -1,0 +1,3 @@
+- model: event.programme
+  pk: 18d91ad6-5a80-4471-999a-27b3860bb2c4
+  fields: {disabled_on: null, name: International Trade Week}


### PR DESCRIPTION
### Description of change

We've been asked to remove the year from the International Trade Week programme.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
