### PR TITLE
Don't link EYB leads without triage or user components to company records

### DIFF
--- a/datahub/investment_lead/services.py
+++ b/datahub/investment_lead/services.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db.models import F, Q
+from django.db.models import F
 
 from datahub.company.models.company import Company
 from datahub.company.models.contact import Contact
@@ -22,13 +22,19 @@ def link_leads_to_companies():
 
 
 def get_leads_to_process():
+    """Returns a list of EYB leads that need company/contact linking.
+
+    This includes leads that are:
+    - not archived
+    - have no related company record
+    - have populated and matching triage and user components
     """
-    Returns a list of EYB leads that are not archived
-    and that need company/contact linking
-    """
-    return EYBLead.objects.filter(archived=False).filter(
-        Q(user_hashed_uuid=F('triage_hashed_uuid')),
+    return EYBLead.objects.filter(
+        archived=False,
         company__isnull=True,
+        user_hashed_uuid=F('triage_hashed_uuid'),
+    ).exclude(
+        user_hashed_uuid='',
     )
 
 

--- a/datahub/investment_lead/test/test_services.py
+++ b/datahub/investment_lead/test/test_services.py
@@ -289,3 +289,18 @@ class TestEYBLeadServices:
         assert eyb_lead.company.contacts.count() == 1
         contact = eyb_lead.company.contacts.first()
         assert_eyb_lead_matches_contact(contact, eyb_lead)
+
+    def test_leads_with_empty_triage_or_user_components_are_not_linked(self):
+        empty_string = ''
+        eyb_lead = EYBLeadFactory(
+            company=None,
+            triage_hashed_uuid=empty_string,
+            user_hashed_uuid=empty_string,
+            marketing_hashed_uuid=generate_hashed_uuid(),
+        )
+        assert eyb_lead.company is None
+
+        link_leads_to_companies()
+        eyb_lead.refresh_from_db()
+
+        assert eyb_lead.company is None


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR fixes an error where EYB leads without a user component  were making it through to the `match_or_create_company_for_eyb_lead` task and, because they do not have an `address_country`, were failing to create a new company record.

In short, it excludes leads that have `triage_hashed_uuid==''` and `user_hashed_uuid==''`. Leads with either the triage or user component populated, but not the other, are already excluded.

This also address the related Sentry alert.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
