### PR TITLE
CLS2-1023 Add marketing hashed uuid to the model and display in admin

### DIFF
--- a/datahub/investment_lead/admin.py
+++ b/datahub/investment_lead/admin.py
@@ -87,6 +87,7 @@ class EYBLeadAdmin(admin.ModelAdmin):
             'Marketing Information',
             {
                 'fields': [
+                    'marketing_hashed_uuid',
                     'utm_name',
                     'utm_source',
                     'utm_medium',

--- a/datahub/investment_lead/migrations/0008_add_marketing_hashed_uuid.py
+++ b/datahub/investment_lead/migrations/0008_add_marketing_hashed_uuid.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('investment_lead', '0007_alter_eyblead_hiring_alter_eyblead_spend'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='eyblead',
+            name='marketing_hashed_uuid',
+            field=models.CharField(blank=True, max_length=256),
+        ),
+    ]

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -202,6 +202,7 @@ class EYBLead(InvestmentLead):
     )
 
     # EYB marketing fields
+    marketing_hashed_uuid = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)
     utm_name = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)
     utm_source = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)
     utm_medium = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -202,7 +202,9 @@ class EYBLead(InvestmentLead):
     )
 
     # EYB marketing fields
-    marketing_hashed_uuid = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)
+    marketing_hashed_uuid = models.CharField(
+        max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True
+    )
     utm_name = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)
     utm_source = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)
     utm_medium = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -203,7 +203,7 @@ class EYBLead(InvestmentLead):
 
     # EYB marketing fields
     marketing_hashed_uuid = models.CharField(
-        max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True
+        max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True,
     )
     utm_name = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)
     utm_source = models.CharField(max_length=CHAR_FIELD_MAX_LENGTH, default='', blank=True)


### PR DESCRIPTION
### Description of change

Adds the marketing hashed uuid to the EYBLead model and displays the field in Django admin.

To test:

- run the migration
- in Django admin go to **INVESTMENT_LEAD** > **EYB leads** > **Add EYB lead +**
- scroll down to the **Marketing Information** section
- **marketing_hashed_uuid** should be the first field displayed

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
