### PR TITLE
CLS2-1069 Fix marketing data ingestion bug

### DIFF
--- a/datahub/investment_lead/tasks/ingest_eyb_marketing.py
+++ b/datahub/investment_lead/tasks/ingest_eyb_marketing.py
@@ -50,12 +50,11 @@ def ingest_eyb_marketing_data(bucket, file):
 class EYBMarketingDataIngestionTask(BaseEYBDataIngestionTask):
     """Long running job to read the marketing file contents and ingest the records."""
 
-    def _get_hashed_uuid(self, record):
-        obj = record.get('object')
+    def _get_hashed_uuid(self, obj):
         return None if obj is None else obj.get('hashed_uuid', None)
 
     def _record_has_no_changes(self, record):
-        hashed_uuid = self._get_hashed_uuid(record)
+        hashed_uuid = self._get_hashed_uuid(record.get('object'))
         if hashed_uuid and EYBLead.objects.filter(marketing_hashed_uuid=hashed_uuid).exists():
             return True
         return False

--- a/datahub/investment_lead/tasks/ingest_eyb_marketing.py
+++ b/datahub/investment_lead/tasks/ingest_eyb_marketing.py
@@ -50,11 +50,12 @@ def ingest_eyb_marketing_data(bucket, file):
 class EYBMarketingDataIngestionTask(BaseEYBDataIngestionTask):
     """Long running job to read the marketing file contents and ingest the records."""
 
-    def _get_hashed_uuid(self, obj):
-        return obj.get('hashed_uuid', None)
+    def _get_hashed_uuid(self, record):
+        obj = record.get('object')
+        return None if obj is None else obj.get('hashed_uuid', None)
 
     def _record_has_no_changes(self, record):
-        hashed_uuid = self._get_hashed_uuid(record['object'])
+        hashed_uuid = self._get_hashed_uuid(record)
         if hashed_uuid and EYBLead.objects.filter(marketing_hashed_uuid=hashed_uuid).exists():
             return True
         return False

--- a/datahub/investment_lead/test/test_tasks/test_ingest_eyb_marketing.py
+++ b/datahub/investment_lead/test/test_tasks/test_ingest_eyb_marketing.py
@@ -172,7 +172,10 @@ class TestEYBMarketingDataIngestionTasks:
         assert updated.utm_content == initial_value
 
     @mock_aws
-    def test_marketing_data_ingestion_does_not_fail_with_empty_records(self, test_marketing_file_path):
+    def test_marketing_data_ingestion_does_not_fail_with_empty_records(
+        self,
+        test_marketing_file_path,
+    ):
         """Test previously ingested records do not trigger an update to the existing instance."""
         hashed_uuid = generate_hashed_uuid()
         initial_value = 'initial value'


### PR DESCRIPTION
### Description of change

We have found that no marketing data has been ingested since the release of the ingestion tasks in (`v50.24.0`)

The job fails when trying to access a non-existent key in the JSON.

This PR addresses that bug and makes sure the key isn't accessed directly via `dict[]` but relies on `get()` instead

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
