### PR TITLE
Update international telephone number validator to allow full stops

### DIFF
--- a/datahub/core/validators/telephone.py
+++ b/datahub/core/validators/telephone.py
@@ -20,12 +20,18 @@ class InternationalTelephoneValidator(RegexValidator):
     """
     Validator for international telephone numbers.
 
-    Validates that phone number is composed of characters found in telephone numbers -
-    0-9, a space, hyphens, or open / close brackets - optionally preceded with a plus sign.
+    Validates that a phone number is composed of characters found in telephone numbers:
+    0-9, spaces, hyphens, full stops, or open/close brackets, optionally preceded with a plus sign.
+    Extensions can be included using 'ext' or 'x' followed by digits.
     """
 
-    regex = r'^\+?[\d() -]{1,}$'
-    message = 'Phone number must be composed of numeric characters.'
+    regex = r'^\+?[\d().\- ]+(?:\s*(?:ext|ext.|x)\s*\d+)?$'
+    message = (
+        'Phone number must be composed of valid characters. '
+        'These include: 0-9, spaces, hyphens, full stops, or open/close brackets, '
+        'optionally preceded with a plus sign. Extensions can be included using '
+        "'ext' or 'x' followed by digits."
+    )
 
 
 class TelephoneCountryCodeValidator(RegexValidator):


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR modifies the international telephone number validator to allow phone numbers with full stops (which some users include when entering international number).

This change is driven by an update to the Expand Your Business (EYB) international telephone number validator. As we create Data Hub contact records from data entered on EYB, we should be accepting these now-valid numbers too.

See [CLS2-1180](https://uktrade.atlassian.net/browse/CLS2-1180) for more.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.


[CLS2-1180]: https://uktrade.atlassian.net/browse/CLS2-1180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ