### PR TITLE
Provide a company when creating companies from StovaAttendees

### DIFF
--- a/datahub/company_activity/tasks/ingest_stova_attendees.py
+++ b/datahub/company_activity/tasks/ingest_stova_attendees.py
@@ -212,8 +212,8 @@ class StovaAttendeeIngestionTask(BaseObjectIngestionTask):
         contains a country field which is used when creating a Company.
 
         :param values: A dictionary of cleaned values from an ingested stova attendee record.
-        :param event: A StovaEvent which this attendee has attended, used for the country field
-            when creating a Company.
+        :param stova_event: A StovaEvent which this attendee has attended, used for the country
+            field when creating a Company.
         :returns: An existing `Company` if found or a newly created `Company`.
         """
         company_name = values['company_name']

--- a/datahub/company_activity/tests/factories.py
+++ b/datahub/company_activity/tests/factories.py
@@ -242,7 +242,7 @@ class StovaEventFactory(factory.django.DjangoModelFactory):
     code = 'CodeTest'
     name = factory.Faker('first_name')
     state = 'London'
-    country = 'England'
+    country = 'UK'
     max_reg = 3
     end_date = now()
     timezone = 'Europe/London'


### PR DESCRIPTION
### Description of change

Companies created from StovaAttendees ((around 35751 on prod)) do not have a country. This causes issues on the frontend and when trying to verify them as the DNB API requires a country field.

Data for StovaAttendees does not provide a country field but StovaEvents are ingested before allowing a StovaAttendee to be ingested. These StovaEvents have a country field and default to 'UK' if not. DNB API and the frontend rely on a company having a country field so when creating companies from StovaAttendees, use the StovaEvent country field.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?

