### PR TITLE
CLS2-976 Add queryset to enable EYB leads to be filtered by country

### DIFF
--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -9,7 +9,7 @@ from datahub.core.test_utils import APITestMixin
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.test.factories import EYBLeadFactory
 from datahub.investment_lead.test.utils import assert_retrieved_eyb_lead_data
-from datahub.metadata.models import Sector, Country
+from datahub.metadata.models import Country, Sector
 
 
 EYB_LEAD_COLLECTION_URL = reverse('api-v4:investment-lead:eyb-lead-collection')
@@ -246,7 +246,9 @@ class TestEYBLeadListAPI(APITestMixin):
         response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'country': default_country.pk})
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
-        country_ids_in_results = set([lead['address']['country']['id'] for lead in response.data['results']])
+        country_ids_in_results = set(
+            [lead['address']['country']['id'] for lead in response.data['results']]
+        )
         assert {str(default_country.pk)} == country_ids_in_results
 
     # TODO: complete test with multiple countries (see sector tests above for example):
@@ -256,4 +258,3 @@ class TestEYBLeadListAPI(APITestMixin):
     # TODO: complete test with a non existent country (see sector tests above for example):
     # def test_filter_by_non_existing_country(self, test_user_with_view_permissions):
     #     """Test filtering EYB leads by non existent country is handled without error."""
-

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -9,7 +9,7 @@ from datahub.core.test_utils import APITestMixin
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.test.factories import EYBLeadFactory
 from datahub.investment_lead.test.utils import assert_retrieved_eyb_lead_data
-from datahub.metadata.models import Sector
+from datahub.metadata.models import Sector, Country
 
 
 EYB_LEAD_COLLECTION_URL = reverse('api-v4:investment-lead:eyb-lead-collection')
@@ -230,3 +230,30 @@ class TestEYBLeadListAPI(APITestMixin):
         response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': 'invalid_value'})
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 0
+
+    def test_filter_by_country(self, test_user_with_view_permissions):
+        """Test filtering EYB leads by one country."""
+        default_country = Country.objects.get(pk=constants.Country.france.value.id)
+        unrelated_country = Country.objects.get(pk=constants.Country.greece.value.id)
+        EYBLeadFactory(address_country_id=default_country.id)
+        EYBLeadFactory(address_country_id=unrelated_country.id)
+
+        api_client = self.create_api_client(user=test_user_with_view_permissions)
+        response = api_client.get(EYB_LEAD_COLLECTION_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+
+        response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'country': default_country.pk})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        country_ids_in_results = set([lead['address']['country']['id'] for lead in response.data['results']])
+        assert {str(default_country.pk)} == country_ids_in_results
+
+    # TODO: complete test with multiple countries (see sector tests above for example):
+    # def test_filter_by_multiple_countries(self, test_user_with_view_permissions):
+    #     """Test filtering EYB leads by multiple countries."""
+
+    # TODO: complete test with a non existent country (see sector tests above for example):
+    # def test_filter_by_non_existing_country(self, test_user_with_view_permissions):
+    #     """Test filtering EYB leads by non existent country is handled without error."""
+

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -276,7 +276,7 @@ class TestEYBLeadListAPI(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
         country_ids_in_results = set(
-            [lead['address']['country']['id'] for lead in response.data['results']]
+            [lead['address']['country']['id'] for lead in response.data['results']],
         )
         assert {
             str(france_country.pk),

--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -247,7 +247,7 @@ class TestEYBLeadListAPI(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         country_ids_in_results = set(
-            [lead['address']['country']['id'] for lead in response.data['results']]
+            [lead['address']['country']['id'] for lead in response.data['results']],
         )
         assert {str(default_country.pk)} == country_ids_in_results
 

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -19,10 +19,13 @@ class EYBLeadViewSet(SoftDeleteCoreViewSet):
         queryset = EYBLead.objects.filter(archived=False).exclude(
             Q(user_hashed_uuid='') | Q(triage_hashed_uuid=''),
         )
+        country_ids = self.request.query_params.getlist('country')
         company_name = self.request.query_params.get('company')
         sector_ids = self.request.query_params.getlist('sector')
         values = self.request.query_params.getlist('value')
 
+        if country_ids:
+            queryset = queryset.filter(company_location__id__in=country_ids)
         if company_name:
             queryset = queryset.filter(company__name__icontains=company_name)
         if sector_ids:

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -25,7 +25,7 @@ class EYBLeadViewSet(SoftDeleteCoreViewSet):
         values = self.request.query_params.getlist('value')
 
         if country_ids:
-            queryset = queryset.filter(company_location__id__in=country_ids)
+            queryset = queryset.filter(address_country__id__in=country_ids)
         if company_name:
             queryset = queryset.filter(company__name__icontains=company_name)
         if sector_ids:


### PR DESCRIPTION
### Description of change

Adds a queryset to enable EYB leads to be filtered by country on the frontend

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
