### PR TITLE
Feature/CLS2-1024 Create EYB marketing serializer

### DIFF
--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -451,10 +451,18 @@ class CreateEYBLeadMarketingSerializer(BaseEYBLeadSerializer):
             'hashed_uuid',
         ]
 
-    name = serializers.CharField(source='utm_name', required=False)
-    medium = serializers.CharField(source='utm_medium', required=False)
-    source = serializers.CharField(source='utm_source', required=False)
-    content = serializers.CharField(source='utm_content', required=False)
+    name = serializers.CharField(
+        source='utm_name', required=False, allow_null=True, allow_blank=True, default='',
+    )
+    medium = serializers.CharField(
+        source='utm_medium', required=False, allow_null=True, allow_blank=True, default='',
+    )
+    source = serializers.CharField(
+        source='utm_source', required=False, allow_null=True, allow_blank=True, default='',
+    )
+    content = serializers.CharField(
+        source='utm_content', required=False, allow_null=True, allow_blank=True, default='',
+    )
     hashed_uuid = serializers.CharField(source='marketing_hashed_uuid', required=True)
 
     def get_related_fields_internal_value(self, data):
@@ -467,7 +475,6 @@ class CreateEYBLeadMarketingSerializer(BaseEYBLeadSerializer):
             'medium': 'utm_medium',
             'source': 'utm_source',
             'content': 'utm_content',
-            'hashed_uuid': 'marketing_hashed_uuid',
         }
         for incoming_field, internal_field in char_fields.items():
             value = data.get(incoming_field, None)

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -87,6 +87,7 @@ MARKETING_FIELDS = [
     'utm_source',
     'utm_medium',
     'utm_content',
+    'marketing_hashed_uuid',
 ]
 
 ALL_FIELDS = ARCHIVABLE_FIELDS + INVESTMENT_LEAD_BASE_FIELDS + \
@@ -476,3 +477,54 @@ class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
                 instance.landing_timeframe,
             ).label if instance.landing_timeframe else None,
         }
+
+class CreateEYBLeadMarketingSerializer(BaseEYBLeadSerializer):
+    class Meta(BaseEYBLeadSerializer.Meta):
+        # TODO: confirm whether content data will be received
+        fields = [
+            'name',
+            'medium',
+            'source',
+            'hashed_uuid',
+        ]
+
+    name = serializers.CharField(source='utm_name', required=False)
+    medium = serializers.CharField(source='utm_medium', required=False)
+    source = serializers.CharField(source='utm_source', required=False)
+    # TODO: confirm whether content data will be received
+    # content = serializers.CharField(source='utm_content', required=False)
+    hashed_uuid = serializers.CharField(source='marketing_hashed_uuid', required=True)
+    
+
+    # TODO: Update the following:
+
+    # def get_related_fields_internal_value(self, data):
+    #     """Provides related fields in a format suitable for internal use."""
+    #     internal_values = {}
+
+    #     # Fields that can be None
+    #     none_fields = {
+    #         'dunsNumber': 'duns_number',
+    #         'agreeTerms': 'agree_terms',
+    #         'agreeInfoEmail': 'agree_info_email',
+    #     }
+    #     for incoming_field, internal_field in none_fields.items():
+    #         value = data.get(incoming_field, None)
+    #         if value == '':
+    #             internal_values[internal_field] = None
+
+    #     # Rest of the character fields
+    #     char_fields = {
+    #         'addressLine2': 'address_2',
+    #         'county': 'address_county',
+    #         'postcode': 'address_postcode',
+    #         'role': 'role',
+    #         'telphoneNumber': 'telephone_number',
+    #         'landingTimeframe': 'landing_timeframe',
+    #     }
+    #     for incoming_field, internal_field in char_fields.items():
+    #         value = data.get(incoming_field, None)
+    #         if value is None:
+    #             internal_values[internal_field] = ''
+
+    #     return internal_values

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -441,6 +441,45 @@ class CreateEYBLeadUserSerializer(BaseEYBLeadSerializer):
         }
 
 
+class CreateEYBLeadMarketingSerializer(BaseEYBLeadSerializer):
+    class Meta(BaseEYBLeadSerializer.Meta):
+        fields = [
+            'name',
+            'medium',
+            'source',
+            'content',
+            'hashed_uuid',
+        ]
+
+    name = serializers.CharField(source='utm_name', required=False)
+    medium = serializers.CharField(source='utm_medium', required=False)
+    source = serializers.CharField(source='utm_source', required=False)
+    content = serializers.CharField(source='utm_content', required=False)
+    hashed_uuid = serializers.CharField(source='marketing_hashed_uuid', required=True)
+    
+
+    # TODO: Update the following:
+
+    def get_related_fields_internal_value(self, data):
+        """Provides related fields in a format suitable for internal use."""
+        internal_values = {}
+
+        # Character fields
+        char_fields = {
+            'name': 'utm_name',
+            'medium': 'utm_medium',
+            'source': 'utm_source',
+            'content': 'utm_content',
+            'hashed_uuid': 'marketing_hashed_uuid',
+        }
+        for incoming_field, internal_field in char_fields.items():
+            value = data.get(incoming_field, None)
+            if value is None:
+                internal_values[internal_field] = ''
+
+        return internal_values
+
+
 class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
 
     class Meta(BaseEYBLeadSerializer.Meta):
@@ -477,54 +516,3 @@ class RetrieveEYBLeadSerializer(BaseEYBLeadSerializer):
                 instance.landing_timeframe,
             ).label if instance.landing_timeframe else None,
         }
-
-class CreateEYBLeadMarketingSerializer(BaseEYBLeadSerializer):
-    class Meta(BaseEYBLeadSerializer.Meta):
-        # TODO: confirm whether content data will be received
-        fields = [
-            'name',
-            'medium',
-            'source',
-            'hashed_uuid',
-        ]
-
-    name = serializers.CharField(source='utm_name', required=False)
-    medium = serializers.CharField(source='utm_medium', required=False)
-    source = serializers.CharField(source='utm_source', required=False)
-    # TODO: confirm whether content data will be received
-    # content = serializers.CharField(source='utm_content', required=False)
-    hashed_uuid = serializers.CharField(source='marketing_hashed_uuid', required=True)
-    
-
-    # TODO: Update the following:
-
-    # def get_related_fields_internal_value(self, data):
-    #     """Provides related fields in a format suitable for internal use."""
-    #     internal_values = {}
-
-    #     # Fields that can be None
-    #     none_fields = {
-    #         'dunsNumber': 'duns_number',
-    #         'agreeTerms': 'agree_terms',
-    #         'agreeInfoEmail': 'agree_info_email',
-    #     }
-    #     for incoming_field, internal_field in none_fields.items():
-    #         value = data.get(incoming_field, None)
-    #         if value == '':
-    #             internal_values[internal_field] = None
-
-    #     # Rest of the character fields
-    #     char_fields = {
-    #         'addressLine2': 'address_2',
-    #         'county': 'address_county',
-    #         'postcode': 'address_postcode',
-    #         'role': 'role',
-    #         'telphoneNumber': 'telephone_number',
-    #         'landingTimeframe': 'landing_timeframe',
-    #     }
-    #     for incoming_field, internal_field in char_fields.items():
-    #         value = data.get(incoming_field, None)
-    #         if value is None:
-    #             internal_values[internal_field] = ''
-
-    #     return internal_values

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -97,7 +97,7 @@ ALL_FIELDS = ARCHIVABLE_FIELDS + INVESTMENT_LEAD_BASE_FIELDS + \
 class BaseEYBLeadSerializer(serializers.ModelSerializer):
     """Base serializer for an EYB lead object.
 
-    EYB serves data from 2 endpoints: triage and user.
+    EYB serves data from 3 endpoints: triage, user and marketing.
     However, in Data Hub, we combine them into one EYB lead model instance.
     """
 
@@ -456,9 +456,6 @@ class CreateEYBLeadMarketingSerializer(BaseEYBLeadSerializer):
     source = serializers.CharField(source='utm_source', required=False)
     content = serializers.CharField(source='utm_content', required=False)
     hashed_uuid = serializers.CharField(source='marketing_hashed_uuid', required=True)
-    
-
-    # TODO: Update the following:
 
     def get_related_fields_internal_value(self, data):
         """Provides related fields in a format suitable for internal use."""

--- a/datahub/investment_lead/test/conftest.py
+++ b/datahub/investment_lead/test/conftest.py
@@ -5,6 +5,7 @@ from datahub.core.test_utils import create_test_user
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 from datahub.investment_lead.models import EYBLead
 from datahub.investment_lead.test.factories import (
+    eyb_lead_marketing_record_faker,
     eyb_lead_triage_record_faker,
     eyb_lead_user_record_faker,
     EYBLeadFactory,
@@ -29,6 +30,11 @@ def eyb_lead_triage_data():
 @pytest.fixture
 def eyb_lead_user_data():
     return eyb_lead_user_record_faker()
+
+
+@pytest.fixture
+def eyb_lead_marketing_data():
+    return eyb_lead_marketing_record_faker()
 
 
 @pytest.fixture

--- a/datahub/investment_lead/test/factories.py
+++ b/datahub/investment_lead/test/factories.py
@@ -150,3 +150,17 @@ def eyb_lead_triage_record_faker(overrides: dict | None = None) -> dict:
     if overrides:
         data.update(overrides)
     return data
+
+
+def eyb_lead_marketing_record_faker(overrides: dict | None = None) -> dict:
+    """Creates a fake marketing record."""
+    data = {
+        'name': fake.word(),
+        'medium': fake.word(),
+        'source': fake.word(),
+        'content': fake.word(),
+        'hashed_uuid': generate_hashed_uuid(),
+    }
+    if overrides:
+        data.update(overrides)
+    return data

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -10,7 +10,7 @@ from datahub.investment_lead.serializers import (
     CreateEYBLeadUserSerializer,
     RetrieveEYBLeadSerializer,
 )
-from datahub.investment_lead.test.factories import generate_hashed_uuid
+from datahub.investment_lead.test.factories import eyb_lead_marketing_record_faker, generate_hashed_uuid
 from datahub.investment_lead.test.utils import (
     assert_ingested_eyb_marketing_data,
     assert_ingested_eyb_triage_data,
@@ -344,16 +344,16 @@ class TestCreateEYBLeadMarketingSerializer:
         [None, ''],
     )
     def test_non_required_fields_with_null_or_empty_values_are_handled_correctly(
-        self, eyb_lead_marketing_data, value,
+        self, value,
     ):
         """Tests null values and empty strings are handled correctly for non-required fields."""
-        eyb_lead_marketing_data.update({
+        marketing_data=eyb_lead_marketing_record_faker({
             'name': value,
             'medium': value,
             'source': value,
             'content': value,
         })
-        serializer = CreateEYBLeadMarketingSerializer(data=eyb_lead_marketing_data)
+        serializer = CreateEYBLeadMarketingSerializer(data=marketing_data)
         assert serializer.is_valid()
         instance = serializer.save()
         assert isinstance(instance, EYBLead)

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -10,7 +10,10 @@ from datahub.investment_lead.serializers import (
     CreateEYBLeadUserSerializer,
     RetrieveEYBLeadSerializer,
 )
-from datahub.investment_lead.test.factories import eyb_lead_marketing_record_faker, generate_hashed_uuid
+from datahub.investment_lead.test.factories import (
+    eyb_lead_marketing_record_faker,
+    generate_hashed_uuid,
+)
 from datahub.investment_lead.test.utils import (
     assert_ingested_eyb_marketing_data,
     assert_ingested_eyb_triage_data,
@@ -347,7 +350,7 @@ class TestCreateEYBLeadMarketingSerializer:
         self, value,
     ):
         """Tests null values and empty strings are handled correctly for non-required fields."""
-        marketing_data=eyb_lead_marketing_record_faker({
+        marketing_data = eyb_lead_marketing_record_faker({
             'name': value,
             'medium': value,
             'source': value,

--- a/datahub/investment_lead/test/utils.py
+++ b/datahub/investment_lead/test/utils.py
@@ -76,7 +76,7 @@ def assert_ingested_eyb_user_data(instance: EYBLead, data: dict):
     - camelCase field names
     - strings for related fields.
     """
-    assert instance.user_hashed_uuid == data['hashedUuid']
+    assert instance.user_hashed_uuid == data.get('hashedUuid')
     assert_datetimes(instance.user_created, data.get('created'))
     assert_datetimes(instance.user_modified, data.get('modified'))
     assert instance.company_name == data.get('companyName')
@@ -95,6 +95,15 @@ def assert_ingested_eyb_user_data(instance: EYBLead, data: dict):
     assert instance.agree_terms == data.get('agreeTerms', None)
     assert instance.agree_info_email == data.get('agreeInfoEmail', None)
     assert instance.landing_timeframe == data.get('landingTimeframe', None)
+
+
+def assert_ingested_eyb_marketing_data(instance: EYBLead, data: dict):
+    """Method to verify the ingested EYB marketing data against the created EYBLead instance."""
+    assert instance.utm_name == data.get('name')
+    assert instance.utm_medium == data.get('medium')
+    assert instance.utm_source == data.get('source')
+    assert instance.utm_content == data.get('content')
+    assert instance.marketing_hashed_uuid == data.get('hashed_uuid')
 
 
 def assert_retrieved_eyb_lead_data(instance: EYBLead, data: dict):
@@ -152,10 +161,11 @@ def assert_retrieved_eyb_lead_data(instance: EYBLead, data: dict):
     ]
 
     # EYB marketing fields
-    assert instance.utm_name == data['utm_name']
-    assert instance.utm_source == data['utm_source']
-    assert instance.utm_medium == data['utm_medium']
-    assert instance.utm_content == data['utm_content']
+    assert instance.utm_name == data.get('utm_name')
+    assert instance.utm_source == data.get('utm_source')
+    assert instance.utm_medium == data.get('utm_medium')
+    assert instance.utm_content == data.get('utm_content')
+    assert instance.marketing_hashed_uuid == data.get('marketing_hashed_uuid')
 
 
 def assert_eyb_lead_matches_company(company: Company, eyb_lead: EYBLead):


### PR DESCRIPTION
### Description of change

Adds the EYB Lead Marketing serializer for the following EYB marketing fields:

- name
- medium
- source
- content
- hashed_uuid


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
