### PR TITLE
CLS2-1014: Default ordering for EYB leads

### DIFF
--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -299,3 +299,19 @@ class TestEYBLeadListAPI(APITestMixin):
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 0
+
+    def test_list_eyb_leads_default_order(self, test_user_with_view_permissions):
+        """Test the default ordering of EYB leads reflects descending created_on."""
+        to_create = 2
+        for _ in range(to_create):
+            EYBLeadFactory()
+
+        api_client = self.create_api_client(user=test_user_with_view_permissions)
+        response = api_client.get(EYB_LEAD_COLLECTION_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data['results']) == to_create
+
+        newest_timestamp = response.data['results'][0]['created_on']
+        oldest_timestamp = response.data['results'][1]['created_on']
+
+        assert newest_timestamp > oldest_timestamp

--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -2,6 +2,8 @@ import logging
 
 from django.db.models import Q
 
+from rest_framework import filters
+
 from datahub.core.viewsets import SoftDeleteCoreViewSet
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.serializers import RetrieveEYBLeadSerializer
@@ -13,6 +15,8 @@ logger = logging.getLogger(__name__)
 
 class EYBLeadViewSet(SoftDeleteCoreViewSet):
     serializer_class = RetrieveEYBLeadSerializer
+    filter_backends = [filters.OrderingFilter]
+    ordering = ['-created_on']
 
     def get_queryset(self):
         """Apply filters to queryset based on query parameters (in GET operations)."""


### PR DESCRIPTION
Addresses [CLS2-1014](https://uktrade.atlassian.net/browse/CLS2-1014)

### Description of change

Simple PR to set the default ordering of EYB Leads from most recent to least recently created. Option was to sort them in the frontend, but it makes more sense to send them already pre-ordered by `-created_on`

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.


[CLS2-1014]: https://uktrade.atlassian.net/browse/CLS2-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ