### PR TITLE
Add raw id fields to prevent timeouts in Reminder admin.

### DIFF
--- a/datahub/reminder/admin.py
+++ b/datahub/reminder/admin.py
@@ -29,6 +29,10 @@ class NoRecentExportInteractionSubscriptionAdmin(admin.ModelAdmin):
     """No Recent Export Interaction Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(NewExportInteractionSubscription)
@@ -36,6 +40,10 @@ class NewExportInteractionSubscriptionAdmin(admin.ModelAdmin):
     """New Export Interaction Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(NoRecentInvestmentInteractionSubscription)
@@ -43,6 +51,10 @@ class NoRecentInvestmentInteractionSubscriptionAdmin(admin.ModelAdmin):
     """No Recent Investment Interaction Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(UpcomingEstimatedLandDateSubscription)
@@ -50,6 +62,10 @@ class UpcomingEstimatedLandDateSubscriptionAdmin(admin.ModelAdmin):
     """Upcoming Estimated Land Date Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(UpcomingTaskReminderSubscription)
@@ -57,6 +73,10 @@ class UpcomingTaskReminderSubscriptionAdmin(admin.ModelAdmin):
     """Upcoming Task Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(TaskAssignedToMeFromOthersSubscription)
@@ -64,6 +84,10 @@ class TaskAssignedToMeFromOthersSubscriptionAdmin(admin.ModelAdmin):
     """Task Assigned To Me From Others Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(TaskOverdueSubscription)
@@ -71,6 +95,10 @@ class TaskOverdueSubscriptionAdmin(admin.ModelAdmin):
     """Task Overdue Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(TaskAmendedByOthersSubscription)
@@ -78,6 +106,10 @@ class TaskAmendedByOthersSubscriptionAdmin(admin.ModelAdmin):
     """Task Amended By Others Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(TaskCompletedSubscription)
@@ -85,20 +117,36 @@ class TaskCompletedSubscriptionAdmin(admin.ModelAdmin):
     """Task Completed Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(NewExportInteractionReminder)
 class NewExportInteractionReminderAdmin(admin.ModelAdmin):
     """New Export Interaction Reminder admin."""
 
-    raw_id_fields = ('adviser', 'company')
+    raw_id_fields = ('adviser', 'company', 'interaction')
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'company__pk',
+        'interaction__pk',
+    )
 
 
 @admin.register(NoRecentExportInteractionReminder)
 class NoRecentExportInteractionReminderAdmin(admin.ModelAdmin):
     """No Recent Export Interaction Reminder admin."""
 
-    raw_id_fields = ('adviser', 'company')
+    raw_id_fields = ('adviser', 'company', 'interaction')
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'company__pk',
+        'interaction__pk',
+    )
 
 
 @admin.register(NoRecentInvestmentInteractionReminder)
@@ -106,6 +154,11 @@ class NoRecentInvestmentInteractionReminderAdmin(admin.ModelAdmin):
     """No Recent Investment Interaction Reminder admin."""
 
     raw_id_fields = ('adviser', 'project')
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'project__pk',
+    )
 
 
 @admin.register(UpcomingEstimatedLandDateReminder)
@@ -113,13 +166,18 @@ class UpcomingEstimatedLandDateReminderAdmin(admin.ModelAdmin):
     """Upcoming Estimated Land Date Reminder admin."""
 
     raw_id_fields = ('adviser', 'project')
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'project__pk',
+    )
 
 
 @admin.register(UpcomingTaskReminder)
 class UpcomingTaskReminderAdmin(admin.ModelAdmin):
     """Upcoming task reminder admin."""
 
-    raw_id_fields = ('adviser',)
+    raw_id_fields = ('adviser', 'task')
     list_display = (
         'id',
         'task',
@@ -132,6 +190,11 @@ class UpcomingTaskReminderAdmin(admin.ModelAdmin):
         'adviser',
         'task',
     )
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'task__pk',
+    )
 
 
 @admin.register(TaskDeletedByOthersSubscription)
@@ -139,63 +202,92 @@ class TaskDeletedByOthersSubscriptionAdmin(admin.ModelAdmin):
     """Task Deleted By Others Subscription admin."""
 
     raw_id_fields = ('adviser',)
+    search_fields = (
+        'pk',
+        'adviser__pk',
+    )
 
 
 @admin.register(TaskAssignedToMeFromOthersReminder)
 class TaskAssignedToMeFromOthersReminderAdmin(admin.ModelAdmin):
     """Task assigned to me from others admin."""
 
-    raw_id_fields = ('adviser',)
+    raw_id_fields = ('adviser', 'task')
     list_display = [
         'event',
         'adviser',
         'task',
     ]
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'task__pk',
+    )
 
 
 @admin.register(TaskAmendedByOthersReminder)
 class TaskAmendedByOthersReminderAdmin(admin.ModelAdmin):
     """Task amended by others admin."""
 
-    raw_id_fields = ('adviser',)
+    raw_id_fields = ('adviser', 'task')
     list_display = [
         'event',
         'adviser',
         'task',
     ]
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'task__pk',
+    )
 
 
 @admin.register(TaskOverdueReminder)
 class TaskOverdueReminderAdmin(admin.ModelAdmin):
     """Task overdue admin."""
 
-    raw_id_fields = ('adviser',)
+    raw_id_fields = ('adviser', 'task')
     list_display = [
         'event',
         'adviser',
         'task',
     ]
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'task__pk',
+    )
 
 
 @admin.register(TaskCompletedReminder)
 class TaskCompletedReminderAdmin(admin.ModelAdmin):
     """Task completed admin."""
 
-    raw_id_fields = ('adviser',)
+    raw_id_fields = ('adviser', 'task')
     list_display = [
         'event',
         'adviser',
         'task',
     ]
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'task__pk',
+    )
 
 
 @admin.register(TaskDeletedByOthersReminder)
 class TaskDeletedByOthersReminderAdmin(admin.ModelAdmin):
     """Task deleted by others admin."""
 
-    raw_id_fields = ('adviser',)
+    raw_id_fields = ('adviser', 'task')
     list_display = [
         'event',
         'adviser',
         'task',
     ]
+    search_fields = (
+        'pk',
+        'adviser__pk',
+        'task__pk',
+    )

--- a/datahub/task/admin.py
+++ b/datahub/task/admin.py
@@ -45,6 +45,12 @@ class TaskAdmin(BaseModelAdminMixin, VersionAdmin):
         'investment_project',
         'company',
         'interaction',
+        'created_by',
+        'modified_by',
+        'archived_by',
+    )
+    autocomplete_fields = (
+        'advisers',
     )
 
     form = TaskAdminForm


### PR DESCRIPTION
### Description of change

This adds `raw_id_fields` to reminder (and task) admin where missing to ensure the related datasets are not loaded into dropdowns causing time outs.

This also adds `search_fields` to make admin more useful.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
