### PR TITLE
Increase timeout for EYB lead ingestion tasks to 30 minutes

### DIFF
--- a/datahub/investment_lead/tasks/ingest_eyb_marketing.py
+++ b/datahub/investment_lead/tasks/ingest_eyb_marketing.py
@@ -1,5 +1,6 @@
 import logging
 
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import DATA_FLOW_EXPORTS_PREFIX
 from datahub.investment_lead.models import EYBLead
@@ -18,7 +19,10 @@ logger = logging.getLogger(__name__)
 
 def eyb_marketing_identification_task() -> None:
     logger.info('EYB marketing identification task started...')
-    identification_task = EYBMarketingIdentificationTask(prefix=MARKETING_PREFIX)
+    identification_task = EYBMarketingIdentificationTask(
+        prefix=MARKETING_PREFIX,
+        job_timeout=THIRTY_MINUTES_IN_SECONDS,
+    )
     identification_task.identify_new_objects(eyb_marketing_ingestion_task)
     logger.info('EYB marketing identification task finished.')
 

--- a/datahub/investment_lead/tasks/ingest_eyb_triage.py
+++ b/datahub/investment_lead/tasks/ingest_eyb_triage.py
@@ -1,5 +1,6 @@
 import logging
 
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.core.queues.job_scheduler import job_scheduler
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import DATA_FLOW_EXPORTS_PREFIX
@@ -19,7 +20,10 @@ logger = logging.getLogger(__name__)
 
 def eyb_triage_identification_task() -> None:
     logger.info('EYB triage identification task started...')
-    identification_task = EYBTriageIdentificationTask(prefix=TRIAGE_PREFIX)
+    identification_task = EYBTriageIdentificationTask(
+        prefix=TRIAGE_PREFIX,
+        job_timeout=THIRTY_MINUTES_IN_SECONDS,
+    )
     identification_task.identify_new_objects(eyb_triage_ingestion_task)
     logger.info('EYB triage identification task finished.')
 

--- a/datahub/investment_lead/tasks/ingest_eyb_user.py
+++ b/datahub/investment_lead/tasks/ingest_eyb_user.py
@@ -1,5 +1,6 @@
 import logging
 
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.core.queues.job_scheduler import job_scheduler
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import DATA_FLOW_EXPORTS_PREFIX
@@ -20,7 +21,10 @@ logger = logging.getLogger(__name__)
 
 def eyb_user_identification_task() -> None:
     logger.info('EYB user identification task started...')
-    identification_task = EYBUserIdentificationTask(prefix=USER_PREFIX)
+    identification_task = EYBUserIdentificationTask(
+        prefix=USER_PREFIX,
+        job_timeout=THIRTY_MINUTES_IN_SECONDS,
+    )
     identification_task.identify_new_objects(eyb_user_ingestion_task)
     logger.info('EYB user identification task finished.')
 

--- a/datahub/investment_lead/test/test_tasks/test_ingest_eyb_marketing.py
+++ b/datahub/investment_lead/test/test_tasks/test_ingest_eyb_marketing.py
@@ -7,7 +7,7 @@ import pytest
 from moto import mock_aws
 from reversion.models import Version
 
-from datahub.core.queues.constants import THREE_MINUTES_IN_SECONDS
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import (
     AWS_REGION,
@@ -72,7 +72,7 @@ def test_identification_task_schedules_ingestion_task(marketing_object_key, capl
             function_kwargs={
                 'object_key': marketing_object_key,
             },
-            job_timeout=THREE_MINUTES_IN_SECONDS,
+            job_timeout=THIRTY_MINUTES_IN_SECONDS,
             queue_name='long-running',
             description=f'Ingest {marketing_object_key}',
         )

--- a/datahub/investment_lead/test/test_tasks/test_ingest_eyb_triage.py
+++ b/datahub/investment_lead/test/test_tasks/test_ingest_eyb_triage.py
@@ -8,7 +8,7 @@ import reversion
 from moto import mock_aws
 from reversion.models import Version
 
-from datahub.core.queues.constants import THREE_MINUTES_IN_SECONDS
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import (
     AWS_REGION,
@@ -74,7 +74,7 @@ def test_identification_task_schedules_ingestion_task(triage_object_key, caplog)
             function_kwargs={
                 'object_key': triage_object_key,
             },
-            job_timeout=THREE_MINUTES_IN_SECONDS,
+            job_timeout=THIRTY_MINUTES_IN_SECONDS,
             queue_name='long-running',
             description=f'Ingest {triage_object_key}',
         )

--- a/datahub/investment_lead/test/test_tasks/test_ingest_eyb_user.py
+++ b/datahub/investment_lead/test/test_tasks/test_ingest_eyb_user.py
@@ -8,7 +8,7 @@ import reversion
 from moto import mock_aws
 from reversion.models import Version
 
-from datahub.core.queues.constants import THREE_MINUTES_IN_SECONDS
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import (
     AWS_REGION,
@@ -74,7 +74,7 @@ def test_identification_task_schedules_ingestion_task(user_object_key, caplog):
             function_kwargs={
                 'object_key': user_object_key,
             },
-            job_timeout=THREE_MINUTES_IN_SECONDS,
+            job_timeout=THIRTY_MINUTES_IN_SECONDS,
             queue_name='long-running',
             description=f'Ingest {user_object_key}',
         )


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

Since triggering a re-ingest of all EYB leads yesterday afternoon, there have been several alerts regarding an increased number of tasks in the short queue; it was expected for this to only occur once. 

After some investigation it was found the EYB lead ingestion tasks have been timing out due to the increased number of records that require processing:

```
An error occurred trying to process data-flow/exports/DirectoryExpandYourBusinessTriageDataPipeline/object.jsonl.gz:
Task exceeded maximum timeout value (180 seconds)
```

This PR increases the timeout to 30 minutes, instead of the default 3 minutes.

A similar approach was taken for the Stova ingestion tasks in #5992.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
