### PR TITLE
feature/sync-with-contacts-preloaded

### DIFF
--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from datahub.company.tasks.adviser import schedule_automatic_adviser_deactivate
 from datahub.company.tasks.company import schedule_automatic_company_archive
 from datahub.company.tasks.contact import (
+    ingest_contact_consent_data,
     schedule_automatic_contact_archive,
 )
 from datahub.company.tasks.export_potential import update_company_export_potential_from_csv
@@ -246,6 +247,15 @@ def schedule_jobs():
     schedule_export_win_auto_resend_client_email()
     schedule_user_reminder_migration()
     schedule_update_company_export_potential_from_csv()
+    job_scheduler(
+        max_retries=3,
+        function=ingest_contact_consent_data,
+        cron=EVERY_HOUR,
+        queue_name=LONG_RUNNING_QUEUE,
+        retry_backoff=True,
+        description='Import contact consent data',
+        job_timeout=HALF_DAY_IN_SECONDS,
+    )
 
 
 def schedule_email_ingestion_tasks():

--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -34,6 +34,7 @@ from datahub.core.queues.constants import (
     # EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
     EVERY_TWO_AM,
     HALF_DAY_IN_SECONDS,
+    ONE_HOUR_IN_SECONDS,
 )
 from datahub.core.queues.health_check import queue_health_check
 from datahub.core.queues.job_scheduler import job_scheduler
@@ -254,7 +255,7 @@ def schedule_jobs():
         queue_name=LONG_RUNNING_QUEUE,
         retry_backoff=True,
         description='Import contact consent data',
-        job_timeout=HALF_DAY_IN_SECONDS,
+        job_timeout=ONE_HOUR_IN_SECONDS * 2,
     )
 
 

--- a/datahub/company/tasks/contact.py
+++ b/datahub/company/tasks/contact.py
@@ -276,7 +276,7 @@ class ContactConsentIngestionTask:
 
                 matching_contacts = contact_dict.get(email)
 
-                if not matching_contacts or len(matching_contacts) == 0:
+                if not matching_contacts:
                     logger.debug(
                         'Email %s in contact consent file has no matching datahub contacts',
                         email,

--- a/datahub/company/tasks/contact.py
+++ b/datahub/company/tasks/contact.py
@@ -2,10 +2,10 @@ import datetime
 import json
 import logging
 import math
+from typing import List
 
 import environ
 import requests
-
 from dateutil import parser
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -202,6 +202,7 @@ class ContactConsentIngestionTask:
                 CONSENT_PREFIX,
             )
             return
+
         for file_key in file_keys:
             try:
                 self.sync_file_with_database(s3_client, file_key)
@@ -213,12 +214,38 @@ class ContactConsentIngestionTask:
                 )
                 raise exc
 
+    def get_grouped_contacts(self) -> dict[str, List[Contact]]:
+        contacts_qs = Contact.objects.all()
+        contact_dict = {}
+        for d in contacts_qs:
+            contact_dict.setdefault(d.email, []).append(d)
+        return contact_dict
+
+    def should_update_contact(self, contact: Contact, consent_row):
+
+        last_modified = consent_row['last_modified'] if 'last_modified' in consent_row else None
+
+        if contact.consent_data_last_modified is None or last_modified is None:
+            return True
+
+        # To avoid issues with different source system time formats, just compare on
+        # the date portion
+        if parser.parse(last_modified).date() > contact.consent_data_last_modified.date():
+            return True
+        return False
+
     def sync_file_with_database(self, client, file_key):
         logger.info(
             'Syncing contact consent file %s with datahub contacts',
             file_key,
         )
         path = f's3://{BUCKET}/{file_key}'
+
+        contact_dict = self.get_grouped_contacts()
+
+        if not contact_dict:
+            logger.info('No contacts were found')
+            return
 
         with open(
             path,
@@ -242,54 +269,50 @@ class ContactConsentIngestionTask:
                     continue
 
                 email = consent_row['email']
-                matching_contacts = Contact.objects.filter(email=email)
 
-                if not matching_contacts.exists():
-                    logger.info(
-                        'Email %s in contact consent file has no matching datahub contact',
+                if not email:
+                    logger.debug('Row %s has no email', i)
+                    continue
+
+                matching_contacts = contact_dict.get(email)
+
+                if not matching_contacts or len(matching_contacts) == 0:
+                    logger.debug(
+                        'Email %s in contact consent file has no matching datahub contacts',
                         email,
                     )
                     continue
 
-                for matching_contact in matching_contacts:
+                for contact in matching_contacts:
 
-                    last_modified = (
-                        consent_row['last_modified'] if 'last_modified' in consent_row else None
-                    )
-
-                    update_row = False
-                    if (
-                        matching_contact.consent_data_last_modified is None
-                        or last_modified is None
-                    ):
-                        update_row = True
-                    # To avoid issues with different source system time formats, just compare on
-                    # the date portion
-                    elif (
-                        parser.parse(last_modified).date()
-                        > matching_contact.consent_data_last_modified.date()
-                    ):
-                        update_row = True
-
-                    if not update_row:
-                        logger.debug(
-                            'Email %s consent data has not been updated in the latest file',
+                    if not self.should_update_contact(contact, consent_row):
+                        logger.info(
+                            'Email %s does not need to be updated',
                             email,
                         )
                         continue
-                    if settings.ENABLE_CONTACT_CONSENT_INGEST:
-                        matching_contact.consent_data = consent_row['consents']
-                        matching_contact.consent_data_last_modified = (
-                            last_modified if last_modified else datetime.datetime.now()
-                        )
-                        matching_contact.save()
 
-                        logger.info('Updated contact consent data for email %s', email)
-                    else:
+                    if not settings.ENABLE_CONTACT_CONSENT_INGEST:
                         logger.info(
                             'Email %s would have consent data updated, but setting is disabled',
                             email,
                         )
+                        continue
+
+                    contact.consent_data = consent_row['consents']
+                    contact.consent_data_last_modified = (
+                        consent_row['last_modified']
+                        if 'last_modified' in consent_row and consent_row['last_modified']
+                        else datetime.datetime.now()
+                    )
+
+                    # We don't need to trigger sync related data signals, use an update
+                    # instead of a save
+                    Contact.objects.filter(id=contact.id).update(
+                        consent_data=contact.consent_data,
+                        consent_data_last_modified=contact.consent_data_last_modified,
+                    )
+                    logger.info('Updated contact consent data for email %s in row %s', email, i)
 
             logger.info(
                 'Finished processing total %s rows for contact consent from file %s',


### PR DESCRIPTION
### Description of change
Using the django DB for individually checking if a contact in the S3 file existed was running slowly on production (200-300 milliseconds per query), with a file that contains 1.3 million rows.

To reduce the number of individual queries being executed against the DB, at the start of the job load all contacts from the DB into a python dictionary. This initial load of users takes around 4-5 minutes, however no further DB reads are required during the processing of the file.

This has been tested on a local environment with 600,000 contacts, and took 6-10 minutes to fully process the file with ENABLE_CONTACT_CONSENT_INGEST setting equal to `False`. Setting this value to `False` allows testing of the file processing logic, without making any changes to the contact in the DB.

When ENABLE_CONTACT_CONSENT_INGEST was set to `True`, the same 600,000 users takes 20-25 minutes to fully process the file and update the contact in the DB with the latest value for that contacts consent. As the only fields this job need to update are the `consent_data` and `consent_data_last_modified`, the `update` django function is used instead of `save` to avoid triggering the subscribed contact signals that submit additional sync jobs to the short queue 

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
