### PR TITLE
feature/fix-flaky-contact-test

### DIFF
--- a/datahub/company/test/tasks/test_contact_task.py
+++ b/datahub/company/test/tasks/test_contact_task.py
@@ -809,9 +809,10 @@ class TestContactConsentIngestionTask:
         the duplicate email as the key and all contacts matching that email as the value
         """
         contacts = ContactFactory.create_batch(3, email='grouped@test.com')
-        assert ContactConsentIngestionTask().get_grouped_contacts() == {
-            'grouped@test.com': contacts,
-        }
+        grouped = ContactConsentIngestionTask().get_grouped_contacts()
+
+        assert 'grouped@test.com' in grouped
+        assert set(grouped['grouped@test.com']) == set(contacts)
 
     def test_should_update_contact_with_row_date_missing_should_return_true(
         self,


### PR DESCRIPTION
### Description of change
Modify test to assert on the contact list returned in the `get_grouped_contacts` function containing the same contacts that were passed in, without failing when the ordering is different.

This could also be fixed by using an order by in the django SQL, however the ingest has no need to have the contacts in an ordered format.

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
