### PR TITLE
Bugfix/stova job timeout

### DIFF
--- a/datahub/company_activity/tasks/ingest_stova_attendees.py
+++ b/datahub/company_activity/tasks/ingest_stova_attendees.py
@@ -8,6 +8,7 @@ from datahub.company.models import Contact
 from datahub.company_activity.models import StovaAttendee
 from datahub.company_activity.models import StovaEvent
 from datahub.company_activity.tasks.constants import STOVA_ATTENDEE_PREFIX
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.event.models import Event
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.tasks import BaseObjectIdentificationTask, BaseObjectIngestionTask
@@ -21,7 +22,10 @@ DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
 def stova_attendee_identification_task() -> None:
     """Identifies the most recent file to be ingested and schedules a task to ingest it"""
     logger.info('Stova attendee identification task started.')
-    identification_task = StovaAttendeeIdentificationTask(prefix=STOVA_ATTENDEE_PREFIX)
+    identification_task = StovaAttendeeIdentificationTask(
+        prefix=STOVA_ATTENDEE_PREFIX,
+        job_timeout=THIRTY_MINUTES_IN_SECONDS,
+    )
     identification_task.identify_new_objects(stova_attendee_ingestion_task)
     logger.info('Stova attendee identification task finished.')
 

--- a/datahub/investment_lead/test/test_tasks/test_ingest_eyb_marketing.py
+++ b/datahub/investment_lead/test/test_tasks/test_ingest_eyb_marketing.py
@@ -7,6 +7,7 @@ import pytest
 from moto import mock_aws
 from reversion.models import Version
 
+from datahub.core.queues.constants import THREE_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import (
     AWS_REGION,
@@ -71,6 +72,7 @@ def test_identification_task_schedules_ingestion_task(marketing_object_key, capl
             function_kwargs={
                 'object_key': marketing_object_key,
             },
+            job_timeout=THREE_MINUTES_IN_SECONDS,
             queue_name='long-running',
             description=f'Ingest {marketing_object_key}',
         )

--- a/datahub/investment_lead/test/test_tasks/test_ingest_eyb_triage.py
+++ b/datahub/investment_lead/test/test_tasks/test_ingest_eyb_triage.py
@@ -8,6 +8,7 @@ import reversion
 from moto import mock_aws
 from reversion.models import Version
 
+from datahub.core.queues.constants import THREE_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import (
     AWS_REGION,
@@ -73,6 +74,7 @@ def test_identification_task_schedules_ingestion_task(triage_object_key, caplog)
             function_kwargs={
                 'object_key': triage_object_key,
             },
+            job_timeout=THREE_MINUTES_IN_SECONDS,
             queue_name='long-running',
             description=f'Ingest {triage_object_key}',
         )

--- a/datahub/investment_lead/test/test_tasks/test_ingest_eyb_user.py
+++ b/datahub/investment_lead/test/test_tasks/test_ingest_eyb_user.py
@@ -8,6 +8,7 @@ import reversion
 from moto import mock_aws
 from reversion.models import Version
 
+from datahub.core.queues.constants import THREE_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import (
     AWS_REGION,
@@ -73,6 +74,7 @@ def test_identification_task_schedules_ingestion_task(user_object_key, caplog):
             function_kwargs={
                 'object_key': user_object_key,
             },
+            job_timeout=THREE_MINUTES_IN_SECONDS,
             queue_name='long-running',
             description=f'Ingest {user_object_key}',
         )

--- a/datahub/metadata/test/test_ingest_postcode_data.py
+++ b/datahub/metadata/test/test_ingest_postcode_data.py
@@ -10,6 +10,7 @@ from moto import mock_aws
 from sentry_sdk import init
 from sentry_sdk.transport import Transport
 
+from datahub.core.queues.constants import THREE_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import (
     AWS_REGION,
@@ -101,6 +102,7 @@ def test_identification_task_schedules_ingestion_task(test_file_path, caplog):
         function_kwargs={
             'object_key': test_file_path,
         },
+        job_timeout=THREE_MINUTES_IN_SECONDS,
         queue_name='long-running',
         description=f'Ingest {test_file_path}',
     )


### PR DESCRIPTION
### Description of change

The queue for ingesting stova attendees is currently timing out. This PR allows the base task to be given an optional timeout instead of using the default of 3 minutes for the individual ingestions.

Fixes: https://sentry.ci.uktrade.digital/organizations/dit/issues/154669/?environment=prod&project=235&query=is%3Aunresolved

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?

