### PR TITLE
Filter EYB leads by `is_high_value=None` (i.e. unknown values)

### DIFF
--- a/datahub/investment_lead/test/test_views.py
+++ b/datahub/investment_lead/test/test_views.py
@@ -197,7 +197,7 @@ class TestEYBLeadListAPI(APITestMixin):
         """Test filtering EYB leads by is high value status"""
         EYBLeadFactory(is_high_value=True)
         EYBLeadFactory(is_high_value=False)
-        EYBLeadFactory(is_high_value=False)
+        EYBLeadFactory(is_high_value=None)
         api_client = self.create_api_client(user=test_user_with_view_permissions)
 
         response = api_client.get(EYB_LEAD_COLLECTION_URL)
@@ -212,8 +212,8 @@ class TestEYBLeadListAPI(APITestMixin):
     def test_filter_by_is_low_value(self, test_user_with_view_permissions):
         """Test filtering EYB leads by is low value status"""
         EYBLeadFactory(is_high_value=True)
-        EYBLeadFactory(is_high_value=True)
         EYBLeadFactory(is_high_value=False)
+        EYBLeadFactory(is_high_value=None)
         api_client = self.create_api_client(user=test_user_with_view_permissions)
 
         response = api_client.get(EYB_LEAD_COLLECTION_URL)
@@ -225,26 +225,44 @@ class TestEYBLeadListAPI(APITestMixin):
         assert response.data['count'] == 1
         assert response.data['results'][0]['is_high_value'] is False
 
-    def test_filter_by_is_high_and_low_value(self, test_user_with_view_permissions):
-        """Test filtering EYB leads by multiple values"""
-        EYBLeadFactory(is_high_value=True)
+    def test_filter_by_unknown_value(self, test_user_with_view_permissions):
+        """Test filtering EYB leads by unknown value."""
         EYBLeadFactory(is_high_value=True)
         EYBLeadFactory(is_high_value=False)
+        EYBLeadFactory(is_high_value=None)
         api_client = self.create_api_client(user=test_user_with_view_permissions)
 
         response = api_client.get(EYB_LEAD_COLLECTION_URL)
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 3
 
-        response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': ['high', 'low']})
+        response = api_client.get(EYB_LEAD_COLLECTION_URL, data={'value': 'unknown'})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        assert response.data['results'][0]['is_high_value'] is None
+
+    def test_filter_by_is_all_values(self, test_user_with_view_permissions):
+        """Test filtering EYB leads by multiple values"""
+        EYBLeadFactory(is_high_value=True)
+        EYBLeadFactory(is_high_value=False)
+        EYBLeadFactory(is_high_value=None)
+        api_client = self.create_api_client(user=test_user_with_view_permissions)
+
+        response = api_client.get(EYB_LEAD_COLLECTION_URL)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 3
+
+        response = api_client.get(
+            EYB_LEAD_COLLECTION_URL, data={'value': ['high', 'low', 'unknown']},
+        )
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 3
 
     def test_filter_by_invalid_value(self, test_user_with_view_permissions):
         """Test filtering EYB leads by an invalid value returns no leads"""
         EYBLeadFactory(is_high_value=True)
-        EYBLeadFactory(is_high_value=True)
         EYBLeadFactory(is_high_value=False)
+        EYBLeadFactory(is_high_value=None)
         api_client = self.create_api_client(user=test_user_with_view_permissions)
 
         response = api_client.get(EYB_LEAD_COLLECTION_URL)


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

At the moment, EYB leads can only be filtered by high (`is_high_value=True`) and low (`is_high_value=False`) values. This does not allow filtering of leads with `is_high_value=None` (i.e. unknown values). This PR adds this functionality - a slight oversight from when we first implemented the filters.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
