### PR TITLE
Add S3 zip files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,6 @@ tags
 
 # Localstack
 .localstack/mounted 
+
+# S3 data files
+*.jsonl.gz


### PR DESCRIPTION
### Description of change

After a recent incident we want to ensure that S3 zip files aren't accidentally committed to the repository. I've added this file extension to `gitignore` to prevent this.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
