### PR TITLE
Dependabot 13th March 2025

### DIFF
--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,7 +6,7 @@ pytest-django==4.10.0
 pytest-cov==6.0.0
 pytest-mock==3.14.0
 pytest-xdist==3.6.1
-ipython==8.33.0
+ipython==8.34.0
 factory-boy==3.3.3
 freezegun==1.5.1
 requests-mock==1.12.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -99,7 +99,7 @@ distlib==0.3.9
     # via virtualenv
 dj-database-url==2.3.0
     # via -r requirements.in
-django==4.2.19
+django==4.2.20
     # via
     #   -r requirements.in
     #   dj-database-url
@@ -124,7 +124,7 @@ django-environ==0.12.0
     # via -r requirements.in
 django-extensions==3.2.3
     # via -r requirements.in
-django-filter==24.3
+django-filter==25.1
     # via -r requirements.in
 django-js-asset==2.0.0
     # via django-mptt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -233,7 +233,7 @@ isort==5.11.4
     # via pylint
 jedi==0.18.2
     # via ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via moto
 jmespath==1.0.1
     # via

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -37,11 +37,11 @@ bigtree==0.25.1
     # via -r requirements.in
 billiard==4.2.0
     # via celery
-boto3==1.37.4
+boto3==1.37.9
     # via
     #   -r requirements.in
     #   moto
-botocore==1.37.4
+botocore==1.37.9
     # via
     #   boto3
     #   moto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -227,7 +227,7 @@ iniconfig==1.1.1
     # via pytest
 ipaddress==1.0.23
     # via mail-parser
-ipython==8.33.0
+ipython==8.34.0
     # via -r requirements-dev.in
 isort==5.11.4
     # via pylint

--- a/requirements.in
+++ b/requirements.in
@@ -28,7 +28,7 @@ dj-database-url==2.3.0
 psycopg2-binary==2.9.10
 psycogreen==1.0.2
 
-boto3==1.37.4
+boto3==1.37.9
 
 notifications-python-client==10.0.1
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # Django and django related
-django==4.2.19
+django==4.2.20
 djangorestframework==3.15.2
 drf-redesign==0.4.0
 django-axes==7.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,9 @@ bigtree==0.25.1
     # via -r requirements.in
 billiard==4.2.0
     # via celery
-boto3==1.37.4
+boto3==1.37.9
     # via -r requirements.in
-botocore==1.37.4
+botocore==1.37.9
     # via
     #   boto3
     #   s3transfer

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ distlib==0.3.8
     # via virtualenv
 dj-database-url==2.3.0
     # via -r requirements.in
-django==4.2.19
+django==4.2.20
     # via
     #   -r requirements.in
     #   dj-database-url


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

This PR delivers dependabot upgrades for the week:
- [Bump django from 4.2.19 to 4.2.20](https://github.com/uktrade/data-hub-api/commit/42cd755cec6f6d9ecb46a6605f8af86314028aa8)
    - Addresses https://github.com/uktrade/data-hub-api/security/dependabot/167
    - Addresses https://github.com/uktrade/data-hub-api/security/dependabot/166
- [Bump ipython from 8.33.0 to 8.34.0](https://github.com/uktrade/data-hub-api/commit/5d7ef5a749dc6c230daeb2ba17079e321c934a7b)
- [Bump jinja2 from 3.1.5 to 3.1.6](https://github.com/uktrade/data-hub-api/commit/d6aba5566c223df15f5c8e66c16bb1d65daf7b0b)
    - Addressess https://github.com/uktrade/data-hub-api/security/dependabot/165
- [Bump boto3 from 1.37.4 to 1.37.9](https://github.com/uktrade/data-hub-api/commit/a071e8ca4e434ec8cc123448c7abc29349170fbf)

The [django-filter](https://github.com/carltongibson/django-filter) package has also been bumped to 25.1. This originally caused the `data-hub-api/datahub/core/test/test_docs.py::TestDocsSchemaView::test_returns_200_if_logged_in` test to fail:

```
self = <rest_framework.schemas.openapi.AutoSchema object at 0x7f37364c6c50>
path = '/adviser/', method = 'GET'

    def get_filter_parameters(self, path, method):
        if not self.allows_filters(path, method):
            return []
        parameters = []
        for filter_backend in self.view.filter_backends:
>           parameters += filter_backend().get_schema_operation_parameters(self.view)
E           AttributeError: 'DjangoFilterBackend' object has no attribute 'get_schema_operation_parameters'

/usr/local/lib/python3.10/site-packages/rest_framework/schemas/openapi.py:312: AttributeError
```

According to the [changelog](https://github.com/carltongibson/django-filter/blob/main/CHANGES.rst), the in-built API schema generation methods (that were deprecated since v23.2), have now been removed.

As recommended in the changelog and [DRF documentation](https://www.django-rest-framework.org/topics/documenting-your-api/#documenting-your-api), this PR also modifies the documentation/schema views to now use [drf-spectacular](https://drf-spectacular.readthedocs.io/en/latest/) instead.

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
