### PR TITLE
CLS2-1195 Management of core team access

### DIFF
--- a/datahub/company/permissions.py
+++ b/datahub/company/permissions.py
@@ -6,7 +6,7 @@ from datahub.company.models import CompanyPermission
 class IsAccountManagerOnCompany(BasePermission):
     """
     Allows users:
-    - that have change_company permission and are one_list_account_owners (account managers/ITA 
+    - that have change_company permission and are one_list_account_owners (account managers/ITA
       Leads) for the current record.
     """
 

--- a/datahub/company/permissions.py
+++ b/datahub/company/permissions.py
@@ -6,12 +6,11 @@ from datahub.company.models import CompanyPermission
 class IsAccountManagerOnCompany(BasePermission):
     """
     Allows users:
-    - that have change_company and change_one_list_tier_and_global_account_manager permissions
-    - or that are one_list_account_owners (account managers/ITA Leads) for the current record.
+    - that have change_company permission and are one_list_account_owners (account managers/ITA 
+      Leads) for the current record.
     """
 
     def has_object_permission(self, request, view, obj):
         return request.user.has_perms([
             f'company.{CompanyPermission.change_company}',
-            f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
-        ]) or (obj.one_list_account_owner == request.user)
+        ]) and (obj.one_list_account_owner == request.user)

--- a/datahub/company/test/test_company_views_core_team.py
+++ b/datahub/company/test/test_company_views_core_team.py
@@ -331,11 +331,14 @@ class TestUpdateOneListCoreTeam(APITestMixin):
         """
         Test that an account manager can update core team members.
         """
+        adviser_user = create_test_user(
+            permission_codenames=(CompanyPermission.change_company,),
+        )
         company = CompanyFactory(
-            one_list_account_owner=AdviserFactory(),
+            one_list_account_owner=adviser_user,
             one_list_tier=random_non_ita_one_list_tier(),
         )
-        api_client = self.create_api_client(user=company.one_list_account_owner)
+        api_client = self.create_api_client(user=adviser_user)
 
         self._assert_update_core_team_members(
             company, existing_team_count, new_team_count, api_client)

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -222,7 +222,11 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         methods=['post'],
         detail=True,
         permission_classes=[
-            IsAccountManagerOnCompany,
+            IsAccountManagerOnCompany
+            or HasPermissions(
+                f'company.{CompanyPermission.change_company}',
+                f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
+            ),
         ],
         schema=StubSchema(),
     )
@@ -273,8 +277,15 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         methods=['patch'],
         detail=True,
         permission_classes=[
-            IsAccountManagerOnCompany,
-        ],
+            IsAccountManagerOnCompany
+            or HasPermissions(
+                f'company.{CompanyPermission.change_company}',
+                f'company.{CompanyPermission.change_one_list_core_team_member}',
+            )
+            or HasPermissions(
+                f'company.{CompanyPermission.change_company}',
+                f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
+            )],
         schema=StubSchema(),
     )
     def update_one_list_core_team(self, request, *args, **kwargs):

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -223,7 +223,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         detail=True,
         permission_classes=[
             IsAccountManagerOnCompany
-            or HasPermissions(
+            | HasPermissions(
                 f'company.{CompanyPermission.change_company}',
                 f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
             ),
@@ -278,11 +278,11 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         detail=True,
         permission_classes=[
             IsAccountManagerOnCompany
-            or HasPermissions(
+            | HasPermissions(
                 f'company.{CompanyPermission.change_company}',
                 f'company.{CompanyPermission.change_one_list_core_team_member}',
             )
-            or HasPermissions(
+            | HasPermissions(
                 f'company.{CompanyPermission.change_company}',
                 f'company.{CompanyPermission.change_one_list_tier_and_global_account_manager}',
             )],


### PR DESCRIPTION
### Description of change

Change IsAccountManagerOnCompany; The user needs to be a One list account owner and have the CompanyPermission.change_company permission.

Existing permission remain but have been moved to the definition of the specific views.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
