### PR TITLE
Delete Event from Opensearch when deleting from database

### DIFF
--- a/datahub/search/event/signals.py
+++ b/datahub/search/event/signals.py
@@ -1,8 +1,12 @@
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 
 from datahub.event.models import Event as DBEvent
+from datahub.search.deletion import delete_document
 from datahub.search.event import EventSearchApp
+from datahub.search.event.models import (
+    Event as SearchEvent,
+)
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async
 
@@ -14,4 +18,14 @@ def sync_event_to_opensearch(instance):
     )
 
 
-receivers = (SignalReceiver(post_save, DBEvent, sync_event_to_opensearch),)
+def remove_event_from_opensearch(instance):
+    """Remove event from opensearch."""
+    transaction.on_commit(
+        lambda pk=instance.pk: delete_document(SearchEvent, pk),
+    )
+
+
+receivers = (
+    SignalReceiver(post_save, DBEvent, sync_event_to_opensearch),
+    SignalReceiver(post_delete, DBEvent, remove_event_from_opensearch),
+)


### PR DESCRIPTION
### Description of change

Currently if an event gets deleted on Data Hub, it does not trigger OpenSearch to also remove the event. This means that when an event is removed from the database, the event will still appear for users on the frontend but clicking on the event will show a 404 (as it no longer exists).

You can't rerun the sync as it won't pick this change up, currently you would need to delete all the indices and recreate them which would take hours on prod.

This PR fixes this by also deleting the event from opensearch if it has been deleted from the database.

Related PRs - other OpenSearch indices are not being updated when their database object is deleted.
Company: https://github.com/uktrade/data-hub-api/pull/6026
Contact: https://github.com/uktrade/data-hub-api/pull/6027
Adviser: https://github.com/uktrade/data-hub-api/pull/6029
Export Country History: https://github.com/uktrade/data-hub-api/pull/6030

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
