### PR TITLE
Improve query for opensearch

### DIFF
--- a/datahub/search/company_activity/apps.py
+++ b/datahub/search/company_activity/apps.py
@@ -1,4 +1,7 @@
+from django.db.models import Prefetch
+
 from datahub.company_activity.models import CompanyActivity as DBCompanyActivity
+from datahub.interaction.models import InteractionDITParticipant
 from datahub.search.apps import SearchApp
 from datahub.search.company_activity.models import CompanyActivity
 
@@ -11,5 +14,16 @@ class CompanyActivitySearchApp(SearchApp):
     view_permissions = ('company_activity.view_companyactivity',)
     queryset = DBCompanyActivity.objects.select_related(
         'interaction',
+        'interaction__communication_channel',
+        'interaction__service',
         'referral',
+        'referral__contact',
+        'referral__created_by',
+        'referral__recipient',
+    ).prefetch_related(
+        'interaction__contacts',
+        Prefetch(
+            'interaction__dit_participants',
+            queryset=InteractionDITParticipant.objects.select_related('adviser', 'team'),
+        ),
     )


### PR DESCRIPTION
### Description of change

When syncing production interactions (4million+) to company activities, the DB CPU maxes out. This updates the query to add the missing joins and prefetched data to try and prevent the DB from being rammed.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?
* [ ] Is the CircleCI build passing?

