### PR TITLE
Add ID fields to datasets

### DIFF
--- a/datahub/dataset/expand_your_business/test/test_views.py
+++ b/datahub/dataset/expand_your_business/test/test_views.py
@@ -23,6 +23,7 @@ def get_expected_data_from_eyb(eyb_lead):
         ]
 
     data = {
+        'id': str(eyb_lead.id),
         'modified_on': format_date_or_datetime(eyb_lead.modified_on),
         # Triage component
         'triage_hashed_uuid': str(eyb_lead.triage_hashed_uuid),

--- a/datahub/dataset/expand_your_business/views.py
+++ b/datahub/dataset/expand_your_business/views.py
@@ -29,6 +29,7 @@ class EYBLeadsDatasetView(BaseFilterDatasetView):
                 ),
             )
             .values(
+                'id',
                 'modified_on',
                 # Triage component
                 'triage_hashed_uuid',

--- a/datahub/dataset/investment_project/test/test_views.py
+++ b/datahub/dataset/investment_project/test/test_views.py
@@ -219,6 +219,9 @@ def get_expected_data_from_project(project, won_date=None):
         )
         if project.uk_region_locations.exists()
         else None,
+        'eyb_lead_ids': [str(lead.id) for lead in project.eyb_leads.all()]
+        if project.eyb_leads.exists()
+        else None,
     }
 
 

--- a/datahub/dataset/investment_project/views.py
+++ b/datahub/dataset/investment_project/views.py
@@ -19,6 +19,7 @@ from datahub.investment.project.models import (
 )
 from datahub.investment.project.query_utils import get_project_code_expression
 from datahub.investment.project.report.spi import get_spi_report_queryset
+from datahub.investment_lead.models import EYBLead
 from datahub.metadata.query_utils import get_sector_name_subquery
 
 
@@ -108,6 +109,12 @@ class InvestmentProjectsDatasetView(BaseFilterDatasetView):
                 'specificprogramme__name',
                 ordering=('specificprogramme__name',),
             ),
+            eyb_lead_ids=get_array_agg_subquery(
+                model=EYBLead.investment_projects.through,
+                join_field_name='investmentproject',
+                expression_to_aggregate='eyblead__id',
+                ordering=('eyblead__id'),
+            ),
         ).values(
             'actual_land_date',
             'actual_uk_region_names',
@@ -174,6 +181,7 @@ class InvestmentProjectsDatasetView(BaseFilterDatasetView):
             'uk_company_id',
             'uk_company_sector',
             'uk_region_location_names',
+            'eyb_lead_ids',
         )
         updated_since = request.GET.get('updated_since')
 


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

We have realised that:
- The investment project dataset is missing a field to indicate which EYB leads a project is associated with
- The EYB lead dataset is missing an ID field

As a result, users are struggling to match up projects and EYB leads in the Data Workspace tables. This PR adds the fields to their respective dataset views.

A subsequent Data Flow PR will be raised to add the fields to the pipelines.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
