### PR TITLE
Fix legacy export wins update history for management commands.

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_legacy_export_wins_company_link.py
+++ b/datahub/dbmaintenance/management/commands/update_legacy_export_wins_company_link.py
@@ -27,6 +27,12 @@ class Command(CSVBaseCommand):
             if export_win.company_id == company_id:
                 return
 
+            if not simulate:
+                # The win likely will not have its original revision in the History
+                with reversion.create_revision():
+                    reversion.add_to_revision(export_win)
+                    reversion.set_comment('Legacy export wins company migration - before.')
+
             export_win.company_id = company_id
 
             if not simulate:
@@ -36,4 +42,4 @@ class Command(CSVBaseCommand):
                             'company_id',
                         ),
                     )
-                    reversion.set_comment('Legacy export wins company migration.')
+                    reversion.set_comment('Legacy export wins company migration - after.')

--- a/datahub/dbmaintenance/management/commands/update_legacy_export_wins_data.py
+++ b/datahub/dbmaintenance/management/commands/update_legacy_export_wins_data.py
@@ -13,6 +13,13 @@ class Command(CSVBaseCommand):
         export_win_id = parse_uuid(row['id'])
 
         export_win = Win.objects.get(id=export_win_id)
+
+        if not simulate:
+            # The win likely will not have its original revision in the History
+            with reversion.create_revision():
+                reversion.add_to_revision(export_win)
+                reversion.set_comment('Legacy export wins data migration - before.')
+
         export_win.company_name = row['company_name']
         export_win.lead_officer_name = row['lead_officer_name']
         export_win.lead_officer_email_address = row['lead_officer_email_address']
@@ -38,4 +45,4 @@ class Command(CSVBaseCommand):
                         'customer_email_address',
                     ),
                 )
-                reversion.set_comment('Legacy export wins data migration.')
+                reversion.set_comment('Legacy export wins data migration - after.')

--- a/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_company_link.py
+++ b/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_company_link.py
@@ -51,10 +51,12 @@ def test_run(s3_stubber, caplog):
         win = Win.objects.get(id=uuid)
         assert win.company_id == company.id
 
-        versions = Version.objects.get_for_object(win)
-        assert versions.count() == 1
+        versions = Version.objects.get_for_object(win).order_by('revision__date_created')
+        assert versions.count() == 2
         comment = versions[0].revision.get_comment()
-        assert comment == 'Legacy export wins company migration.'
+        assert comment == 'Legacy export wins company migration - before.'
+        comment = versions[1].revision.get_comment()
+        assert comment == 'Legacy export wins company migration - after.'
 
     assert f'Company with ID {bad_company_id} does not exist' in caplog.text
 

--- a/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_data.py
+++ b/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_data.py
@@ -112,10 +112,12 @@ def test_run(s3_stubber, caplog):
         assert win.customer_job_title == customer_job_title
         assert win.customer_email_address == customer_email_address
 
-        versions = Version.objects.get_for_object(win)
-        assert versions.count() == 1
+        versions = Version.objects.get_for_object(win).order_by('revision__date_created')
+        assert versions.count() == 2
         comment = versions[0].revision.get_comment()
-        assert comment == 'Legacy export wins data migration.'
+        assert comment == 'Legacy export wins data migration - before.'
+        comment = versions[1].revision.get_comment()
+        assert comment == 'Legacy export wins data migration - after.'
 
 
 def test_simulate(s3_stubber, caplog):


### PR DESCRIPTION
### Description of change

This PR ensures there is before and after record of the win when running management commands for linking company and updating legacy fields.
This is because migrated records do not always have their current revision in the history.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
