### PR TITLE
Validate duplicate advisers.

### DIFF
--- a/datahub/export_win/serializers.py
+++ b/datahub/export_win/serializers.py
@@ -49,6 +49,13 @@ from datahub.export_win.tasks import (
     update_customer_response_for_lead_officer_notification_id,
     update_customer_response_token_for_email_notification_id,
 )
+from datahub.export_win.validators import (
+    DuplicateContributingAdviserValidator,
+    DuplicateTeamMemberValidator,
+    LeadOfficerAndContributingAdviserValidator,
+    LeadOfficerAndTeamMemberValidator,
+    TeamMembersAndContributingAdvisersValidator,
+)
 from datahub.metadata.models import Country, Sector
 
 
@@ -302,6 +309,13 @@ class WinSerializer(ModelSerializer):
             'last_sent',
             'migrated_on',
         )
+        validators = [
+            DuplicateContributingAdviserValidator(),
+            DuplicateTeamMemberValidator(),
+            LeadOfficerAndContributingAdviserValidator(),
+            LeadOfficerAndTeamMemberValidator(),
+            TeamMembersAndContributingAdvisersValidator(),
+        ]
 
     def create(self, validated_data):
         """Create win, corresponding breakdowns and advisers."""

--- a/datahub/export_win/validators.py
+++ b/datahub/export_win/validators.py
@@ -1,0 +1,96 @@
+from rest_framework import serializers
+
+
+class DuplicateContributingAdviserValidator:
+    """Validates that same contributing adviser is not supplied more than once."""
+
+    def __call__(self, data):
+        """Performs validation."""
+        contributing_advisers = data.get('contributing_advisers', [])
+        if not contributing_advisers:
+            contributing_advisers = data.get('advisers', [])
+
+        if not contributing_advisers:
+            return
+
+        advisers = [item['adviser'] for item in contributing_advisers]
+        if len(advisers) > len(set(advisers)):
+            raise serializers.ValidationError(
+                'A contributing adviser cannot be a duplicate.',
+                code='duplicate_contributing_adviser',
+            )
+
+
+class DuplicateTeamMemberValidator:
+    """Validates that same team member is not supplied more than once."""
+
+    def __call__(self, data):
+        """Performs validation."""
+        team_members = data.get('team_members', [])
+        if not team_members:
+            return
+
+        if len(team_members) > len(set(team_members)):
+            raise serializers.ValidationError(
+                'A team member cannot be a duplicate.',
+                code='duplicate_team_member',
+            )
+
+
+class LeadOfficerAndContributingAdviserValidator:
+    """Validates that same contributing adviser is not a lead officer."""
+
+    def __call__(self, data):
+        """Performs validation."""
+        contributing_advisers = data.get('contributing_advisers', [])
+        if not contributing_advisers:
+            contributing_advisers = data.get('advisers', [])
+
+        if not contributing_advisers:
+            return
+
+        lead_officer = data.get('lead_officer', None)
+
+        if any(item['adviser'] == lead_officer for item in contributing_advisers):
+            raise serializers.ValidationError(
+                'A contributing adviser cannot also be lead officer.',
+                code='lead_officer_as_contributing_adviser',
+            )
+
+
+class LeadOfficerAndTeamMemberValidator:
+    """Validates that same team member is not a lead officer."""
+
+    def __call__(self, data):
+        """Performs validation."""
+        team_members = data.get('team_members', [])
+        if not team_members:
+            return
+
+        lead_officer = data.get('lead_officer', None)
+
+        if lead_officer in team_members:
+            raise serializers.ValidationError(
+                'A team member cannot also be lead officer.',
+                code='lead_officer_as_team_member',
+            )
+
+
+class TeamMembersAndContributingAdvisersValidator:
+    """Validates that same team member is not a contributing adviser."""
+
+    def __call__(self, data):
+        """Performs validation."""
+        team_members = data.get('team_members', [])
+        contributing_advisers = data.get('contributing_advisers', [])
+        if not contributing_advisers:
+            contributing_advisers = data.get('advisers', [])
+
+        team_member_ids = [item.id for item in team_members]
+        adviser_ids = [item['adviser'].id for item in contributing_advisers]
+
+        if set(team_member_ids) & set(adviser_ids):
+            raise serializers.ValidationError(
+                'A team member cannot also be a contributing adviser.',
+                code='team_member_as_contributing_adviser',
+            )


### PR DESCRIPTION
### Description of change

This adds validation to Export Win serialiser so that the following cannot happen:

            A contributing adviser cannot be a duplicate.
            A team member cannot be a duplicate.
            A contributing adviser cannot also be lead officer.
            A team member cannot also be lead officer.
            A team member cannot also be a contributing adviser.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
