### PR TITLE
Allow creation and deletion of generic files

### DIFF
--- a/datahub/documents/serializers.py
+++ b/datahub/documents/serializers.py
@@ -15,8 +15,8 @@ from datahub.documents.utils import format_content_type
 
 class SharePointDocumentSerializer(serializers.ModelSerializer):
 
-    created_by = NestedRelatedField(Advisor, extra_fields=['name', 'email'])
-    modified_by = NestedRelatedField(Advisor, extra_fields=['name', 'email'])
+    created_by = NestedRelatedField(Advisor, extra_fields=['name', 'email'], read_only=True)
+    modified_by = NestedRelatedField(Advisor, extra_fields=['name', 'email'], read_only=True)
 
     class Meta:
         model = SharePointDocument
@@ -74,8 +74,8 @@ class RelatedObjectRelatedField(serializers.RelatedField):
 class GenericDocumentRetrieveSerializer(serializers.ModelSerializer):
     """Serializer for retrieving Generic Document objects."""
 
-    created_by = NestedRelatedField(Advisor, extra_fields=['name', 'email'])
-    modified_by = NestedRelatedField(Advisor, extra_fields=['name', 'email'])
+    created_by = NestedRelatedField(Advisor, extra_fields=['name', 'email'], read_only=True)
+    modified_by = NestedRelatedField(Advisor, extra_fields=['name', 'email'], read_only=True)
     document = DocumentRelatedField(read_only=True)
     related_object = RelatedObjectRelatedField(read_only=True)
 
@@ -91,3 +91,55 @@ class GenericDocumentRetrieveSerializer(serializers.ModelSerializer):
             'related_object_type': format_content_type(instance.related_object_type),
         })
         return representation
+
+
+class GenericDocumentCreateSerializer(serializers.Serializer):
+    """Serializer for creating Generic Document objects.
+
+    To add support for a new document type, add it to the list in `validate_document_type`.
+    """
+
+    # Document type information
+    document_type = serializers.CharField()
+    document_data = serializers.JSONField()
+
+    # Related object information
+    related_object_type = serializers.CharField()
+    related_object_id = serializers.UUIDField()
+
+    def validate_document_type(self, value):
+        """Validate the document type is supported."""
+        if value not in ['documents.sharepointdocument']:
+            raise serializers.ValidationError(
+                f"Unsupported document type: {value}. Format should be 'app_label.model'.",
+            )
+        app_label, model = value.split('.')
+        content_type = ContentType.objects.get(app_label=app_label, model=model)
+        return content_type
+
+    def validate_related_object_type(self, value):
+        """Validate the related object type exists."""
+        try:
+            app_label, model = value.split('.')
+            content_type = ContentType.objects.get(app_label=app_label, model=model)
+            return content_type
+        except (ValueError, ContentType.DoesNotExist):
+            raise serializers.ValidationError(
+                f"Invalid related object type: {value}. Format should be 'app_label.model'.",
+            )
+
+    def validate(self, data):
+        """Perform cross-field validation.
+
+        More specifically, validate the received related_object_id exists in the
+        related_object_type's queryset.
+        """
+        related_model = data['related_object_type'].model_class()
+        try:
+            related_object = related_model.objects.get(id=data['related_object_id'])
+        except related_model.DoesNotExist:
+            raise serializers.ValidationError(
+                f"Related object with id {data['related_object_id']} does not exist.",
+            )
+        data['related_object'] = related_object
+        return data

--- a/datahub/documents/urls.py
+++ b/datahub/documents/urls.py
@@ -5,9 +5,11 @@ from datahub.documents.views import GenericDocumentViewSet
 
 generic_document_collection = GenericDocumentViewSet.as_view({
     'get': 'list',
+    'post': 'create',
 })
 generic_document_item = GenericDocumentViewSet.as_view({
     'get': 'retrieve',
+    'delete': 'destroy',
 })
 
 urlpatterns = [


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

Following on from #5989, this PR adds functionality to create and delete generic documents, along with their underlying specific-type document.

#### Test Instructions

1. Create generic documents via POST request to `v4/document/` with the following payload:

```json
{
    "document_type": "documents.sharepointdocument",
    "document_data": {
        "title": "Project Proposal",
        "url": "https://sharepoint.example.com/sites/project/proposal.docx"
    },
    "related_object_type": "company.company",
    "related_object_id": "<uuid of company>"
}
```

> This example is specifically for a company sharepoint document, which is currently the only supported type.

2. Soft-delete (i.e. archive) generic documents with a DELETE request to `v4/document/<uuid:pk>`.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
