### PR TITLE
Tweaks to the EYB lead retrieve serialiser

### DIFF
--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -219,6 +219,27 @@ class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
             if f not in ADDRESS_FIELDS
         ] + ['address']
 
+    def to_representation(self, instance):
+        """Convert model instance to built-in Python (JSON friendly) data types.
+
+        Specifically, we want to convert `UPPER_CASE` values to `Sentence case` labels
+        for choice fields.
+        """
+        related_fields = {
+            'intent': [
+                EYBLead.IntentChoices(intent_choice).label
+                for intent_choice in instance.intent
+            ],
+            'hiring': EYBLead.HiringChoices(instance.hiring).label,
+            'spend': EYBLead.SpendChoices(instance.spend).label,
+            'landing_timeframe': EYBLead.LandingTimeframeChoices(
+                instance.landing_timeframe,
+            ).label,
+        }
+        rep = super().to_representation(instance)
+        rep.update(related_fields)
+        return rep
+
     sector = NestedRelatedField(Sector)
     location = NestedRelatedField(UKRegion)
     company_location = NestedRelatedField(Country)

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from datahub.company.models import Company
 from datahub.core.serializers import (
     AddressSerializer,
     NestedRelatedField,
@@ -225,3 +226,4 @@ class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
         source_model=EYBLead,
         address_source_prefix='address',
     )
+    company = NestedRelatedField(Company)

--- a/datahub/investment_lead/test/utils.py
+++ b/datahub/investment_lead/test/utils.py
@@ -40,12 +40,9 @@ def verify_eyb_lead_data(
     assert_datetimes(instance.triage_created, data['triage_created'])
     assert_datetimes(instance.triage_modified, data['triage_modified'])
     assert instance.sector_sub == data['sector_sub']
-    assert instance.intent == data['intent']
     assert instance.intent_other == data['intent_other']
     assert instance.location_city == data['location_city']
     assert instance.location_none == data['location_none']
-    assert instance.hiring == data['hiring']
-    assert instance.spend == data['spend']
     assert instance.spend_other == data['spend_other']
     assert instance.is_high_value == data['is_high_value']
 
@@ -60,7 +57,6 @@ def verify_eyb_lead_data(
     assert instance.telephone_number == data['telephone_number']
     assert instance.agree_terms == data['agree_terms']
     assert instance.agree_info_email == data['agree_info_email']
-    assert instance.landing_timeframe == data['landing_timeframe']
 
     # Company fields
     assert instance.duns_number == data['duns_number']
@@ -78,6 +74,22 @@ def verify_eyb_lead_data(
         assert instance.address_town == data['address']['town']
         assert instance.address_county == data['address']['county']
         assert instance.address_postcode == data['address']['postcode']
+
+    # Choice fields
+    if data_type == 'nested':
+        assert [
+            EYBLead.IntentChoices(intent_choice).label
+            for intent_choice in instance.intent
+        ] == data['intent']
+        assert EYBLead.HiringChoices(instance.hiring).label == data['hiring']
+        assert EYBLead.SpendChoices(instance.spend).label == data['spend']
+        assert EYBLead.LandingTimeframeChoices(instance.landing_timeframe).label \
+            == data['landing_timeframe']
+    else:
+        assert instance.intent == data['intent']
+        assert instance.hiring == data['hiring']
+        assert instance.spend == data['spend']
+        assert instance.landing_timeframe == data['landing_timeframe']
 
     # Related fields
     if data_type == 'post':

--- a/datahub/investment_lead/test/utils.py
+++ b/datahub/investment_lead/test/utils.py
@@ -98,5 +98,6 @@ def verify_eyb_lead_data(
         assert str(instance.company_location.id) == data['company_location']['id']
         assert str(instance.address_area.id) == data['address']['area']['id']
         assert str(instance.address_country.id) == data['address']['country']['id']
+        assert str(instance.company.id) == data['company']['id']
     else:
         raise ValueError(f'Invalid value "{data_type}" for argument data_type')


### PR DESCRIPTION
### Description of change

After working on the frontend EYB lead collection and detail pages, we realised we wanted to make a few tweaks to the retrieve serialiser:

- Define `eyb_lead.company` as a nested serialiser field so we have the company `name` in addition to the `id`.
- Convert choice fields from `UPPER_CASE` values to `Sentence case` labels so we don't have to do so in the frontend

#### Before

```json
    "intent": [
        "OTHER",
        "SET_UP_NEW_PREMISES",
        "ONWARD_SALES_AND_EXPORTS_FROM_THE_UK"
    ],
    "company": "a655f0e2-211a-4513-a3f8-3e067dfb1cbc",
```

#### After

```json
    "intent": [
        "Other",
        "Set up new premises",
        "Onward sales and exports from the UK"
    ],
    "company": {
        "name": "Ward PLC",
        "id": "a655f0e2-211a-4513-a3f8-3e067dfb1cbc"
    },
```

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
