### PR TITLE
Improve queries used by opensearch sync

### DIFF
--- a/datahub/search/company_activity/apps.py
+++ b/datahub/search/company_activity/apps.py
@@ -16,7 +16,7 @@ class CompanyActivitySearchApp(SearchApp):
         'company',
         'interaction',
         'interaction__communication_channel',
-        'interaction__service',
+        'interaction__service__parent',
         'referral',
         'referral__contact',
         'referral__created_by',

--- a/datahub/search/large_capital_opportunity/apps.py
+++ b/datahub/search/large_capital_opportunity/apps.py
@@ -17,20 +17,27 @@ class LargeCapitalOpportunitySearchApp(SearchApp):
     export_permission = f'opportunity.{LargeCapitalOpportunityPermission.export}'
     exclude_from_global_search = True
     queryset = DBLargeCapitalOpportunity.objects.select_related(
+        'created_by',
+        'created_by__dit_team',
         'lead_dit_relationship_manager',
+        'lead_dit_relationship_manager__dit_team',
+        'opportunity_value_type',
         'type',
         'status',
         'required_checks_conducted',
         'required_checks_conducted_by',
+        'required_checks_conducted_by__dit_team',
         'estimated_return_rate',
     ).prefetch_related(
         'promoters',
         'other_dit_contacts',
         'investment_projects',
+        'investment_projects__investmentprojectcode',
         'asset_classes',
         'investment_types',
         'sources_of_funding',
         'time_horizons',
         'construction_risks',
         'uk_region_locations',
+        'reasons_for_abandonment',
     )

--- a/datahub/search/large_investor_profile/apps.py
+++ b/datahub/search/large_investor_profile/apps.py
@@ -15,7 +15,10 @@ class LargeInvestorProfileSearchApp(SearchApp):
     export_permission = f'investor_profile.{InvestorProfilePermission.export}'
     exclude_from_global_search = True
     queryset = DBLargeCapitalInvestorProfile.objects.select_related(
+        'created_by',
+        'created_by__dit_team',
         'investor_company',
+        'investor_company__address_country',
         'investor_type',
         'required_checks_conducted',
         'minimum_return_rate',

--- a/datahub/search/omis/apps.py
+++ b/datahub/search/omis/apps.py
@@ -18,11 +18,16 @@ class OrderSearchApp(SearchApp):
     view_permissions = (f'order.{OrderPermission.view}',)
     export_permission = f'order.{OrderPermission.export}'
     queryset = DBOrder.objects.select_related(
+        'billing_address_country',
+        'cancellation_reason',
+        'cancelled_by',
         'company',
+        'completed_by',
         'contact',
-        'created_by',
+        'created_by__dit_team',
         'primary_market',
-        'sector',
+        'sector__parent__parent',
+        'uk_region',
     ).prefetch_related(
         'service_types',
         Prefetch('assignees', queryset=OrderAssignee.objects.select_related('adviser__dit_team')),

--- a/datahub/search/task/apps.py
+++ b/datahub/search/task/apps.py
@@ -10,6 +10,9 @@ class TaskSearchApp(SearchApp):
     search_model = Task
     view_permissions = (f'task.{TaskPermission.view_task}',)
     queryset = DBTask.objects.all().select_related(
+        'created_by',
         'investment_project',
         'interaction',
+    ).prefetch_related(
+        'advisers',
     )


### PR DESCRIPTION
### Description of change

Improves the querysets used to sync data to Opensearch. The additional queries which I can't get to 0 involve the sector model which uses [Django MPTT](https://django-mptt.readthedocs.io/en/latest/). This grabs ancestors, siblings etc and I'm not sure how to prefetch these yet.

**Improvements**
**CompanyActivity**
Total additional queries before: 1
Total additional queries after: 0

**LargeCaptialInvestment**
Total additional queries before: 7
Total additional queries after: 0

**LargeInvestorProfile**
Total additional queries before: 3
Total additional queries after: 0

**Omis**
Total additional queries before: 6
Total additional queries after: 1

**Task**
Total additional queries before: 2
Total additional queries after: 0

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [ ] Is the CircleCI build passing?

