### PR TITLE
Sync UK company and project site address fields on applicable projects

### DIFF
--- a/datahub/investment/project/signals.py
+++ b/datahub/investment/project/signals.py
@@ -121,3 +121,29 @@ def update_country_investment_originates_from(sender, **kwargs):
             investment_project.save(
                 update_fields=('country_investment_originates_from',),
             )
+
+
+def update_site_address_is_company_address(sender, **kwargs):
+    """
+    Updates investment project addresses when an investor company's address changes.
+    """
+    instance = kwargs['instance']
+    created = kwargs['created']
+    if not created:
+        investment_projects = InvestmentProject.objects.filter(
+            uk_company_id=instance.pk,
+        )
+
+        for investment_project in investment_projects:
+            if investment_project.site_address_is_company_address:
+                investment_project.address_1 = instance.address_1
+                investment_project.address_2 = instance.address_2
+                investment_project.address_town = instance.address_town
+                investment_project.address_postcode = instance.address_postcode
+
+            investment_project.save(
+                update_fields=(
+                    'address_1', 'address_2', 'address_town',
+                    'address_postcode',
+                ),
+            )


### PR DESCRIPTION
### Description of change

We are [replacing the old site decided question with a new one](https://github.com/uktrade/data-hub-frontend/pull/7511): is the [investment project] site address the same as the [uk recipient] company address? If users select "yes", the investment project's site address should be set to the uk company address; functionality that will be handled by the frontend before sending the PATCH request.

However, if the UK company address is subsequently updated, we wanted to ensure that applicable investment projects had their site address fields updated too; hence this PR.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
