### PR TITLE
Add parent and subsidiary companies as filter option in API

### DIFF
--- a/datahub/search/company_activity/serializers.py
+++ b/datahub/search/company_activity/serializers.py
@@ -22,6 +22,9 @@ class SearchCompanyActivityQuerySerializer(EntitySearchQuerySerializer):
     date_after = RelaxedDateTimeField(required=False)
     date_before = RelaxedDateTimeField(required=False)
 
+    include_parent_companies = serializers.BooleanField(required=False, default=False)
+    include_subsidiary_companies = serializers.BooleanField(required=False, default=False)
+
     SORT_BY_FIELDS = (
         'date',
     )


### PR DESCRIPTION
### Description of change

Allows the API to to include parent and subsidiary companies in its response when given a company. This is mostly a copy from the existing implementation for investments where it uses dnb-service to get parent and subsidiary companies.

Existing investments code this is based off: https://github.com/uktrade/data-hub-api/blob/b74eab4b83b0dae6c08c845f3d5963ec2dc73897/datahub/search/investment/views.py#L214

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
