### PR TITLE
feature/add-consent-field-to-contact-serializer

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -237,11 +237,13 @@ class ContactSerializer(PermittedFieldsModelSerializer):
             'modified_on',
             'address_area',
             'consent_data',
+            'consent_data_last_modified',
             'consent_data_management_url',
         )
         read_only_fields = (
             'archived_documents_url_path',
             'consent_data',
+            'consent_data_last_modified',
             'consent_data_management_url',
         )
         validators = [

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -1,5 +1,4 @@
-from datetime import date
-import datetime
+from datetime import date, datetime
 
 import factory
 import pytest
@@ -934,7 +933,7 @@ class ViewContactBase(APITestMixin):
             notes='lorem ipsum',
             valid_email=True,
             consent_data={'consent': True},
-            consent_data_last_modified=datetime.datetime.now(),
+            consent_data_last_modified=datetime.now(),
         )
         url = reverse(f'{self.endpoint_namespace}:contact:detail', kwargs={'pk': contact.pk})
         response = self.api_client.get(url)

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -1,4 +1,5 @@
 from datetime import date
+import datetime
 
 import factory
 import pytest
@@ -149,6 +150,7 @@ class AddContactBase(APITestMixin):
             'modified_on': '2017-04-18T13:25:30.986208Z',
             'valid_email': None,
             'consent_data': None,
+            'consent_data_last_modified': None,
             'consent_data_management_url': None,
         }
 
@@ -466,6 +468,7 @@ class TestAddContactV4(AddContactBase):
             'modified_on': '2017-04-18T13:25:30.986208Z',
             'valid_email': True,
             'consent_data': None,
+            'consent_data_last_modified': None,
             'consent_data_management_url': 'http://domain.com/?email=foo@bar.com',
         }
 
@@ -589,6 +592,7 @@ class EditContactBase(APITestMixin):
             'modified_on': '2017-04-19T13:25:30.986208Z',
             'valid_email': True,
             'consent_data': None,
+            'consent_data_last_modified': None,
             'consent_data_management_url': 'http://domain.com/?email=foo@bar.com',
         }
 
@@ -790,6 +794,7 @@ class TestEditContactV4(EditContactBase):
             'modified_on': '2017-04-19T13:25:30.986208Z',
             'valid_email': True,
             'consent_data': None,
+            'consent_data_last_modified': None,
             'consent_data_management_url': 'http://domain.com/?email=foo@bar.com',
         }
 
@@ -929,6 +934,7 @@ class ViewContactBase(APITestMixin):
             notes='lorem ipsum',
             valid_email=True,
             consent_data={'consent': True},
+            consent_data_last_modified=datetime.datetime.now(),
         )
         url = reverse(f'{self.endpoint_namespace}:contact:detail', kwargs={'pk': contact.pk})
         response = self.api_client.get(url)
@@ -982,6 +988,7 @@ class ViewContactBase(APITestMixin):
             'modified_on': '2017-04-18T13:25:30.986208Z',
             'valid_email': True,
             'consent_data': {'consent': True},
+            'consent_data_last_modified': '2017-04-18T13:25:30.986208Z',
             'consent_data_management_url': 'http://domain.com/?email=foo@bar.com',
         }
 
@@ -1216,6 +1223,7 @@ class ContactListBase(APITestMixin):
                     },
                     'valid_email': True,
                     'consent_data': {'consent': False},
+                    'consent_data_last_modified': None,
                     'consent_data_management_url': 'http://domain.com/?email=foo@bar.com',
                 },
             ],


### PR DESCRIPTION
### Description of change
Include the `consent_data_last_modified` field in the contact serializer for a GET request. This value is going to be displayed in the front end to users in an upcoming change
<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
