### PR TITLE
Schedule ingest activity data with instance

### DIFF
--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -124,7 +124,7 @@ def schedule_jobs():
         description='Update companies from dnb service',
     )
     job_scheduler(
-        function=CompanyActivityIngestionTask.ingest_activity_data,
+        function=CompanyActivityIngestionTask().ingest_activity_data,
         cron=EVERY_HOUR,
         description='Check S3 for new Company Activity data files and schedule ingestion',
     )

--- a/datahub/company_activity/tasks/ingest_company_activity.py
+++ b/datahub/company_activity/tasks/ingest_company_activity.py
@@ -18,12 +18,10 @@ GREAT_PREFIX = f'{PREFIX}GreatGovUKFormsPipeline/'
 
 
 class CompanyActivityIngestionTask:
-    def __init__(self):
-        self.s3_client = boto3.client('s3', REGION)
-
     def _list_objects(self, bucket_name, prefix):
         """Returns a list all objects with specified prefix."""
-        response = self.s3_client.list_objects(
+        s3_client = boto3.client('s3', REGION)
+        response = s3_client.list_objects(
             Bucket=bucket_name,
             Prefix=prefix,
         )

--- a/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
@@ -60,12 +60,8 @@ class TestCompanyActivityIngestionTasks:
 
         scheduler = Scheduler(queue, connection=Redis.from_url(settings.REDIS_BASE_URL))
         scheduled_jobs = scheduler.get_jobs()
-        ingestion_task = (
-            'datahub.company_activity.tasks.ingest_company_activity.'
-            'CompanyActivityIngestionTask.ingest_activity_data'
-        )
+        ingestion_task = 'ingest_activity_data'
         scheduled_job = [job for job in scheduled_jobs if job.func_name == ingestion_task][0]
-        assert scheduled_job.func_name == ingestion_task
         assert scheduled_job.meta['cron_string'] == EVERY_HOUR
 
         # Prevents the scheduler loop from running after tests finish by unloading the module again


### PR DESCRIPTION
### Description of change

Fix:

```
{"EventMessage": "[Job 2c8848c1-bd64-4529-9fda-fb113319de98]: exception raised while executing (datahub.company_activity.tasks.ingest_company_activity.CompanyActivityIngestionTask.ingest_activity_data)\nTraceback (most recent call last):\n File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.10/site-packages/rq/worker.py\", line 1430, in perform_job\n rv = job.perform()\n File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.10/site-packages/rq/job.py\", line 1280, in perform\n self._result = self._execute()\n File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.10/site-packages/rq/job.py\", line 1317, in _execute\n result = self.func(*self.args, **self.kwargs)\nTypeError: CompanyActivityIngestionTask.ingest_activity_data() missing 1 required positional argument: 'self'\n", "EventCount": 1, "EventStartTime": "2024-10-02T11:00:15.806268", "EventEndTime": "2024-10-02T11:00:15.806268", "EventType": "rq.worker", "EventResult": "NA", "EventSeverity": "Medium", "EventOriginalSeverity": "ERROR", "EventSchema": "ProcessEvent", "EventSchemaVersion": "0.1.4", "ActingAppType": "Django", "AdditionalFields": {"DjangoLogFormatterAsimVersion": "0.0.6", "TraceHeaders": {}}}
```

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
