### PR TITLE
Tell browsers to use https instead of http for 1 hour

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -747,3 +747,7 @@ CSP_REPORT_ONLY = False
 
 S3_LOCAL_ENDPOINT_URL = env("S3_LOCAL_ENDPOINT_URL", default='')
 ENABLE_CONTACT_CONSENT_INGEST = env("ENABLE_CONTACT_CONSENT_INGEST", default=False)
+
+# Initially set to 1 hour, to increase once confirmed it's successful.
+SECURE_HSTS_SECONDS = 3600
+SECURE_HSTS_INCLUDE_SUBDOMAINS = True


### PR DESCRIPTION
### Description of change

This is a Django settings which instructs browsers to visit the site with HTTPS instead of HTTP. You can read me more about it in the [docs](https://docs.djangoproject.com/en/5.1/ref/middleware/#http-strict-transport-security).

As recommended by Django, I've set it to only do this for 1 hour at a time to ensure it doesn't break anything. Once its tested on UAT and been on PROD this can be updated to 1 year.

Later the preload option will also be added once it seems to be running fine on prod for a week or two.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
