### PR TITLE
Add two new event programmes

### DIFF
--- a/datahub/event/migrations/0031_update_event_programme.py
+++ b/datahub/event/migrations/0031_update_event_programme.py
@@ -1,0 +1,20 @@
+from pathlib import PurePath
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def update_event_programmes(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps, PurePath(__file__).parent / "0031_update_event_programme.yaml"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('event', '0030_add_stova_event_relation'),
+    ]
+
+    operations = [
+        migrations.RunPython(update_event_programmes, migrations.RunPython.noop),
+    ]

--- a/datahub/event/migrations/0031_update_event_programme.yaml
+++ b/datahub/event/migrations/0031_update_event_programme.yaml
@@ -1,0 +1,6 @@
+- model: event.programme
+  pk: 819e049e-d28e-4f55-be97-37ee88023d88
+  fields: { disabled_on: null, name: Export Summit Flagship 2025 }
+- model: event.programme
+  pk: 9570faa5-9bb9-4f03-b09c-0b496aa77313
+  fields: { disabled_on: null, name: Export Summit Roadshows 2025 }


### PR DESCRIPTION
### Description of change

Adds two new event programmes:

- Export Summit Flagship 2025
- Export Summit Roadshows 2025

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
