### PR TITLE
Create EYB lead revisions and show in Django admin

### DIFF
--- a/datahub/investment_lead/admin.py
+++ b/datahub/investment_lead/admin.py
@@ -1,9 +1,10 @@
 from django.contrib import admin
+from reversion.admin import VersionAdmin
 
 from datahub.investment_lead.models import EYBLead
 
 
-class EYBLeadAdmin(admin.ModelAdmin):
+class EYBLeadAdmin(VersionAdmin):
     search_fields = [
         'triage_hashed_uuid',
         'user_hashed_uuid',

--- a/datahub/investment_lead/test/test_tasks/utils.py
+++ b/datahub/investment_lead/test/test_tasks/utils.py
@@ -34,6 +34,7 @@ def file_contents_faker(
         elif default_faker == 'user':
             records = [eyb_lead_user_record_faker()]
         elif default_faker == 'marketing':
+            nested = False  # marketing records are not nested
             records = [eyb_lead_marketing_record_faker()]
     json_lines = [
         json.dumps({'object': record}, default=str)


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

Despite EYBLeads being a versioned model, the automated ingestion tasks do not create revisions when ingesting leads, nor does the admin page show revisions. This PR adds such functionality.

### Before

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/5d4a07d9-a84a-4c7c-9623-9185e36cfca4" />

### After

<img width="1145" alt="image" src="https://github.com/user-attachments/assets/2ab9000f-8ff2-4de0-a16a-15b45a51e074" />

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
