### PR TITLE
TET-880: Use secure cookie flag everywhere

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -242,6 +242,7 @@ else:
 
 # Set the session cookie in admin, defaults to 20 minutes
 SESSION_COOKIE_AGE = env('SESSION_COOKIE_AGE', default=20 * 60)
+SESSION_COOKIE_SECURE = True
 
 # Staff SSO integration settings
 


### PR DESCRIPTION
### Description of change
https://uktrade.atlassian.net/browse/TET-880

The Django admin messages contrib module takes it's cookie settings from the general Django config. The [SESSION_COOKIE_SECURE](https://docs.djangoproject.com/en/5.1/ref/settings/#std-setting-SESSION_COOKIE_SECURE) setting defaults to off, which means the messages cookies were also being created with the flag off, for example in the request below. This was flagged in the most recent pen test.

`POST http://localhost:8000/admin/company/advisor/f4a33f93-6303-4a7e-a813-ab4c204df2e3/change/`
Before:
![Screenshot 2025-02-14 at 09 55 42](https://github.com/user-attachments/assets/76e2d617-67b7-4b1f-9126-705d0a24892c)

After:
![Screenshot 2025-02-14 at 11 54 39](https://github.com/user-attachments/assets/80ce98d3-9b30-45b8-a1c9-a12e4143e8a8)



### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
