### PR TITLE
CLS2-1035 Sync CompanyActivity with EYB Lead on save 

### DIFF
--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -112,6 +112,7 @@ COMPANY_ACTIVITY_CREATED_BY_MODELS = [
     GreatExportEnquiryFactory,
     InvestmentProjectFactory,
     OrderFactory,
+    EYBLeadFactory,
 ]
 
 

--- a/datahub/company_activity/tasks/sync.py
+++ b/datahub/company_activity/tasks/sync.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 def relate_company_activity_to_interactions(batch_size=500):
     """
-    Grabs all interactions so they can be related to in the
+    Grabs all interactions so they can be related to the
     `CompanyActivity` model with bulk_create. Excludes any
     interactions already associated in the CompanyActivity model.
 
@@ -47,7 +47,7 @@ def relate_company_activity_to_interactions(batch_size=500):
 
 def relate_company_activity_to_referrals(batch_size=500):
     """
-    Grabs all referrals so they can be related to in the
+    Grabs all referrals so they can be related to the
     `CompanyActivity` model with a bulk_create. Excludes any
     referrals already associated in the CompanyActivity model.
 
@@ -77,7 +77,7 @@ def relate_company_activity_to_referrals(batch_size=500):
 
 def relate_company_activity_to_investment_projects(batch_size=500):
     """
-    Grabs all investment projects so they can be related to in the
+    Grabs all investment projects so they can be related to the
     `CompanyActivity` model with a bulk_create. Excludes any
     investment projects already associated in the CompanyActivity model.
     """
@@ -107,7 +107,7 @@ def relate_company_activity_to_investment_projects(batch_size=500):
 
 def relate_company_activity_to_orders(batch_size=500):
     """
-    Grabs all omis orders so they can be related to in the
+    Grabs all omis orders so they can be related to the
     `CompanyActivity` model with a bulk_create. Excludes any
     order projects already associated in the CompanyActivity model.
     """
@@ -137,7 +137,7 @@ def relate_company_activity_to_orders(batch_size=500):
 
 def relate_company_activity_to_great(batch_size=500):
     """
-    Grabs all great export enquiry so they can be related to in the
+    Grabs all great export enquiry so they can be related to the
     `CompanyActivity` model with a bulk_create. Excludes any
     great export enquiry already associated in the CompanyActivity model.
     """
@@ -167,23 +167,23 @@ def relate_company_activity_to_great(batch_size=500):
 
 def relate_company_activity_to_eyb_lead(batch_size=500):
     """
-    Grabs all EYB leads so they can be related to in the
+    Grabs all EYB leads so they can be related to the
     `CompanyActivity` model with a bulk_create. Excludes any
     EYB leads already associated in the CompanyActivity model.
     """
     activity = set(
         CompanyActivity.objects.filter(
-            eyb_lead_id__isnull=False,
+            eyb_lead__isnull=False,
         ).values_list('eyb_lead', flat=True),
     )
 
     eyb_leads = EYBLead.objects.filter(
-        company_id__isnull=False,
+        company__isnull=False,
     ).values('id', 'created_on', 'company_id')
 
     objs = [
         CompanyActivity(
-            eyb_lead=eyb_lead['id'],
+            eyb_lead_id=eyb_lead['id'],
             date=eyb_lead['created_on'],
             company_id=eyb_lead['company_id'],
             activity_source=CompanyActivity.ActivitySource.eyb_lead,

--- a/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
@@ -1,0 +1,76 @@
+from unittest import mock
+
+import pytest
+
+from datahub.company_activity.models import CompanyActivity
+from datahub.company_activity.tasks.sync import (
+    relate_company_activity_to_eyb_lead,
+    schedule_sync_data_to_company_activity,
+)
+from datahub.investment_lead.test.factories import EYBLeadFactory
+
+
+@pytest.mark.django_db
+class TestCompanyActivityEYBLeadTasks:
+    """
+    Tests for the schedule_sync_data_to_company_activity task.
+    """
+
+    def test_eyb_leads_are_copied_to_company_activity(self):
+        """
+        Test that eyb leads are added to the CompanyActivity model.
+        """
+        eyb_leads = EYBLeadFactory.create_batch(5)
+
+        # Remove the created CompanyActivities added by the eyb lead `save` method
+        # to mimic already existing data in staging and prod database.
+        CompanyActivity.objects.all().delete()
+        assert CompanyActivity.objects.count() == 0
+
+        # Check the "existing" eyb leads are added to the company activity model
+        schedule_sync_data_to_company_activity(relate_company_activity_to_eyb_lead)
+        assert CompanyActivity.objects.count() == len(eyb_leads)
+
+        company_activity = CompanyActivity.objects.get(eyb_lead=eyb_leads[0])
+        assert company_activity.date == eyb_leads[0].created_on
+        assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
+        assert company_activity.eyb_lead.id == eyb_leads[0].id
+
+    @mock.patch('datahub.company_activity.models.CompanyActivity.objects.bulk_create')
+    def test_eyb_leads_are_bulk_created_in_batches(self, mocked_bulk_create, caplog):
+        """
+        Test that eyb leads are bulk created in batches.
+        """
+        caplog.set_level('INFO')
+        batch_size = 5
+
+        EYBLeadFactory.create_batch(10)
+
+        # Delete any activity created through the investments save method.
+        CompanyActivity.objects.all().delete()
+        assert CompanyActivity.objects.count() == 0
+
+        # Ensure eyb leads are bulk_created
+        relate_company_activity_to_eyb_lead(batch_size)
+        assert mocked_bulk_create.call_count == 2
+
+        assert (
+            f'Creating in batches of: {batch_size} CompanyActivities. 10 remaining.' in caplog.text
+        )
+        assert (
+            f'Creating in batches of: {batch_size} CompanyActivities. 5 remaining.' in caplog.text
+        )
+        assert 'Finished bulk creating CompanyActivities.' in caplog.text
+
+    def test_eyb_leads_with_a_company_activity_are_not_added_again(self):
+        """
+        Test that eyb leads which are already part of the `CompanyActivity` model
+        are not added again.
+        """
+        EYBLeadFactory.create_batch(4)
+
+        assert CompanyActivity.objects.count() == 4
+
+        # Check count remains unchanged.
+        schedule_sync_data_to_company_activity(relate_company_activity_to_eyb_lead)
+        assert CompanyActivity.objects.count() == 4

--- a/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
@@ -34,7 +34,7 @@ class TestCompanyActivityEYBLeadTasks:
         company_activity = CompanyActivity.objects.get(eyb_lead=eyb_leads[0])
         assert company_activity.date == eyb_leads[0].created_on
         assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
-        assert company_activity.eyb_lead.id == eyb_leads[0].id
+        assert company_activity.eyb_lead_id == eyb_leads[0].id
 
     @mock.patch('datahub.company_activity.models.CompanyActivity.objects.bulk_create')
     def test_eyb_leads_are_bulk_created_in_batches(self, mocked_bulk_create, caplog):

--- a/datahub/company_activity/tests/test_tasks/test_order_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_order_task.py
@@ -13,12 +13,12 @@ from datahub.omis.order.test.factories import OrderFactory
 @pytest.mark.django_db
 class TestCompanyActivityOrderTasks:
     """
-    Tests for the schedule_sync_investments_to_company_activity task.
+    Tests for the schedule_sync_data_to_company_activity task.
     """
 
     def test_orders_are_copied_to_company_activity(self):
         """
-        Test that investments are added to the CompanyActivity model.
+        Test that omis orders are added to the CompanyActivity model.
         """
         orders = OrderFactory.create_batch(5)
 

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -234,8 +234,5 @@ class EYBLead(InvestmentLead):
             CompanyActivity.objects.update_or_create(
                 eyb_lead_id=self.id,
                 activity_source=CompanyActivity.ActivitySource.eyb_lead,
-                defaults={
-                    'date': self.created_on,
-                    'company_id': self.company.id,
-                },
+                defaults={'date': self.created_on, 'company_id': self.company_id},
             )

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -231,8 +231,8 @@ class EYBLead(InvestmentLead):
             if not self.company:
                 return
             CompanyActivity.objects.update_or_create(
-                order_id=self.id,
-                activity_source=CompanyActivity.ActivitySource.order,
+                eyb_lead_id=self.id,
+                activity_source=CompanyActivity.ActivitySource.eyb_lead,
                 defaults={
                     'date': self.created_on,
                     'company_id': self.company.id,

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -225,6 +225,7 @@ class EYBLead(InvestmentLead):
 
     def save(self, *args, **kwargs):
         """
+        Creates a CompanyActivity when a EYB Lead is saved
         """
         with transaction.atomic():
             super().save(*args, **kwargs)

--- a/datahub/investment_lead/test/test_models.py
+++ b/datahub/investment_lead/test/test_models.py
@@ -1,9 +1,29 @@
 import pytest
 
+from datahub.company_activity.models import CompanyActivity
+from datahub.investment_lead.test.factories import EYBLeadFactory
+
 
 @pytest.mark.django_db
 class TestEYBLead:
     """Tests EYB Lead model"""
+
+    def test_save_without_company_no_company_activity(self):
+        assert not CompanyActivity.objects.all().exists()
+        EYBLeadFactory(company=None)
+        assert not CompanyActivity.objects.all().exists()
+
+    def test_save_with_company_creates_company_activity(self):
+        assert not CompanyActivity.objects.all().exists()
+
+        eyb_lead = EYBLeadFactory()
+
+        assert CompanyActivity.objects.all().count() == 1
+
+        company_activity = CompanyActivity.objects.get(eyb_lead=eyb_lead.id)
+        assert company_activity.company_id == eyb_lead.company.id
+        assert company_activity.date == eyb_lead.created_on
+        assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
 
     def test_str(self, eyb_lead_instance_from_db):
         """Test the human friendly string representation of the object"""


### PR DESCRIPTION
### Description of change

This PR takes care of [CLS2-1035](https://uktrade.atlassian.net/browse/CLS2-1035)

Part 2 out of 3 of [CLS2-1031](https://uktrade.atlassian.net/browse/CLS2-1031) (hence the separate feature branch)

- [x] Create and schedule a task to relate all new `EYBLead` to `CompanyActivity`
- [x] Update save method in `EYBLead` model
- [x] Tests

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.


[CLS2-1035]: https://uktrade.atlassian.net/browse/CLS2-1035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLS2-1031]: https://uktrade.atlassian.net/browse/CLS2-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ