### PR TITLE
Remove feature flag for viewing legacy export wins.

### DIFF
--- a/datahub/export_win/__init__.py
+++ b/datahub/export_win/__init__.py
@@ -1,3 +1,0 @@
-EXPORT_WINS_LEGACY_DATA_FEATURE_FLAG_NAME = (
-    'export-wins-legacy-data',
-)

--- a/datahub/export_win/test/test_win_views.py
+++ b/datahub/export_win/test/test_win_views.py
@@ -36,9 +36,6 @@ from datahub.core.test_utils import (
     create_test_user,
     format_date_or_datetime,
 )
-from datahub.export_win import (
-    EXPORT_WINS_LEGACY_DATA_FEATURE_FLAG_NAME,
-)
 from datahub.export_win.models import (
     CustomerResponse,
     CustomerResponseToken,
@@ -54,21 +51,9 @@ from datahub.export_win.test.factories import (
     WinAdviserFactory,
     WinFactory,
 )
-from datahub.feature_flag.test.factories import UserFeatureFlagFactory
 from datahub.metadata.test.factories import TeamFactory
 
 pytestmark = pytest.mark.django_db
-
-
-@pytest.fixture()
-def export_wins_legacy_data_feature_flag():
-    """
-    Creates the Export wins legacy data user feature flag.
-    """
-    yield UserFeatureFlagFactory(
-        code=EXPORT_WINS_LEGACY_DATA_FEATURE_FLAG_NAME,
-        is_active=True,
-    )
 
 
 @pytest.fixture()
@@ -476,17 +461,8 @@ class TestListWinView(APITestMixin):
 
         assert response_data['count'] == 2
 
-    @pytest.mark.parametrize(
-        'list_legacy_data',
-        (
-            True,
-            False,
-        ),
-    )
-    def test_list_with_legacy_wins(self, list_legacy_data, export_wins_legacy_data_feature_flag):
+    def test_list_with_legacy_wins(self):
         """Tests listing wins."""
-        if list_legacy_data:
-            self.user.features.set([export_wins_legacy_data_feature_flag])
         WinFactory.create_batch(2, adviser=self.user)
         WinFactory.create_batch(2, adviser=self.user, migrated_on=now())
         url = reverse('api-v4:export-win:collection')
@@ -495,7 +471,7 @@ class TestListWinView(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
 
-        assert response_data['count'] == (4 if list_legacy_data else 2)
+        assert response_data['count'] == 4
 
     def test_list_default_sorting(self):
         """Tests wins are sorted."""

--- a/datahub/export_win/views.py
+++ b/datahub/export_win/views.py
@@ -23,7 +23,6 @@ from rest_framework.views import exception_handler, Response
 from datahub.core.schemas import StubSchema
 
 from datahub.core.viewsets import CoreViewSet
-from datahub.export_win import EXPORT_WINS_LEGACY_DATA_FEATURE_FLAG_NAME
 from datahub.export_win.decorators import validate_script_and_html_tags
 from datahub.export_win.models import (
     CustomerResponse,
@@ -40,9 +39,7 @@ from datahub.export_win.tasks import (
     notify_export_win_email_by_rq_email,
     update_customer_response_token_for_email_notification_id,
 )
-from datahub.feature_flag.utils import (
-    is_user_feature_flag_active,
-)
+
 
 logger = logging.getLogger(__name__)
 
@@ -131,21 +128,11 @@ class WinViewSet(CoreViewSet):
 
     def get_queryset(self):
         """Filter the queryset to the authenticated user."""
-        if is_user_feature_flag_active(
-            EXPORT_WINS_LEGACY_DATA_FEATURE_FLAG_NAME,
-            self.request.user,
-        ):
-            migrated_filter = {}
-        else:
-            migrated_filter = {
-                'migrated_on__isnull': True,
-            }
         return (
             super()
             .get_queryset()
             .filter(
                 is_anonymous_win=False,
-                **migrated_filter,
             )
             .exclude(
                 ~Q(adviser=self.request.user),


### PR DESCRIPTION
### Description of change

This removes the feature flag that enabled users to view legacy export wins. It should now be available to all, so feature flag is not needed.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
