### PR TITLE
Add additional logging to the update_company_duns_number command

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_company_duns_number.py
+++ b/datahub/dbmaintenance/management/commands/update_company_duns_number.py
@@ -11,7 +11,12 @@ logger = getLogger(__name__)
 
 
 class Command(CSVBaseCommand):
-    """Command to update Company.duns_number."""
+    """
+    Command to update Company.duns_number.
+
+    Adds additional logging to show where the duns number update would fail. The duns number is
+    unique on the Company model.
+    """
 
     additional_logging: dict
 
@@ -19,8 +24,9 @@ class Command(CSVBaseCommand):
         super().__init__(*args, **kwargs)
         self.additional_logging = {
             'errors': [],
-            'duplicate_company_already_merged_with_target': 0,
-            'duplicate_company_already_merged': 0,
+            'company_already_merged_with_target': 0,
+            'company_already_merged': 0,
+            'duns_already_assigned': 0,
         }
 
     def _process_row(self, row, simulate=False, **options):
@@ -32,14 +38,13 @@ class Command(CSVBaseCommand):
         if company.duns_number == duns_number:
             return
 
+        if duns_number is not None and self.is_duns_already_assigned_to_another_company(
+            company,
+            duns_number,
+        ):
+            return
+
         company.duns_number = duns_number
-
-        target_company = Company.objects.filter(duns_number=duns_number).first()
-        if target_company and self.is_source_already_merged_into_target(company, target_company):
-            return
-
-        if self.is_source_already_merged(company):
-            return
 
         if simulate:
             return
@@ -58,20 +63,64 @@ class Command(CSVBaseCommand):
             )
             raise error
 
-    def is_source_already_merged_into_target(self, company: Company, target_company: str) -> bool:
+    def is_duns_already_assigned_to_another_company(
+        self, company: Company, duns_number: str,
+    ) -> bool:
+        """
+        If another company exists with the target duns, this is an issue as duns numbers are
+        unique. These are logged individually.
+
+        :param company: The source company we want to update.
+        :param duns_number: The duns number we want to give the source company.
+        :return: Returns True if the duns number already exists for another company, False
+            otherwise.
+        """
+        company_with_duns = Company.objects.filter(duns_number=duns_number).first()
+        if not company_with_duns:
+            return False
+
+        if self.is_source_already_merged_into_target(company, company_with_duns):
+            self.additional_logging['company_already_merged_with_target'] += 1
+            return True
+
+        if self.is_source_already_merged(company):
+            self.additional_logging['company_already_merged'] += 1
+            return True
+
+        # If source is not merged but another company has the target duns, we cannot update
+        # this company as duns numbers are unique on the Company model. Log this error.
+        self.additional_logging['duns_already_assigned'] += 1
+        self.additional_logging['errors'].append(
+            {
+                'id': company.pk,
+                'duns_number': company_with_duns.duns_number,
+                'error': (
+                    'Cannot assign duns number to company as another company already has '
+                    f'this duns number. Company with duns already: {company_with_duns.id}',
+                ),
+            },
+        )
+        return True
+
+    def is_source_already_merged_into_target(
+        self,
+        company: Company,
+        target_company: Company,
+    ) -> bool:
         """
         Checks if the source has already been merged into another company with the target duns
         number. These companies should not have the duns number updated as they have been marked
         as a duplicate and merged into another company with that company having the correct duns
         number.
 
+        :param company: The source company we want to update.
+        :param target_company: A company which already has the target duns.
         :returns: True if the source company has already been merged into a company with the target
             duns numbers. False otherwise.
         """
-        if company.transferred_to_id != target_company.id:
-            return False
-        self.additional_logging['duplicate_company_already_merged_with_target'] += 1
-        return True
+        if company.transferred_to_id == target_company.id:
+            return True
+        return False
 
     def is_source_already_merged(self, company: Company) -> bool:
         """
@@ -79,13 +128,13 @@ class Command(CSVBaseCommand):
         not have the duns number updated as they have been marked as a duplicate and merged into
         another company.
 
+        :param company: The source company we want to update.
         :returns: True if the source company has already been merged into a company. False
             otherwise.
         """
-        if not company.transferred_to_id:
-            return False
-        self.additional_logging['duplicate_company_already_merged'] += 1
-        return True
+        if company.transferred_to_id:
+            return True
+        return False
 
     def handle(self, *args, **options):
         """
@@ -93,14 +142,17 @@ class Command(CSVBaseCommand):
         """
         super().handle(*args, **options)
         logger.info('Errors:')
-        logger.info(self.additional_logging)
         logger.info(f'{self.additional_logging["errors"]}')
         logger.info(
-            'Total companies already merged with a company matching target duns: '
-            f'{self.additional_logging["duplicate_company_already_merged_with_target"]}',
+            'Total companies where duns cannot be assigned as duns assigned to another company: '
+            f'{self.additional_logging["duns_already_assigned"]}',
         )
         logger.info(
-            'Total companies already merged and not updated: '
-            f'{self.additional_logging["duplicate_company_already_merged_with_target"]}',
+            'Total companies already merged with company matching target duns so not updated: '
+            f'{self.additional_logging["company_already_merged_with_target"]}',
+        )
+        logger.info(
+            'Total companies already merged and marked as duplicates so not updated: '
+            f'{self.additional_logging["company_already_merged"]}',
         )
         self.additional_logging.clear()

--- a/datahub/dbmaintenance/management/commands/update_company_duns_number.py
+++ b/datahub/dbmaintenance/management/commands/update_company_duns_number.py
@@ -13,6 +13,16 @@ logger = getLogger(__name__)
 class Command(CSVBaseCommand):
     """Command to update Company.duns_number."""
 
+    additional_logging: dict
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.additional_logging = {
+            'errors': [],
+            'duplicate_company_already_merged_with_target': 0,
+            'duplicate_company_already_merged': 0,
+        }
+
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         pk = parse_uuid(row['id'])
@@ -24,9 +34,73 @@ class Command(CSVBaseCommand):
 
         company.duns_number = duns_number
 
+        target_company = Company.objects.filter(duns_number=duns_number).first()
+        if target_company and self.is_source_already_merged_into_target(company, target_company):
+            return
+
+        if self.is_source_already_merged(company):
+            return
+
         if simulate:
             return
 
-        with reversion.create_revision():
-            company.save(update_fields=('duns_number',))
-            reversion.set_comment('Duns number updated.')
+        try:
+            with reversion.create_revision():
+                company.save(update_fields=('duns_number',))
+                reversion.set_comment('Duns number updated.')
+        except Exception as error:
+            self.additional_logging['errors'].append(
+                {
+                    'id': pk,
+                    'duns_number': duns_number,
+                    'error': error,
+                },
+            )
+            raise error
+
+    def is_source_already_merged_into_target(self, company: Company, target_company: str) -> bool:
+        """
+        Checks if the source has already been merged into another company with the target duns
+        number. These companies should not have the duns number updated as they have been marked
+        as a duplicate and merged into another company with that company having the correct duns
+        number.
+
+        :returns: True if the source company has already been merged into a company with the target
+            duns numbers. False otherwise.
+        """
+        if company.transferred_to_id != target_company.id:
+            return False
+        self.additional_logging['duplicate_company_already_merged_with_target'] += 1
+        return True
+
+    def is_source_already_merged(self, company: Company) -> bool:
+        """
+        Checks if the source has already been merged into another company. These companies should
+        not have the duns number updated as they have been marked as a duplicate and merged into
+        another company.
+
+        :returns: True if the source company has already been merged into a company. False
+            otherwise.
+        """
+        if not company.transferred_to_id:
+            return False
+        self.additional_logging['duplicate_company_already_merged'] += 1
+        return True
+
+    def handle(self, *args, **options):
+        """
+        Process the CSV file and logs some additional logging to help with the company duns update.
+        """
+        super().handle(*args, **options)
+        logger.info('Errors:')
+        logger.info(self.additional_logging)
+        logger.info(f'{self.additional_logging["errors"]}')
+        logger.info(
+            'Total companies already merged with a company matching target duns: '
+            f'{self.additional_logging["duplicate_company_already_merged_with_target"]}',
+        )
+        logger.info(
+            'Total companies already merged and not updated: '
+            f'{self.additional_logging["duplicate_company_already_merged_with_target"]}',
+        )
+        self.additional_logging.clear()


### PR DESCRIPTION
### Description of change

When doing a data cleanse from Dun & Bradstreet, we have attempted to update thousands of companies with a new duns number. Many of these failed however if was difficult to see all the reasons why for reporting.

This PR adds additional logging to capture the common errors and to also capture the errors as a whole and log at the end of the command rather than per record (problem when batching 1000+) companies at a time.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
