### PR TITLE
Add legacy Export wins migration commands.

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_legacy_export_wins_company_link.py
+++ b/datahub/dbmaintenance/management/commands/update_legacy_export_wins_company_link.py
@@ -1,0 +1,39 @@
+import reversion
+
+from django.core.management.base import CommandError
+
+from datahub.company.models import Company
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.export_win.models import Win
+
+
+class Command(CSVBaseCommand):
+    """Command to update legacy Export Win mapping to Data Hub Company."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        export_win_id = parse_uuid(row['export_win_id'])
+        company_id = parse_uuid(row['data_hub_id']) if row['data_hub_id'] else None
+
+        if company_id:
+            try:
+                Company.objects.get(pk=company_id)
+            except Company.DoesNotExist:
+                raise CommandError(f'Company with ID {company_id} does not exist')
+
+            export_win = Win.objects.get(id=export_win_id)
+
+            if export_win.company_id == company_id:
+                return
+
+            export_win.company_id = company_id
+
+            if not simulate:
+                with reversion.create_revision():
+                    export_win.save(
+                        update_fields=(
+                            'company_id',
+                        ),
+                    )
+                    reversion.set_comment('Legacy export wins company migration.')

--- a/datahub/dbmaintenance/management/commands/update_legacy_export_wins_data.py
+++ b/datahub/dbmaintenance/management/commands/update_legacy_export_wins_data.py
@@ -1,0 +1,41 @@
+import reversion
+
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.export_win.models import Win
+
+
+class Command(CSVBaseCommand):
+    """Command to update legacy Export Win data."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        export_win_id = parse_uuid(row['id'])
+
+        export_win = Win.objects.get(id=export_win_id)
+        export_win.company_name = row['company_name']
+        export_win.lead_officer_name = row['lead_officer_name']
+        export_win.lead_officer_email_address = row['lead_officer_email_address']
+        export_win.adviser_name = row['user_name']
+        export_win.adviser_email_address = row['user_email']
+        export_win.line_manager_name = row['line_manager_name']
+        export_win.customer_name = row['customer_name']
+        export_win.customer_job_title = row['customer_job_title']
+        export_win.customer_email_address = row['customer_email_address']
+
+        if not simulate:
+            with reversion.create_revision():
+                export_win.save(
+                    update_fields=(
+                        'company_name',
+                        'lead_officer_name',
+                        'lead_officer_email_address',
+                        'adviser_name',
+                        'adviser_email_address',
+                        'line_manager_name',
+                        'customer_name',
+                        'customer_job_title',
+                        'customer_email_address',
+                    ),
+                )
+                reversion.set_comment('Legacy export wins data migration.')

--- a/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_company_link.py
+++ b/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_company_link.py
@@ -1,0 +1,102 @@
+from io import BytesIO
+from uuid import uuid4
+
+import pytest
+from django.core.management import call_command
+
+from reversion.models import Version
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.export_win.models import Win
+from datahub.export_win.test.factories import WinFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('ERROR')
+    companies = CompanyFactory.create_batch(4)
+    wins = WinFactory.create_batch(4, company=None)
+
+    uuids = [win.id for win in wins]
+    company_uuids = [company.id for company in companies]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_contents = ['export_win_id,data_hub_id']
+    for uuid, company_uuid in zip(uuids, company_uuids):
+        csv_contents.append(f'{uuid},{company_uuid}')
+
+    bad_company_id = uuid4()
+    csv_contents.append(f'{uuid4()},{bad_company_id}')
+
+    csv_content = '\n'.join(csv_contents)
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_legacy_export_wins_company_link', bucket, object_key)
+
+    for uuid, company in zip(uuids, companies):
+        win = Win.objects.get(id=uuid)
+        assert win.company_id == company.id
+
+        versions = Version.objects.get_for_object(win)
+        assert versions.count() == 1
+        comment = versions[0].revision.get_comment()
+        assert comment == 'Legacy export wins company migration.'
+
+    assert f'Company with ID {bad_company_id} does not exist' in caplog.text
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+    companies = CompanyFactory.create_batch(4)
+    wins = WinFactory.create_batch(4, company=None)
+
+    uuids = [win.id for win in wins]
+    company_uuids = [company.id for company in companies]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_contents = ['export_win_id,data_hub_id']
+    for uuid, company_uuid in zip(uuids, company_uuids):
+        csv_contents.append(f'{uuid},{company_uuid}')
+
+    bad_company_id = uuid4()
+    csv_contents.append(f'{uuid4()},{bad_company_id}')
+
+    csv_content = '\n'.join(csv_contents)
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_legacy_export_wins_company_link', bucket, object_key, simulate=True)
+
+    for uuid in uuids:
+        win = Win.objects.get(id=uuid)
+        assert win.company_id is None
+
+        versions = Version.objects.get_for_object(win)
+        assert versions.count() == 0
+
+    assert f'Company with ID {bad_company_id} does not exist' in caplog.text

--- a/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_data.py
+++ b/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_data.py
@@ -1,0 +1,222 @@
+from io import BytesIO
+
+import pytest
+from django.core.management import call_command
+
+from faker import Faker
+from reversion.models import Version
+
+from datahub.export_win.models import Win
+from datahub.export_win.test.factories import WinFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('ERROR')
+
+    fake = Faker()
+    wins = WinFactory.create_batch(4, company=None)
+
+    uuids = [win.id for win in wins]
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_contents = [
+        'id,company_name,lead_officer_name,lead_officer_email_address,user_name,'
+        'user_email,line_manager_name,customer_name,customer_job_title,'
+        'customer_email_address',
+    ]
+    company_names = [fake.company() for _ in range(4)]
+    lead_officer_names = [fake.name() for _ in range(4)]
+    lead_officer_email_addresses = [fake.email() for _ in range(4)]
+    user_names = [fake.name() for _ in range(4)]
+    user_emails = [fake.email() for _ in range(4)]
+    line_manager_names = [fake.name() for _ in range(4)]
+    customer_names = [fake.name() for _ in range(4)]
+    customer_job_titles = [fake.job() for _ in range(4)]
+    customer_email_addresses = [fake.email() for _ in range(4)]
+
+    for (
+        uuid,
+        company_name,
+        lead_officer_name,
+        lead_officer_email_address,
+        user_name, user_email,
+        line_manager_name,
+        customer_name,
+        customer_job_title,
+        customer_email_address,
+    ) in zip(
+        uuids,
+        company_names,
+        lead_officer_names,
+        lead_officer_email_addresses,
+        user_names,
+        user_emails,
+        line_manager_names,
+        customer_names,
+        customer_job_titles,
+        customer_email_addresses,
+    ):
+        csv_contents.append(f'{uuid},"{company_name}",{lead_officer_name},'
+                            f'{lead_officer_email_address},{user_name},'
+                            f'{user_email},{line_manager_name},{customer_name},'
+                            f'"{customer_job_title}",{customer_email_address}')
+
+    csv_content = '\n'.join(csv_contents)
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_legacy_export_wins_data', bucket, object_key)
+
+    for (
+        uuid,
+        company_name,
+        lead_officer_name,
+        lead_officer_email_address,
+        user_name, user_email,
+        line_manager_name,
+        customer_name,
+        customer_job_title,
+        customer_email_address,
+    ) in zip(
+        uuids,
+        company_names,
+        lead_officer_names,
+        lead_officer_email_addresses,
+        user_names,
+        user_emails,
+        line_manager_names,
+        customer_names,
+        customer_job_titles,
+        customer_email_addresses,
+    ):
+        win = Win.objects.get(id=uuid)
+        assert win.company_name == company_name
+        assert win.lead_officer_name == lead_officer_name
+        assert win.lead_officer_email_address == lead_officer_email_address
+        assert win.adviser_name == user_name
+        assert win.adviser_email_address == user_email
+        assert win.line_manager_name == line_manager_name
+        assert win.customer_name == customer_name
+        assert win.customer_job_title == customer_job_title
+        assert win.customer_email_address == customer_email_address
+
+        versions = Version.objects.get_for_object(win)
+        assert versions.count() == 1
+        comment = versions[0].revision.get_comment()
+        assert comment == 'Legacy export wins data migration.'
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+
+    fake = Faker()
+    wins = WinFactory.create_batch(4, company=None)
+
+    uuids = [win.id for win in wins]
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_contents = [
+        'id,company_name,lead_officer_name,lead_officer_email_address,user_name,'
+        'user_email,line_manager_name,customer_name,customer_job_title, '
+        'customer_email_address',
+    ]
+    company_names = [f'"{fake.company()}"' for _ in range(4)]
+    lead_officer_names = [fake.name() for _ in range(4)]
+    lead_officer_email_addresses = [fake.email() for _ in range(4)]
+    user_names = [fake.name() for _ in range(4)]
+    user_emails = [fake.email() for _ in range(4)]
+    line_manager_names = [fake.name() for _ in range(4)]
+    customer_names = [fake.name() for _ in range(4)]
+    customer_job_titles = [fake.job() for _ in range(4)]
+    customer_email_addresses = [fake.email() for _ in range(4)]
+
+    for (
+        uuid,
+        company_name,
+        lead_officer_name,
+        lead_officer_email_address,
+        user_name, user_email,
+        line_manager_name,
+        customer_name,
+        customer_job_title,
+        customer_email_address,
+    ) in zip(
+        uuids,
+        company_names,
+        lead_officer_names,
+        lead_officer_email_addresses,
+        user_names,
+        user_emails,
+        line_manager_names,
+        customer_names,
+        customer_job_titles,
+        customer_email_addresses,
+    ):
+        csv_contents.append(f'{uuid},"{company_name}",{lead_officer_name},'
+                            f'{lead_officer_email_address},{user_name},'
+                            f'{user_email},{line_manager_name},{customer_name},'
+                            f'"{customer_job_title}",{customer_email_address}')
+
+    csv_content = '\n'.join(csv_contents)
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_legacy_export_wins_data', bucket, object_key, simulate=True)
+
+    for (
+        uuid,
+        company_name,
+        lead_officer_name,
+        lead_officer_email_address,
+        user_name, user_email,
+        line_manager_name,
+        customer_name,
+        customer_job_title,
+        customer_email_address,
+    ) in zip(
+        uuids,
+        company_names,
+        lead_officer_names,
+        lead_officer_email_addresses,
+        user_names,
+        user_emails,
+        line_manager_names,
+        customer_names,
+        customer_job_titles,
+        customer_email_addresses,
+    ):
+        win = Win.objects.get(id=uuid)
+        assert win.company_name != company_name
+        assert win.lead_officer_name != lead_officer_name
+        assert win.lead_officer_email_address != lead_officer_email_address
+        assert win.adviser_name != user_name
+        assert win.adviser_email_address != user_email
+        assert win.line_manager_name != line_manager_name
+        assert win.customer_name != customer_name
+        assert win.customer_job_title != customer_job_title
+        assert win.customer_email_address != customer_email_address
+
+        versions = Version.objects.get_for_object(win)
+        assert versions.count() == 0


### PR DESCRIPTION
### Description of change

This adds two DB maintenance commands.

One will update legacy Export wins company matches from spreadsheet.

Other will update legacy Export wins data for company, company contact, adviser, lead officer and line manager. 


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
