### PR TITLE
TET-939: Handle explicit null values for contact name

### DIFF
--- a/datahub/company_activity/tasks/ingest_great_data.py
+++ b/datahub/company_activity/tasks/ingest_great_data.py
@@ -69,9 +69,15 @@ class GreatIngestionTask:
         return company
 
     def _create_contact(self, data, company, form_id):
+        first_name = data.get('first_name', '')
+        if first_name is None:
+            first_name = ''
+        last_name = data.get('last_name', '')
+        if last_name is None:
+            last_name = ''
         contact = Contact.objects.create(
-            first_name=data.get('first_name', ''),
-            last_name=data.get('last_name', ''),
+            first_name=first_name,
+            last_name=last_name,
             job_title=data.get('job_title', ''),
             full_telephone_number=data.get('uk_telephone_number', ''),
             email=data.get('email', ''),
@@ -108,17 +114,24 @@ class GreatIngestionTask:
         return Company.objects.filter(name=name).first()
 
     def _get_company_contact(self, data):
-        first_name = data.get('first_name')
-        last_name = data.get('last_name')
+        first_name = data.get('first_name', '')
+        last_name = data.get('last_name', '')
         phone_number = data.get('uk_telephone_number')
         email = data.get('email')
 
-        contacts = Contact.objects.filter(first_name=first_name, last_name=last_name)
+        contacts = Contact.objects.all()
+        if first_name:
+            contacts.filter(first_name=first_name)
+        if last_name:
+            contacts.filter(last_name=last_name)
         if phone_number:
             contacts = contacts.filter(full_telephone_number=phone_number)
         if email:
             contacts = contacts.filter(email=email)
-        if contacts.exists():
+        # If we have not been able to filter contacts down to exactly 1
+        # we should rather risk creating a duplicate to be manually merged
+        # than risk assigning to an incorrect contact
+        if contacts.count() == 1:
             return contacts.first()
 
     def _get_business_type(self, business_type_name):

--- a/datahub/company_activity/tasks/ingest_great_data.py
+++ b/datahub/company_activity/tasks/ingest_great_data.py
@@ -121,9 +121,9 @@ class GreatIngestionTask:
 
         contacts = Contact.objects.all()
         if first_name:
-            contacts.filter(first_name=first_name)
+            contacts = contacts.filter(first_name=first_name)
         if last_name:
-            contacts.filter(last_name=last_name)
+            contacts = contacts.filter(last_name=last_name)
         if phone_number:
             contacts = contacts.filter(full_telephone_number=phone_number)
         if email:

--- a/datahub/company_activity/tests/test_tasks/test_great_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_great_ingestion_task.py
@@ -263,6 +263,106 @@ class TestGreatIngestionTasks:
         assert result.company == company
 
     @pytest.mark.django_db
+    def test_company_contact_first_name_filtering(self):
+        """
+        Test that contact is filtered on first name correctly
+        """
+        company = CompanyFactory(company_number='123')
+        contact = ContactFactory(company=company)
+        name = 'Some non-existent business'
+        ContactFactory(company=company)
+        data = f"""
+            {{
+                "id": "5250",
+                "created_at": "2024-09-19T14:00:34.069",
+                "data": {{
+                    "company_registration_number": "",
+                    "business_name": "{name}",
+                    "first_name": "{contact.first_name}"
+                }}
+            }}
+        """
+        task = GreatIngestionTask()
+        task.json_to_model(json.loads(data))
+        result = GreatExportEnquiry.objects.get(form_id='5250')
+        assert result.company == company
+
+    @pytest.mark.django_db
+    def test_company_contact_last_name_filtering(self):
+        """
+        Test that contact is filtered on last name correctly
+        """
+        company = CompanyFactory(company_number='123')
+        contact = ContactFactory(company=company)
+        name = 'Some non-existent business'
+        ContactFactory(company=company)
+        data = f"""
+            {{
+                "id": "5250",
+                "created_at": "2024-09-19T14:00:34.069",
+                "data": {{
+                    "company_registration_number": "",
+                    "business_name": "{name}",
+                    "last_name": "{contact.last_name}"
+                }}
+            }}
+        """
+        task = GreatIngestionTask()
+        task.json_to_model(json.loads(data))
+        result = GreatExportEnquiry.objects.get(form_id='5250')
+        assert result.company == company
+
+    @pytest.mark.django_db
+    def test_company_contact_email_filtering(self):
+        """
+        Test that contact is filtered on email correctly
+        """
+        company = CompanyFactory(company_number='123')
+        contact = ContactFactory(company=company, email='valid@example.com')
+        name = 'Some non-existent business'
+        ContactFactory(company=company, email='something@example.com')
+        data = f"""
+            {{
+                "id": "5250",
+                "created_at": "2024-09-19T14:00:34.069",
+                "data": {{
+                    "company_registration_number": "",
+                    "business_name": "{name}",
+                    "email": "{contact.email}"
+                }}
+            }}
+        """
+        task = GreatIngestionTask()
+        task.json_to_model(json.loads(data))
+        result = GreatExportEnquiry.objects.get(form_id='5250')
+        assert result.company == company
+
+    @pytest.mark.django_db
+    def test_company_contact_phone_filtering(self):
+        """
+        Test that contact is filtered on phone correctly
+        """
+        company = CompanyFactory(company_number='123')
+        contact = ContactFactory(company=company, full_telephone_number='1234')
+        name = 'Some non-existent business'
+        ContactFactory(company=company, full_telephone_number='6789')
+        data = f"""
+            {{
+                "id": "5250",
+                "created_at": "2024-09-19T14:00:34.069",
+                "data": {{
+                    "company_registration_number": "",
+                    "business_name": "{name}",
+                    "uk_telephone_number": "{contact.full_telephone_number}"
+                }}
+            }}
+        """
+        task = GreatIngestionTask()
+        task.json_to_model(json.loads(data))
+        result = GreatExportEnquiry.objects.get(form_id='5250')
+        assert result.company == company
+
+    @pytest.mark.django_db
     def test_unmapped_company(self, caplog):
         """
         Test that when a company can't be mapped based on Companies


### PR DESCRIPTION
### Description of change

Fixes: https://sentry.ci.uktrade.digital/organizations/dit/issues/142995

The assumption here is that it may be valid for people not to fill in a first or last name in the Great Export Enquiry form. As long as we have some piece of information, we may still be able to match them to a contact, and if we can't we may still be able to contact them or fill it in later.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
