### PR TITLE
Fix: check for empty strings before checking for + symbol.

### DIFF
--- a/datahub/core/test/test_utils.py
+++ b/datahub/core/test/test_utils.py
@@ -189,6 +189,7 @@ def test_format_currency_range_string_separator(string, expected):
 @pytest.mark.parametrize(
     'string,more_or_less,smart_more_or_less,expected',
     (
+        ('', True, True, ''),
         ('0-9999', True, True, 'Less than £10,000'),
         ('0-10000', True, True, 'Less than £10,000'),
         ('0-1000000', True, True, 'Less than £1 million'),
@@ -204,6 +205,7 @@ def test_format_currency_range_string_separator(string, expected):
         ('0-10000', False, False, '£0 to £10,000'),
         ('0-1000000', False, False, '£0 to £1 million'),
         ('10000001+', False, False, '£10 million+'),
+        ('', False, False, ''),
         # Return string as Sentence case for invalid numbers
         ('SPECIFIC_AMOUNT', False, False, 'Specific amount'),
     ),

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -149,7 +149,7 @@ def format_currency_range_string(
         prefix = ''
         postfix = ''
         if more_or_less:
-            if string[-1] == '+':
+            if string and string[-1] == '+':
                 prefix = 'More than '
                 string = string.rstrip('+')
             values = string.split(separator)
@@ -158,7 +158,7 @@ def format_currency_range_string(
                     values[1] = int(values[1]) + 1
                 return f'Less than {format_currency(values[1], symbol=symbol)}'
         else:
-            if string[-1] == '+':
+            if string and string[-1] == '+':
                 postfix = '+'
                 string = string.rstrip('+')
             values = string.split(separator)


### PR DESCRIPTION
### Description of change

Fix live issue where no check for empty string is made.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
