### PR TITLE
Increase Ingest Great Data job timeout

### DIFF
--- a/datahub/company_activity/tasks/ingest_company_activity.py
+++ b/datahub/company_activity/tasks/ingest_company_activity.py
@@ -18,6 +18,7 @@ REGION = env('AWS_DEFAULT_REGION', default='eu-west-2')
 BUCKET = f"data-flow-bucket-{env('ENVIRONMENT', default='')}"
 PREFIX = 'data-flow/exports/'
 GREAT_PREFIX = f'{PREFIX}GreatGovUKFormsPipeline/'
+TWO_HOURS_IN_SECONDS = 7200
 
 
 def ingest_activity_data():
@@ -88,6 +89,7 @@ class CompanyActivityIngestionTask:
             function=ingest_great_data,
             function_kwargs={'bucket': BUCKET, 'file': latest_file},
             queue_name='long-running',
+            job_timeout=TWO_HOURS_IN_SECONDS,
             description='Ingest Great data file',
         )
         logger.info(f'Scheduled ingestion of {latest_file}')

--- a/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
@@ -18,7 +18,7 @@ from rq_scheduler import Scheduler
 from datahub.company_activity.models import IngestedFile
 from datahub.company_activity.tasks import ingest_great_data
 from datahub.company_activity.tasks.ingest_company_activity import (
-    BUCKET, GREAT_PREFIX, ingest_activity_data, REGION,
+    BUCKET, GREAT_PREFIX, ingest_activity_data, REGION, TWO_HOURS_IN_SECONDS,
 )
 from datahub.core.queues.constants import EVERY_HOUR
 from datahub.core.queues.job_scheduler import job_scheduler
@@ -103,6 +103,7 @@ class TestCompanyActivityIngestionTasks:
         assert job.func_name == ingestion_task
         assert job.kwargs['bucket'] == BUCKET
         assert job.kwargs['file'] == new_file
+        assert job.timeout == TWO_HOURS_IN_SECONDS
 
     @pytest.mark.django_db
     # Patch so that we can test the job is queued, rather than having it be run instantly


### PR DESCRIPTION
### Description of change

The job currently times out after the default 3 mins having processed ~ 48,500 of the ~490,000 Great records. This PR sets the timeout to 3 hours. Since the dataset will keep growing it includes plenty of buffer.

Timeout log: https://elk.ci.uktrade.digital/_dashboards/app/discover#/doc/928da200-ccd5-11ee-9824-750186e3b9e4/copilot-service-logs-000141?id=Q8Qri5IB_N2COvfPJsSx

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
