### PR TITLE
Send address fields for `uk_company` instead of `investor_company`

### DIFF
--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -326,18 +326,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         required=False,
         allow_null=True,
     )
-    investor_company = NestedRelatedField(
-        Company,
-        [
-            'name',
-            'address_1',
-            'address_2',
-            'address_town',
-            'address_postcode',
-        ],
-        required=True,
-        allow_null=False,
-    )
+    investor_company = NestedRelatedField(Company, required=True, allow_null=False)
     investor_company_country = NestedRelatedField(meta_models.Country, read_only=True)
     investor_type = NestedRelatedField(InvestorType, required=False, allow_null=True)
     intermediate_company = NestedRelatedField(Company, required=False, allow_null=True)
@@ -422,7 +411,18 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
         many=True,
         required=False,
     )
-    uk_company = NestedRelatedField(Company, required=False, allow_null=True)
+    uk_company = NestedRelatedField(
+        Company,
+        [
+            'name',
+            'address_1',
+            'address_2',
+            'address_town',
+            'address_postcode',
+        ],
+        required=False,
+        allow_null=True,
+    )
     incomplete_fields = serializers.ListField(child=serializers.CharField(), read_only=True)
     requirements_complete = serializers.SerializerMethodField()
 

--- a/datahub/investment/project/test/test_serializers.py
+++ b/datahub/investment/project/test/test_serializers.py
@@ -1,7 +1,9 @@
 import pytest
 
-
-from datahub.company.test.factories import AdviserFactory
+from datahub.company.test.factories import (
+    AdviserFactory,
+    CompanyFactory,
+)
 from datahub.core import constants
 from datahub.investment.project.serializers import (
     IProjectSerializer,
@@ -167,27 +169,14 @@ class TestIProjectSerializer:
             serializer.validated_data['country_investment_originates_from'],
         ) == constants.Country.argentina.value.name
 
-    def test_investor_company_required_fields(self):
-        """Tests require fields for investor_company"""
-        project = InvestmentProjectFactory()
+    def test_uk_company_address_fields(self):
+        """Tests address fields are sent with UK company nested object."""
+        project = InvestmentProjectFactory(uk_company=CompanyFactory())
         serializer = IProjectSerializer(project)
-        assert serializer.data['investor_company']['id'] == str(project.investor_company.id)
-        assert (
-            serializer.data['investor_company']['name'] == project.investor_company.name
-        )
-        assert (
-            serializer.data['investor_company']['address_1']
-            == project.investor_company.address_1
-        )
-        assert (
-            serializer.data['investor_company']['address_2']
-            == project.investor_company.address_2
-        )
-        assert (
-            serializer.data['investor_company']['address_town']
-            == project.investor_company.address_town
-        )
-        assert (
-            serializer.data['investor_company']['address_postcode']
-            == project.investor_company.address_postcode
-        )
+        assert serializer.data['uk_company']['id'] == str(project.uk_company.id)
+        assert serializer.data['uk_company']['name'] == project.uk_company.name
+        assert serializer.data['uk_company']['address_1'] == project.uk_company.address_1
+        assert serializer.data['uk_company']['address_2'] == project.uk_company.address_2
+        assert serializer.data['uk_company']['address_town'] == project.uk_company.address_town
+        assert serializer.data['uk_company']['address_postcode'] == \
+            project.uk_company.address_postcode

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -745,10 +745,6 @@ class TestRetrieveView(APITestMixin):
         assert response_data['investor_company'] == {
             'id': str(investor_company.id),
             'name': investor_company.name,
-            'address_1': investor_company.address_1,
-            'address_2': investor_company.address_2,
-            'address_postcode': investor_company.address_postcode,
-            'address_town': investor_company.address_town,
         }
         assert response_data['investor_company_country'] == {
             'id': str(investor_company.address_country.id),


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

Following on from #5912, we have realised we meant to send the address fields for the `uk_company`, rather than the `investor_company`. This PR fixes that.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
