### PR TITLE
Feature CLS2-982 add missing EYB lead search fields

### DIFF
--- a/datahub/company_activity/tasks/sync.py
+++ b/datahub/company_activity/tasks/sync.py
@@ -184,8 +184,7 @@ def relate_company_activity_to_eyb_lead(batch_size=500):
     objs = [
         CompanyActivity(
             eyb_lead_id=eyb_lead['id'],
-            date=eyb_lead['triage_created'] if eyb_lead['triage_created']
-            else eyb_lead['created_on'],
+            date=eyb_lead['triage_created'],
             company_id=eyb_lead['company_id'],
             activity_source=CompanyActivity.ActivitySource.eyb_lead,
         )

--- a/datahub/company_activity/tasks/sync.py
+++ b/datahub/company_activity/tasks/sync.py
@@ -179,12 +179,13 @@ def relate_company_activity_to_eyb_lead(batch_size=500):
 
     eyb_leads = EYBLead.objects.filter(
         company__isnull=False,
-    ).values('id', 'created_on', 'company_id')
+    ).values('id', 'created_on', 'triage_created', 'company_id')
 
     objs = [
         CompanyActivity(
             eyb_lead_id=eyb_lead['id'],
-            date=eyb_lead['created_on'],
+            date=eyb_lead['triage_created'] if eyb_lead['triage_created']
+            else eyb_lead['created_on'],
             company_id=eyb_lead['company_id'],
             activity_source=CompanyActivity.ActivitySource.eyb_lead,
         )

--- a/datahub/company_activity/tasks/sync.py
+++ b/datahub/company_activity/tasks/sync.py
@@ -184,7 +184,8 @@ def relate_company_activity_to_eyb_lead(batch_size=500):
     objs = [
         CompanyActivity(
             eyb_lead_id=eyb_lead['id'],
-            date=eyb_lead['triage_created'],
+            date=eyb_lead['triage_created'] if eyb_lead['triage_created'] is not None
+            else eyb_lead['created_on'],
             company_id=eyb_lead['company_id'],
             activity_source=CompanyActivity.ActivitySource.eyb_lead,
         )

--- a/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
@@ -1,6 +1,7 @@
 import datetime
 
 from unittest import mock
+
 import pytest
 
 from datahub.company_activity.models import CompanyActivity

--- a/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
@@ -1,7 +1,7 @@
-from unittest import mock
+import datetime
 
+from unittest import mock
 import pytest
-import pytz
 
 from datahub.company_activity.models import CompanyActivity
 from datahub.company_activity.tasks.sync import (
@@ -33,7 +33,9 @@ class TestCompanyActivityEYBLeadTasks:
         assert CompanyActivity.objects.count() == len(eyb_leads)
 
         company_activity = CompanyActivity.objects.get(eyb_lead=eyb_leads[0])
-        assert company_activity.date == eyb_leads[0].triage_created.replace(tzinfo=pytz.UTC)
+        assert company_activity.date == eyb_leads[0].triage_created.replace(
+            tzinfo=datetime.timezone.utc,
+        )
         assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
         assert company_activity.eyb_lead_id == eyb_leads[0].id
 

--- a/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
+++ b/datahub/company_activity/tests/test_tasks/test_eyb_lead_tasks.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+import pytz
 
 from datahub.company_activity.models import CompanyActivity
 from datahub.company_activity.tasks.sync import (
@@ -32,7 +33,7 @@ class TestCompanyActivityEYBLeadTasks:
         assert CompanyActivity.objects.count() == len(eyb_leads)
 
         company_activity = CompanyActivity.objects.get(eyb_lead=eyb_leads[0])
-        assert company_activity.date == eyb_leads[0].created_on
+        assert company_activity.date == eyb_leads[0].triage_created.replace(tzinfo=pytz.UTC)
         assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
         assert company_activity.eyb_lead_id == eyb_leads[0].id
 

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -234,5 +234,9 @@ class EYBLead(InvestmentLead):
             CompanyActivity.objects.update_or_create(
                 eyb_lead_id=self.id,
                 activity_source=CompanyActivity.ActivitySource.eyb_lead,
-                defaults={'date': self.triage_created, 'company_id': self.company_id},
+                defaults={
+                    'date': self.triage_created if self.triage_created is not None
+                    else self.created_on,
+                    'company_id': self.company_id,
+                },
             )

--- a/datahub/investment_lead/models.py
+++ b/datahub/investment_lead/models.py
@@ -234,5 +234,5 @@ class EYBLead(InvestmentLead):
             CompanyActivity.objects.update_or_create(
                 eyb_lead_id=self.id,
                 activity_source=CompanyActivity.ActivitySource.eyb_lead,
-                defaults={'date': self.created_on, 'company_id': self.company_id},
+                defaults={'date': self.triage_created, 'company_id': self.company_id},
             )

--- a/datahub/investment_lead/test/test_models.py
+++ b/datahub/investment_lead/test/test_models.py
@@ -1,5 +1,6 @@
+import datetime
+
 import pytest
-import pytz
 
 from datahub.company_activity.models import CompanyActivity
 from datahub.investment_lead.test.factories import EYBLeadFactory
@@ -23,7 +24,9 @@ class TestEYBLead:
 
         company_activity = CompanyActivity.objects.get(eyb_lead=eyb_lead.id)
         assert company_activity.company_id == eyb_lead.company.id
-        assert company_activity.date == eyb_lead.triage_created.replace(tzinfo=pytz.UTC)
+        assert company_activity.date == eyb_lead.triage_created.replace(
+            tzinfo=datetime.timezone.utc,
+        )
         assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
 
     def test_save_with_company_creates_company_activity_when_triage_created_is_none(self):

--- a/datahub/investment_lead/test/test_models.py
+++ b/datahub/investment_lead/test/test_models.py
@@ -26,6 +26,20 @@ class TestEYBLead:
         assert company_activity.date == eyb_lead.triage_created.replace(tzinfo=pytz.UTC)
         assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
 
+    def test_save_with_company_creates_company_activity_when_triage_created_is_none(self):
+        assert not CompanyActivity.objects.all().exists()
+
+        eyb_lead = EYBLeadFactory()
+        eyb_lead.triage_created = None
+        eyb_lead.save()
+
+        assert CompanyActivity.objects.all().count() == 1
+
+        company_activity = CompanyActivity.objects.get(eyb_lead=eyb_lead.id)
+        assert company_activity.company_id == eyb_lead.company.id
+        assert company_activity.date == eyb_lead.created_on
+        assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
+
     def test_str(self, eyb_lead_instance_from_db):
         """Test the human friendly string representation of the object"""
         assert str(eyb_lead_instance_from_db) == eyb_lead_instance_from_db.name

--- a/datahub/investment_lead/test/test_models.py
+++ b/datahub/investment_lead/test/test_models.py
@@ -1,4 +1,5 @@
 import pytest
+import pytz
 
 from datahub.company_activity.models import CompanyActivity
 from datahub.investment_lead.test.factories import EYBLeadFactory
@@ -22,7 +23,7 @@ class TestEYBLead:
 
         company_activity = CompanyActivity.objects.get(eyb_lead=eyb_lead.id)
         assert company_activity.company_id == eyb_lead.company.id
-        assert company_activity.date == eyb_lead.created_on
+        assert company_activity.date == eyb_lead.triage_created.replace(tzinfo=pytz.UTC)
         assert company_activity.activity_source == CompanyActivity.ActivitySource.eyb_lead
 
     def test_str(self, eyb_lead_instance_from_db):

--- a/datahub/search/company_activity/dict_utils.py
+++ b/datahub/search/company_activity/dict_utils.py
@@ -95,6 +95,8 @@ def activity_eyb_lead_dict(obj):
     return {
         'id': str(obj.id),
         'created_on': obj.created_on,
+        'triage_created': obj.triage_created,
         'company_name': obj.company_name,
         'duns_number': obj.duns_number,
+        'is_high_value': obj.is_high_value,
     }

--- a/datahub/search/company_activity/fields.py
+++ b/datahub/search/company_activity/fields.py
@@ -1,4 +1,4 @@
-from opensearch_dsl import Date, Keyword, Object, Text
+from opensearch_dsl import Boolean, Date, Keyword, Object, Text
 
 from datahub.search import fields
 from datahub.search.interaction.models import _DITParticipant
@@ -87,5 +87,7 @@ def activity_eyb_lead_field():
             'created_on': Date(),
             'company_name': Text(index=False),
             'duns_number': Text(index=False),
+            'triage_created': Date(),
+            'is_high_value': Boolean(),
         },
     )

--- a/datahub/search/company_activity/test/test_dict_utils.py
+++ b/datahub/search/company_activity/test/test_dict_utils.py
@@ -104,3 +104,5 @@ def test_activity_eyb_lead_dict():
     assert result['created_on'] == eyb_lead.created_on
     assert result['duns_number'] == eyb_lead.duns_number
     assert result['company_name'] == eyb_lead.company_name
+    assert result['triage_created'] == eyb_lead.triage_created
+    assert result['is_high_value'] == eyb_lead.is_high_value

--- a/datahub/search/company_activity/test/test_models.py
+++ b/datahub/search/company_activity/test/test_models.py
@@ -325,6 +325,8 @@ def test_company_activity_eyb_lead_to_dict():
             'created_on': eyb_lead.created_on,
             'duns_number': eyb_lead.duns_number,
             'company_name': eyb_lead.company_name,
+            'is_high_value': eyb_lead.is_high_value,
+            'triage_created': eyb_lead.triage_created,
         },
         'activity_source': DBCompanyActivity.ActivitySource.eyb_lead,
         'id': company_activity.pk,


### PR DESCRIPTION
### Description of change

Add triage_created and is_high_value fields to open search for Investment Project EYB Leads.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
