### PR TITLE
Feature/tet 998 when contact deleted remove from opensearch

### DIFF
--- a/datahub/search/contact/signals.py
+++ b/datahub/search/contact/signals.py
@@ -1,8 +1,10 @@
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 
 from datahub.company.models import Company as DBCompany, Contact as DBContact
 from datahub.search.contact import ContactSearchApp
+from datahub.search.contact.models import Contact as SearchContact
+from datahub.search.deletion import delete_document
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async, sync_related_objects_async
 
@@ -21,7 +23,15 @@ def related_contact_sync_search(instance):
     )
 
 
+def remove_contact_from_opensearch(instance):
+    """Remove contact from opensearch."""
+    transaction.on_commit(
+        lambda pk=instance.pk: delete_document(SearchContact, pk),
+    )
+
+
 receivers = (
     SignalReceiver(post_save, DBContact, contact_sync_search),
     SignalReceiver(post_save, DBCompany, related_contact_sync_search),
+    SignalReceiver(post_delete, DBContact, remove_contact_from_opensearch),
 )


### PR DESCRIPTION
### Description of change

Currently if a contact gets deleted on Data Hub, it does not trigger OpenSearch to also remove the contact. This means that when a contact is removed from the database, the contact will still appear for users on the frontend but clicking on the contact will show a 404 (as it no longer exists).

You can't rerun the sync as it won't pick this change up, currently you would need to delete all the indices and recreate them which would take hours on prod.

This PR fixes this by also deleting the contact from opensearch if it has been deleted from the database.

Related PRs - other OpenSearch indices are not being updated when their database object is deleted.
Company: https://github.com/uktrade/data-hub-api/pull/6026
Event: https://github.com/uktrade/data-hub-api/pull/6028
Adviser: https://github.com/uktrade/data-hub-api/pull/6029
Export Country History: https://github.com/uktrade/data-hub-api/pull/6030

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
