### PR TITLE
feature/use-opensearch-for-consent-job-searching-instead-of-DB

### DIFF
--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from datahub.company.tasks.adviser import schedule_automatic_adviser_deactivate
 from datahub.company.tasks.company import schedule_automatic_company_archive
 from datahub.company.tasks.contact import (
+    ingest_contact_consent_data,
     schedule_automatic_contact_archive,
 )
 from datahub.company.tasks.export_potential import update_company_export_potential_from_csv
@@ -246,6 +247,15 @@ def schedule_jobs():
     schedule_export_win_auto_resend_client_email()
     schedule_user_reminder_migration()
     schedule_update_company_export_potential_from_csv()
+    job_scheduler(
+        max_retries=3,
+        function=ingest_contact_consent_data,
+        cron=EVERY_HOUR,
+        queue_name=LONG_RUNNING_QUEUE,
+        retry_backoff=True,
+        description='Import contact consent data',
+        job_timeout=HALF_DAY_IN_SECONDS,
+    )
 
 
 def schedule_email_ingestion_tasks():

--- a/datahub/company/test/tasks/test_contact_task.py
+++ b/datahub/company/test/tasks/test_contact_task.py
@@ -918,6 +918,24 @@ class TestContactConsentIngestionTask:
         )
 
     @mock_aws
+    def test_search_contacts_returns_expected_matches(
+        self,
+        opensearch_with_collector,
+    ):
+        """
+        Test the index returns expected contact matches
+        """
+        contact_1 = ContactFactory(email='index_search@bar.com')
+        ContactFactory(email='not_found@bar.com')
+
+        opensearch_with_collector.flush_and_refresh()
+        search_results = ContactConsentIngestionTask().search_contacts(contact_1.email)
+
+        assert len(search_results) == 1
+        assert search_results[0]['id'] == str(contact_1.id)
+        assert search_results[0]['email'] == contact_1.email
+
+    @mock_aws
     def test_delete_file_removes_file_using_boto3(self):
         """
         Test that the file is deleted from the bucket


### PR DESCRIPTION
### Description of change
Using the django DB for checking if a contact in the S3 file existed was running slowly on production (200-300 milliseconds per query), with a file that contains 1.3 million rows.

To reduce impact on the DB, instead use the opensearch server to query if a contact has an email matching the row in the S3 file. This approach for checking contacts is much faster (single digit milliseconds), and a query is only made to the DB once validation checks have been ran on the last ingested date.

This has been tested on a local environment with 350,000 contacts, and took 30-35 minutes

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
