### PR TITLE
Feature/tet 812 ingest stova data

### DIFF
--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -18,7 +18,7 @@ from datahub.company.tasks.contact import (
 )
 from datahub.company.tasks.export_potential import update_company_export_potential_from_csv
 from datahub.company_activity.tasks.ingest_company_activity import ingest_activity_data
-from datahub.company_activity.tasks.ingest_stova_events import stova_identification_and_ingest_task
+from datahub.company_activity.tasks.ingest_stova_events import ingest_stova_event_data
 from datahub.core.queues.constants import (
     EVERY_EIGHT_AM,
     EVERY_EIGHT_THIRTY_AM_ON_FIRST_EACH_MONTH,
@@ -141,7 +141,7 @@ def schedule_jobs():
         description='Check S3 for new EYB triage data files and schedule ingestion',
     )
     job_scheduler(
-        function=stova_identification_and_ingest_task,
+        function=ingest_stova_event_data,
         cron=EVERY_HOUR,
         description='Check S3 for new Stova Event files and schedule ingestion',
     )

--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -18,7 +18,7 @@ from datahub.company.tasks.contact import (
 )
 from datahub.company.tasks.export_potential import update_company_export_potential_from_csv
 from datahub.company_activity.tasks.ingest_company_activity import ingest_activity_data
-from datahub.company_activity.tasks.ingest_stova_events import stova_identification_task
+from datahub.company_activity.tasks.ingest_stova_events import stova_identification_and_ingest_task
 from datahub.core.queues.constants import (
     EVERY_EIGHT_AM,
     EVERY_EIGHT_THIRTY_AM_ON_FIRST_EACH_MONTH,
@@ -141,7 +141,7 @@ def schedule_jobs():
         description='Check S3 for new EYB triage data files and schedule ingestion',
     )
     job_scheduler(
-        function=stova_identification_task,
+        function=stova_identification_and_ingest_task,
         cron=EVERY_HOUR,
         description='Check S3 for new Stova Event files and schedule ingestion',
     )

--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -18,6 +18,7 @@ from datahub.company.tasks.contact import (
 )
 from datahub.company.tasks.export_potential import update_company_export_potential_from_csv
 from datahub.company_activity.tasks.ingest_company_activity import ingest_activity_data
+from datahub.company_activity.tasks.ingest_stova_events import stova_identification_task
 from datahub.core.queues.constants import (
     EVERY_EIGHT_AM,
     EVERY_EIGHT_THIRTY_AM_ON_FIRST_EACH_MONTH,
@@ -138,6 +139,11 @@ def schedule_jobs():
         function=ingest_eyb_triage_file,
         cron=EVERY_HOUR,
         description='Check S3 for new EYB triage data files and schedule ingestion',
+    )
+    job_scheduler(
+        function=stova_identification_task,
+        cron=EVERY_HOUR,
+        description='Check S3 for new Stova Event files and schedule ingestion',
     )
 
     if settings.ENABLE_ESTIMATED_LAND_DATE_REMINDERS:

--- a/datahub/company_activity/models/stova_event.py
+++ b/datahub/company_activity/models/stova_event.py
@@ -65,8 +65,8 @@ class StovaEvent(models.Model):
             self.create_or_update_datahub_event()
 
     def create_or_update_datahub_event(self) -> Event:
-        # Dates are converted from string to datetime after saving, so refresh self otherwise
-        # dates will still be string.
+        # Dates are converted from string to datetime after saving, so refresh otherwise dates will
+        # still be string.
         # https://docs.djangoproject.com/en/4.2/ref/models/instances/#what-happens-when-you-save
         self.refresh_from_db()
         event, _ = Event.objects.update_or_create(
@@ -82,10 +82,22 @@ class StovaEvent(models.Model):
                 'address_county': self.location_state,
                 'address_postcode': self.location_postcode,
                 'address_country': get_country_by_country_name(self.country, 'GB'),
+                'service_id': self.get_stova_event_service_id(),
                 'notes': self.description,
             },
         )
         return event
+
+    @staticmethod
+    def get_stova_event_service_id() -> str:
+        """
+        The frontend expects a service which we don't get from Stova. This service is created for
+        ingested stova events called "Stova Event Service". These service are metadata created in
+        migrations files so we can guarantee it exists before the application is run.
+
+        :returns: A id of a `Service` with the name "Stova Event Service".
+        """
+        return 'f6671176-6493-43ba-a92d-899281efcb55'
 
     @staticmethod
     def get_or_create_stova_event_type() -> EventType:

--- a/datahub/company_activity/tasks/__init__.py
+++ b/datahub/company_activity/tasks/__init__.py
@@ -1,11 +1,11 @@
 from datahub.company_activity.tasks.ingest_great_data import ingest_great_data
 from datahub.company_activity.tasks.ingest_stova_events import (
-    stova_identification_task,
+    stova_identification_and_ingest_task,
     stova_ingestion_task,
 )
 
 __all__ = (
     ingest_great_data,
-    stova_identification_task,
+    stova_identification_and_ingest_task,
     stova_ingestion_task,
 )

--- a/datahub/company_activity/tasks/__init__.py
+++ b/datahub/company_activity/tasks/__init__.py
@@ -1,7 +1,11 @@
 from datahub.company_activity.tasks.ingest_great_data import ingest_great_data
-from datahub.company_activity.tasks.ingest_stova_events import ingest_stova_data
+from datahub.company_activity.tasks.ingest_stova_events import (
+    stova_identification_task,
+    stova_ingestion_task,
+)
 
 __all__ = (
     ingest_great_data,
-    ingest_stova_data,
+    stova_identification_task,
+    stova_ingestion_task,
 )

--- a/datahub/company_activity/tasks/__init__.py
+++ b/datahub/company_activity/tasks/__init__.py
@@ -1,11 +1,11 @@
 from datahub.company_activity.tasks.ingest_great_data import ingest_great_data
 from datahub.company_activity.tasks.ingest_stova_events import (
-    stova_identification_and_ingest_task,
+    ingest_stova_event_data,
     stova_ingestion_task,
 )
 
 __all__ = (
     ingest_great_data,
-    stova_identification_and_ingest_task,
+    ingest_stova_event_data,
     stova_ingestion_task,
 )

--- a/datahub/company_activity/tasks/ingest_stova_events.py
+++ b/datahub/company_activity/tasks/ingest_stova_events.py
@@ -13,7 +13,8 @@ logger = logging.getLogger(__name__)
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
 
-def stova_identification_task() -> None:
+def stova_identification_and_ingest_task() -> None:
+    """Identifies the most recent file to be ingested and schedules a task to ingest it"""
     logger.info('Stova event identification task started.')
     identification_task = StovaEventIndentificationTask(prefix=STOVA_EVENT_PREFIX)
     identification_task.identify_new_objects(stova_ingestion_task)
@@ -21,6 +22,7 @@ def stova_identification_task() -> None:
 
 
 def stova_ingestion_task(object_key: str) -> None:
+    """Ingest the given key (file) from S3"""
     logger.info(f'Stova event ingestion task started for file {object_key}.')
     ingestion_task = StovaEventIngestionTask(
         object_key=object_key,

--- a/datahub/company_activity/tasks/ingest_stova_events.py
+++ b/datahub/company_activity/tasks/ingest_stova_events.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 
 
-def stova_identification_and_ingest_task() -> None:
+def ingest_stova_event_data() -> None:
     """Identifies the most recent file to be ingested and schedules a task to ingest it"""
     logger.info('Stova event identification task started.')
     identification_task = StovaEventIndentificationTask(prefix=STOVA_EVENT_PREFIX)

--- a/datahub/company_activity/tasks/ingest_stova_events.py
+++ b/datahub/company_activity/tasks/ingest_stova_events.py
@@ -43,7 +43,7 @@ class StovaEventIngestionTask(BaseObjectIngestionTask):
     def _process_record(self, record: dict) -> None:
         """Saves an event from Stova from the S3 bucket into a `StovaEvent`"""
         if not self.existing_ids:
-            self.existing_ids = list(StovaEvent.objects.values_list('stova_event_id', flat=True))
+            self.existing_ids = set(StovaEvent.objects.values_list('stova_event_id', flat=True))
 
         stova_event_id = record.get('id')
         if stova_event_id in self.existing_ids:

--- a/datahub/company_activity/tasks/ingest_stova_events.py
+++ b/datahub/company_activity/tasks/ingest_stova_events.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.core.exceptions import ValidationError
 from django.db import IntegrityError
 
 from datahub.company_activity.models import StovaEvent
@@ -87,6 +88,12 @@ class StovaEventIngestionTask(BaseObjectIngestionTask):
             StovaEvent.objects.create(**values)
         except IntegrityError as error:
             logger.error(
-                'Error processing Stova event record, stova_event_id: {stova_event_id}. ',
+                f'Error processing Stova event record, stova_event_id: {stova_event_id}. '
+                f'Error: {error}',
+            )
+        except ValidationError as error:
+            logger.error(
+                'Got unexpected value for a field when processing Stova event record, '
+                f'stova_event_id: {stova_event_id}. '
                 f'Error: {error}',
             )

--- a/datahub/company_activity/tests/models/test_stova_event.py
+++ b/datahub/company_activity/tests/models/test_stova_event.py
@@ -29,6 +29,8 @@ class TestStovaEvent:
 
         assert datahub_event.address_country.name == 'United States'
 
+        assert str(datahub_event.service_id) == 'f6671176-6493-43ba-a92d-899281efcb55'
+
         stova_event.delete()
         assert not Event.objects.all().exists()
 

--- a/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
@@ -167,8 +167,8 @@ class TestStovaIngestionTasks:
         """
         Test that the ingested stova event fields are saved to the StovaEvent model.
         """
-        S3ObjectProcessMock = mock.Mock()
-        task = StovaEventIngestionTask('dummy-prefix', S3ObjectProcessMock)
+        s3_processor_mock = mock.Mock()
+        task = StovaEventIngestionTask('dummy-prefix', s3_processor_mock)
         data = test_base_stova_event
         task._process_record(data)
         result = StovaEvent.objects.get(stova_event_id=2367)

--- a/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
@@ -16,7 +16,7 @@ from sentry_sdk.transport import Transport
 from datahub.company_activity.models import StovaEvent
 from datahub.company_activity.tasks.constants import BUCKET, REGION, STOVA_EVENT_PREFIX
 from datahub.company_activity.tasks.ingest_stova_events import (
-    stova_identification_task,
+    stova_identification_and_ingest_task,
     stova_ingestion_task,
     StovaEventIngestionTask,
 )
@@ -123,7 +123,7 @@ class TestStovaIngestionTasks:
         setup_s3_bucket(BUCKET)
         setup_s3_files(BUCKET, test_file, test_file_path)
         with caplog.at_level(logging.INFO):
-            stova_identification_task()
+            stova_identification_and_ingest_task()
             assert 'Stova event identification task started.' in caplog.text
             assert 'Stova event identification task finished.' in caplog.text
             assert f'Stova event ingestion task started for file {test_file_path}' in caplog.text

--- a/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
@@ -16,7 +16,7 @@ from sentry_sdk.transport import Transport
 from datahub.company_activity.models import StovaEvent
 from datahub.company_activity.tasks.constants import BUCKET, REGION, STOVA_EVENT_PREFIX
 from datahub.company_activity.tasks.ingest_stova_events import (
-    stova_identification_and_ingest_task,
+    ingest_stova_event_data,
     stova_ingestion_task,
     StovaEventIngestionTask,
 )
@@ -123,7 +123,7 @@ class TestStovaIngestionTasks:
         setup_s3_bucket(BUCKET)
         setup_s3_files(BUCKET, test_file, test_file_path)
         with caplog.at_level(logging.INFO):
-            stova_identification_and_ingest_task()
+            ingest_stova_event_data()
             assert 'Stova event identification task started.' in caplog.text
             assert 'Stova event identification task finished.' in caplog.text
             assert f'Stova event ingestion task started for file {test_file_path}' in caplog.text

--- a/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
@@ -113,6 +113,7 @@ class TestStovaIngestionTasks:
 
     @pytest.mark.django_db
     @mock_aws
+    @override_settings(S3_LOCAL_ENDPOINT_URL=None)
     def test_stova_data_file_ingestion(self, caplog, test_file, test_file_path):
         """
         Test that a Aventri/Stova data file is ingested correctly and the ingested file
@@ -133,6 +134,7 @@ class TestStovaIngestionTasks:
 
     @pytest.mark.django_db
     @mock_aws
+    @override_settings(S3_LOCAL_ENDPOINT_URL=None)
     def test_skip_previously_ingested_records(self, test_file_path, test_base_stova_event):
         """
         Test that we skip updating records that have already been ingested

--- a/datahub/ingest/tasks.py
+++ b/datahub/ingest/tasks.py
@@ -90,7 +90,6 @@ class BaseObjectIdentificationTask:
             function=ingestion_task_function,
             function_kwargs={
                 'object_key': latest_object_key,
-                's3_processor': self.s3_processor,
             },
             queue_name=self.long_queue_checker.queue.name,
             description=f'Ingest {latest_object_key}',
@@ -139,6 +138,7 @@ class BaseObjectIngestionTask:
         try:
             with smart_open.open(
                 f's3://{self.s3_processor.bucket}/{self.object_key}',
+                transport_params={'client': self.s3_processor.s3_client},
             ) as s3_object:
                 for line in s3_object:
                     deserialized_line = json.loads(line)

--- a/datahub/ingest/test/test_boto3.py
+++ b/datahub/ingest/test/test_boto3.py
@@ -30,6 +30,7 @@ pytestmark = pytest.mark.django_db
 
 class TestGetS3Client:
 
+    @override_settings(S3_LOCAL_ENDPOINT_URL=None)
     def test_get_s3_client_returns_boto3_instance(self):
         with mock.patch('datahub.ingest.boto3.boto3.client') as patched_s3_client:
             get_s3_client(TEST_AWS_REGION)

--- a/datahub/ingest/test/test_tasks.py
+++ b/datahub/ingest/test/test_tasks.py
@@ -216,7 +216,6 @@ class TestBaseObjectIdentificationTask:
             function=base_ingestion_task,
             function_kwargs={
                 'object_key': TEST_OBJECT_KEY,
-                's3_processor': identification_task.s3_processor,
             },
             queue_name='long-running',
             description=f'Ingest {TEST_OBJECT_KEY}',

--- a/datahub/metadata/migrations/0089_add_stova_serivce.py
+++ b/datahub/metadata/migrations/0089_add_stova_serivce.py
@@ -1,0 +1,35 @@
+from pathlib import PurePath
+
+import mptt
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, _):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0089_add_stova_serivce.yaml'
+    )
+
+
+def rebuild_tree(apps, _):
+    Service = apps.get_model('metadata', 'Service')
+    manager = mptt.managers.TreeManager()
+    manager.model = Service
+    mptt.register(Service, order_insertion_by=['segment'])
+    manager.contribute_to_class(Service, 'objects')
+    manager.rebuild()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0088_add_countries'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+        migrations.RunPython(rebuild_tree, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0089_add_stova_serivce.yaml
+++ b/datahub/metadata/migrations/0089_add_stova_serivce.yaml
@@ -1,0 +1,12 @@
+- model: metadata.service
+  pk: f6671176-6493-43ba-a92d-899281efcb55
+  fields:
+    disabled_on: ~
+    order: 1325
+    segment: Stova Event Service
+    parent:
+    contexts: ["event"]
+    lft: 0
+    rght: 0
+    tree_id: 0
+    level: 0


### PR DESCRIPTION
### Description of change

Ingest Stova event data into DataHub `StovaEvent` model which copies it into a DataHub `Event`.

This uses the new generic ingest app from here: https://github.com/uktrade/data-hub-api/pull/5847.

Events require a Service which is not provided by Stova, after speaking with Tom Aldridge and we are going to create a new service "Stova Event Service" which will be applied to all ingested Stova Events.

Each row (stova event) will not be updated but the ingested file will be updated with new events so there is no requirement to update the already ingested Stova Events.

Depending on: https://github.com/uktrade/data-hub-frontend/pull/7422 as the service requires being added to the frontend as well.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?

