### PR TITLE
Check for already ingested Great files by prefix

### DIFF
--- a/datahub/company_activity/tasks/constants.py
+++ b/datahub/company_activity/tasks/constants.py
@@ -1,0 +1,7 @@
+import environ
+
+env = environ.Env()
+REGION = env('AWS_DEFAULT_REGION', default='eu-west-2')
+BUCKET = f"data-flow-bucket-{env('ENVIRONMENT', default='')}"
+PREFIX = 'data-flow/exports/'
+GREAT_PREFIX = f'{PREFIX}ExportGreatContactFormData/'

--- a/datahub/company_activity/tasks/ingest_company_activity.py
+++ b/datahub/company_activity/tasks/ingest_company_activity.py
@@ -1,7 +1,6 @@
 import logging
 
 import boto3
-import environ
 
 from django.conf import settings
 
@@ -10,14 +9,10 @@ from rq import Queue, Worker
 
 from datahub.company_activity.models import IngestedFile
 from datahub.company_activity.tasks import ingest_great_data
+from datahub.company_activity.tasks.constants import BUCKET, GREAT_PREFIX, REGION
 from datahub.core.queues.job_scheduler import job_scheduler
 
 logger = logging.getLogger(__name__)
-env = environ.Env()
-REGION = env('AWS_DEFAULT_REGION', default='eu-west-2')
-BUCKET = f"data-flow-bucket-{env('ENVIRONMENT', default='')}"
-PREFIX = 'data-flow/exports/'
-GREAT_PREFIX = f'{PREFIX}ExportGreatContactFormData/'
 TWO_HOURS_IN_SECONDS = 7200
 
 

--- a/datahub/company_activity/tasks/ingest_great_data.py
+++ b/datahub/company_activity/tasks/ingest_great_data.py
@@ -3,18 +3,15 @@ import logging
 
 from datetime import datetime
 
-import environ
-
 from smart_open import open
 
 from datahub.company.models.company import Company
 from datahub.company.models.contact import Contact
 from datahub.company_activity.models import GreatExportEnquiry, IngestedFile
+from datahub.company_activity.tasks.constants import GREAT_PREFIX
 from datahub.metadata.models import BusinessType, Country, EmployeeRange, Sector
 
 logger = logging.getLogger(__name__)
-env = environ.Env()
-REGION = env('AWS_DEFAULT_REGION', default='eu-west-2')
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
 
@@ -46,7 +43,9 @@ class GreatIngestionTask:
 
     def _get_last_ingestion_datetime(self):
         try:
-            return IngestedFile.objects.latest('created_on').created_on.timestamp()
+            return IngestedFile.objects.filter(
+                filepath__icontains=GREAT_PREFIX,
+            ).latest('created_on').created_on.timestamp()
         except IngestedFile.DoesNotExist:
             return None
 

--- a/datahub/company_activity/tests/factories.py
+++ b/datahub/company_activity/tests/factories.py
@@ -126,7 +126,7 @@ class CompanyActivityIngestedFileFactory(factory.django.DjangoModelFactory):
     CompanyActivity ingested file factory
     """
 
-    filepath = 'data-flow/exports/GreatContactFormData/20240920T000000.jsonl.gz'
+    filepath = 'data-flow/exports/ExportGreatContactFormData/20240920T000000.jsonl.gz'
     created_on = now()
 
     class Meta:

--- a/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_ingestion_tasks.py
@@ -17,8 +17,9 @@ from rq_scheduler import Scheduler
 
 from datahub.company_activity.models import IngestedFile
 from datahub.company_activity.tasks import ingest_great_data
+from datahub.company_activity.tasks.constants import BUCKET, GREAT_PREFIX, REGION
 from datahub.company_activity.tasks.ingest_company_activity import (
-    BUCKET, GREAT_PREFIX, ingest_activity_data, REGION, TWO_HOURS_IN_SECONDS,
+    ingest_activity_data, TWO_HOURS_IN_SECONDS,
 )
 from datahub.core.queues.constants import EVERY_HOUR
 from datahub.core.queues.job_scheduler import job_scheduler


### PR DESCRIPTION
### Description of change

Since EYB now also use the IngestedFiles model we need to filter by prefix otherwise we'll pull the wrong latest ingest data.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
