### PR TITLE
CLS2-903: Link EYB record to existing company based on DUNs number

### DIFF
--- a/datahub/investment_lead/services.py
+++ b/datahub/investment_lead/services.py
@@ -11,6 +11,9 @@ def match_by_duns_number(duns_number):
 
     Args:
         duns_number (string): a DnB number
+    Returns:
+        found (boolean): true/false based on success of search
+        company (object): a Company object or None
     """
     companies = Company.objects.filter(duns_number=duns_number)
 
@@ -18,14 +21,20 @@ def match_by_duns_number(duns_number):
         # match found
         return True, companies[0]
 
-    # TODO: what to do if len > 1?
+    # TODO: if len(companies) > 1 what to do? raise or treat as not found?
     return False, None
 
 
 def process_eyb_lead(eyb_lead):
-    """_summary_
+    """Matches an EYB lead with an existing Company via DnB number
 
     Args:
-        eyb_lead (_type_): _description_
+        eyb_lead (object): an EYB lead object
     """
-    return
+
+    if eyb_lead.duns_number is not None:
+        found, company = match_by_duns_number(eyb_lead.duns_number)
+
+        if found:
+            eyb_lead.company = company
+            eyb_lead.save()

--- a/datahub/investment_lead/services.py
+++ b/datahub/investment_lead/services.py
@@ -17,8 +17,7 @@ def match_by_duns_number(duns_number):
     """
     companies = Company.objects.filter(duns_number=duns_number)
 
-    if len(companies) == 1:
-        # match found
+    if companies.count() == 1:
         return True, companies[0]
 
     # no match found

--- a/datahub/investment_lead/services.py
+++ b/datahub/investment_lead/services.py
@@ -21,7 +21,7 @@ def match_by_duns_number(duns_number):
         # match found
         return True, companies[0]
 
-    # TODO: if len(companies) > 1 what to do? raise or treat as not found?
+    # no match found
     return False, None
 
 

--- a/datahub/investment_lead/services.py
+++ b/datahub/investment_lead/services.py
@@ -1,6 +1,25 @@
 import logging
 
+from datahub.company.models.company import Company
+
 logger = logging.getLogger(__name__)
+
+
+def match_by_duns_number(duns_number):
+    """ Uses an EYB lead provided DnB number
+    to search Data Hub for existing Companies
+
+    Args:
+        duns_number (string): a DnB number
+    """
+    companies = Company.objects.filter(duns_number=duns_number)
+
+    if len(companies) == 1:
+        # match found
+        return True, companies[0]
+
+    # TODO: what to do if len > 1?
+    return False, None
 
 
 def process_eyb_lead(eyb_lead):
@@ -9,3 +28,4 @@ def process_eyb_lead(eyb_lead):
     Args:
         eyb_lead (_type_): _description_
     """
+    return

--- a/datahub/investment_lead/services.py
+++ b/datahub/investment_lead/services.py
@@ -6,7 +6,7 @@ logger = logging.getLogger(__name__)
 
 
 def match_by_duns_number(duns_number):
-    """ Uses an EYB lead provided DnB number
+    """Uses an EYB lead provided DnB number
     to search Data Hub for existing Companies
 
     Args:
@@ -31,7 +31,6 @@ def process_eyb_lead(eyb_lead):
     Args:
         eyb_lead (object): an EYB lead object
     """
-
     if eyb_lead.duns_number is not None:
         found, company = match_by_duns_number(eyb_lead.duns_number)
 

--- a/datahub/investment_lead/test/test_services.py
+++ b/datahub/investment_lead/test/test_services.py
@@ -29,6 +29,15 @@ class TestEYBLeadServices:
         assert found is False
         assert found_company is None
 
+    def test_attach_existing_company_from_eyb_lead(self):
+        company = CompanyFactory(duns_number='123456789')
+        eyb_lead = EYBLeadFactory(duns_number='123456789')
+
+        process_eyb_lead(eyb_lead)
+
+        assert eyb_lead.company is not None
+        assert eyb_lead.company == company
+
     def test_add_new_company_from_eyb_lead(self):
         eyb_lead = EYBLeadFactory(duns_number=None)
 

--- a/datahub/investment_lead/test/test_services.py
+++ b/datahub/investment_lead/test/test_services.py
@@ -1,7 +1,8 @@
 import pytest
 
 from datahub.company.models.company import Company
-from datahub.investment_lead.services import process_eyb_lead
+from datahub.company.test.factories import CompanyFactory
+from datahub.investment_lead.services import match_by_duns_number, process_eyb_lead
 from datahub.investment_lead.test.factories import EYBLeadFactory
 from datahub.investment_lead.test.utils import assert_company_matches_eyb_lead
 
@@ -9,6 +10,24 @@ from datahub.investment_lead.test.utils import assert_company_matches_eyb_lead
 @pytest.mark.django_db
 class TestEYBLeadServices:
     """Tests EYB Lead services"""
+
+    def test_duns_number_matches_existing_company(self):
+        company = CompanyFactory(duns_number='123456789')
+        eyb_lead = EYBLeadFactory(duns_number='123456789')
+
+        found, found_company = match_by_duns_number(eyb_lead.duns_number)
+
+        assert found is True
+        assert found_company.id == company.id
+
+    def test_duns_number_does_not_match_company(self):
+        CompanyFactory(duns_number='123456789')
+        eyb_lead = EYBLeadFactory(duns_number='123456788')
+
+        found, found_company = match_by_duns_number(eyb_lead.duns_number)
+
+        assert found is False
+        assert found_company is None
 
     def test_add_new_company_from_eyb_lead(self):
         eyb_lead = EYBLeadFactory(duns_number=None)


### PR DESCRIPTION
### Description of change

Addresses [CLS2-903](https://uktrade.atlassian.net/browse/CLS2-903)

This PR adds the possibility to link a `EYB Lead` object to a `Company` following successful match via duns number. The match is done internally in DataHub and not externally to the DnB api.
If there is no match will be dealt with by another ticket ([CLS2-902](https://uktrade.atlassian.net/browse/CLS2-902))

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.


[CLS2-903]: https://uktrade.atlassian.net/browse/CLS2-903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLS2-902]: https://uktrade.atlassian.net/browse/CLS2-902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ