### PR TITLE
CLS2-916 Likelihood of landing mandatory at Assign PM stage

### DIFF
--- a/datahub/investment/project/test/test_validate.py
+++ b/datahub/investment/project/test/test_validate.py
@@ -15,7 +15,10 @@ from datahub.investment.project.serializers import (
     TEAM_FIELDS,
     VALUE_FIELDS,
 )
-from datahub.investment.project.test.factories import InvestmentProjectFactory
+from datahub.investment.project.test.factories import (
+    AssignPMInvestmentProjectFactory,
+    InvestmentProjectFactory,
+)
 from datahub.investment.project.validate import (
     _get_desired_stage_order,
     validate,
@@ -368,6 +371,15 @@ def test_validate_verify_win_instance_with_cond_fields():
     )
     errors = validate(instance=project)
     assert not errors
+
+
+def test_likelihood_to_land_assign_pm_stage_missing_error():
+    """Tests missing likelihood to land missing at assign pm stage."""
+    project = AssignPMInvestmentProjectFactory(
+        likelihood_to_land_id=None,
+    )
+    errors = validate(instance=project)
+    assert 'likelihood_to_land' in errors
 
 
 @pytest.mark.parametrize(

--- a/datahub/investment/project/test/test_validate.py
+++ b/datahub/investment/project/test/test_validate.py
@@ -16,7 +16,7 @@ from datahub.investment.project.serializers import (
     VALUE_FIELDS,
 )
 from datahub.investment.project.test.factories import (
-    AssignPMInvestmentProjectFactory,
+    ActiveInvestmentProjectFactory,
     InvestmentProjectFactory,
 )
 from datahub.investment.project.validate import (
@@ -375,7 +375,7 @@ def test_validate_verify_win_instance_with_cond_fields():
 
 def test_likelihood_to_land_assign_pm_stage_missing_error():
     """Tests missing likelihood to land missing at assign pm stage."""
-    project = AssignPMInvestmentProjectFactory(
+    project = ActiveInvestmentProjectFactory(
         likelihood_to_land_id=None,
     )
     errors = validate(instance=project)

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -1468,7 +1468,7 @@ class TestPartialUpdateView(APITestMixin):
         project = AssignPMInvestmentProjectFactory(
             project_assurance_adviser=adviser,
             project_manager=adviser,
-            likelihood_to_land_id=None
+            likelihood_to_land_id=None,
         )
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
         request_data = {

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -1462,6 +1462,27 @@ class TestPartialUpdateView(APITestMixin):
             'project_manager': ['This field is required.'],
         }
 
+    def test_change_stage_active_missing_likelihood_to_land_failure(self):
+        """Tests moving a complete project to the Active stage."""
+        adviser = AdviserFactory()
+        project = AssignPMInvestmentProjectFactory(
+            project_assurance_adviser=adviser,
+            project_manager=adviser,
+            likelihood_to_land_id=None
+        )
+        url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
+        request_data = {
+            'stage': {
+                'id': constants.InvestmentProjectStage.active.value.id,
+            },
+        }
+        response = self.api_client.patch(url, data=request_data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data == {
+            'likelihood_to_land': ['This field is required.'],
+        }
+
     def test_change_stage_active_success(self):
         """Tests moving a complete project to the Active stage."""
         adviser = AdviserFactory()

--- a/datahub/investment/project/validate.py
+++ b/datahub/investment/project/validate.py
@@ -64,6 +64,7 @@ class InvestmentProjectStageValidationConfig:
             'uk_company': Stage.verify_win.value,
             'investor_type': Stage.verify_win.value,
             'level_of_involvement': Stage.verify_win.value,
+            'likelihood_to_land': Stage.assign_pm.value,
         }
 
     @classmethod

--- a/datahub/investment/project/validate.py
+++ b/datahub/investment/project/validate.py
@@ -64,7 +64,7 @@ class InvestmentProjectStageValidationConfig:
             'uk_company': Stage.verify_win.value,
             'investor_type': Stage.verify_win.value,
             'level_of_involvement': Stage.verify_win.value,
-            'likelihood_to_land': Stage.assign_pm.value,
+            'likelihood_to_land': Stage.active.value,
         }
 
     @classmethod

--- a/datahub/search/investment/test/test_signals.py
+++ b/datahub/search/investment/test/test_signals.py
@@ -343,7 +343,9 @@ def test_incomplete_fields_syncs_when_project_changes(opensearch_with_signals):
     """
     When project fields change, the incomplete fields should update accordingly.
     """
-    project = InvestmentProjectFactory(stage_id=InvestmentProjectStage.won.value.id)
+    project = InvestmentProjectFactory(
+        stage_id=InvestmentProjectStage.won.value.id,
+        likelihood_to_land_id=None)
     adviser = AdviserFactory()
 
     opensearch_with_signals.indices.refresh()
@@ -375,6 +377,7 @@ def test_incomplete_fields_syncs_when_project_changes(opensearch_with_signals):
         'uk_company',
         'investor_type',
         'level_of_involvement',
+        'likelihood_to_land',
         'total_investment',
         'uk_region_locations',
         'foreign_equity_investment',
@@ -413,6 +416,7 @@ def test_incomplete_fields_syncs_when_project_changes(opensearch_with_signals):
         'uk_company',
         'investor_type',
         'level_of_involvement',
+        'likelihood_to_land',
         'competitor_countries',
         'uk_region_locations',
         'average_salary',


### PR DESCRIPTION
### Description of change

This PR addresses [CLS2-916](https://uktrade.atlassian.net/browse/CLS2-916) and makes the field `likelihood_to_land` mandatory at `Assign PM` stage of an `InvestmentProject`

API counterpart of https://github.com/uktrade/data-hub-frontend/pull/7194

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.


[CLS2-916]: https://uktrade.atlassian.net/browse/CLS2-916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ