### PR TITLE
Add company name to matched status filter

### DIFF
--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -486,6 +486,13 @@ class Company(ArchivableModel, BaseModel):
         return self.address_country.id == united_kingdom_id
 
     @property
+    def has_name(self):
+        """Whether a company is based in the UK or not."""
+        if not self.name or self.name == '':
+            return False
+        return True
+
+    @property
     def is_global_ultimate(self):
         """
         Whether this company is the global ultimate or not.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -492,7 +492,7 @@ class Company(ArchivableModel, BaseModel):
 
         :returns: True if company has a name, False if blank or null.
         """
-        if not self.name or self.name == '':
+        if not self.name:
             return False
         return True
 

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -486,8 +486,12 @@ class Company(ArchivableModel, BaseModel):
         return self.address_country.id == united_kingdom_id
 
     @property
-    def has_name(self):
-        """Whether a company is based in the UK or not."""
+    def has_name(self) -> bool:
+        """
+        Whether the company name is empty or not.
+
+        :returns: True if company has a name, False if blank or null.
+        """
         if not self.name or self.name == '':
             return False
         return True

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -103,3 +103,22 @@ class TestOneListAccountOwner():
 
         company.save()
         mock_schedule_sync_investment_projects_of_subsidiary_companies.assert_not_called()
+
+
+class TestCompany:
+    """Tests for the Company model"""
+
+    @pytest.mark.parametrize(
+        'name,expected_return',
+        (
+            ('', False),
+            ('This is a company with a name', True),
+            (' ', True),
+        ),
+    )
+    def test_has_name(self, name: str, expected_return: bool) -> None:
+        """
+        Test the has_name property returns the correct response for a variety of scenarios.
+        """
+        company = CompanyFactory(name=name)
+        assert company.has_name == expected_return

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -7,10 +7,6 @@ from datahub.search import dict_utils, fields
 from datahub.search.models import BaseSearchModel
 
 
-
-
-
-
 def _adviser_field_with_indexed_id():
     return Object(
         properties={

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -7,6 +7,10 @@ from datahub.search import dict_utils, fields
 from datahub.search.models import BaseSearchModel
 
 
+
+
+
+
 def _adviser_field_with_indexed_id():
     return Object(
         properties={
@@ -38,6 +42,7 @@ class Company(BaseSearchModel):
     future_interest_countries = fields.id_name_field()
     global_headquarters = fields.id_name_field()
     headquarter_type = fields.id_name_field()
+    has_name = Boolean()
     modified_on = Date()
     name = Text(
         fields={

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -13,6 +13,7 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
 
     id = SingleOrListField(child=StringUUIDField(), required=False)
     archived = serializers.BooleanField(required=False)
+    has_name = serializers.BooleanField(required=False)
     headquarter_type = SingleOrListField(
         child=StringUUIDField(allow_null=True),
         required=False,

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -364,6 +364,7 @@ class TestSearch(APITestMixin):
                     'export_sub_segment': company.export_sub_segment,
                     'export_to_countries': [],
                     'future_interest_countries': [],
+                    'has_name': True,
                     'headquarter_type': company.headquarter_type,
                     'sector': {
                         'id': str(company.sector.id),

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -37,6 +37,7 @@ class TestCompanySearchModel:
             'modified_on',
             'name',
             'global_headquarters',
+            'has_name',
             'reference_code',
             'sector',
             'latest_interaction_date',

--- a/datahub/search/company/test/test_opensearch.py
+++ b/datahub/search/company/test/test_opensearch.py
@@ -425,6 +425,9 @@ def test_mapping(opensearch):
                 'type': 'object',
             },
             'number_of_employees': {'type': 'integer'},
+            'has_name': {
+                'type': 'boolean',
+            },
             'global_ultimate_duns_number': {'type': 'keyword'},
             'is_global_ultimate': {'type': 'boolean'},
         },
@@ -731,6 +734,7 @@ def test_indexed_doc(opensearch):
         'headquarter_type',
         'id',
         'modified_on',
+        'has_name',
         'name',
         'global_headquarters',
         'reference_code',

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -47,6 +47,7 @@ class SearchCompanyAPIViewMixin:
         'id',
         'archived',
         'headquarter_type',
+        'has_name',
         'is_global_ultimate',
         'name',
         'sector_descends',


### PR DESCRIPTION
### Description of change

Adds a new property to the company model `has_name` which checks whether the company has a name or not. This is used for OpenSearch to pickup so the frontend can filter on this field.

This is to hide the companies with no name on the frontend by default but still allow them to be shown if requested.

Related frontend work: https://github.com/uktrade/data-hub-frontend/pull/7591

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?


