### PR TITLE
Stop attempting to extract marketing data from nested key

### DIFF
--- a/datahub/investment_lead/test/test_tasks/test_ingest_eyb_marketing.py
+++ b/datahub/investment_lead/test/test_tasks/test_ingest_eyb_marketing.py
@@ -141,7 +141,7 @@ class TestEYBMarketingDataIngestionTasks:
         """
         initial_eyb_lead_count = EYBLead.objects.count()
         initial_ingested_count = IngestedFile.objects.count()
-        file_contents = file_contents_faker(default_faker='marketing')
+        file_contents = file_contents_faker(default_faker='marketing', nested=False)
         setup_s3_bucket(BUCKET, [test_marketing_file_path], [file_contents])
         with caplog.at_level(logging.INFO):
             ingest_eyb_marketing_data(BUCKET, test_marketing_file_path)
@@ -164,7 +164,7 @@ class TestEYBMarketingDataIngestionTasks:
                 'content': updated_value,
             }),
         ]
-        file_contents = file_contents_faker(records)
+        file_contents = file_contents_faker(records, nested=False)
         setup_s3_bucket(BUCKET, [test_marketing_file_path], [file_contents])
         ingest_eyb_marketing_data(BUCKET, test_marketing_file_path)
         assert EYBLead.objects.count() == 1
@@ -182,7 +182,7 @@ class TestEYBMarketingDataIngestionTasks:
         EYBLeadFactory(marketing_hashed_uuid=hashed_uuid, utm_content=initial_value)
         assert EYBLead.objects.count() == 1
         records = []
-        file_contents = file_contents_faker(records)
+        file_contents = file_contents_faker(records, nested=False)
         setup_s3_bucket(BUCKET, [test_marketing_file_path], [file_contents])
         ingest_eyb_marketing_data(BUCKET, test_marketing_file_path)
         assert EYBLead.objects.count() == 1
@@ -223,7 +223,7 @@ class TestEYBMarketingDataIngestionTasks:
         ]
 
         file_path = f'{MARKETING_PREFIX}1.jsonl.gz'
-        file_contents = file_contents_faker(records)
+        file_contents = file_contents_faker(records, nested=False)
         setup_s3_bucket(BUCKET, [file_path], [file_contents])
         with caplog.at_level(logging.INFO):
             ingest_eyb_marketing_data(BUCKET, file_path)

--- a/datahub/investment_lead/test/test_tasks/utils.py
+++ b/datahub/investment_lead/test/test_tasks/utils.py
@@ -18,7 +18,9 @@ def setup_s3_client():
     return boto3.client('s3', REGION)
 
 
-def file_contents_faker(records: list[dict] = None, default_faker: str = 'triage') -> bytes:
+def file_contents_faker(
+    records: list[dict] = None, default_faker: str = 'triage', nested: bool = True,
+) -> bytes:
     """Create fake file contents with the specified list of records.
 
     Returns compressed lines of JSON encoded with UTF-8.
@@ -35,6 +37,7 @@ def file_contents_faker(records: list[dict] = None, default_faker: str = 'triage
             records = [eyb_lead_marketing_record_faker()]
     json_lines = [
         json.dumps({'object': record}, default=str)
+        if nested else json.dumps(record, default=str)
         for record in records
     ]
     compressed_content = gzip.compress('\n'.join(json_lines).encode('utf-8'))


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

We currently attempt to extract EYB marketing records from a nested `'object'` key, however, the incoming data is not nested. This raises an error and means no marketing records are ingested. This PR fixes this.

The `EYBMarketingDataIngestionTask` now contains some duplicate code, especially in the `json_to_model` method. However, it was felt this was a reasonable quick fix while we await [the new common ingestion functionality](https://github.com/uktrade/data-hub-api/pull/5847).

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
