### PR TITLE
Add query params to EYB lead retrieve view

### DIFF
--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -119,6 +119,10 @@ class Sector(Enum):
         'Defence : Land',
         '7c432bdc-77e0-49ac-8d5f-1eece499ae2a',
     )
+    mining = Constant(
+        'Mining',
+        'a622c9d2-5f95-e211-a939-e4115bead28a',
+    )
     mining_mining_vehicles_transport_equipment = Constant(
         'Mining : Mining vehicles, transport and equipment',
         'e17c69f9-8c65-457e-9a65-fd7c52a45700',

--- a/datahub/investment_lead/test/factories.py
+++ b/datahub/investment_lead/test/factories.py
@@ -33,7 +33,9 @@ class EYBLeadFactory(factory.django.DjangoModelFactory):
     triage_modified = factory.LazyFunction(timezone.now)
     sector = factory.LazyAttribute(lambda o: random.choice(list(Sector.objects.all())))
     sector_sub = factory.LazyAttribute(lambda o: f'{o.sector.segment}')
-    intent = random.choices(EYBLead.IntentChoices.values, k=random.randint(1, 6))
+    intent = factory.LazyAttribute(
+        lambda o: random.sample(EYBLead.IntentChoices.values, k=random.randint(1, 4)),
+    )
     intent_other = ''
     location_id = constants.UKRegion.wales.value.id
     location_city = 'Cardiff'

--- a/datahub/investment_lead/test/factories.py
+++ b/datahub/investment_lead/test/factories.py
@@ -40,8 +40,8 @@ class EYBLeadFactory(factory.django.DjangoModelFactory):
     location_id = constants.UKRegion.wales.value.id
     location_city = 'Cardiff'
     location_none = False
-    hiring = random.choice(EYBLead.HiringChoices.values)
-    spend = random.choice(EYBLead.SpendChoices.values)
+    hiring = factory.LazyAttribute(lambda o: random.choice(EYBLead.HiringChoices.values))
+    spend = factory.LazyAttribute(lambda o: random.choice(EYBLead.SpendChoices.values))
     spend_other = ''
     is_high_value = factory.Faker('pybool')
 
@@ -57,7 +57,9 @@ class EYBLeadFactory(factory.django.DjangoModelFactory):
     telephone_number = factory.Faker('phone_number')
     agree_terms = factory.Faker('pybool')
     agree_info_email = factory.Faker('pybool')
-    landing_timeframe = random.choice(EYBLead.LandingTimeframeChoices.values)
+    landing_timeframe = factory.LazyAttribute(
+        lambda o: random.choice(EYBLead.LandingTimeframeChoices.values),
+    )
     company_website = factory.Faker('url')
 
     # Company fields

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -194,12 +194,28 @@ class TestEYBLeadListAPI(APITestMixin):
         """Test filtering EYB leads by is high value status"""
         EYBLeadFactory(is_high_value=True)
         EYBLeadFactory(is_high_value=False)
+        EYBLeadFactory(is_high_value=False)
         api_client = self.create_api_client(user=test_user_with_view_permissions)
+
+        response = api_client.get(EYB_LEAD_COLLECTION_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 3
 
         response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': 'high'})
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         assert response.data['results'][0]['is_high_value'] is True
+
+    def test_filter_by_is_low_value(self, test_user_with_view_permissions):
+        """Test filtering EYB leads by is low value status"""
+        EYBLeadFactory(is_high_value=True)
+        EYBLeadFactory(is_high_value=True)
+        EYBLeadFactory(is_high_value=False)
+        api_client = self.create_api_client(user=test_user_with_view_permissions)
+
+        response = api_client.get(EYB_LEAD_COLLECTION_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 3
 
         response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': 'low'})
         assert response.status_code == status.HTTP_200_OK

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -5,11 +5,13 @@ import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.company.test.factories import CompanyFactory
 from datahub.core import constants
 from datahub.core.test_utils import APITestMixin
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.test.factories import EYBLeadFactory
 from datahub.investment_lead.test.utils import verify_eyb_lead_data
+from datahub.metadata.models import Sector
 
 
 EYB_LEAD_COLLECTION_URL = reverse('api-v4:investment-lead:eyb-lead-collection')
@@ -153,3 +155,42 @@ class TestEYBLeadListAPI(APITestMixin):
         assert response.data['count'] == number_of_leads
         assert response.data['next'] is not None
         assert len(response.data['results']) == pagination_limit
+
+    def test_filter_by_company_name(self, test_user_with_view_permissions):
+        """Test filtering EYB leads by company name"""
+        company_name = 'Mars Exports Ltd'
+        company = CompanyFactory(name=company_name)
+        EYBLeadFactory(company=company)
+        EYBLeadFactory()
+        api_client = self.create_api_client(user=test_user_with_view_permissions)
+        response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'company': company_name})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['company']['name'] == company_name
+
+    def test_filter_by_sector(self, test_user_with_view_permissions):
+        """Test filtering EYB leads by sector id"""
+        sector = Sector.objects.get(pk=constants.Sector.renewable_energy_wind.value.id)
+        EYBLeadFactory(sector=sector)
+        EYBLeadFactory()
+        api_client = self.create_api_client(user=test_user_with_view_permissions)
+        response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'sector': sector.pk})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['sector']['id'] == str(sector.pk)
+
+    def test_filter_by_is_high_value(self, test_user_with_view_permissions):
+        """Test filtering EYB leads by is high value status"""
+        EYBLeadFactory(is_high_value=True)
+        EYBLeadFactory(is_high_value=False)
+        api_client = self.create_api_client(user=test_user_with_view_permissions)
+
+        response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': 'high'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['is_high_value'] is True
+
+        response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': 'low'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['is_high_value'] is False

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -57,9 +57,9 @@ class EYBLeadViewSet(HawkResponseSigningMixin, SoftDeleteCoreViewSet):
             descendent_sectors = sector.get_descendants(include_self=True)
             queryset = queryset.filter(sector__in=descendent_sectors)
         if value is not None:
-            if value.lower() in ['high', 'h']:
+            if value.lower() == 'high':
                 queryset = queryset.filter(is_high_value=True)
-            elif value.lower() in ['low', 'l']:
+            if value.lower() == 'low':
                 queryset = queryset.filter(is_high_value=False)
 
         return queryset

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -51,15 +51,18 @@ class EYBLeadViewSet(HawkResponseSigningMixin, SoftDeleteCoreViewSet):
         if company_name:
             queryset = queryset.filter(company__name__icontains=company_name)
         if sector_id:
-            # This will be a level 0 sector id;
-            # We want to find and return all leads with sectors that have this ancestor
-            sector = Sector.objects.get(pk=sector_id)
-            descendent_sectors = sector.get_descendants(include_self=True)
-            queryset = queryset.filter(sector__in=descendent_sectors)
+            try:
+                # This will be a level 0 sector id;
+                # We want to find and return all leads with sectors that have this ancestor
+                sector = Sector.objects.get(pk=sector_id)
+                descendent_sectors = sector.get_descendants(include_self=True)
+                queryset = queryset.filter(sector__in=descendent_sectors)
+            except Exception:
+                queryset = queryset.none()
         if value is not None:
-            if value.lower() == 'high':
+            if value.lower().strip() == 'high':
                 queryset = queryset.filter(is_high_value=True)
-            if value.lower() == 'low':
+            if value.lower().strip() == 'low':
                 queryset = queryset.filter(is_high_value=False)
 
         return queryset

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -40,6 +40,25 @@ class EYBLeadViewSet(HawkResponseSigningMixin, SoftDeleteCoreViewSet):
             return CreateEYBLeadSerializer
         return RetrieveEYBLeadSerializer
 
+    def get_queryset(self):
+        """Apply filters to queryset based on query parameters (in GET operations)."""
+        queryset = super().get_queryset()
+        company_name = self.request.query_params.get('company')
+        sector_id = self.request.query_params.get('sector')
+        value = self.request.query_params.get('value')
+
+        if company_name:
+            queryset = queryset.filter(company__name__icontains=company_name)
+        if sector_id:
+            queryset = queryset.filter(sector__pk=sector_id)
+        if value is not None:
+            if value.lower() in ['high', 'h']:
+                queryset = queryset.filter(is_high_value=True)
+            elif value.lower() in ['low', 'l']:
+                queryset = queryset.filter(is_high_value=False)
+
+        return queryset
+
     def create(self, request):
         """POST route definition.
 


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR adds query parameters to the EYB lead retrieve view so that users can filter the leads collection page in the frontend (currently being worked on).

Specifically, users can filter by:
- Company name
- Sector (this finds leads with sectors that have the chosen sector as an ancestor)
- Value of lead ('high' or 'low')

### Test Instructions

After generating some test data with the factory:

```python
from datahub.investment_lead.test.factories import EYBLeadFactory
EYBLeadFactory.create_batch(20)
```

You can filter the leads by passing in values for each query parameter:

```
http://localhost:8000/v4/investment-lead/eyb?company=name&sector=uuid&value=high/low
```

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
