### PR TITLE
Fix a link to the release notes tab

### DIFF
--- a/docs/Deployments.md
+++ b/docs/Deployments.md
@@ -21,7 +21,7 @@ You can use the [GitHub comparison tool](https://github.com/uktrade/data-hub-api
 
 4. Check that the tag worked by using the [GitHub comparison tool](https://github.com/uktrade/data-hub-api/compare) again to compare main to the new tag. If done correctly, there should be no difference. 
 
-5. Create a GH pre-release by clicking `Draft a new release` on the [releases page](https://github.com/uktrade/data-hub-frontend/releases).
+5. Create a GH pre-release by clicking `Draft a new release` on the [releases page](https://github.com/uktrade/data-hub-api/releases).
 
 The release title should be `v<VERSION_NUMBER>` and release notes can be created by clicking the `Auto-generate release notes` button.
 


### PR DESCRIPTION
### Description of change

Changes the link in `Deployments.md` to stay in `data-hub-api/releases` rather than taking us to `data-hub-frontend/releases`

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
