### PR TITLE
Delete Adviser from Opensearch when deleting from database

### DIFF
--- a/datahub/search/adviser/signals.py
+++ b/datahub/search/adviser/signals.py
@@ -1,8 +1,12 @@
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 
 from datahub.company.models import Advisor as DBAdviser
 from datahub.search.adviser import AdviserSearchApp
+from datahub.search.adviser.models import (
+    Adviser as SearchAdviser,
+)
+from datahub.search.deletion import delete_document
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async
 
@@ -14,4 +18,14 @@ def sync_adviser_to_opensearch(instance):
     )
 
 
-receivers = (SignalReceiver(post_save, DBAdviser, sync_adviser_to_opensearch),)
+def remove_adviser_from_opensearch(instance):
+    """Remove adviser from opensearch."""
+    transaction.on_commit(
+        lambda pk=instance.pk: delete_document(SearchAdviser, pk),
+    )
+
+
+receivers = (
+    SignalReceiver(post_save, DBAdviser, sync_adviser_to_opensearch),
+    SignalReceiver(post_delete, DBAdviser, remove_adviser_from_opensearch),
+)


### PR DESCRIPTION
### Description of change

Currently if an adviser gets deleted on Data Hub, it does not trigger OpenSearch to also remove the adviser. This means that when an adviser is removed from the database, the adviser will still appear for users on the frontend but interacting with the adviser will show a 404/ cause errors (as it no longer exists).

You can't rerun the sync as it won't pick this change up, currently you would need to delete all the indices and recreate them which would take hours on prod.

This PR fixes this by also deleting the adviser from opensearch if it has been deleted from the database.

Related PRs - other OpenSearch indices are not being updated when their database object is deleted.
Company: https://github.com/uktrade/data-hub-api/pull/6026
Contact: https://github.com/uktrade/data-hub-api/pull/6027
Event: https://github.com/uktrade/data-hub-api/pull/6028
Export Country History: https://github.com/uktrade/data-hub-api/pull/6030

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
