### PR TITLE
feature/add-consent-data-to-contact-index

### DIFF
--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -63,6 +63,7 @@ class Contact(BaseSearchModel):
     full_telephone_number = Keyword()
     title = fields.id_name_field()
     valid_email = Boolean()
+    consent_data_last_modified = Date()
 
     MAPPINGS = {
         'adviser': dict_utils.contact_or_adviser_dict,

--- a/datahub/search/contact/serializers.py
+++ b/datahub/search/contact/serializers.py
@@ -28,6 +28,7 @@ class SearchContactQuerySerializer(EntitySearchQuerySerializer):
     created_by = SingleOrListField(child=StringUUIDField(), required=False)
     created_on_exists = serializers.BooleanField(required=False)
     valid_email = serializers.BooleanField(required=False)
+    consent_data_last_modified = serializers.DateTimeField(required=False)
 
     SORT_BY_FIELDS = (
         'address_country.name',

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -19,6 +19,7 @@ def test_contact_dbmodel_to_dict(opensearch):
         'title',
         'company',
         'created_on',
+        'consent_data_last_modified',
         'created_by',
         'modified_on',
         'archived',

--- a/datahub/search/contact/test/test_opensearch.py
+++ b/datahub/search/contact/test/test_opensearch.py
@@ -160,6 +160,9 @@ def test_mapping(opensearch):
                 },
                 'type': 'object',
             },
+            'consent_data_last_modified': {
+                'type': 'date',
+            },
             'created_by': {
                 'properties': {
                     'dit_team': {

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -625,6 +625,7 @@
     modified_on: "2018-06-05T00:00:00Z"
     archived_documents_url_path: "/documents/123"
     consent_data: [{"source_system": "System A", "consent_domain": "Domestic", "email_contact_consent": true, "telephone_contact_consent": false}]
+    consent_data_last_modified: "2024-09-09T14:10:00"
 
 - model: company.contact
   pk: 1430e18a-52ac-4185-b71d-b2be5a771fd0
@@ -642,6 +643,8 @@
     notes: This is a dummy contact for testing
     created_on: "2018-02-28T15:00:00Z"
     modified_on: "2018-06-05T00:00:00Z"
+    consent_data: [{"source_system": "System B", "consent_domain": "International", "email_contact_consent": false, "telephone_contact_consent": false}]
+    consent_data_last_modified: "2023-09-09T14:10:00"
 
 - model: company_referral.companyreferral
   pk: 02e4cce0-caf5-4eb8-8d6d-ebdd69a6545b


### PR DESCRIPTION
### Description of change
Add `consent_data_last_modified` to the contact index in opensearch. A future PR is going to use this field for contact searching
<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
