### PR TITLE
Use existing _should_process_record function to decide whether to ingest record

### DIFF
--- a/datahub/company_activity/tests/test_tasks/test_stova_attendee_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_attendee_ingestion_task.py
@@ -219,13 +219,15 @@ class TestStovaIngestionTasks:
         data = test_base_stova_attendee
         data['id'] = existing_stova_attendee.stova_attendee_id
 
+        # Check that the record should not be processed if it already exists.
         with caplog.at_level(logging.INFO):
-            task._process_record(data)
+            assert task._should_process_record(data) is False
             assert (
                 'Record already exists for stova_attendee_id: '
                 f'{existing_stova_attendee.stova_attendee_id}'
             ) in caplog.text
 
+        # Check that if there are duplicate IDs in the JSON but not our DB, this is handled.
         data['id'] = 999999
         task._process_record(data)
         with caplog.at_level(logging.ERROR):

--- a/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
@@ -205,12 +205,14 @@ class TestStovaIngestionTasks:
         data = test_base_stova_event
         data['id'] = existing_stova_event.stova_event_id
 
+        # Check that the record should not be processed if it already exists.
         with caplog.at_level(logging.INFO):
-            task._process_record(data)
+            assert task._should_process_record(data) is False
             assert (
                 f'Record already exists for stova_event_id: {existing_stova_event.stova_event_id}'
             ) in caplog.text
 
+        # Check that if there are duplicate IDs in the JSON but not our DB, this is handled.
         data['id'] = 999999
         task._process_record(data)
         with caplog.at_level(logging.ERROR):

--- a/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_ingestion_task.py
@@ -191,13 +191,10 @@ class TestStovaIngestionTasks:
             assert model_value == file_value
 
     @pytest.mark.django_db
-    def test_stova_event_fields_with_duplicate_event_ids(self, caplog, test_base_stova_event):
-        """
-        Test that if they are records with duplicate event ids, they are not created.
-
-        This checks for both scenarios where we have already stored an event in our DB and also
-        where the file contains two rows with the same event_id.
-        """
+    def test_stova_event_fields_with_duplicate_attendee_ids_in_db(
+        self, caplog, test_base_stova_event,
+    ):
+        """Test already ingested records to do pass the `_should_process_record` check."""
         s3_processor_mock = mock.Mock()
         task = StovaEventIngestionTask('dummy-prefix', s3_processor_mock)
 
@@ -205,14 +202,23 @@ class TestStovaIngestionTasks:
         data = test_base_stova_event
         data['id'] = existing_stova_event.stova_event_id
 
-        # Check that the record should not be processed if it already exists.
         with caplog.at_level(logging.INFO):
             assert task._should_process_record(data) is False
             assert (
                 f'Record already exists for stova_event_id: {existing_stova_event.stova_event_id}'
             ) in caplog.text
 
-        # Check that if there are duplicate IDs in the JSON but not our DB, this is handled.
+    @pytest.mark.django_db
+    def test_stova_event_fields_with_duplicate_attendee_ids_in_json(
+        self, caplog, test_base_stova_event,
+    ):
+        """
+        Test records which have duplicate IDs in their JSON do not raise errors and are logged.
+        """
+        s3_processor_mock = mock.Mock()
+        task = StovaEventIngestionTask('dummy-prefix', s3_processor_mock)
+
+        data = test_base_stova_event
         data['id'] = 999999
         task._process_record(data)
         with caplog.at_level(logging.ERROR):


### PR DESCRIPTION
### Description of change

The base ingestion class we use to ingest data already has a function `_should_process_record` to determine whether to ingest an individual record or not. By default this function checks for a `modified` key in the JSON to compare its datetime to decide it is should be ingested. The key `modified` does not exist for Stova and the error is handled however the base function uses `logger.error` which throws a sentry alert.

This PR overrides this function for Stova and moves the logic for checking whether a record should be ingested or not into the overriden `_should_process_record` function. This will prevent the checks for the `modified` field which does not exist for Stova.

Fixes sentry alert: https://sentry.ci.uktrade.digital/organizations/dit/issues/149837/?environment=staging&project=235&query=is%3Aunresolved+is%3Aneeds_review&statsPeriod=24h

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
