### PR TITLE
Allow multiple sectors and values in EYB lead retrieve query parameters

### DIFF
--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -111,6 +111,10 @@ class Sector(Enum):
         'Consumer and retail',
         '355f977b-8ac3-e211-a646-e4115bead28a',
     )
+    defence = Constant(
+        'Defence',
+        '7dbb9fc6-5f95-e211-a939-e4115bead28a',
+    )
     defence_air = Constant(
         'Defence : Air',
         '03dbd3fb-24e4-421e-bcc1-1dfcd63b2eeb',

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -286,3 +286,18 @@ class TestEYBLeadListAPI(APITestMixin):
         response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': ['high', 'low']})
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 3
+
+    def test_filter_by_invalid_value(self, test_user_with_view_permissions):
+        """Test filtering EYB leads by an invalid value returns no leads"""
+        EYBLeadFactory(is_high_value=True)
+        EYBLeadFactory(is_high_value=True)
+        EYBLeadFactory(is_high_value=False)
+        api_client = self.create_api_client(user=test_user_with_view_permissions)
+
+        response = api_client.get(EYB_LEAD_COLLECTION_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 3
+
+        response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': 'invalid_value'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 0

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -51,15 +51,12 @@ class EYBLeadViewSet(HawkResponseSigningMixin, SoftDeleteCoreViewSet):
         if company_name:
             queryset = queryset.filter(company__name__icontains=company_name)
         if sector_ids:
-            try:
-                # This will be a list of level 0 sector ids;
-                # We want to find and return all leads with sectors that have these ancestors
-                descendent_sectors = []
-                for sector in Sector.objects.filter(pk__in=sector_ids):
-                    descendent_sectors.extend(sector.get_descendants(include_self=True))
-                queryset = queryset.filter(sector__in=descendent_sectors)
-            except Exception:
-                queryset = queryset.none()
+            # This will be a list of level 0 sector ids;
+            # We want to find and return all leads with sectors that have these ancestors
+            descendent_sectors = []
+            for sector in Sector.objects.filter(pk__in=sector_ids):
+                descendent_sectors.extend(sector.get_descendants(include_self=True))
+            queryset = queryset.filter(sector__in=descendent_sectors)
         if values:
             value_mappings = {
                 'high': True,

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -45,25 +45,32 @@ class EYBLeadViewSet(HawkResponseSigningMixin, SoftDeleteCoreViewSet):
         """Apply filters to queryset based on query parameters (in GET operations)."""
         queryset = super().get_queryset()
         company_name = self.request.query_params.get('company')
-        sector_id = self.request.query_params.get('sector')
-        value = self.request.query_params.get('value')
+        sector_ids = self.request.query_params.getlist('sector')
+        values = self.request.query_params.getlist('value')
 
         if company_name:
             queryset = queryset.filter(company__name__icontains=company_name)
-        if sector_id:
+        if sector_ids:
             try:
-                # This will be a level 0 sector id;
-                # We want to find and return all leads with sectors that have this ancestor
-                sector = Sector.objects.get(pk=sector_id)
-                descendent_sectors = sector.get_descendants(include_self=True)
+                # This will be a list of level 0 sector ids;
+                # We want to find and return all leads with sectors that have these ancestors
+                descendent_sectors = []
+                for sector in Sector.objects.filter(pk__in=sector_ids):
+                    descendent_sectors.extend(sector.get_descendants(include_self=True))
                 queryset = queryset.filter(sector__in=descendent_sectors)
             except Exception:
                 queryset = queryset.none()
-        if value is not None:
-            if value.lower().strip() == 'high':
-                queryset = queryset.filter(is_high_value=True)
-            if value.lower().strip() == 'low':
-                queryset = queryset.filter(is_high_value=False)
+        if values:
+            value_mappings = {
+                'high': True,
+                'low': False,
+            }
+            booleans_to_filter_by = []
+            for value in values:
+                value_string = value.lower().strip()
+                if value_string in value_mappings.keys():
+                    booleans_to_filter_by.append(value_mappings[value_string])
+            queryset = queryset.filter(is_high_value__in=booleans_to_filter_by)
 
         return queryset
 


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR allows multiple sector id's and values to be passed as query parameters to the EYB lead retrieve endpoint. 

### Test Instructions

1. Generate some EYB leads using the factory

```python
from datahub.investment_lead.test.factories import EYBLeadFactory
EYBLeadFactory.create_batch(100)
```

2. Filter the leads by multiple sectors:

```
v4/investment-lead/eyb?sector=<sector_id>&sector=<other_sector_id>
```

3. Or multiple values:

```
v4/investment-lead/eyb?value=high&value=low
```

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
