### PR TITLE
Use correct Postgres and Opensearch images in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ job_defaults: &job_defaults
     python_image:
       type: string
 
-    es_image:
+    os_image:
       type: string
 
     postgres_image:
@@ -57,7 +57,7 @@ job_defaults: &job_defaults
   docker:
     - image: <<parameters.python_image>>
 
-    - image: <<parameters.es_image>>
+    - image: <<parameters.os_image>>
       environment:
         discovery.type: single-node
         plugins.security.disabled: "true"
@@ -126,5 +126,5 @@ workflows:
       - build:
           publish_coverage: true
           python_image: python:3.10.5
-          postgres_image: postgres:12
-          es_image: opensearchproject/opensearch:1.2.4
+          postgres_image: postgres:16
+          os_image: opensearchproject/opensearch:2.11.0


### PR DESCRIPTION
### Description of change

When I was doing Dependabot yesterday I noticed that we were still using a Postgres 12 image in CircleCI. I've changed this to use Postgres 16 to match the actual codeabse, as well as changing the Opensearch image.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
