### PR TITLE
Adding check on ID of record created to skip if already processed

### DIFF
--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -53,11 +53,10 @@ from datahub.export_win.tasks import (
     update_notify_email_delivery_status_for_customer_response,
     update_notify_email_delivery_status_for_customer_response_token,
 )
-
-from datahub.investment_lead.tasks.ingest_eyb_triage import eyb_triage_identification_task
 from datahub.investment.project.tasks import (
     schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
 )
+from datahub.investment_lead.tasks.ingest_eyb_triage import eyb_triage_identification_task
 from datahub.omis.payment.tasks import refresh_pending_payment_gateway_sessions
 from datahub.reminder.migration_tasks import run_ita_users_migration, run_post_users_migration
 from datahub.reminder.tasks import (

--- a/cron-scheduler.py
+++ b/cron-scheduler.py
@@ -37,7 +37,7 @@ from datahub.core.queues.constants import (
     EVERY_TEN_MINUTES,
     EVERY_TEN_PM,
     EVERY_THREE_AM,
-    # EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
+    EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
     EVERY_TWO_AM,
     HALF_DAY_IN_SECONDS,
     ONE_HOUR_IN_SECONDS,
@@ -54,10 +54,10 @@ from datahub.export_win.tasks import (
     update_notify_email_delivery_status_for_customer_response_token,
 )
 
-# from datahub.investment.project.tasks import (
-#     schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
-# )
 from datahub.investment_lead.tasks.ingest_eyb_triage import eyb_triage_identification_task
+from datahub.investment.project.tasks import (
+    schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
+)
 from datahub.omis.payment.tasks import refresh_pending_payment_gateway_sessions
 from datahub.reminder.migration_tasks import run_ita_users_migration, run_post_users_migration
 from datahub.reminder.tasks import (
@@ -163,12 +163,11 @@ def schedule_jobs():
             description='schedule_generate_estimated_land_date_reminders',
         )
 
-    # TODO: uncomment this once the infinite loop issue (when refreshing GVA) has been fixed
-    # job_scheduler(
-    #     function=schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
-    #     cron=EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
-    #     description='schedule_refresh_gross_value_added_value_for_fdi_investment_projects',
-    # )
+    job_scheduler(
+        function=schedule_refresh_gross_value_added_value_for_fdi_investment_projects,
+        cron=EVERY_THREE_AM_ON_TWENTY_EIGHTH_EACH_MONTH,
+        description='schedule_refresh_gross_value_added_value_for_fdi_investment_projects',
+    )
 
     if settings.ENABLE_ESTIMATED_LAND_DATE_REMINDERS_EMAIL_DELIVERY_STATUS:
         job_scheduler(

--- a/data_generator.py
+++ b/data_generator.py
@@ -31,6 +31,7 @@ from datahub.company.test.factories import (
     SubsidiaryFactory,
 )
 
+
 class DisableSignals:
     def __init__(self, disabled_signals=None):
         self.stashed_signals = defaultdict(list)
@@ -114,4 +115,3 @@ with DisableSignals():
 
     elapsed = time.time() - start_time
     print(f'{timedelta(seconds=elapsed)}')  # noqa
-    

--- a/data_generator.py
+++ b/data_generator.py
@@ -30,7 +30,7 @@ from datahub.company.test.factories import (
     ContactFactory,
     SubsidiaryFactory,
 )
-
+from datahub.investment.project.test.factories import InvestmentProjectFactory
 
 class DisableSignals:
     def __init__(self, disabled_signals=None):

--- a/data_generator.py
+++ b/data_generator.py
@@ -30,7 +30,6 @@ from datahub.company.test.factories import (
     ContactFactory,
     SubsidiaryFactory,
 )
-from datahub.investment.project.test.factories import InvestmentProjectFactory
 
 class DisableSignals:
     def __init__(self, disabled_signals=None):
@@ -115,3 +114,4 @@ with DisableSignals():
 
     elapsed = time.time() - start_time
     print(f'{timedelta(seconds=elapsed)}')  # noqa
+    

--- a/datahub/investment/project/tasks.py
+++ b/datahub/investment/project/tasks.py
@@ -81,8 +81,12 @@ def refresh_gross_value_added_value_for_fdi_investment_projects():
     which sets the Gross Value added data for a project.
     """
     investment_projects = get_investment_projects_to_refresh_gva_values()
+    processed_ids = set()
     for project in investment_projects.iterator():
+        if project.id in processed_ids:
+            continue
         project.save(update_fields=['gross_value_added', 'gva_multiplier'])
+        processed_ids.add(project.id)
 
     logger.info(
         'Task refresh_gross_value_added_value_for_fdi_investment_projects completed',


### PR DESCRIPTION
### Description of change

The cron job is falling into an infinite loop. The assumption is that the dataset is being modified during processing, causing the iterator to pick up the same record repeatedly and process it again. Tested this locally with 10,000 generated records and ran the code with logs; it seems to work fine. Another possible cause could be issues with the linked model relationships. Plan to test this in the deployed environment to see if the issue persists and will log a new bug if necessary.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
  
  The branch should not be stale or have conflicts at the time reviews are requested.

* [x] Is the CircleCI build passing?

### General points


* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
