### PR TITLE
Bugfix/tet 606 fix company merge

### DIFF
--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -19,6 +19,7 @@ from datahub.company.test.factories import (
     ContactFactory,
     ExportFactory,
     ObjectiveFactory,
+    OneListCoreTeamMemberFactory,
 )
 from datahub.company_activity.tests.factories import (
     CompanyActivityGreatFactory,
@@ -29,6 +30,7 @@ from datahub.company_referral.test.factories import (
     CompanyReferralFactory,
 )
 from datahub.event.test.factories import EventFactory
+from datahub.export_win.test.factories import LegacyExportWinsToDataHubCompanyFactory
 from datahub.export_win.test.factories import (
     BreakdownFactory,
     CustomerResponseFactory,
@@ -49,8 +51,13 @@ from datahub.investment.project.test.factories import (
     InvestmentProjectTeamMemberFactory,
     InvestmentSectorFactory,
 )
+from datahub.investment_lead.test.factories import EYBLeadFactory
 from datahub.metadata.test.factories import SectorFactory
 from datahub.omis.order.test.factories import OrderFactory
+from datahub.reminder.test.factories import (
+    NewExportInteractionReminderFactory,
+    NoRecentExportInteractionReminderFactory,
+)
 from datahub.task.test.factories import TaskFactory
 from datahub.user.company_list.test.factories import (
     CompanyListItemFactory,
@@ -66,6 +73,7 @@ MAPPINGS = {
     'company.CompanyExportCountryHistory': CompanyExportCountryHistoryFactory,
     'company.Contact': ContactFactory,
     'company.Objective': ObjectiveFactory,
+    'company.OneListCoreTeamMember': OneListCoreTeamMemberFactory,
     'company_activity.CompanyActivity': CompanyActivityInteractionFactory,
     'company_activity.Great': CompanyActivityGreatFactory,
     'company_activity.IngestedFile': CompanyActivityIngestedFileFactory,
@@ -73,6 +81,7 @@ MAPPINGS = {
     'company_list.PipelineItem': PipelineItemFactory,
     'company_referral.CompanyReferral': CompanyReferralFactory,
     'event.Event': EventFactory,
+    'export_win.LegacyExportWinsToDataHubCompany': LegacyExportWinsToDataHubCompanyFactory,
     'interaction.InteractionDITParticipant': InteractionDITParticipantFactory,
     'interaction.Interaction': CompanyInteractionFactory,
     'interaction.InteractionExportCountry': InteractionExportCountryFactory,
@@ -80,10 +89,13 @@ MAPPINGS = {
     'investment.InvestmentProjectTeamMember': InvestmentProjectTeamMemberFactory,
     'investment.InvestmentActivity': InvestmentActivityFactory,
     'investment.InvestmentSector': InvestmentSectorFactory,
+    'investment_lead.EYBLead': EYBLeadFactory,
     'investor_profile.LargeCapitalInvestorProfile': LargeCapitalInvestorProfileFactory,
     'opportunity.LargeCapitalOpportunity': LargeCapitalOpportunityFactory,
     'metadata.Sector': SectorFactory,
     'order.Order': OrderFactory,
+    'reminder.NewExportInteractionReminder': NewExportInteractionReminderFactory,
+    'reminder.NoRecentExportInteractionReminder': NoRecentExportInteractionReminderFactory,
     'task.Task': TaskFactory,
     'export_win.Win': WinFactory,
     'export_win.CustomerResponse': CustomerResponseFactory,

--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -30,10 +30,10 @@ from datahub.company_referral.test.factories import (
     CompanyReferralFactory,
 )
 from datahub.event.test.factories import EventFactory
-from datahub.export_win.test.factories import LegacyExportWinsToDataHubCompanyFactory
 from datahub.export_win.test.factories import (
     BreakdownFactory,
     CustomerResponseFactory,
+    LegacyExportWinsToDataHubCompanyFactory,
     WinAdviserFactory,
     WinFactory,
 )

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -38,7 +38,14 @@ def _default_object_updater(obj, field, target, source):
         return
 
     setattr(obj, field, target)
-    obj.save(update_fields=(field, 'modified_on'))
+
+    update_fields = (field, )
+
+    # Not all models have modified_on field.
+    if hasattr(obj, 'modified_on'):
+        update_fields = (field, 'modified_on')
+
+    obj.save(update_fields=update_fields)
 
 
 class MergeConfiguration(NamedTuple):

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -49,7 +49,16 @@ def _default_object_updater(obj, field, target, source):
 
 
 class MergeConfiguration(NamedTuple):
-    """Specifies how merging should be handled for a particular related model."""
+    """
+    Used to specify which `model` and its `field`/s to be merged into the `source_model`.
+
+    :param model: The model related to the `source_model` model. i.e. `Interaction`.
+    :param fields: The field/s in the given `model` which relates to the company.
+    :param source_model: The model to merge into.
+    :param object_updater: A function to update the related field/s. If the default function is
+        not suitable you can pass your own. For example if you need have unique constraints you
+        need to handle.
+    """
 
     model: Type[models.Model]
     fields: Sequence[str]

--- a/datahub/company/merge_company.py
+++ b/datahub/company/merge_company.py
@@ -77,14 +77,6 @@ ALLOWED_RELATIONS_FOR_MERGING = {
     # the front end if required)
     CompanyExportCountry.company.field,
     CompanyExportCountryHistory.company.field,
-
-    # Not added to MERGE_CONFIGURATION as don't want to overwrite the existing companies global
-    # headquarters.
-    Company.global_headquarters.field,
-
-    # Not added to MERGE_CONFIGURATION as filled in as part of the company merge process.
-    Company.transferred_to.field,
-    Company.transferred_from.field,
 }
 
 
@@ -136,6 +128,9 @@ def merge_companies(source_company: Company, target_company: Company, user):
     """
     Merges the source company into the target company.
     MergeNotAllowedError will be raised if the merge is not allowed.
+
+    Companies with relations to another Company are not allowed to be merged. They would need to
+    be manually updated in the Admin before merging.
     """
     is_source_valid, invalid_obj = is_model_a_valid_merge_source(
         source_company,

--- a/datahub/company/merge_company.py
+++ b/datahub/company/merge_company.py
@@ -3,24 +3,35 @@ import logging
 import reversion
 
 from datahub.company.merge import (
-    _default_object_updater,
     is_model_a_valid_merge_source,
     is_model_a_valid_merge_target,
     MergeConfiguration,
     MergeNotAllowedError,
     update_objects,
 )
+from datahub.company.merge_utils.merge_relations import (
+    company_list_item_updater,
+    large_capital_opportunity_updater,
+    one_list_core_team_member_updater,
+    pipeline_item_updater,
+)
 from datahub.company.models import (
     Company,
+    CompanyExport,
     CompanyExportCountry,
     CompanyExportCountryHistory,
     Contact,
+    Objective,
+    OneListCoreTeamMember,
 )
 from datahub.company_activity.models import CompanyActivity
 from datahub.company_referral.models import CompanyReferral
 from datahub.dnb_api.utils import _get_rollback_version
 from datahub.interaction.models import Interaction
+from datahub.investment.investor_profile.models import LargeCapitalInvestorProfile
+from datahub.investment.opportunity.models import LargeCapitalOpportunity
 from datahub.investment.project.models import InvestmentProject
+from datahub.investment_lead.models import EYBLead
 from datahub.omis.order.models import Order
 from datahub.user.company_list.models import CompanyListItem, PipelineItem
 
@@ -29,19 +40,26 @@ logger = logging.getLogger(__name__)
 # Merging is not allowed if the source company has any relations that aren't in
 # this list. This is to avoid references to the source company being inadvertently
 # left behind.
+# EXCLUDE RELATIONS: To Exclude relations, add them here, don't add them to MERGE_CONFIGURATION.
 ALLOWED_RELATIONS_FOR_MERGING = {
     # These relations are moved to the target company on merge
     Company._meta.get_field('company_list_items').remote_field,
     Company._meta.get_field('pipeline_list_items').remote_field,
     Company._meta.get_field('wins').remote_field,
     CompanyActivity.company.field,
+    CompanyExport.company.field,
     CompanyReferral.company.field,
     Contact.company.field,
+    EYBLead.company.field,
     Interaction.company.field,
     Interaction.companies.field,
     InvestmentProject.investor_company.field,
     InvestmentProject.intermediate_company.field,
     InvestmentProject.uk_company.field,
+    LargeCapitalInvestorProfile.investor_company.field,
+    LargeCapitalOpportunity.promoters.field,
+    Objective.company.field,
+    OneListCoreTeamMember.company.field,
     Order.company.field,
 
     # Merging is allowed if the source company has export countries, but note that
@@ -49,6 +67,14 @@ ALLOWED_RELATIONS_FOR_MERGING = {
     # the front end if required)
     CompanyExportCountry.company.field,
     CompanyExportCountryHistory.company.field,
+
+    # Not added to MERGE_CONFIGURATION as don't want to overwrite the existing companies global
+    # headquarters.
+    Company.global_headquarters.field,
+
+    # Not added to MERGE_CONFIGURATION as filled in as part of the company merge process.
+    Company.transferred_to.field,
+    Company.transferred_from.field
 }
 
 
@@ -66,33 +92,29 @@ FIELD_TO_DESCRIPTION_MAPPING = {
 }
 
 
-def _company_list_item_updater(list_item, field, target_company, source_company):
-    # If there is already a list item for the target company, delete this list item instead
-    # as duplicates are not allowed
-    if CompanyListItem.objects.filter(list_id=list_item.list_id, company=target_company).exists():
-        list_item.delete()
-    else:
-        _default_object_updater(list_item, field, target_company, source_company)
-
-
-def _pipeline_item_updater(pipeline_item, field, target_company, source_company):
-    # If there is already a pipeline item for the adviser for the target company
-    # delete this item instead as the same company can't be added for the same adviser again
-    if PipelineItem.objects.filter(adviser=pipeline_item.adviser, company=target_company).exists():
-        pipeline_item.delete()
-    else:
-        _default_object_updater(pipeline_item, field, target_company, source_company)
-
-
+# Models related to a company for merging companies and how to merge them.
+# If its not a simple relation (like OneToMany) then you can specify a function for how each item
+# is merged.
+# Relations NOT added here but included in ALLOWED_RELATIONS_FOR_MERGING will NOT be merged.
 MERGE_CONFIGURATION = [
     MergeConfiguration(Interaction, ('company', 'companies'), Company),
     MergeConfiguration(CompanyReferral, ('company',), Company),
     MergeConfiguration(CompanyActivity, ('company',), Company),
+    MergeConfiguration(CompanyExport, ('company',), Company),
     MergeConfiguration(Contact, ('company',), Company),
+    MergeConfiguration(EYBLead, ('company',), Company),
     MergeConfiguration(InvestmentProject, INVESTMENT_PROJECT_COMPANY_FIELDS, Company),
+    MergeConfiguration(LargeCapitalInvestorProfile, ('investor_company',), Company),
+    MergeConfiguration(
+        LargeCapitalOpportunity, ('promoters',), Company, large_capital_opportunity_updater
+    ),
     MergeConfiguration(Order, ('company',), Company),
-    MergeConfiguration(CompanyListItem, ('company',), Company, _company_list_item_updater),
-    MergeConfiguration(PipelineItem, ('company',), Company, _pipeline_item_updater),
+    MergeConfiguration(CompanyListItem, ('company',), Company, company_list_item_updater),
+    MergeConfiguration(PipelineItem, ('company',), Company, pipeline_item_updater),
+    MergeConfiguration(Objective, ('company',), Company),
+    MergeConfiguration(
+        OneListCoreTeamMember, ('company',), Company, one_list_core_team_member_updater
+    ),
 ]
 
 
@@ -112,7 +134,7 @@ def merge_companies(source_company: Company, target_company: Company, user):
         logger.error(
             f"""MergeNotAllowedError {source_company.id}
             for company {target_company.id}.
-            Invalid bojects: {invalid_obj}""",
+            Invalid objects: {invalid_obj}""",
         )
         raise MergeNotAllowedError()
 

--- a/datahub/company/merge_company.py
+++ b/datahub/company/merge_company.py
@@ -74,7 +74,7 @@ ALLOWED_RELATIONS_FOR_MERGING = {
 
     # Not added to MERGE_CONFIGURATION as filled in as part of the company merge process.
     Company.transferred_to.field,
-    Company.transferred_from.field
+    Company.transferred_from.field,
 }
 
 
@@ -106,14 +106,14 @@ MERGE_CONFIGURATION = [
     MergeConfiguration(InvestmentProject, INVESTMENT_PROJECT_COMPANY_FIELDS, Company),
     MergeConfiguration(LargeCapitalInvestorProfile, ('investor_company',), Company),
     MergeConfiguration(
-        LargeCapitalOpportunity, ('promoters',), Company, large_capital_opportunity_updater
+        LargeCapitalOpportunity, ('promoters',), Company, large_capital_opportunity_updater,
     ),
     MergeConfiguration(Order, ('company',), Company),
     MergeConfiguration(CompanyListItem, ('company',), Company, company_list_item_updater),
     MergeConfiguration(PipelineItem, ('company',), Company, pipeline_item_updater),
     MergeConfiguration(Objective, ('company',), Company),
     MergeConfiguration(
-        OneListCoreTeamMember, ('company',), Company, one_list_core_team_member_updater
+        OneListCoreTeamMember, ('company',), Company, one_list_core_team_member_updater,
     ),
 ]
 

--- a/datahub/company/merge_company.py
+++ b/datahub/company/merge_company.py
@@ -27,12 +27,18 @@ from datahub.company.models import (
 from datahub.company_activity.models import CompanyActivity
 from datahub.company_referral.models import CompanyReferral
 from datahub.dnb_api.utils import _get_rollback_version
+from datahub.export_win.models import LegacyExportWinsToDataHubCompany
 from datahub.interaction.models import Interaction
 from datahub.investment.investor_profile.models import LargeCapitalInvestorProfile
 from datahub.investment.opportunity.models import LargeCapitalOpportunity
 from datahub.investment.project.models import InvestmentProject
 from datahub.investment_lead.models import EYBLead
 from datahub.omis.order.models import Order
+from datahub.reminder.models import (
+    NewExportInteractionReminder,
+    NoRecentExportInteractionReminder,
+)
+from datahub.task.models import Task
 from datahub.user.company_list.models import CompanyListItem, PipelineItem
 
 logger = logging.getLogger(__name__)
@@ -58,9 +64,13 @@ ALLOWED_RELATIONS_FOR_MERGING = {
     InvestmentProject.uk_company.field,
     LargeCapitalInvestorProfile.investor_company.field,
     LargeCapitalOpportunity.promoters.field,
+    LegacyExportWinsToDataHubCompany.company.field,
+    NewExportInteractionReminder.company.field,
+    NoRecentExportInteractionReminder.company.field,
     Objective.company.field,
     OneListCoreTeamMember.company.field,
     Order.company.field,
+    Task.company.field,
 
     # Merging is allowed if the source company has export countries, but note that
     # they aren't moved to the target company (these can be manually moved in
@@ -108,7 +118,11 @@ MERGE_CONFIGURATION = [
     MergeConfiguration(
         LargeCapitalOpportunity, ('promoters',), Company, large_capital_opportunity_updater,
     ),
+    MergeConfiguration(LegacyExportWinsToDataHubCompany, ('company',), Company),
     MergeConfiguration(Order, ('company',), Company),
+    MergeConfiguration(NewExportInteractionReminder, ('company',), Company),
+    MergeConfiguration(NoRecentExportInteractionReminder, ('company',), Company),
+    MergeConfiguration(Task, ('company',), Company),
     MergeConfiguration(CompanyListItem, ('company',), Company, company_list_item_updater),
     MergeConfiguration(PipelineItem, ('company',), Company, pipeline_item_updater),
     MergeConfiguration(Objective, ('company',), Company),

--- a/datahub/company/merge_contact.py
+++ b/datahub/company/merge_contact.py
@@ -57,7 +57,7 @@ def merge_contacts(source_contact: Contact, target_contact: Contact, user):
         logger.error(
             f"""MergeNotAllowedError {source_contact.id}
             for contact {target_contact.id}.
-            Invalid bojects: {invalid_obj}""",
+            Invalid objects: {invalid_obj}""",
         )
         raise MergeNotAllowedError()
 

--- a/datahub/company/merge_utils/merge_relations.py
+++ b/datahub/company/merge_utils/merge_relations.py
@@ -1,12 +1,12 @@
 # Any relations in the company merge which requires additional logic when merging.
+from datahub.company.merge import (
+    _default_object_updater,
+)
 from datahub.company.models import (
     OneListCoreTeamMember,
 )
 from datahub.investment.opportunity.models import LargeCapitalOpportunity
 from datahub.user.company_list.models import CompanyListItem, PipelineItem
-from datahub.company.merge import (
-    _default_object_updater,
-)
 
 
 def company_list_item_updater(list_item, field, target_company, source_company):

--- a/datahub/company/merge_utils/merge_relations.py
+++ b/datahub/company/merge_utils/merge_relations.py
@@ -47,22 +47,6 @@ def large_capital_opportunity_updater(large_capital_opp, field, target_company, 
         _default_object_updater(large_capital_opp, field, target_company, source_company)
 
 
-def large_capital_investor_profile_updater(one_list_item, field, target_company, source_company):
-    """
-    The OneListCoreTeamMember model has a unique together contraint for company and adviser.
-
-    Before copying, if the target company already contains the adviser from the source company,
-    ignore it.
-    """
-    if OneListCoreTeamMember.objects.filter(
-        adviser_id=one_list_item.adviser_id,
-        company=target_company,
-    ).exists():
-        return
-    else:
-        _default_object_updater(one_list_item, field, target_company, source_company)
-
-
 def pipeline_item_updater(pipeline_item, field, target_company, source_company):
     # If there is already a pipeline item for the adviser for the target company
     # delete this item instead as the same company can't be added for the same adviser again

--- a/datahub/company/merge_utils/merge_relations.py
+++ b/datahub/company/merge_utils/merge_relations.py
@@ -1,0 +1,72 @@
+# Any relations in the company merge which requires additional logic when merging.
+from datahub.company.models import (
+    OneListCoreTeamMember,
+)
+from datahub.investment.opportunity.models import LargeCapitalOpportunity
+from datahub.user.company_list.models import CompanyListItem, PipelineItem
+from datahub.company.merge import (
+    _default_object_updater,
+)
+
+
+def company_list_item_updater(list_item, field, target_company, source_company):
+    # If there is already a list item for the target company, delete this list item instead
+    # as duplicates are not allowed
+    if CompanyListItem.objects.filter(list_id=list_item.list_id, company=target_company).exists():
+        list_item.delete()
+    else:
+        _default_object_updater(list_item, field, target_company, source_company)
+
+
+def one_list_core_team_member_updater(one_list_item, field, target_company, source_company):
+    """
+    The OneListCoreTeamMember model has a unique together contraint for company and adviser.
+
+    Before copying, if the target company already contains the adviser from the source company,
+    ignore it.
+    """
+    if OneListCoreTeamMember.objects.filter(
+        adviser_id=one_list_item.adviser_id,
+        company=target_company,
+    ).exists():
+        return
+    else:
+        _default_object_updater(one_list_item, field, target_company, source_company)
+
+
+def large_capital_opportunity_updater(large_capital_opp, field, target_company, source_company):
+    """
+    If the LargeCapitalOpportunity already exists in the target, ignore it. Otherwise add it.
+    """
+    if LargeCapitalOpportunity.objects.filter(
+        id=large_capital_opp.id,
+        promoters__id=target_company.id,
+    ).exists():
+        return
+    else:
+        _default_object_updater(large_capital_opp, field, target_company, source_company)
+
+
+def large_capital_investor_profile_updater(one_list_item, field, target_company, source_company):
+    """
+    The OneListCoreTeamMember model has a unique together contraint for company and adviser.
+
+    Before copying, if the target company already contains the adviser from the source company,
+    ignore it.
+    """
+    if OneListCoreTeamMember.objects.filter(
+        adviser_id=one_list_item.adviser_id,
+        company=target_company,
+    ).exists():
+        return
+    else:
+        _default_object_updater(one_list_item, field, target_company, source_company)
+
+
+def pipeline_item_updater(pipeline_item, field, target_company, source_company):
+    # If there is already a pipeline item for the adviser for the target company
+    # delete this item instead as the same company can't be added for the same adviser again
+    if PipelineItem.objects.filter(adviser=pipeline_item.adviser, company=target_company).exists():
+        pipeline_item.delete()
+    else:
+        _default_object_updater(pipeline_item, field, target_company, source_company)

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -680,6 +680,7 @@ class Company(ArchivableModel, BaseModel):
             export_country.delete()
 
 
+@reversion.register_base_model()
 class OneListCoreTeamMember(models.Model):
     """
     Adviser who is a member of the One List Core Team of a company.

--- a/datahub/company/test/test_merge_company.py
+++ b/datahub/company/test/test_merge_company.py
@@ -146,28 +146,12 @@ def company_with_investment_projects_factory():
 class TestDuplicateCompanyMerger:
     """Tests DuplicateCompanyMerger."""
 
-    # Default expect values for company changes to 0, changed per test.
-    # Usually need to add a new company relation in here for the tests, manually updating
-    # the number of relations to be merged using the spread operator.
-    base_expected_result = {
-        CompanyActivity: {'company': 0},
-        CompanyExport: {'company': 0},
-        CompanyListItem: {'company': 0},
-        CompanyReferral: {'company': 0},
-        Contact: {'company': 0},
-        EYBLead: {'company': 0},
-        Interaction: {'company': 0, 'companies': 0},
-        InvestmentProject: {field: 0 for field in INVESTMENT_PROJECT_COMPANY_FIELDS},
-        LargeCapitalInvestorProfile: {'investor_company': 0},
-        LargeCapitalOpportunity: {'promoters': 0},
-        LegacyExportWinsToDataHubCompany: {'company': 0},
-        NewExportInteractionReminder: {'company': 0},
-        NoRecentExportInteractionReminder: {'company': 0},
-        Objective: {'company': 0},
-        OneListCoreTeamMember: {'company': 0},
-        Order: {'company': 0},
-        PipelineItem: {'company': 0},
-        Task: {'company': 0},
+    # The model and its fields related to a Company and a count for
+    # how many fields were merged during the company merge.
+    # i.e. {..., Contact: {'company': 0} }
+    base_expected_results = {
+        configuration.model: {field: 0 for field in configuration.fields}
+        for configuration in MERGE_CONFIGURATION
     }
 
     @pytest.mark.parametrize(
@@ -175,13 +159,13 @@ class TestDuplicateCompanyMerger:
         (
             (
                 CompanyFactory,
-                base_expected_result,
+                base_expected_results,
                 True,
             ),
             (
                 company_with_interactions_and_contacts_factory,
                 {
-                    **base_expected_result,
+                    **base_expected_results,
                     CompanyActivity: {'company': 3},
                     Contact: {'company': 3},
                     Interaction: {'company': 3, 'companies': 3},
@@ -191,7 +175,7 @@ class TestDuplicateCompanyMerger:
             (
                 company_with_contacts_factory,
                 {
-                    **base_expected_result,
+                    **base_expected_results,
                     Contact: {'company': 3},
                 },
                 True,
@@ -199,7 +183,7 @@ class TestDuplicateCompanyMerger:
             (
                 company_with_referrals_factory,
                 {
-                    **base_expected_result,
+                    **base_expected_results,
                     CompanyActivity: {'company': 3},
                     CompanyReferral: {'company': 3},
                 },
@@ -208,7 +192,7 @@ class TestDuplicateCompanyMerger:
             (
                 company_with_company_list_items_factory,
                 {
-                    **base_expected_result,
+                    **base_expected_results,
                     CompanyListItem: {'company': 3},
                 },
                 True,
@@ -216,7 +200,7 @@ class TestDuplicateCompanyMerger:
             (
                 company_with_pipeline_items_factory,
                 {
-                    **base_expected_result,
+                    **base_expected_results,
                     PipelineItem: {'company': 3},
                 },
                 True,
@@ -224,7 +208,7 @@ class TestDuplicateCompanyMerger:
             (
                 company_with_investment_projects_factory,
                 {
-                    **base_expected_result,
+                    **base_expected_results,
                     CompanyActivity: {'company': 1},
                     InvestmentProject: {
                         field: 1 for field in INVESTMENT_PROJECT_COMPANY_FIELDS
@@ -236,7 +220,7 @@ class TestDuplicateCompanyMerger:
             (
                 company_with_orders_factory,
                 {
-                    **base_expected_result,
+                    **base_expected_results,
                     Contact: {'company': 3},
                     Order: {'company': 3},
 
@@ -246,7 +230,7 @@ class TestDuplicateCompanyMerger:
             (
                 ArchivedCompanyFactory,
                 {
-                    **base_expected_result,
+                    **base_expected_results,
                 },
                 False,
             ),
@@ -318,7 +302,7 @@ class TestDuplicateCompanyMerger:
             result = merge_companies(source_company, target_company, user)
 
         assert result == {
-            **self.base_expected_result,
+            **self.base_expected_results,
             CompanyActivity: {'company': len(source_company_activity_items)},
             CompanyListItem: {'company': len(source_company_list_items)},
             CompanyReferral: {'company': len(source_referrals)},
@@ -404,7 +388,7 @@ class TestDuplicateCompanyMerger:
             company = {'company': 1}
 
         assert result == {
-            **self.base_expected_result,
+            **self.base_expected_results,
             # each interaction has a contact, that's why 4 contacts should be moved
             CompanyActivity: company,
             InvestmentProject: {

--- a/datahub/company/test/test_merge_company.py
+++ b/datahub/company/test/test_merge_company.py
@@ -26,11 +26,11 @@ from datahub.company.models import (
 from datahub.company.test.factories import (
     AdviserFactory,
     ArchivedCompanyFactory,
-    ExportFactory,
     CompanyExportCountryFactory,
     CompanyExportCountryHistoryFactory,
     CompanyFactory,
     ContactFactory,
+    ExportFactory,
     ObjectiveFactory,
     OneListCoreTeamMemberFactory,
 )

--- a/datahub/company/test/test_merge_company.py
+++ b/datahub/company/test/test_merge_company.py
@@ -784,16 +784,18 @@ class TestDuplicateCompanyMerger:
         LargeCapitalOpportunityFactory(promoters=[source_company])
         LargeCapitalOpportunityFactory(promoters=[target_company])
 
-        # Target has only 1 export before merge
+        # Shared one, should not be merged.
+        LargeCapitalOpportunityFactory(promoters=[target_company, source_company])
+
         assert LargeCapitalOpportunity.objects.filter(
             promoters=target_company,
-        ).count() == 1
+        ).count() == 2
 
         merge_companies(source_company, target_company, adviser)
 
         assert LargeCapitalOpportunity.objects.filter(
             promoters=target_company,
-        ).count() == 2
+        ).count() == 3
 
     def test_company_new_export_interaction_reminder_merges_successfully(self):
         """

--- a/datahub/company/test/test_merge_company_relations.py
+++ b/datahub/company/test/test_merge_company_relations.py
@@ -42,9 +42,6 @@ class TestDuplicateCompanyMerger:
             @reversion.register_base_model()
             class ModelRelatedToACompany(models.Model):
         ```
-
-        To get the full error message, you may be better to run this test with
-        the -s flag.
         """
         relations = get_related_fields(Company)
         for relation in relations:

--- a/datahub/company/test/test_merge_company_relations.py
+++ b/datahub/company/test/test_merge_company_relations.py
@@ -1,0 +1,57 @@
+import pytest
+
+from datahub.company.merge_company import (
+    ALLOWED_RELATIONS_FOR_MERGING,
+)
+from datahub.company.models import Company
+from datahub.core.model_helpers import get_related_fields
+
+
+@pytest.mark.django_db
+class TestDuplicateCompanyMerger:
+    """Tests DuplicateCompanyMerger."""
+
+    def test_company_fields_are_setup_for_merging(self):
+        """
+        Test all the models related to a company are accounted for when merging
+        companies. This is used by support to merge duplicate companies and
+        breaks when relations are not accounted for.
+
+        If your test fails here, you may have related something to a company and this relation
+        needs to be accounted for.
+
+        If this relations is to be merged, add it to both:
+        ```
+            ALLOWED_RELATIONS_FOR_MERGING
+            MERGE_CONFIGURATION
+        ```
+
+        If the relation is NOT to be merged, it can ignored by adding it ONLY to:
+        ```
+            ALLOWED_RELATIONS_FOR_MERGING
+        ```
+
+        You will also need to add your relation to the `base_expected_result` inside
+        `TestDuplicateCompanyMerger` and then add any of your own tests.
+
+        Models for company merge also require the reversion decorator to undo the changes
+        if the merge fails:
+        ```
+            from datahub.core import reversion
+
+            @reversion.register_base_model()
+            class ModelRelatedToACompany(models.Model):
+        ```
+
+        To get the full error message, you may be better to run this test with
+        the -s flag.
+        """
+        relations = get_related_fields(Company)
+        for relation in relations:
+            assert relation.remote_field in ALLOWED_RELATIONS_FOR_MERGING, [(
+                'Required relationship missing from company merge. \n'
+                f'Field: {relation.field.name} \n'
+                f'Model: {relation.model} \n'
+                f'Related Name: {relation.related_name} \n'
+                f'Related Model: {relation.related_model} \n'
+            )]

--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -782,6 +782,7 @@ class CustomerResponseToken(models.Model):
         return f'Token: {self.id} ({self.expires_on})'
 
 
+@reversion.register_base_model()
 class LegacyExportWinsToDataHubCompany(models.Model):
     """Maps Legacy Export win to Data Hub company."""
 

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -9,6 +9,7 @@ from django.core.validators import (
 from django.db import models
 from mptt.fields import TreeForeignKey
 
+from datahub.core import reversion
 from datahub.core.models import ArchivableModel
 
 
@@ -26,6 +27,7 @@ class InvestmentLead(ArchivableModel):
         abstract = True
 
 
+@reversion.register_base_model()
 class EYBLead(InvestmentLead):
     """Model for an Expand Your Business (EYB) investment lead.
 

--- a/datahub/reminder/models.py
+++ b/datahub/reminder/models.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
+from datahub.core import reversion
 from datahub.task.models import Task
 
 
@@ -176,6 +177,7 @@ class BaseReminder(models.Model):
         return self.event
 
 
+@reversion.register_base_model()
 class NewExportInteractionReminder(BaseReminder):
     """
     New export interaction reminders.
@@ -198,6 +200,7 @@ class NewExportInteractionReminder(BaseReminder):
         return self.interaction.date if self.interaction else self.company.created_on
 
 
+@reversion.register_base_model()
 class NoRecentExportInteractionReminder(BaseReminder):
     """
     No recent export interaction reminders.


### PR DESCRIPTION
### Description of change

Updates the company merge tool to include the new models related to a `Company`.

There is a new tests which checks for any model related to a `Company`. If it is not part of the company merge, then the test fail.

For data you do not want to merge with the company merge you can:

- Add it into the `ALLOWED_RELATIONS_FOR_MERGING` but **NOT** the `MERGE_CONFIGURATION`.

For data you do want to merge with the company merge you you can:

- Add it into the `ALLOWED_RELATIONS_FOR_MERGING` **AND** the `MERGE_CONFIGURATION`.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
