### PR TITLE
Add company_export filter to interactions v4 endpoint.

### DIFF
--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -65,6 +65,7 @@ class InteractionViewSetV4(ArchivableViewSetMixin, CoreViewSet):
         'event_id',
         'investment_project_id',
         'large_capital_opportunity_id',
+        'company_export_id',
     ]
     ordering_fields = (
         'company__name',


### PR DESCRIPTION
### Description of change

This adds missing `company_export` filter to V4 interactions endpoint.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
