### PR TITLE
Add management command to set `site_address_is_company_address` for existing projects

### DIFF
--- a/datahub/investment/project/management/commands/set_site_address_is_company_address.py
+++ b/datahub/investment/project/management/commands/set_site_address_is_company_address.py
@@ -1,0 +1,53 @@
+import logging
+
+from django.core.management.base import BaseCommand
+
+from datahub.investment.project.models import InvestmentProject
+
+
+logger = logging.getLogger(__name__)
+
+
+# TODO: Remove command once it has been run as one-off data modification
+
+
+class Command(BaseCommand):
+    """Command to do a one-off modification of investment projects."""
+
+    help = 'Sets site_address_is_company_address value for existing projects.'
+
+    def handle(self, *args, **options):
+        """Method to set site_address_is_company_address value for existing projects.
+
+        Business rules are as follows for projects that have:
+        - site_address_is_company_address == None and site_decided == True: set
+        site_address_is_company_address to False.
+        - site_address_is_company_address == None and site_decided == False/None: leave
+        site_address_is_company_address as None.
+        """
+        try:
+            projects = InvestmentProject.objects.filter(
+                site_address_is_company_address__isnull=True,
+                site_decided=True,
+            )
+            if projects.exists():
+                logger.info(
+                    f'Found {projects.count()} projects with '
+                    'site_address_is_company_address == None and site_decided == True. '
+                    'Modifying...',
+                )
+                updated_count = projects.update(site_address_is_company_address=False)
+                logger.info(
+                    f'Set site_address_is_company_address to False on {updated_count} projects.',
+                )
+            else:
+                logger.warning(
+                    'No projects with '
+                    'site_address_is_company_address == None and site_decided == True found. '
+                    'Exiting...',
+                )
+        except Exception as e:
+            logger.error(
+                'An error occurred trying to set site_address_is_company_address '
+                f'value for existing projects: {str(e)}',
+            )

--- a/datahub/investment/project/test/management/commands/test_set_site_address_is_company_address.py
+++ b/datahub/investment/project/test/management/commands/test_set_site_address_is_company_address.py
@@ -1,0 +1,83 @@
+import logging
+
+from unittest import mock
+
+import pytest
+
+from django.core.management import call_command
+
+from datahub.investment.project.models import InvestmentProject
+from datahub.investment.project.test.factories import InvestmentProjectFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+# TODO: Remove file once command has been run as one-off data modification
+
+
+def test_set_site_address_is_company_address(caplog):
+    # setup investment projects
+    project_to_be_modified = InvestmentProjectFactory(
+        site_address_is_company_address=None,
+        site_decided=True,
+    )
+    InvestmentProjectFactory(
+        site_address_is_company_address=None,
+        site_decided=False,
+    )
+    InvestmentProjectFactory(
+        site_address_is_company_address=None,
+        site_decided=None,
+    )
+    InvestmentProjectFactory(site_address_is_company_address=True)
+    InvestmentProjectFactory(site_address_is_company_address=False)
+
+    # initial assertions
+    assert project_to_be_modified.site_address_is_company_address is None
+    assert InvestmentProject.objects.count() == 5
+    assert InvestmentProject.objects.filter(site_address_is_company_address=None).count() == 3
+    assert InvestmentProject.objects.filter(site_address_is_company_address=True).count() == 1
+    assert InvestmentProject.objects.filter(site_address_is_company_address=False).count() == 1
+
+    # execute job
+    with caplog.at_level(logging.INFO):
+        call_command('set_site_address_is_company_address')
+        assert (
+            'Found 1 projects with '
+            'site_address_is_company_address == None and site_decided == True. '
+            'Modifying...'
+        ) in caplog.text
+        assert 'Set site_address_is_company_address to False on 1 projects.' in caplog.text
+
+    # final assertions
+    project_to_be_modified.refresh_from_db()
+    assert project_to_be_modified.site_address_is_company_address is False
+    assert InvestmentProject.objects.count() == 5
+    assert InvestmentProject.objects.filter(site_address_is_company_address=None).count() == 2
+    assert InvestmentProject.objects.filter(site_address_is_company_address=True).count() == 1
+    assert InvestmentProject.objects.filter(site_address_is_company_address=False).count() == 2
+
+
+def test_set_site_address_is_company_address_when_theres_no_projects(caplog):
+    with caplog.at_level(logging.INFO):
+        call_command('set_site_address_is_company_address')
+        assert (
+            'No projects with '
+            'site_address_is_company_address == None and site_decided == True found. '
+            'Exiting...'
+        ) in caplog.text
+
+
+def test_set_site_address_is_company_address_handles_error(caplog):
+    with (
+        mock.patch('datahub.investment.project.models.InvestmentProject.objects')
+        as mock_objects,
+        caplog.at_level(logging.ERROR),
+    ):
+        mock_objects.filter.side_effect = Exception('A mocked filtering error')
+        call_command('set_site_address_is_company_address')
+        assert (
+            'An error occurred trying to set site_address_is_company_address '
+            'value for existing projects'
+        ) in caplog.text


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR adds a management command to set `site_address_is_company_address` to a sensible default for existing projects. This will avoid the majority of users having to re-visit the question in the frontend if they've previously answered the `site_decided` question.

Business rules are as follows for projects that have:
- `site_address_is_company_address == None and site_decided == True`: set `site_address_is_company_address` to False.
- `site_address_is_company_address == None and site_decided == False/None`: leave `site_address_is_company_address` as None.

Once this management command has been run once in production, it shall be removed.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
