### PR TITLE
Fix flaky merge contact test.

### DIFF
--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -183,7 +183,7 @@ class ContactFactory(factory.django.DjangoModelFactory):
     full_telephone_number = '+44 123456789'
     address_same_as_company = True
     created_on = now()
-    archived_documents_url_path = factory.Faker('uri_path')
+    archived_documents_url_path = factory.LazyFunction(lambda: f'/documents/{uuid.uuid4()}')
 
     class Meta:
         model = 'company.Contact'


### PR DESCRIPTION
### Description of change

The factory.Faker('uri_path') has very low entropy, so there is a great chance that multiple contacts will have exactly the same `archived_documents_url_path`. That means the test `test_merge_succeeds_when_target_contact_and_source_contact_have_complete_info` would occasionally fail as it checks if contacts have distinct `archived_documents_url_path`.
The fix changes how the path is generated, so that it is always unique.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
