### PR TITLE
Add company export to interaction dataset.

### DIFF
--- a/datahub/dataset/interaction/test/test_views.py
+++ b/datahub/dataset/interaction/test/test_views.py
@@ -12,6 +12,7 @@ from datahub.core.test_utils import format_date_or_datetime, get_attr_or_none
 from datahub.dataset.core.test import BaseDatasetViewTest
 from datahub.interaction.test.factories import (
     CompaniesInteractionWithExportBarrierOtherFactory,
+    CompanyExportInteractionFactory,
     CompanyInteractionFactory,
     CompanyInteractionFactoryWithPolicyFeedback,
     CompanyInteractionFactoryWithRelatedTradeAgreements,
@@ -31,6 +32,11 @@ def get_expected_data_from_interaction(interaction):
         'communication_channel__name': get_attr_or_none(
             interaction,
             'communication_channel.name',
+        ),
+        'company_export_id': (
+            str(interaction.company_export_id)
+            if interaction.company_export_id is not None
+            else None
         ),
         'company_id': str(interaction.company.id),
         'contact_ids': [str(x.id) for x in interaction.contacts.all().order_by('pk')],
@@ -103,6 +109,7 @@ class TestInteractionsDatasetViewSet(BaseDatasetViewTest):
 
     @pytest.mark.parametrize(
         'interaction_factory', (
+            CompanyExportInteractionFactory,
             CompanyInteractionFactory,
             CompanyInteractionFactoryWithPolicyFeedback,
             CompaniesInteractionWithExportBarrierOtherFactory,

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -69,6 +69,7 @@ class InteractionsDatasetView(BaseFilterDatasetView):
             'id',
             'interaction_link',
             'investment_project_id',
+            'company_export_id',
             'kind',
             'modified_on',
             'net_company_receipt',


### PR DESCRIPTION
### Description of change

This adds `company_export_id` to Interaction dataset feed.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
