### PR TITLE
Add address fields to company serialiser

### DIFF
--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -326,7 +326,18 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         required=False,
         allow_null=True,
     )
-    investor_company = NestedRelatedField(Company, required=True, allow_null=False)
+    investor_company = NestedRelatedField(
+        Company,
+        [
+            'name',
+            'address_1',
+            'address_2',
+            'address_town',
+            'address_postcode',
+        ],
+        required=True,
+        allow_null=False,
+    )
     investor_company_country = NestedRelatedField(meta_models.Country, read_only=True)
     investor_type = NestedRelatedField(InvestorType, required=False, allow_null=True)
     intermediate_company = NestedRelatedField(Company, required=False, allow_null=True)

--- a/datahub/investment/project/test/test_serializers.py
+++ b/datahub/investment/project/test/test_serializers.py
@@ -166,3 +166,28 @@ class TestIProjectSerializer:
         assert str(
             serializer.validated_data['country_investment_originates_from'],
         ) == constants.Country.argentina.value.name
+
+    def test_investor_company_required_fields(self):
+        """Tests require fields for investor_company"""
+        project = InvestmentProjectFactory()
+        serializer = IProjectSerializer(project)
+        assert serializer.data['investor_company']['id'] == str(project.investor_company.id)
+        assert (
+            serializer.data['investor_company']['name'] == project.investor_company.name
+        )
+        assert (
+            serializer.data['investor_company']['address_1']
+            == project.investor_company.address_1
+        )
+        assert (
+            serializer.data['investor_company']['address_2']
+            == project.investor_company.address_2
+        )
+        assert (
+            serializer.data['investor_company']['address_town']
+            == project.investor_company.address_town
+        )
+        assert (
+            serializer.data['investor_company']['address_postcode']
+            == project.investor_company.address_postcode
+        )

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -745,6 +745,10 @@ class TestRetrieveView(APITestMixin):
         assert response_data['investor_company'] == {
             'id': str(investor_company.id),
             'name': investor_company.name,
+            'address_1': investor_company.address_1,
+            'address_2': investor_company.address_2,
+            'address_postcode': investor_company.address_postcode,
+            'address_town': investor_company.address_town,
         }
         assert response_data['investor_company_country'] == {
             'id': str(investor_company.address_country.id),


### PR DESCRIPTION
### Description of change

This PR addresses adding the address fields from company to nested related field serialiser.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
