### PR TITLE
Add command to update legacy wins totals.

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_legacy_export_wins_totals.py
+++ b/datahub/dbmaintenance/management/commands/update_legacy_export_wins_totals.py
@@ -1,0 +1,39 @@
+import reversion
+
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.export_win.models import Win
+
+
+class Command(CSVBaseCommand):
+    """Command to update totals for Legacy export wins."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        export_win_id = parse_uuid(row['id'])
+        total_expected_export_value = int(row['total_expected_export_value'])
+        total_expected_non_export_value = int(row['total_expected_non_export_value'])
+        total_expected_odi_value = int(row['total_expected_odi_value'])
+
+        export_win = Win.objects.get(id=export_win_id)
+
+        if not simulate:
+            # The win likely will not have its original revision in the History
+            with reversion.create_revision():
+                reversion.add_to_revision(export_win)
+                reversion.set_comment('Legacy export wins totals migration - before.')
+
+        export_win.total_expected_export_value = total_expected_export_value
+        export_win.total_expected_non_export_value = total_expected_non_export_value
+        export_win.total_expected_odi_value = total_expected_odi_value
+
+        if not simulate:
+            with reversion.create_revision():
+                export_win.save(
+                    update_fields=(
+                        'total_expected_export_value',
+                        'total_expected_non_export_value',
+                        'total_expected_odi_value',
+                    ),
+                )
+                reversion.set_comment('Legacy export wins totals migration - after.')

--- a/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_totals.py
+++ b/datahub/dbmaintenance/test/commands/test_update_legacy_export_wins_totals.py
@@ -1,0 +1,146 @@
+from io import BytesIO
+from uuid import uuid4
+
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from reversion.models import Version
+
+from datahub.export_win.models import Win
+from datahub.export_win.test.factories import WinFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('ERROR')
+    wins = WinFactory.create_batch(
+        4,
+        total_expected_export_value=0,
+        total_expected_non_export_value=0,
+        total_expected_odi_value=0,
+        migrated_on=timezone.now(),
+    )
+    dh_win = WinFactory(
+        total_expected_export_value=0,
+        total_expected_non_export_value=0,
+        total_expected_odi_value=0,
+    )
+    uuids = [win.id for win in [*wins, dh_win]]
+    total_expected_export_values = [100, 200, 300, 400, 500]
+    total_expected_non_export_values = [200, 300, 400, 500, 600]
+    total_expected_odi_values = [10, 20, 30, 40, 50]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_contents = ['id,total_expected_export_value,total_expected_non_export_value,'
+                    'total_expected_odi_value']
+    for uuid, export_value, non_export_value, odi_value in zip(
+        uuids,
+        total_expected_export_values,
+        total_expected_non_export_values,
+        total_expected_odi_values,
+    ):
+        csv_contents.append(f'{uuid},{export_value},{non_export_value},{odi_value}')
+
+    csv_contents.append(f'{uuid4()},0,0,0,0')
+
+    csv_content = '\n'.join(csv_contents)
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_legacy_export_wins_totals', bucket, object_key)
+
+    for uuid, export_value, non_export_value, odi_value in zip(
+        uuids,
+        total_expected_export_values,
+        total_expected_non_export_values,
+        total_expected_odi_values,
+    ):
+        win = Win.objects.get(id=uuid)
+        if win == dh_win:
+            assert win.total_expected_export_value == 0
+            assert win.total_expected_non_export_value == 0
+            assert win.total_expected_odi_value == 0
+        else:
+            assert win.total_expected_export_value == export_value
+            assert win.total_expected_non_export_value == non_export_value
+            assert win.total_expected_odi_value == odi_value
+
+        versions = Version.objects.get_for_object(win).order_by('revision__date_created')
+        assert versions.count() == 2
+        comment = versions[0].revision.get_comment()
+        assert comment == 'Legacy export wins totals migration - before.'
+        comment = versions[1].revision.get_comment()
+        assert comment == 'Legacy export wins totals migration - after.'
+
+    assert 'Win matching query does not exist.' in caplog.text
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+    wins = WinFactory.create_batch(
+        4,
+        total_expected_export_value=0,
+        total_expected_non_export_value=0,
+        total_expected_odi_value=0,
+        migrated_on=timezone.now(),
+    )
+
+    uuids = [win.id for win in wins]
+    total_expected_export_values = [100, 200, 300, 400]
+    total_expected_non_export_values = [200, 300, 400, 500]
+    total_expected_odi_values = [10, 20, 30, 40]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_contents = ['id,total_expected_export_value,total_expected_non_export_value,'
+                    'total_expected_odi_value']
+    for uuid, export_value, non_export_value, odi_value in zip(
+        uuids,
+        total_expected_export_values,
+        total_expected_non_export_values,
+        total_expected_odi_values,
+    ):
+        csv_contents.append(f'{uuid},{export_value},{non_export_value},{odi_value}')
+
+    csv_contents.append(f'{uuid4()},0,0,0,0')
+
+    csv_content = '\n'.join(csv_contents)
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_legacy_export_wins_totals', bucket, object_key, simulate=True)
+
+    for uuid in uuids:
+        win = Win.objects.get(id=uuid)
+        assert win.total_expected_export_value == 0
+        assert win.total_expected_non_export_value == 0
+        assert win.total_expected_odi_value == 0
+
+        versions = Version.objects.get_for_object(win).order_by('revision__date_created')
+        assert versions.count() == 0
+
+    assert 'Win matching query does not exist.' in caplog.text

--- a/datahub/export_win/legacy_migration.py
+++ b/datahub/export_win/legacy_migration.py
@@ -246,6 +246,9 @@ def create_export_win_from_legacy(item):
 
     win = {
         'id': item.get('id'),
+        'total_expected_export_value': item.get('total_expected_export_value'),
+        'total_expected_non_export_value': item.get('total_expected_non_export_value'),
+        'total_expected_odi_value': item.get('total_expected_odi_value'),
     }
     for field, resolver in must_resolvers.items():
         resolved = resolver(item, win)

--- a/datahub/export_win/models.py
+++ b/datahub/export_win/models.py
@@ -501,10 +501,12 @@ class Win(BaseModel):
             self.total_expected_odi_value = 0
             super().save(*args, **kwargs)
 
-        calc_total = calculate_totals_for_export_win(self)
-        self.total_expected_export_value = calc_total['total_export_value']
-        self.total_expected_non_export_value = calc_total['total_non_export_value']
-        self.total_expected_odi_value = calc_total['total_odi_value']
+        # Don't recalculate totals for migrated legacy Export wins
+        if not self.migrated_on:
+            calc_total = calculate_totals_for_export_win(self)
+            self.total_expected_export_value = calc_total['total_export_value']
+            self.total_expected_non_export_value = calc_total['total_non_export_value']
+            self.total_expected_odi_value = calc_total['total_odi_value']
         super().save(*args, **kwargs)
 
 

--- a/datahub/export_win/test/test_legacy_migration.py
+++ b/datahub/export_win/test/test_legacy_migration.py
@@ -136,6 +136,9 @@ legacy_wins = {
             'confirmation_marketing_source': 'Don’t know',
             'confirmation_portion_without_help': 'No value without our help',
             'country_name': 'Austria',
+            'total_expected_export_value': 0,
+            'total_expected_non_export_value': 0,
+            'total_expected_odi_value': 0,
         }],
     },
     mock_legacy_wins_page_urls['wins'][1]: {
@@ -210,6 +213,9 @@ legacy_wins = {
             'confirmation_marketing_source': 'Don’t know',
             'confirmation_portion_without_help': 'No value without our help',
             'country_name': 'Austria',
+            'total_expected_export_value': 0,
+            'total_expected_non_export_value': 0,
+            'total_expected_odi_value': 0,
         }, {
             'associated_programme_1': None,
             'associated_programme_2': None,
@@ -255,6 +261,9 @@ legacy_wins = {
             'type_of_support_3': None,
             'user__email': 'abc@test',
             'user__name': 'Abc Def',
+            'total_expected_export_value': 0,
+            'total_expected_non_export_value': 0,
+            'total_expected_odi_value': 0,
         }, {
             'associated_programme_1': None,
             'associated_programme_2': None,
@@ -304,6 +313,9 @@ legacy_wins = {
             'confirmation__comments': None,
             'confirmation__name': None,
             'confirmation__other_marketing_source': None,
+            'total_expected_export_value': 0,
+            'total_expected_non_export_value': 0,
+            'total_expected_odi_value': 0,
         }, {
             'associated_programme_1': None,
             'associated_programme_2': None,
@@ -353,6 +365,9 @@ legacy_wins = {
             'confirmation__comments': None,
             'confirmation__name': None,
             'confirmation__other_marketing_source': None,
+            'total_expected_export_value': 0,
+            'total_expected_non_export_value': 0,
+            'total_expected_odi_value': 0,
         }, {
             'associated_programme_1': None,
             'associated_programme_2': None,
@@ -403,6 +418,9 @@ legacy_wins = {
             'confirmation__name': None,
             'confirmation__other_marketing_source': None,
             'is_active': False,
+            'total_expected_export_value': 0,
+            'total_expected_non_export_value': 0,
+            'total_expected_odi_value': 0,
         }, {  # Tests if deleted win will be updated
             'associated_programme_1': None,
             'associated_programme_2': None,
@@ -453,6 +471,9 @@ legacy_wins = {
             'confirmation__name': None,
             'confirmation__other_marketing_source': None,
             'is_active': False,
+            'total_expected_export_value': 0,
+            'total_expected_non_export_value': 0,
+            'total_expected_odi_value': 0,
         }],
     },
     mock_legacy_wins_page_urls['breakdowns'][0]: {


### PR DESCRIPTION
### Description of change

This adds a command that will let us update legacy Export wins totals from given spreadsheet.

This PR also ensures that the totals will not be recalculated for legacy Export wins.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
