### PR TITLE
FEATURE/CLS2-1034 Add EYBLead to Company Activity -  search

### DIFF
--- a/datahub/search/company_activity/apps.py
+++ b/datahub/search/company_activity/apps.py
@@ -32,7 +32,6 @@ class CompanyActivitySearchApp(SearchApp):
         'great_export_enquiry',
         'great_export_enquiry__contact',
         'eyb_lead',
-        'eyb_lead__company',
     ).prefetch_related(
         'interaction__contacts',
         Prefetch(

--- a/datahub/search/company_activity/apps.py
+++ b/datahub/search/company_activity/apps.py
@@ -31,6 +31,10 @@ class CompanyActivitySearchApp(SearchApp):
         'order__created_by',
         'great_export_enquiry',
         'great_export_enquiry__contact',
+        'eyb_lead',
+        'eyb_lead__company_name',
+        'eyb_lead__company__name',
+        'eyb_lead__duns_number',
     ).prefetch_related(
         'interaction__contacts',
         Prefetch(

--- a/datahub/search/company_activity/apps.py
+++ b/datahub/search/company_activity/apps.py
@@ -32,9 +32,7 @@ class CompanyActivitySearchApp(SearchApp):
         'great_export_enquiry',
         'great_export_enquiry__contact',
         'eyb_lead',
-        'eyb_lead__company_name',
-        'eyb_lead__company__name',
-        'eyb_lead__duns_number',
+        'eyb_lead__company',
     ).prefetch_related(
         'interaction__contacts',
         Prefetch(

--- a/datahub/search/company_activity/dict_utils.py
+++ b/datahub/search/company_activity/dict_utils.py
@@ -96,5 +96,5 @@ def activity_eyb_lead_dict(obj):
         'id': str(obj.id),
         'created_on': obj.created_on,
         'company_name': obj.company_name,
-        'dnb_number': obj.dnb_number
+        'duns_number': obj.duns_number,
     }

--- a/datahub/search/company_activity/dict_utils.py
+++ b/datahub/search/company_activity/dict_utils.py
@@ -85,3 +85,16 @@ def activity_great_dict(obj):
         'meta_subject': obj.meta_subject,
         'data_enquiry': obj.data_enquiry,
     }
+
+
+def activity_eyb_lead_dict(obj):
+    """Creates a dictionary for an eyb lead."""
+    if obj is None:
+        return None
+
+    return {
+        'id': str(obj.id),
+        'created_on': obj.created_on,
+        'company_name': obj.company_name,
+        'dnb_number': obj.dnb_number
+    }

--- a/datahub/search/company_activity/fields.py
+++ b/datahub/search/company_activity/fields.py
@@ -78,3 +78,14 @@ def activity_great_field():
             'data_enquiry': Text(index=False),
         },
     )
+
+
+def activity_eyb_lead_field():
+    return Object(
+        properties={
+            'id': Keyword(),
+            'created_on': Date(),
+            'company_name': Text(index=False),
+            'dnb_number': Text(index=False),
+        },
+    )

--- a/datahub/search/company_activity/fields.py
+++ b/datahub/search/company_activity/fields.py
@@ -86,6 +86,6 @@ def activity_eyb_lead_field():
             'id': Keyword(),
             'created_on': Date(),
             'company_name': Text(index=False),
-            'dnb_number': Text(index=False),
+            'duns_number': Text(index=False),
         },
     )

--- a/datahub/search/company_activity/models.py
+++ b/datahub/search/company_activity/models.py
@@ -2,20 +2,20 @@ from opensearch_dsl import Date, Keyword, Text
 
 from datahub.search import dict_utils, fields
 from datahub.search.company_activity.dict_utils import (
+    activity_eyb_lead_dict,
     activity_great_dict,
     activity_interaction_dict,
     activity_investment_dict,
     activity_order_dict,
     activity_referral_dict,
-    activity_eyb_lead_dict,
 )
 from datahub.search.company_activity.fields import (
+    activity_eyb_lead_field,
     activity_great_field,
     activity_interaction_field,
     activity_investment_field,
     activity_order_field,
     activity_referral_field,
-    activity_eyb_lead_field,
 )
 from datahub.search.models import BaseSearchModel
 

--- a/datahub/search/company_activity/models.py
+++ b/datahub/search/company_activity/models.py
@@ -7,6 +7,7 @@ from datahub.search.company_activity.dict_utils import (
     activity_investment_dict,
     activity_order_dict,
     activity_referral_dict,
+    activity_eyb_lead_dict,
 )
 from datahub.search.company_activity.fields import (
     activity_great_field,
@@ -14,6 +15,7 @@ from datahub.search.company_activity.fields import (
     activity_investment_field,
     activity_order_field,
     activity_referral_field,
+    activity_eyb_lead_field,
 )
 from datahub.search.models import BaseSearchModel
 
@@ -32,6 +34,7 @@ class CompanyActivity(BaseSearchModel):
     investment = activity_investment_field()
     order = activity_order_field()
     great_export_enquiry = activity_great_field()
+    eyb_lead = activity_eyb_lead_field()
 
     COMPUTED_MAPPINGS = {}
 
@@ -42,6 +45,7 @@ class CompanyActivity(BaseSearchModel):
         'investment': activity_investment_dict,
         'order': activity_order_dict,
         'great_export_enquiry': activity_great_dict,
+        'eyb_lead': activity_eyb_lead_dict,
     }
 
     SEARCH_FIELDS = (

--- a/datahub/search/company_activity/signals.py
+++ b/datahub/search/company_activity/signals.py
@@ -11,6 +11,7 @@ from datahub.interaction.models import (
     Interaction as DBInteraction,
 )
 from datahub.investment.project.models import InvestmentProject as DBInvestmentProject
+from datahub.investment_lead.models import EYBLead as DBEYBLead
 from datahub.omis.order.models import Order as DBOrder
 from datahub.search.company_activity import CompanyActivitySearchApp
 from datahub.search.company_activity.models import (
@@ -61,5 +62,6 @@ receivers = (
     SignalReceiver(post_save, DBOrder, sync_related_activity_to_opensearch),
     SignalReceiver(post_save, DBGreatExportEnquiry, sync_related_activity_to_opensearch),
     SignalReceiver(post_save, DBInvestmentProject, sync_related_activity_to_opensearch),
+    SignalReceiver(post_save, DBEYBLead, sync_related_activity_to_opensearch),
     SignalReceiver(post_delete, DBCompanyActivity, remove_interaction_from_opensearch),
 )

--- a/datahub/search/company_activity/test/test_dict_utils.py
+++ b/datahub/search/company_activity/test/test_dict_utils.py
@@ -4,6 +4,7 @@ from datahub.company_activity.tests.factories import GreatExportEnquiryFactory
 from datahub.company_referral.test.factories import CompanyReferralFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
+from datahub.investment_lead.test.factories import EYBLeadFactory
 from datahub.omis.order.test.factories import OrderFactory
 from datahub.search.company_activity import dict_utils
 
@@ -89,3 +90,17 @@ def test_activity_great_dict():
     assert result['contact']['id'] == str(great.contact.id)
     assert result['meta_subject'] == great.meta_subject
     assert result['data_enquiry'] == great.data_enquiry
+
+
+def test_activity_eyb_lead_dict():
+    obj = None
+    result = dict_utils.activity_eyb_lead_dict(obj)
+    assert result is None
+
+    eyb_lead = EYBLeadFactory()
+    result = dict_utils.activity_eyb_lead_dict(eyb_lead)
+
+    assert result['id'] == str(eyb_lead.id)
+    assert result['created_on'] == eyb_lead.created_on
+    assert result['duns_number'] == eyb_lead.duns_number
+    assert result['company_name'] == eyb_lead.company_name

--- a/datahub/search/company_activity/test/test_models.py
+++ b/datahub/search/company_activity/test/test_models.py
@@ -4,6 +4,7 @@ import pytest
 
 from datahub.company_activity.models import CompanyActivity as DBCompanyActivity
 from datahub.company_activity.tests.factories import (
+    CompanyActivityEYBLeadFactory,
     CompanyActivityGreatExportEnquiryFactory,
     CompanyActivityInteractionFactory,
     CompanyActivityInvestmentProjectFactory,
@@ -27,6 +28,7 @@ def test_company_activity_referral_to_dict():
         'investment': company_activity.investment,
         'order': company_activity.order,
         'great_export_enquiry': company_activity.great_export_enquiry,
+        'eyb_lead': company_activity.eyb_lead,
         'referral': {
             'id': str(company_activity.referral_id),
             'completed_on': company_activity.referral.completed_on,
@@ -123,6 +125,7 @@ def test_company_activity_interaction_to_dict():
         'referral': company_activity.referral,
         'order': company_activity.order,
         'great_export_enquiry': company_activity.great_export_enquiry,
+        'eyb_lead': company_activity.eyb_lead,
         'company': (
             {
                 'id': str(company_activity.company_id),
@@ -159,6 +162,7 @@ def test_company_activity_investment_to_dict():
         'interaction': company_activity.interaction,
         'order': company_activity.order,
         'great_export_enquiry': company_activity.great_export_enquiry,
+        'eyb_lead': company_activity.eyb_lead,
         'investment': {
             'id': str(company_activity.investment.id),
             'name': company_activity.investment.name,
@@ -207,6 +211,7 @@ def test_company_activity_order_to_dict():
         'investment': company_activity.investment,
         'referral': company_activity.referral,
         'great_export_enquiry': company_activity.great_export_enquiry,
+        'eyb_lead': company_activity.eyb_lead,
         'company': (
             {
                 'id': str(company_activity.company_id),
@@ -285,7 +290,43 @@ def test_company_activity_great_to_dict():
             'meta_subject': great.meta_subject,
             'data_enquiry': great.data_enquiry,
         },
+        'eyb_lead': company_activity.eyb_lead,
         'activity_source': DBCompanyActivity.ActivitySource.great_export_enquiry,
+        'id': company_activity.pk,
+        '_document_type': CompanyActivitySearchApp.name,
+        'date': company_activity.date,
+    }
+
+
+def test_company_activity_eyb_lead_to_dict():
+    """Test converting a CompanyActivity with an eyb lead to a dict."""
+    company_activity = CompanyActivityEYBLeadFactory.build()
+
+    result = CompanyActivity.db_object_to_dict(company_activity)
+    eyb_lead = company_activity.eyb_lead
+
+    assert result == {
+        'interaction': company_activity.interaction,
+        'investment': company_activity.investment,
+        'referral': company_activity.referral,
+        'company': (
+            {
+                'id': str(company_activity.company_id),
+                'name': company_activity.company.name,
+                'trading_names': company_activity.company.trading_names,
+            }
+            if company_activity.company
+            else None
+        ),
+        'order': company_activity.order,
+        'great_export_enquiry': company_activity.great_export_enquiry,
+        'eyb_lead': {
+            'id': str(eyb_lead.id),
+            'created_on': eyb_lead.created_on,
+            'duns_number': eyb_lead.duns_number,
+            'company_name': eyb_lead.company_name,
+        },
+        'activity_source': DBCompanyActivity.ActivitySource.eyb_lead,
         'id': company_activity.pk,
         '_document_type': CompanyActivitySearchApp.name,
         'date': company_activity.date,

--- a/datahub/search/company_activity/test/test_views.py
+++ b/datahub/search/company_activity/test/test_views.py
@@ -16,6 +16,7 @@ from datahub.company.test.factories import (
 )
 from datahub.company_activity.models import CompanyActivity
 from datahub.company_activity.tests.factories import (
+    CompanyActivityEYBLeadFactory,
     CompanyActivityInteractionFactory,
     CompanyActivityInvestmentProjectFactory,
     CompanyActivityOmisOrderFactory,
@@ -62,6 +63,9 @@ def company_activities(opensearch_with_collector):
                 CompanyActivityOmisOrderFactory(company=company_1),
                 CompanyActivityOmisOrderFactory(company=company_1),
                 CompanyActivityOmisOrderFactory(company=company_2),
+                CompanyActivityEYBLeadFactory(company=company_1),
+                CompanyActivityEYBLeadFactory(company=company_1),
+                CompanyActivityEYBLeadFactory(company=company_2),
             ],
         )
 
@@ -123,7 +127,7 @@ class TestCompanyActivityEntitySearchView(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
-        assert len(response_data['results']) == 12
+        assert len(response_data['results']) == 15
 
     def test_default_sort_by_date(self, opensearch_with_collector):
         """Tests default sorting of results by date (descending)."""


### PR DESCRIPTION
### Description of change

This PR takes care of [CLS2-1034](https://uktrade.atlassian.net/browse/CLS2-1034)

Part 3 out of 3 of [CLS2-1031](https://uktrade.atlassian.net/browse/CLS2-1031) (hence the separate feature branch)

- [x] Add the `CompanyActivityEYBLead` to search
- [x] Tests

On approval, then `feature/cls2-1031-...` will be merged into main as well

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.


[CLS2-1034]: https://uktrade.atlassian.net/browse/CLS2-1034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLS2-1031]: https://uktrade.atlassian.net/browse/CLS2-1031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ