### PR TITLE
Create Interaction for Stova Attendee with default fake advisor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -124,7 +124,12 @@ def aws_credentials():
 
 
 @pytest.fixture
-def s3_client(aws_credentials):
+def bucket_name():
+    return TEST_S3_BUCKET_NAME
+
+
+@pytest.fixture
+def s3_client(aws_credentials, bucket_name):
     """Fixture for a mocked S3 client.
 
     Also creates a bucket named `test-bucket` in the same region.
@@ -132,7 +137,7 @@ def s3_client(aws_credentials):
     with mock_aws():
         s3_client = boto3.client('s3', region_name=TEST_AWS_REGION)
         s3_client.create_bucket(
-            Bucket=TEST_S3_BUCKET_NAME,
+            Bucket=bucket_name,
             CreateBucketConfiguration={'LocationConstraint': TEST_AWS_REGION},
         )
         yield s3_client

--- a/datahub/company_activity/tasks/ingest_stova_attendees.py
+++ b/datahub/company_activity/tasks/ingest_stova_attendees.py
@@ -270,6 +270,7 @@ class StovaAttendeeIngestionTask(BaseObjectIngestionTask):
                 were_countries_discussed=False,
             )
             interaction.contacts.add(contact)
+            interaction.companies.add(company)
             interaction.dit_participants.add(InteractionDITParticipant.objects.create(
                 adviser=adviser,
                 interaction=interaction,

--- a/datahub/company_activity/tests/conftest.py
+++ b/datahub/company_activity/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+from datahub.ingest.boto3 import S3ObjectProcessor
+from datahub.ingest.constants import (
+    S3_BUCKET_NAME,
+    TEST_PREFIX,
+)
+
+
+@pytest.fixture
+def prefix():
+    return TEST_PREFIX
+
+
+@pytest.fixture
+def bucket_name():
+    return S3_BUCKET_NAME
+
+
+@pytest.fixture
+def s3_object_processor(s3_client, prefix):
+    """Fixture for an S3ObjectProcessor instance."""
+    return S3ObjectProcessor(
+        prefix=prefix,
+        bucket=S3_BUCKET_NAME,
+        s3_client=s3_client,
+    )

--- a/datahub/company_activity/tests/test_tasks/test_stova_attendee_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_attendee_ingestion_task.py
@@ -388,7 +388,7 @@ class TestStovaIngestionTasks:
             first_name='Stova Default',
             last_name='Adviser',
             is_active=False,
-        ).first() is None
+        ).exists() is False
 
         ingestion_task.ingest_object()
 
@@ -397,7 +397,7 @@ class TestStovaIngestionTasks:
             first_name='Stova Default',
             last_name='Adviser',
             is_active=False,
-        ).first() is not None
+        ).exists() is True
 
     @pytest.mark.django_db
     def test_stova_attendee_ingestion_uses_existing_default_adviser_if_exists(
@@ -460,14 +460,14 @@ class TestStovaIngestionTasks:
         ).first()
         assert interaction is not None
         assert interaction.company == contact.company
-        assert interaction.companies.all().count() == 1
-        assert interaction.companies.all().first() == contact.company
+        assert interaction.companies.count() == 1
+        assert interaction.companies.first() == contact.company
         assert interaction.kind == Interaction.Kind.SERVICE_DELIVERY
         assert interaction.is_event is True
         assert interaction.theme == Interaction.Theme.OTHER
         assert interaction.was_policy_feedback_provided is False
         assert interaction.were_countries_discussed is False
-        assert interaction.dit_participants.all().first().adviser.email == (
+        assert interaction.dit_participants.first().adviser.email == (
             'stova_default@businessandtrade.gov.uk'
         )
 
@@ -515,7 +515,7 @@ class TestStovaIngestionTasks:
         """Test that no Stova Attendee is created if the interaction fails to create."""
         # Make event invalid for an interaction
         stova_event = StovaEventFactory()
-        datahub_event = stova_event.datahub_event.all().first()
+        datahub_event = stova_event.datahub_event.first()
         datahub_event.start_date = None
         datahub_event.save()
         stova_event.refresh_from_db()

--- a/datahub/company_activity/tests/test_tasks/test_stova_attendee_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_attendee_ingestion_task.py
@@ -460,6 +460,8 @@ class TestStovaIngestionTasks:
         ).first()
         assert interaction is not None
         assert interaction.company == contact.company
+        assert interaction.companies.all().count() == 1
+        assert interaction.companies.all().first() == contact.company
         assert interaction.kind == Interaction.Kind.SERVICE_DELIVERY
         assert interaction.is_event is True
         assert interaction.theme == Interaction.Theme.OTHER

--- a/datahub/company_activity/tests/test_tasks/test_stova_attendee_ingestion_task.py
+++ b/datahub/company_activity/tests/test_tasks/test_stova_attendee_ingestion_task.py
@@ -14,7 +14,7 @@ from sentry_sdk import init
 from sentry_sdk.transport import Transport
 
 from datahub.company.models import Company
-from datahub.company.test.factories import CompanyFactory, ContactFactory
+from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.company_activity.models import StovaAttendee
 from datahub.company_activity.tasks.constants import BUCKET, REGION, STOVA_ATTENDEE_PREFIX
 from datahub.company_activity.tasks.ingest_stova_attendees import (
@@ -66,7 +66,8 @@ def setup_s3_files(bucket_name, test_file, test_file_path):
 @pytest.fixture
 def test_base_stova_attendee():
     event_id = 1234
-    StovaEventFactory(stova_event_id=event_id)
+    adviser = AdviserFactory()
+    StovaEventFactory(stova_event_id=event_id, modified_by=adviser.email)
 
     return {
         'id': 2367,


### PR DESCRIPTION
### Description of change

To show as an Attendee of a DataHub `Event`, you must be a `Contact` in an `Interaction` for that `Event`.
This PR creates interactions from StovaAttendees. It also creates a new fake default advisor for assigning these interactions as the Stova Data does not provide an accurate way to give us Advisor emails.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
