### PR TITLE
Fix flaky dataset task test.

### DIFF
--- a/datahub/dataset/task/test/test_views.py
+++ b/datahub/dataset/task/test/test_views.py
@@ -31,7 +31,10 @@ def get_expected_data_from_task(task):
         'due_date': format_date_or_datetime(task.due_date),
         'reminder_days': task.reminder_days,
         'email_reminders_enabled': task.email_reminders_enabled,
-        'adviser_ids': [str(adviser.id) for adviser in task.advisers.all().order_by('first_name')],
+        'adviser_ids': [str(adviser.id) for adviser in task.advisers.all().order_by(
+            'first_name',
+            'id',
+        )],
         'reminder_date': task.reminder_date,
         'investment_project_id': str(task.investment_project.id)
         if task.investment_project else None,

--- a/datahub/dataset/task/views.py
+++ b/datahub/dataset/task/views.py
@@ -11,7 +11,10 @@ class TasksDatasetView(BaseFilterDatasetView):
     def get_dataset(self, request):
         """Returns queryset of Task records"""
         queryset = Task.objects.annotate(
-            adviser_ids=ArrayAgg('advisers__id', ordering='advisers__first_name'),
+            adviser_ids=ArrayAgg('advisers__id', ordering=[
+                'advisers__first_name',
+                'advisers__id',
+            ]),
         ).values(
             'created_on',
             'created_by_id',


### PR DESCRIPTION
### Description of change

If the advisers had the same first name, they could be in different order than the test expect them to be. 
It caused test to fail occasionally.
The fix additionally orders advisers by id, so the order is now deterministic.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
