### PR TITLE
Revert "Bump rq from 1.16.2 to 2.0.0" and rq patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,14 +84,6 @@ job_defaults: &job_defaults
         name: Install dependencies
         command: python -m pip install --cache-dir ~/cache/pip --progress-bar off -r requirements-dev.txt
 
-    # patch rq-scheduler for compatibility with rq 2.0.0 
-    # this can be removed if there is an update to rq-scheduler that resolves this issue
-    - run:
-        name: Patch rq-scheduler for compatibility with rq 2.0.0
-        command: |
-          sed -i "/from rq.connections import resolve_connection/d" /usr/local/lib/python3.10/site-packages/rq_scheduler/scheduler.py
-          sed -i "s/self.connection = resolve_connection(connection)/self.connection = connection/" /usr/local/lib/python3.10/site-packages/rq_scheduler/scheduler.py
-
     - save_cache:
         name: Save pip cache
         key: v2-<< parameters.python_image >>-{{ checksum "requirements-dev.txt" }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -454,7 +454,7 @@ requests-toolbelt==1.0.0
     # via -r requirements.in
 responses==0.25.3
     # via moto
-rq==2.0.0
+rq==1.16.2
     # via
     #   -r requirements.in
     #   rq-scheduler

--- a/requirements.in
+++ b/requirements.in
@@ -62,7 +62,7 @@ requests_toolbelt==1.0.0
 sentry_sdk==2.17.0
 
 # RQ and associated helpers
-rq==2.0.0
+rq==1.16.2
 rq-scheduler==0.13.1
 
 # For logging tables

--- a/requirements.txt
+++ b/requirements.txt
@@ -283,7 +283,7 @@ requests==2.32.3
     #   requests-toolbelt
 requests-toolbelt==1.0.0
     # via -r requirements.in
-rq==2.0.0
+rq==1.16.2
     # via
     #   -r requirements.in
     #   rq-scheduler


### PR DESCRIPTION
### Description of change

This is to revert rq update which cause deployment error

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
