### PR TITLE
Check for no current RQ job running

### DIFF
--- a/datahub/company_activity/tasks/ingest_company_activity.py
+++ b/datahub/company_activity/tasks/ingest_company_activity.py
@@ -56,7 +56,7 @@ class CompanyActivityIngestionTask:
                 return True
         for worker in Worker.all(queue=rq_queue):
             job = worker.get_current_job()
-            if self._job_matches(job, file):
+            if job is not None and self._job_matches(job, file):
                 return True
         return False
 

--- a/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
@@ -190,7 +190,8 @@ class TestCompanyActivityIngestionTasks:
     @mock_aws
     def test_no_running_job(self, mock_worker, mock_scheduler, test_files):
         """
-        Test that when that already queued checks succeed when there are no running jobs
+        Test that the check for an already running ingestion job succeeds
+        when there are no jobs currently running
         """
         setup_s3_bucket(BUCKET, test_files)
         redis = Redis.from_url(settings.REDIS_BASE_URL)

--- a/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
@@ -181,6 +181,29 @@ class TestCompanyActivityIngestionTasks:
         assert rq_queue.count == initial_job_count
 
     @pytest.mark.django_db
+    # Patch so that we can test the job is queued, rather than having it be run instantly
+    @patch(
+        'datahub.core.queues.job_scheduler.DataHubScheduler',
+        return_value=DataHubScheduler(is_async=True),
+    )
+    @patch('datahub.company_activity.tasks.ingest_company_activity.Worker')
+    @mock_aws
+    def test_no_running_job(self, mock_worker, mock_scheduler, test_files):
+        """
+        Test that when that already queued checks succeed when there are no running jobs
+        """
+        setup_s3_bucket(BUCKET, test_files)
+        redis = Redis.from_url(settings.REDIS_BASE_URL)
+        rq_queue = Queue('long-running', connection=redis)
+        rq_queue.empty()
+        initial_job_count = rq_queue.count
+        mock_worker_instance = Worker(['long-running'], connection=redis)
+        mock_worker_instance.get_current_job = MagicMock(return_value=None)
+        mock_worker.all.return_value = [mock_worker_instance]
+        ingest_activity_data()
+        assert rq_queue.count == initial_job_count + 1
+
+    @pytest.mark.django_db
     @mock_aws
     def test_child_job(self, caplog, test_files):
         """
@@ -188,6 +211,9 @@ class TestCompanyActivityIngestionTasks:
         """
         new_file = GREAT_PREFIX + '20240920T000000/full_ingestion.jsonl.gz'
         setup_s3_bucket(BUCKET, test_files)
+        redis = Redis.from_url(settings.REDIS_BASE_URL)
+        rq_queue = Queue('long-running', connection=redis)
+        rq_queue.empty()
         for file in test_files:
             if not file == new_file:
                 IngestedFile.objects.create(filepath=file)


### PR DESCRIPTION
### Description of change

Fix checking currently running job when there isn't one

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
