### PR TITLE
Revert back to ForeignKey as OneToOne crashes opensearch sync

### DIFF
--- a/datahub/company_activity/models/company_activity.py
+++ b/datahub/company_activity/models/company_activity.py
@@ -51,7 +51,7 @@ class CompanyActivity(models.Model):
     )
 
     # A single company activity must have one of the following relationships, but not multiple.
-    interaction = models.OneToOneField(
+    interaction = models.ForeignKey(
         'interaction.Interaction',
         unique=True,
         null=True,
@@ -63,7 +63,7 @@ class CompanyActivity(models.Model):
             '(referral, event etc)'
         ),
     )
-    referral = models.OneToOneField(
+    referral = models.ForeignKey(
         'company_referral.CompanyReferral',
         unique=True,
         null=True,
@@ -75,7 +75,7 @@ class CompanyActivity(models.Model):
             '(interaction, event etc)'
         ),
     )
-    investment = models.OneToOneField(
+    investment = models.ForeignKey(
         'investment.InvestmentProject',
         unique=True,
         null=True,
@@ -87,7 +87,7 @@ class CompanyActivity(models.Model):
             '(interaction, event etc)'
         ),
     )
-    order = models.OneToOneField(
+    order = models.ForeignKey(
         'order.Order',
         unique=True,
         null=True,


### PR DESCRIPTION
### Description of change

Django throws a warning suggesting unique foreignkeys are may be better served with a OneToOne relation however this requires additional code in the OpenSearch sync to handle both OneToOne and FKs.

See work required here: https://github.com/uktrade/data-hub-api/pull/5749

Related Sentry alert: https://sentry.ci.uktrade.digital/organizations/dit/issues/138602/?project=235&query=is%3Aunresolved

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?

