### PR TITLE
CLS2-1015 Expose Investment Projects in EYB Lead retrieve serializer

### DIFF
--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -6,6 +6,7 @@ from datahub.core.serializers import (
     AddressSerializer,
     NestedRelatedField,
 )
+from datahub.investment.project.models import InvestmentProject
 from datahub.investment_lead.models import EYBLead
 from datahub.metadata.models import (
     Country,
@@ -446,7 +447,7 @@ class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
         fields = [
             f for f in ALL_FIELDS
             if f not in ADDRESS_FIELDS
-        ] + ['address']
+        ] + ['address', 'investment_projects']
 
     sector = NestedRelatedField(Sector)
     proposed_investment_region = NestedRelatedField(UKRegion)
@@ -455,6 +456,7 @@ class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
         address_source_prefix='address',
     )
     company = NestedRelatedField(Company)
+    investment_projects = NestedRelatedField(InvestmentProject, many=True)
 
     def get_related_fields_representation(self, instance):
         """Provides related fields in a representation-friendly format.

--- a/datahub/investment_lead/test/conftest.py
+++ b/datahub/investment_lead/test/conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 from datahub.core import constants
 from datahub.core.test_utils import create_test_user
+from datahub.investment.project.test.factories import InvestmentProjectFactory
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.test.factories import (
     eyb_lead_triage_record_faker,
@@ -41,10 +42,12 @@ def eyb_lead_factory_overrides():
     canada_country = Country.objects.get(
         pk=constants.Country.canada.value.id,
     )
+    investment_project = InvestmentProjectFactory()
     overrides = {
         'sector': mining_sector,
         'proposed_investment_region': wales_region,
         'address_country': canada_country,
+        'investment_projects': [investment_project.id],
     }
     return overrides
 

--- a/datahub/investment_lead/test/utils.py
+++ b/datahub/investment_lead/test/utils.py
@@ -145,6 +145,11 @@ def assert_retrieved_eyb_lead_data(instance: EYBLead, data: dict):
     assert instance.agree_info_email == data['agree_info_email']
     assert EYBLead.LandingTimeframeChoices(instance.landing_timeframe).label \
         == data['landing_timeframe']
+    assert [
+        str(ip.id) for ip in instance.investment_projects.all()
+    ] == [
+        data_ip['id'] for data_ip in data['investment_projects']
+    ]
 
     # EYB marketing fields
     assert instance.utm_name == data['utm_name']


### PR DESCRIPTION
### Description of change

This PR addresses the backend side of CLS2-1015
This PR adds Investment Projects to the available fields in EYB Lead serializer.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
