### PR TITLE
Add export experience migration command for legacy Export wins.

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_legacy_export_wins_export_experience.py
+++ b/datahub/dbmaintenance/management/commands/update_legacy_export_wins_export_experience.py
@@ -1,0 +1,36 @@
+import reversion
+
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.export_win.models import Win
+
+
+class Command(CSVBaseCommand):
+    """Command to update export experience for Legacy export wins."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        export_win_id = parse_uuid(row['export_win_id'])
+        export_experience_id = row['export_experience_id']
+
+        export_win = Win.objects.get(id=export_win_id)
+
+        if export_win.export_experience_id == export_experience_id:
+            return
+
+        if not simulate:
+            # The win likely will not have its original revision in the History
+            with reversion.create_revision():
+                reversion.add_to_revision(export_win)
+                reversion.set_comment('Legacy export wins export experience migration - before.')
+
+        export_win.export_experience_id = export_experience_id
+
+        if not simulate:
+            with reversion.create_revision():
+                export_win.save(
+                    update_fields=(
+                        'export_experience_id',
+                    ),
+                )
+                reversion.set_comment('Legacy export wins export experience migration - after.')

--- a/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_export_experience.py
+++ b/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_export_experience.py
@@ -1,0 +1,100 @@
+from io import BytesIO
+from uuid import uuid4
+
+import pytest
+from django.core.management import call_command
+
+from reversion.models import Version
+
+from datahub.company.test.factories import ExportExperienceFactory
+from datahub.export_win.models import Win
+from datahub.export_win.test.factories import WinFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('ERROR')
+    wins = WinFactory.create_batch(4, company=None)
+
+    uuids = [win.id for win in wins]
+    export_experiences = ExportExperienceFactory.create_batch(4)
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_contents = ['export_win_id,export_experience_id']
+    for uuid, export_experience in zip(uuids, export_experiences):
+        csv_contents.append(f'{uuid},{export_experience.id}')
+
+    csv_contents.append(f'{uuid4()},{uuid4()}')
+
+    csv_content = '\n'.join(csv_contents)
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_legacy_export_wins_export_experience', bucket, object_key)
+
+    for uuid, export_experience in zip(uuids, export_experiences):
+        win = Win.objects.get(id=uuid)
+        assert win.export_experience_id == export_experience.id
+
+        versions = Version.objects.get_for_object(win).order_by('revision__date_created')
+        assert versions.count() == 2
+        comment = versions[0].revision.get_comment()
+        assert comment == 'Legacy export wins export experience migration - before.'
+        comment = versions[1].revision.get_comment()
+        assert comment == 'Legacy export wins export experience migration - after.'
+
+    assert 'Win matching query does not exist.' in caplog.text
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+    wins = WinFactory.create_batch(4, company=None)
+
+    uuids = [win.id for win in wins]
+    export_experiences = ExportExperienceFactory.create_batch(4)
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_contents = ['export_win_id,export_experience_id']
+    for uuid, export_experience in zip(uuids, export_experiences):
+        csv_contents.append(f'{uuid},{export_experience.id}')
+
+    csv_contents.append(f'{uuid4()},{uuid4()}')
+
+    csv_content = '\n'.join(csv_contents)
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_legacy_export_wins_export_experience', bucket, object_key, simulate=True)
+
+    for uuid, export_experience in zip(uuids, export_experiences):
+        win = Win.objects.get(id=uuid)
+        assert win.export_experience_id != export_experience.id
+
+        versions = Version.objects.get_for_object(win).order_by('revision__date_created')
+        assert versions.count() == 0
+
+    assert 'Win matching query does not exist.' in caplog.text


### PR DESCRIPTION
### Description of change

This adds a migration command that should update export experience field for given wins.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
