### PR TITLE
Revert change to export wins adviser dataset endpoint.

### DIFF
--- a/datahub/dataset/export_wins/views.py
+++ b/datahub/dataset/export_wins/views.py
@@ -11,6 +11,7 @@ from django.db.models import (
     JSONField,
     Min,
     OuterRef,
+    Q,
     Subquery,
     Value,
     When,
@@ -85,7 +86,10 @@ class ExportWinsAdvisersDatasetView(BaseDatasetView):
             .annotate(
                 id=F('legacy_id'),
                 name=Case(
-                    When(win__migrated_on__isnull=False, then=F('name')),
+                    When(
+                        Q(win__migrated_on__isnull=False) & Q(adviser__isnull=True),
+                        then=F('name'),
+                    ),
                     default=Concat(
                         F('adviser__first_name'),
                         Value(' '),


### PR DESCRIPTION
### Description of change

This ensures that when `adviser` is available for migrated legacy win, the adviser name is returned instead of `name` field.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
