### PR TITLE
Disable Great Ingestion Job for now

### DIFF
--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -14,7 +14,7 @@ from datahub.company.tasks.adviser import schedule_automatic_adviser_deactivate
 from datahub.company.tasks.company import schedule_automatic_company_archive
 from datahub.company.tasks.contact import schedule_automatic_contact_archive
 from datahub.company.tasks.export_potential import update_company_export_potential_from_csv
-from datahub.company_activity.tasks.ingest_company_activity import ingest_activity_data
+# from datahub.company_activity.tasks.ingest_company_activity import ingest_activity_data
 from datahub.core.queues.constants import (
     EVERY_EIGHT_AM,
     EVERY_EIGHT_THIRTY_AM_ON_FIRST_EACH_MONTH,
@@ -123,11 +123,11 @@ def schedule_jobs():
         cron=EVERY_MIDNIGHT,
         description='Update companies from dnb service',
     )
-    job_scheduler(
-        function=ingest_activity_data,
-        cron=EVERY_HOUR,
-        description='Check S3 for new Company Activity data files and schedule ingestion',
-    )
+    # job_scheduler(
+    #     function=ingest_activity_data,
+    #     cron=EVERY_HOUR,
+    #     description='Check S3 for new Company Activity data files and schedule ingestion',
+    # )
 
     if settings.ENABLE_ESTIMATED_LAND_DATE_REMINDERS:
         job_scheduler(

--- a/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
@@ -1,6 +1,6 @@
-import importlib
+# import importlib
 import logging
-import sys
+# import sys
 
 from unittest.mock import MagicMock, patch
 
@@ -13,14 +13,14 @@ from moto import mock_aws
 from redis import Redis
 from rq import Queue, Worker
 from rq.job import Job
-from rq_scheduler import Scheduler
+# from rq_scheduler import Scheduler
 
 from datahub.company_activity.models import IngestedFile
 from datahub.company_activity.tasks import ingest_great_data
 from datahub.company_activity.tasks.ingest_company_activity import (
     BUCKET, GREAT_PREFIX, ingest_activity_data, REGION,
 )
-from datahub.core.queues.constants import EVERY_HOUR
+# from datahub.core.queues.constants import EVERY_HOUR
 from datahub.core.queues.job_scheduler import job_scheduler
 from datahub.core.queues.scheduler import DataHubScheduler
 
@@ -49,24 +49,25 @@ def setup_s3_bucket(bucket_name, test_files):
 
 
 class TestCompanyActivityIngestionTasks:
-    @patch('os.system')
-    def test_company_activity_ingestion_task_schedule(self, mock_system):
-        """
-        Test that a task is scheduled to check for new Company Activity data
-        """
-        # Import inside test to prevent the os.system call from running before the patch
-        cron = importlib.import_module('cron-scheduler')
-        cron.schedule_jobs()
-        queue = 'long-running'
+    # @patch('os.system')
+    # def test_company_activity_ingestion_task_schedule(self, mock_system):
+    #     """
+    #     Test that a task is scheduled to check for new Company Activity data
+    #     """
+    #     # Import inside test to prevent the os.system call from running before the patch
+    #     cron = importlib.import_module('cron-scheduler')
+    #     cron.schedule_jobs()
+    #     queue = 'long-running'
 
-        scheduler = Scheduler(queue, connection=Redis.from_url(settings.REDIS_BASE_URL))
-        scheduled_jobs = scheduler.get_jobs()
-        func = 'datahub.company_activity.tasks.ingest_company_activity.ingest_activity_data'
-        scheduled_job = [job for job in scheduled_jobs if job.func_name == func][0]
-        assert scheduled_job.meta['cron_string'] == EVERY_HOUR
+    #     scheduler = Scheduler(queue, connection=Redis.from_url(settings.REDIS_BASE_URL))
+    #     scheduled_jobs = scheduler.get_jobs()
+    #     func = 'datahub.company_activity.tasks.ingest_company_activity.ingest_activity_data'
+    #     scheduled_job = [job for job in scheduled_jobs if job.func_name == func][0]
+    #     assert scheduled_job.meta['cron_string'] == EVERY_HOUR
 
-        # Prevents the scheduler loop from running after tests finish by unloading the module again
-        sys.modules.pop('cron-scheduler')
+    #     # Prevents the scheduler loop from running after tests finish by unloading the
+    #     # module again
+    #     sys.modules.pop('cron-scheduler')
 
     @pytest.mark.django_db
     # Patch so that we can test the job is queued, rather than having it be run instantly


### PR DESCRIPTION
### Description of change

Disabling to stop the flood of Sentry alerts until we figure out how to map Company and Country from Great data properly.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
