### PR TITLE
Feature/cls2 1231 one list permission changes

### DIFF
--- a/datahub/company/permissions.py
+++ b/datahub/company/permissions.py
@@ -1,0 +1,51 @@
+from django.db.models.query_utils import Q
+from rest_framework.filters import BaseFilterBackend
+
+from datahub.core.permissions import (
+    get_model_action_for_view_action,
+    IsAssociatedToObjectPermission,
+    ObjectAssociationCheckerBase,
+    ViewBasedModelPermissions,
+)
+from datahub.core.utils import StrEnum
+from datahub.investment.project.models import InvestmentProject
+
+class _PermissionTemplate(StrEnum):
+    """Permission codename templates."""
+
+    all = '{app_label}.{action}_all_{model_name}'
+    associated = '{app_label}.{action}_associated_{model_name}'
+    standard = '{app_label}.{action}_{model_name}'
+    stage_to_won = '{app_label}.{action}_stage_to_won_{model_name}'
+
+
+class CompanyModelPermissions(ViewBasedModelPermissions):
+    """
+    Custom permissions class for investment views.
+
+    This differs from the standard DjangoModelPermissions class in that:
+    - the permissions mapping is based on view/model actions rather than HTTP methods
+    - the user only needs to have one the permissions corresponding to each action, rather than
+      all of them
+    """
+
+    many_to_many = False
+    model = InvestmentProject
+
+    permission_mapping = {
+        'add': (
+            _PermissionTemplate.standard,
+        ),
+        'view': (
+            _PermissionTemplate.all,
+            _PermissionTemplate.associated,
+        ),
+        'change': (
+            _PermissionTemplate.all,
+            _PermissionTemplate.associated,
+            _PermissionTemplate.stage_to_won,
+        ),
+        'delete': (
+            _PermissionTemplate.standard,
+        ),
+    }

--- a/datahub/company/permissions.py
+++ b/datahub/company/permissions.py
@@ -9,6 +9,10 @@ from datahub.core.permissions import (
 )
 from datahub.core.utils import StrEnum
 from datahub.investment.project.models import InvestmentProject
+from datahub.company.models import Company, CompanyPermission
+from rest_framework.permissions import BasePermission
+from datahub.core.permissions import HasPermissions
+
 
 class _PermissionTemplate(StrEnum):
     """Permission codename templates."""
@@ -17,6 +21,23 @@ class _PermissionTemplate(StrEnum):
     associated = '{app_label}.{action}_associated_{model_name}'
     standard = '{app_label}.{action}_{model_name}'
     stage_to_won = '{app_label}.{action}_stage_to_won_{model_name}'
+
+    # f'company.{CompanyPermission.change_company}',
+    # f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
+
+
+class IsAccountManagerOnCompany(BasePermission):
+    """
+    Allows access only to users that are account managers for the current company.
+    """
+
+    def has_permission(self, request, view):
+        return HasPermissions(
+            f'company.{CompanyPermission.change_company}',
+            f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
+        )
+
+        # return bool(request.user and request.user.is_authenticated)
 
 
 class CompanyModelPermissions(ViewBasedModelPermissions):
@@ -30,7 +51,7 @@ class CompanyModelPermissions(ViewBasedModelPermissions):
     """
 
     many_to_many = False
-    model = InvestmentProject
+    model = Company
 
     permission_mapping = {
         'add': (
@@ -41,9 +62,17 @@ class CompanyModelPermissions(ViewBasedModelPermissions):
             _PermissionTemplate.associated,
         ),
         'change': (
+            _PermissionTemplate.standard,
             _PermissionTemplate.all,
-            _PermissionTemplate.associated,
-            _PermissionTemplate.stage_to_won,
+            # _PermissionTemplate.associated,
+            # _PermissionTemplate.stage_to_won,
+            # CompanyPermission.add_company,
+            # CompanyPermission.
+            # CompanyPermission.change_company,
+            # CompanyPermission.change_one_list_tier_and_global_account_manager,
+            CompanyPermission.change_company,
+            CompanyPermission.change_one_list_tier_and_global_account_manager,
+            CompanyPermission.change_one_list_core_team_member,
         ),
         'delete': (
             _PermissionTemplate.standard,

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -5,6 +5,7 @@ from typing import Optional
 from uuid import UUID
 
 from django.conf import settings
+from datahub.core.permissions import HasPermissions
 from django.db import models, transaction
 from django.utils.translation import gettext_lazy
 from rest_framework import serializers
@@ -58,6 +59,7 @@ from datahub.core.validators import (
 from datahub.metadata import models as meta_models
 from datahub.metadata.serializers import TeamWithGeographyField
 from datahub.metadata.utils import convert_usd_to_gbp
+# from permissions import CompanyModelPermissions
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -665,9 +667,17 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             ),
         )
         permissions = {
+            # HasPermissions(CompanyModelPermissions),
             f'company.{CompanyPermission.view_company_document}': 'archived_documents_url_path',
             'company.view_companyexportcountry': 'export_countries',
         }
+
+        # permission_classes=[
+        #     HasPermissions(
+        #         f'company.{CompanyPermission.change_company}',
+        #         f'company.{CompanyPermission.change_one_list_core_team_member}',
+        #     ),
+        # ],
 
 
 class AssignRegionalAccountManagerSerializer(serializers.Serializer):

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -5,7 +5,6 @@ from typing import Optional
 from uuid import UUID
 
 from django.conf import settings
-from datahub.core.permissions import HasPermissions
 from django.db import models, transaction
 from django.utils.translation import gettext_lazy
 from rest_framework import serializers
@@ -59,7 +58,6 @@ from datahub.core.validators import (
 from datahub.metadata import models as meta_models
 from datahub.metadata.serializers import TeamWithGeographyField
 from datahub.metadata.utils import convert_usd_to_gbp
-# from permissions import CompanyModelPermissions
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -667,17 +665,9 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             ),
         )
         permissions = {
-            # HasPermissions(CompanyModelPermissions),
             f'company.{CompanyPermission.view_company_document}': 'archived_documents_url_path',
             'company.view_companyexportcountry': 'export_countries',
         }
-
-        # permission_classes=[
-        #     HasPermissions(
-        #         f'company.{CompanyPermission.change_company}',
-        #         f'company.{CompanyPermission.change_one_list_core_team_member}',
-        #     ),
-        # ],
 
 
 class AssignRegionalAccountManagerSerializer(serializers.Serializer):

--- a/datahub/company/test/test_company_views_one_list.py
+++ b/datahub/company/test/test_company_views_one_list.py
@@ -149,7 +149,8 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
         versions = Version.objects.get_for_object(company)
         assert versions.count() == 1
         assert versions[0].field_dict['one_list_tier_id'] == new_one_list_tier.id
-        assert versions[0].field_dict['one_list_account_owner_id'] == company.one_list_account_owner.id
+        assert versions[0].field_dict['one_list_account_owner_id'] == \
+            company.one_list_account_owner.id
 
     @pytest.mark.django_db
     def test_returns_403_on_editing_one_list_tier_by_other_global_account_manager(

--- a/datahub/company/test/test_company_views_one_list.py
+++ b/datahub/company/test/test_company_views_one_list.py
@@ -129,7 +129,9 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
 
         url = self._get_url(company)
 
-        new_one_list_tier = random_non_ita_one_list_tier()
+        new_one_list_tier = random_non_ita_one_list_tier(
+            exclude=company.one_list_tier,
+        )
 
         response = api_client.post(
             url,
@@ -168,7 +170,9 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
 
         url = self._get_url(company)
 
-        new_one_list_tier = random_non_ita_one_list_tier()
+        new_one_list_tier = random_non_ita_one_list_tier(
+            exclude=company.one_list_tier,
+        )
 
         response = api_client.post(
             url,

--- a/datahub/company/test/test_company_views_one_list.py
+++ b/datahub/company/test/test_company_views_one_list.py
@@ -113,72 +113,70 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
         assert versions[0].field_dict['one_list_tier_id'] == new_one_list_tier.id
         assert versions[0].field_dict['one_list_account_owner_id'] == global_account_manager.id
 
-    # @pytest.mark.parametrize(
-    #     'company_factory,can_edit',
-    #     (
-    #         pytest.param(
-    #             pytest.param(
-    #                 lambda: CompanyFactory(
-    #                     one_list_account_owner=AdviserFactory(),
-    #                     one_list_tier=random_non_ita_one_list_tier(),
-    #                 ),
-    #             ),
-    #             True,
-    #         ),
-    #         pytest.param(
-    #             pytest.param(
-    #                 lambda: CompanyFactory(
-    #                     one_list_account_owner=AdviserFactory(),
-    #                     one_list_tier=random_non_ita_one_list_tier(),
-    #                 ),
-    #                 id='existing-global-account-manager',
-    #             ),
-    #             False,
-    #         ),
-    #     ),
-    # )
     @pytest.mark.django_db
     def test_assigns_one_list_tier_by_global_account_manager(
         self,
-        # company_factory,
-        # can_edit,
     ):
         """
         Test that a global account manager:
-
         - can update the One List tier of the company they are managing
-        - can not update the One List tier of a company they are not managing.
         """
         company = CompanyFactory(
             one_list_account_owner=AdviserFactory(),
             one_list_tier=random_non_ita_one_list_tier(),
         )
         api_client = self.create_api_client(user=company.one_list_account_owner)
+
         url = self._get_url(company)
 
         new_one_list_tier = random_non_ita_one_list_tier()
-
-        global_account_manager = AdviserFactory()
 
         response = api_client.post(
             url,
             {
                 'one_list_tier': new_one_list_tier.id,
-                'global_account_manager': global_account_manager.id,
+                'global_account_manager': company.one_list_account_owner.id,
             },
         )
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
         company.refresh_from_db()
-        assert company.one_list_account_owner == global_account_manager
+        assert company.one_list_account_owner == company.one_list_account_owner
         assert company.one_list_tier_id == new_one_list_tier.pk
-        assert company.modified_by == one_list_editor
+        assert company.modified_by == company.one_list_account_owner
 
         # Check that object version is stored correctly
         versions = Version.objects.get_for_object(company)
         assert versions.count() == 1
         assert versions[0].field_dict['one_list_tier_id'] == new_one_list_tier.id
-        assert versions[0].field_dict['one_list_account_owner_id'] == global_account_manager.id
+        assert versions[0].field_dict['one_list_account_owner_id'] == company.one_list_account_owner.id
+
+    @pytest.mark.django_db
+    def test_cannot_assign_one_list_tier_by_other_global_account_manager(
+        self,
+    ):
+        """
+        Test that a global account manager:
+        - can not update the One List tier of a company they are not managing.
+        """
+        company = CompanyFactory(
+            one_list_account_owner=AdviserFactory(),
+        )
+
+        api_client = self.create_api_client()
+
+        url = self._get_url(company)
+
+        new_one_list_tier = random_non_ita_one_list_tier()
+
+        response = api_client.post(
+            url,
+            {
+                'one_list_tier': new_one_list_tier.id,
+                'global_account_manager': company.one_list_account_owner.id,
+            },
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(
         'company_factory,adviser_id_fn,new_one_list_tier_id_fn,expected_errors',

--- a/datahub/company/test/test_company_views_one_list.py
+++ b/datahub/company/test/test_company_views_one_list.py
@@ -74,13 +74,13 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
         ),
     )
     @pytest.mark.django_db
-    def test_assigns_one_list_tier_and_global_account_manager(
+    def test_assigns_one_list_tier_and_account_manager(
         self,
         company_factory,
         one_list_editor,
     ):
         """
-        Test that a One List tier and global account manager can be assigned to:
+        Test that a One List tier and account manager can be assigned to:
 
         - a company not on the One List
         - a company on random One List tier except 'Tier D - International Trade Adviser Accounts'
@@ -114,11 +114,11 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
         assert versions[0].field_dict['one_list_account_owner_id'] == global_account_manager.id
 
     @pytest.mark.django_db
-    def test_assigns_one_list_tier_by_global_account_manager(
+    def test_assigns_one_list_tier_by_account_manager(
         self,
     ):
         """
-        Test that a global account manager:
+        Test that an account manager:
         - can update the One List tier of the company they are managing
         """
         company = CompanyFactory(
@@ -155,11 +155,11 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
             company.one_list_account_owner.id
 
     @pytest.mark.django_db
-    def test_returns_403_on_editing_one_list_tier_by_other_global_account_manager(
+    def test_returns_403_on_editing_one_list_tier_by_other_account_manager(
         self,
     ):
         """
-        Test that a global account manager:
+        Test that an account manager:
         - can not update the One List tier of a company they are not managing.
         """
         company = CompanyFactory(

--- a/datahub/company/test/test_company_views_one_list.py
+++ b/datahub/company/test/test_company_views_one_list.py
@@ -152,7 +152,7 @@ class TestUpdateOneListTierAndGlobalAccountManager(APITestMixin):
         assert versions[0].field_dict['one_list_account_owner_id'] == company.one_list_account_owner.id
 
     @pytest.mark.django_db
-    def test_cannot_assign_one_list_tier_by_other_global_account_manager(
+    def test_returns_403_on_editing_one_list_tier_by_other_global_account_manager(
         self,
     ):
         """

--- a/datahub/company/test/utils.py
+++ b/datahub/company/test/utils.py
@@ -5,11 +5,16 @@ from datahub.core.test_utils import (
 )
 
 
-def random_non_ita_one_list_tier():
-    """Returns random non ITA One List tier."""
+def random_non_ita_one_list_tier(exclude=None):
+    """
+    Returns random non ITA One List tier.
+    :param exclude: OneListTier object to also exclude
+    """
     queryset = OneListTier.objects.exclude(
         pk=OneListTierID.tier_d_international_trade_advisers.value,
     )
+    if exclude is not None:
+        queryset.exclude(pk=exclude.id)
     return random_obj_for_queryset(queryset)
 
 

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -30,8 +30,8 @@ from datahub.company.models import (
     Contact,
     Objective,
 )
-from datahub.company.permissions import CompanyModelPermissions, IsAccountManagerOnCompany
 from datahub.company.pagination import ContactPageSize
+from datahub.company.permissions import IsAccountManagerOnCompany
 from datahub.company.queryset import (
     get_contact_queryset,
     get_export_country_queryset,

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -273,10 +273,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         methods=['patch'],
         detail=True,
         permission_classes=[
-            HasPermissions(
-                f'company.{CompanyPermission.change_company}',
-                f'company.{CompanyPermission.change_one_list_core_team_member}',
-            ),
+            IsAccountManagerOnCompany,
         ],
         schema=StubSchema(),
     )

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -30,6 +30,7 @@ from datahub.company.models import (
     Contact,
     Objective,
 )
+from datahub.company.permissions import CompanyModelPermissions, IsAccountManagerOnCompany
 from datahub.company.pagination import ContactPageSize
 from datahub.company.queryset import (
     get_contact_queryset,
@@ -221,10 +222,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         methods=['post'],
         detail=True,
         permission_classes=[
-            HasPermissions(
-                f'company.{CompanyPermission.change_company}',
-                f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
-            ),
+            IsAccountManagerOnCompany,
         ],
         schema=StubSchema(),
     )


### PR DESCRIPTION
### Description of change

Allow account managers to change the one list tier and core team of companies they are assigned to. Existing edit functionality for administrators and super users remains.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
