### PR TITLE
Add signal to delete company from opensearch when company is deleted

### DIFF
--- a/datahub/search/company/signals.py
+++ b/datahub/search/company/signals.py
@@ -1,9 +1,13 @@
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 
 from datahub.company.models import Company as DBCompany
 from datahub.interaction.models import Interaction as DBInteraction
 from datahub.search.company import CompanySearchApp
+from datahub.search.company.models import (
+    Company as SearchCompany,
+)
+from datahub.search.deletion import delete_document
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async, sync_related_objects_async
 
@@ -36,9 +40,17 @@ def sync_related_company_to_opensearch(instance):
     )
 
 
+def remove_company_from_opensearch(instance):
+    """Remove company from opensearch."""
+    transaction.on_commit(
+        lambda pk=instance.pk: delete_document(SearchCompany, pk),
+    )
+
+
 receivers = (
     SignalReceiver(post_save, DBCompany, company_sync_search),
     SignalReceiver(post_save, DBCompany, company_subsidiaries_sync_search),
     SignalReceiver(post_save, DBCompany, company_investment_projects_sync_search),
     SignalReceiver(post_save, DBInteraction, sync_related_company_to_opensearch),
+    SignalReceiver(post_delete, DBCompany, remove_company_from_opensearch),
 )


### PR DESCRIPTION
### Description of change

Currently if a company gets deleted on Data Hub, it does not trigger OpenSearch to also remove the company. This means that when a company is removed from the database, the company will still appear for users on the frontend but clicking on the company will show a 404 (as it no longer exists). See error video below.

You can't rerun the sync as it won't pick this change up, currently you would need to delete all the indices and recreate them which would take hours on prod.

This PR fixes this by also deleting the company from opensearch if it has been deleted from the database.

Related PRs - other OpenSearch indices are not being updated when their database object is deleted.
Contacts: https://github.com/uktrade/data-hub-api/pull/6027
Event: https://github.com/uktrade/data-hub-api/pull/6028
Adviser: https://github.com/uktrade/data-hub-api/pull/6029
Export Country History: https://github.com/uktrade/data-hub-api/pull/6030

https://github.com/user-attachments/assets/c2164010-1538-49ef-a433-a65d7788e5ef


### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
