### PR TITLE
Fix/cls2-1038 DUNS number empty string

### DIFF
--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -418,7 +418,6 @@ class CreateEYBLeadUserSerializer(BaseEYBLeadSerializer):
 
         # Rest of the character fields
         char_fields = {
-            'dunsNumber': 'duns_number',
             'addressLine2': 'address_2',
             'county': 'address_county',
             'postcode': 'address_postcode',

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -413,7 +413,7 @@ class CreateEYBLeadUserSerializer(BaseEYBLeadSerializer):
         }
         for incoming_field, internal_field in none_fields.items():
             value = data.get(incoming_field, None)
-            if value is None:
+            if value == '':
                 internal_values[internal_field] = None
 
         # Rest of the character fields

--- a/datahub/investment_lead/services.py
+++ b/datahub/investment_lead/services.py
@@ -65,7 +65,8 @@ def add_new_company_from_eyb_lead(eyb_lead: EYBLead):
     """
     # Create company record
     company = Company()
-    company.duns_number = eyb_lead.duns_number
+
+    company.duns_number = eyb_lead.duns_number if eyb_lead.duns_number else None
     company.name = eyb_lead.company_name
     company.sector = eyb_lead.sector
     company.address_1 = eyb_lead.address_1
@@ -93,7 +94,7 @@ def match_or_create_company_for_eyb_lead(eyb_lead):
         company (object): a company object
     """
     company = None
-    if eyb_lead.duns_number is not None:
+    if eyb_lead.duns_number:
         company = find_match_by_duns_number(eyb_lead.duns_number)
 
     if company is None:

--- a/datahub/investment_lead/test/test_services.py
+++ b/datahub/investment_lead/test/test_services.py
@@ -67,6 +67,31 @@ class TestEYBLeadServices:
         assert eyb_lead.company == company
 
     @pytest.mark.parametrize(
+        'duns_number_param',
+        [
+            '',
+            None
+        ],
+    )
+    def test_duns_does_not_match_when_empty_or_none(self, duns_number_param):
+        """An empty or None duns_number shouldn't match with any company."""
+        eyb_lead = EYBLeadFactory(
+            company=None,
+            duns_number=duns_number_param
+        )
+        empty_company = CompanyFactory(
+            duns_number=duns_number_param
+        )
+
+        initial_companies_count = Company.objects.count()
+        assert eyb_lead.company is None
+
+        match_or_create_company_for_eyb_lead(eyb_lead)
+
+        assert Company.objects.count() == initial_companies_count + 1
+        assert eyb_lead.company is not empty_company
+
+    @pytest.mark.parametrize(
         'function_to_test',
         [
             'raise_exception_for_eyb_lead_without_company',

--- a/datahub/investment_lead/test/test_services.py
+++ b/datahub/investment_lead/test/test_services.py
@@ -70,17 +70,17 @@ class TestEYBLeadServices:
         'duns_number_param',
         [
             '',
-            None
+            None,
         ],
     )
     def test_duns_does_not_match_when_empty_or_none(self, duns_number_param):
         """An empty or None duns_number shouldn't match with any company."""
         eyb_lead = EYBLeadFactory(
             company=None,
-            duns_number=duns_number_param
+            duns_number=duns_number_param,
         )
         empty_company = CompanyFactory(
-            duns_number=duns_number_param
+            duns_number=duns_number_param,
         )
 
         initial_companies_count = Company.objects.count()


### PR DESCRIPTION
### Description of change

Addresses [CLS2-1038](https://uktrade.atlassian.net/browse/CLS2-1038)

**The issue:**

_Note: `empty` here means empty string_

there's been 65 EYB leads that have been matched with the same company, despite having different stored company details. After investigation, we noticed this company has been saved with an `empty` (not `None`) value for `duns_number`
This causes a few wrong behaviours:
- when an EYB lead with the same `empty` duns_number value is matched against existing companies, it would be paired to this one company above (expected behaviour: no company matched)
- when a company is created from an EYB lead with an `empty` duns_number, the new company would violate the uniqueness constraint, raising an integrity error (expected behaviour: the new company gets created with `duns_number=None`, as `empty string` shouldn't be permitted at all)

**The fix:**

- the EYB lead create/matching service now ensures `duns_number` is truthy
- the EYB lead company creation function coerces `empty` duns_number into `None`
- the serializer coerces `empty` into `None` for duns_number


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.


[CLS2-1038]: https://uktrade.atlassian.net/browse/CLS2-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ