### PR TITLE
Allow ingesting of EYB Leads without full name set

### DIFF
--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -367,7 +367,7 @@ class CreateEYBLeadUserSerializer(BaseEYBLeadSerializer):
         source='company_website', required=False, allow_null=True, allow_blank=True, default='',
     )
     fullName = serializers.CharField(  # noqa: N815
-        source='full_name', allow_null=True, allow_blank=True, default=NOT_SET
+        source='full_name', allow_null=True, allow_blank=True, default=NOT_SET,
     )
     role = serializers.CharField(required=False, allow_null=True, allow_blank=True, default='')
     email = serializers.CharField(required=True)
@@ -395,8 +395,8 @@ class CreateEYBLeadUserSerializer(BaseEYBLeadSerializer):
             )
         return value
 
-    def validate_fullName(self, value):
-        """Default to Not set for empty values too """
+    def validate_fullName(self, value):  # noqa: N802
+        """Default to Not set for empty values too."""
         if not value:
             value = NOT_SET
         return value

--- a/datahub/investment_lead/serializers.py
+++ b/datahub/investment_lead/serializers.py
@@ -14,6 +14,7 @@ from datahub.metadata.models import (
     UKRegion,
 )
 
+NOT_SET = 'Not set'
 
 ARCHIVABLE_FIELDS = [
     'archived',
@@ -365,7 +366,9 @@ class CreateEYBLeadUserSerializer(BaseEYBLeadSerializer):
     companyWebsite = serializers.CharField(  # noqa: N815
         source='company_website', required=False, allow_null=True, allow_blank=True, default='',
     )
-    fullName = serializers.CharField(source='full_name', required=True)  # noqa: N815
+    fullName = serializers.CharField(  # noqa: N815
+        source='full_name', allow_null=True, allow_blank=True, default=NOT_SET
+    )
     role = serializers.CharField(required=False, allow_null=True, allow_blank=True, default='')
     email = serializers.CharField(required=True)
     telephoneNumber = serializers.CharField(  # noqa: N815
@@ -390,6 +393,12 @@ class CreateEYBLeadUserSerializer(BaseEYBLeadSerializer):
             raise serializers.ValidationError(
                 f'Company location/country ISO2 code "{value.upper()}" does not exist.',
             )
+        return value
+
+    def validate_fullName(self, value):
+        """Default to Not set for empty values too """
+        if not value:
+            value = NOT_SET
         return value
 
     def get_related_fields_internal_value(self, data):

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -208,7 +208,6 @@ class TestCreateEYBLeadUserSerializer:
             'addressLine1',
             'town',
             'companyLocation',
-            'fullName',
             'email',
         ]
         for key in required_fields:
@@ -253,7 +252,6 @@ class TestCreateEYBLeadUserSerializer:
             'addressLine1': value,
             'town': value,
             'companyLocation': value,
-            'fullName': value,
             'email': value,
         }
         serializer = CreateEYBLeadUserSerializer(data=test_data)
@@ -269,6 +267,7 @@ class TestCreateEYBLeadUserSerializer:
         """Tests null values and empty strings are handled correctly for non-required fields."""
         eyb_lead_user_data.update({
             'dunsNumber': value,
+            'fullName': value,
             'addressLine2': value,
             'county': value,
             'postcode': value,
@@ -285,6 +284,28 @@ class TestCreateEYBLeadUserSerializer:
         assert isinstance(instance, EYBLead)
         assert EYBLead.objects.count() == 1
         assert_ingested_eyb_user_data(instance, serializer.data)
+
+
+    @pytest.mark.parametrize(
+        'value,expected_value', 
+        (
+            (None, 'Not set'),
+            ('', 'Not set'),
+            ('Abc Def', 'Abc Def'),
+        )
+    )
+    def test_full_name_defaults_to_not_set_for_empty_or_null(self, eyb_lead_user_data, value, expected_value):
+        """Tests null values and empty strings are handled correctly for non-required fields."""
+        eyb_lead_user_data.update({
+            'fullName': value,
+        })
+        serializer = CreateEYBLeadUserSerializer(data=eyb_lead_user_data)
+        assert serializer.is_valid()
+        instance = serializer.save()
+        assert isinstance(instance, EYBLead)
+        assert EYBLead.objects.count() == 1
+        assert_ingested_eyb_user_data(instance, serializer.data)
+        assert instance.full_name == expected_value
 
 
 class TestCreateEYBLeadMarketingSerializer:

--- a/datahub/investment_lead/test/test_serializers.py
+++ b/datahub/investment_lead/test/test_serializers.py
@@ -285,16 +285,20 @@ class TestCreateEYBLeadUserSerializer:
         assert EYBLead.objects.count() == 1
         assert_ingested_eyb_user_data(instance, serializer.data)
 
-
     @pytest.mark.parametrize(
-        'value,expected_value', 
+        'value,expected_value',
         (
             (None, 'Not set'),
             ('', 'Not set'),
             ('Abc Def', 'Abc Def'),
-        )
+        ),
     )
-    def test_full_name_defaults_to_not_set_for_empty_or_null(self, eyb_lead_user_data, value, expected_value):
+    def test_full_name_defaults_to_not_set_for_empty_or_null(
+        self,
+        eyb_lead_user_data,
+        value,
+        expected_value,
+    ):
         """Tests null values and empty strings are handled correctly for non-required fields."""
         eyb_lead_user_data.update({
             'fullName': value,


### PR DESCRIPTION
Allow ingesting of EYB Leads without full name set. Empty full name values default to 'Not set'

### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
