### PR TITLE
Filter EYB leads by both `EYBLead.company_name` and `EYBLead.company.name`

### DIFF
--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -31,7 +31,9 @@ class EYBLeadViewSet(SoftDeleteCoreViewSet):
         if country_ids:
             queryset = queryset.filter(address_country__id__in=country_ids)
         if company_name:
-            queryset = queryset.filter(company__name__icontains=company_name)
+            queryset = queryset.filter(
+                Q(company__name__icontains=company_name) | Q(company_name__icontains=company_name),
+            )
         if sector_ids:
             # This will be a list of level 0 sector ids;
             # We want to find and return all leads with sectors that have these ancestors


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

When filtering EYB leads by company name, users were reporting unreliable results and that they were missing leads. 

This PR ensures the company name filter searches both the `EYBLead.company.name` and `EYBLead.company_name` fields. The latter contains the user entered name, the former is the name of the linked company record (matched on either duns number of created with the user-entered data).

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
