### PR TITLE
Allow sorting of EYB leads by `triage_created` and `company.name`

### DIFF
--- a/datahub/investment_lead/views.py
+++ b/datahub/investment_lead/views.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 class EYBLeadViewSet(SoftDeleteCoreViewSet):
     serializer_class = RetrieveEYBLeadSerializer
     filter_backends = [filters.OrderingFilter]
-    ordering = ['-created_on']
+    ordering = ['-triage_created']
+    ordering_fields = ['triage_created', 'company__name']
 
     def _filter_by_overseas_regions(self, queryset):
         overseas_region_ids = self.request.query_params.getlist('overseas_region')


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR allows EYB leads to be sorted by those most recently created on EYB (indicated by the `triage_created` field) and company name (specifically, the `company.name` field).

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
