### PR TITLE
Prevent interactions without a company linking as an activity

### DIFF
--- a/datahub/company_activity/tasks.py
+++ b/datahub/company_activity/tasks.py
@@ -46,6 +46,8 @@ def relate_company_activity_to_interactions():
 
     interactions = Interaction.objects.exclude(
         id__in=activity_interactions,
+    ).filter(
+        company_id__isnull=False,
     ).values('id', 'date', 'company_id')
 
     objs = [

--- a/datahub/company_activity/tests/test_tasks/test_interaction_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_interaction_task.py
@@ -22,7 +22,7 @@ class TestCompanyActivityInteractionTasks:
 
         # Remove the created CompanyActivities added by the Interactions `save` method
         # to mimick already existing data in staging and prod database.
-        assert CompanyActivity.objects.all().delete()
+        CompanyActivity.objects.all().delete()
         assert CompanyActivity.objects.count() == 0
 
         # Check the "existing" interactions are addded to the company activity model
@@ -49,3 +49,17 @@ class TestCompanyActivityInteractionTasks:
         # Check count remains unchanged.
         schedule_sync_interactions_to_company_activity()
         assert CompanyActivity.objects.count() == 4
+
+    def test_interactions_without_a_company_activity_are_not_added(self):
+        """
+        Test that interactions which have no company are not added.
+        """
+        CompanyInteractionFactory(company=None)
+
+        # Delete any activity created through the interactions save method.
+        CompanyActivity.objects.all().delete()
+        assert CompanyActivity.objects.count() == 0
+
+        # Schedule the sync and ensure interaction with no company is not added.
+        schedule_sync_interactions_to_company_activity()
+        assert CompanyActivity.objects.count() == 0

--- a/datahub/company_activity/tests/test_tasks/test_referral_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_referral_task.py
@@ -22,7 +22,7 @@ class TestCompanyActivityReferralTasks:
 
         # Remove the created CompanyActivities added by the CompanyReferral `save` method
         # to mimick already existing data in staging and prod database.
-        assert CompanyActivity.objects.all().delete()
+        CompanyActivity.objects.all().delete()
         assert CompanyActivity.objects.count() == 0
 
         # Check the "existing" referrals are addded to the company activity model


### PR DESCRIPTION
### Description of change

When relating interactions to an activity, there are some interactions on staging which have no company and this causes a crash. The company field is not required on the interaction model (I think due to the company vs companies fields) This PR prevents interactions without a company from being added to a company activity.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
