### PR TITLE
Unschedule job to refresh GVA for FDI investment projects

### DIFF
--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -27,7 +27,7 @@ from datahub.core.queues.constants import (
     EVERY_TEN_MINUTES,
     EVERY_TEN_PM,
     EVERY_THREE_AM,
-    EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
+    # EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
     EVERY_TWO_AM,
     HALF_DAY_IN_SECONDS,
 )
@@ -42,9 +42,9 @@ from datahub.export_win.tasks import (
     update_notify_email_delivery_status_for_customer_response,
     update_notify_email_delivery_status_for_customer_response_token,
 )
-from datahub.investment.project.tasks import (
-    schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
-)
+# from datahub.investment.project.tasks import (
+#     schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
+# )
 from datahub.omis.payment.tasks import refresh_pending_payment_gateway_sessions
 from datahub.reminder.migration_tasks import run_ita_users_migration, run_post_users_migration
 from datahub.reminder.tasks import (
@@ -130,11 +130,12 @@ def schedule_jobs():
             description='schedule_generate_estimated_land_date_reminders',
         )
 
-    job_scheduler(
-        function=schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
-        cron=EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
-        description='schedule_refresh_gross_value_added_value_for_fdi_investment_projects',
-    )
+    # TODO: uncomment this once the infinite loop issue (when refreshing GVA) has been fixed
+    # job_scheduler(
+    #     function=schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
+    #     cron=EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
+    #     description='schedule_refresh_gross_value_added_value_for_fdi_investment_projects',
+    # )
 
     if settings.ENABLE_ESTIMATED_LAND_DATE_REMINDERS_EMAIL_DELIVERY_STATUS:
         job_scheduler(


### PR DESCRIPTION
### Description of change

This PR unschedules a job to refresh GVA for FDI investment projects before it runs on the 28th of this month. 

The reason for this is because an issue has been identified where the job creates an infinite loop, flooding the RQ, blocking other jobs, and in some cases, causing the app to crash.

This is a temporary action to give us more time to fix the issue and will be reverted once implemented.

JIRA: https://uktrade.atlassian.net/browse/CLS2-926

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
