### PR TITLE
Delete ExportCountryHistory from Opensearch when deleting from database

### DIFF
--- a/datahub/search/export_country_history/signals.py
+++ b/datahub/search/export_country_history/signals.py
@@ -1,8 +1,12 @@
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 
 from datahub.company.models import CompanyExportCountryHistory as DBCompanyExportCountryHistory
+from datahub.search.deletion import delete_document
 from datahub.search.export_country_history import ExportCountryHistoryApp
+from datahub.search.export_country_history.models import (
+    ExportCountryHistory as SearchExportCountryHistory,
+)
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async
 
@@ -14,6 +18,16 @@ def export_country_history_sync_search(instance):
     )
 
 
+def remove_export_country_history_from_opensearch(instance):
+    """Remove export country history from opensearch."""
+    transaction.on_commit(
+        lambda pk=instance.pk: delete_document(SearchExportCountryHistory, pk),
+    )
+
+
 receivers = (
     SignalReceiver(post_save, DBCompanyExportCountryHistory, export_country_history_sync_search),
+    SignalReceiver(
+        post_delete, DBCompanyExportCountryHistory, remove_export_country_history_from_opensearch,
+    ),
 )


### PR DESCRIPTION
### Description of change

Currently if an ExportCountryHistory gets deleted on Data Hub, it does not trigger OpenSearch to also remove the ExportCountryHistory. This means that when an ExportCountryHistory is removed from the database, the ExportCountryHistory will still appear for users on the frontend but interacting with the ExportCountryHistory will show a 404/ cause errors (as it no longer exists).

You can't rerun the sync as it won't pick this change up, currently you would need to delete all the indices and recreate them which would take hours on prod.

This PR fixes this by also deleting the ExportCountryHistory from opensearch if it has been deleted from the database.

Related PRs - other OpenSearch indices are not being updated when their database object is deleted.
Company: https://github.com/uktrade/data-hub-api/pull/6026
Contact: https://github.com/uktrade/data-hub-api/pull/6027
Event: https://github.com/uktrade/data-hub-api/pull/6028
Adviser: https://github.com/uktrade/data-hub-api/pull/6029
### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [x] Is the CircleCI build passing?
