### PR TITLE
Fix EYB lead admin page crashing

### DIFF
--- a/datahub/investment_lead/admin.py
+++ b/datahub/investment_lead/admin.py
@@ -4,6 +4,11 @@ from datahub.investment_lead.models import EYBLead
 
 
 class EYBLeadAdmin(admin.ModelAdmin):
+    search_fields = [
+        'triage_hashed_uuid',
+        'user_hashed_uuid',
+        'company_name',
+    ]
     list_display = [
         'id',
         'created_on',
@@ -12,7 +17,7 @@ class EYBLeadAdmin(admin.ModelAdmin):
     ]
     raw_id_fields = [
         'company',
-        'investment_project',
+        'investment_projects',
     ]
     readonly_fields = [
         'id',

--- a/datahub/investment_lead/admin.py
+++ b/datahub/investment_lead/admin.py
@@ -8,13 +8,16 @@ class EYBLeadAdmin(admin.ModelAdmin):
         'id',
         'created_on',
         'modified_on',
+        'company_name',
+    ]
+    raw_id_fields = [
         'company',
+        'investment_project',
     ]
     readonly_fields = [
         'id',
         'created_on',
         'modified_on',
-        'investment_projects',
     ]
     fieldsets = [
         (


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

In production, when you view an EYB lead in the admin, the server times out and crashes. This is because the EYB lead admin page uses the default fields for `EYBLead.company` and `EYBLead.investment_projects`, which subsequently incurs large overhead of having to select all the related instances to display in the drop-down. Spoiler alert: this is a lot in production.

This PR changes these fields to `raw_id_fields` which avoids this - see the Django docs [here](https://docs.djangoproject.com/en/5.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.raw_id_fields).

> For those curious, the default fields cause Django's backend to perform a `DECLARE "" NO SCROLL CURSOR WITH HOLD FOR SELECT` query on the related instance tables. Even for just 20,000 thousand related instances, this query was taking 30x longer than the rest.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
