### PR TITLE
Chore/cls2 1354 update investment delivery partners le ps to id ps

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_delivery_partners.py
@@ -10,38 +10,71 @@ from datahub.investment.project.models import InvestmentProject
 logger = getLogger(__name__)
 
 delivery_partner_mappings = [
+    # Cumbria LEP -> Cumbria
     {'lep': 'e96192bb-09f1-e511-8ffa-e4115bead28a', 'idp': '4d2d0351-ffaa-4a0d-986a-f13be4ec2198'},
+    # Greater Manchester LEP -> Greater Manchester Combined Authority
     {'lep': '9abd575e-0af1-e511-8ffa-e4115bead28a', 'idp': '182e76ca-868d-4ca4-a336-17a26719f786'},
+    # Liverpool City Region LEP -> Liverpool City Region Combined Authority
     {'lep': '87b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'dedd7553-63fe-41cc-874f-740d4cec8f97'},
+    # Lancashire LEP -> Lancashire Combined Authority
     {'lep': '7db87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'c49e39af-fd14-49d6-ae34-aa9a4a9da65f'},
+    # North East LEP -> North East Mayoral Combined Authority (NEMCA)
     {'lep': '6e85b4e3-0df1-e511-8ffa-e4115bead28a', 'idp': '58d8d795-fbb2-4ae5-aaa2-5c4415c78448'},
+    # Tees Valley LEP -> Tees Valley Combined Authority (TVCA)
     {'lep': 'd5b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'b6e3d185-24ae-4b63-8c98-5717acf8e83e'},
+    # Leeds City Region LEP -> West Yorkshire Combined Authority (WYCA)
     {'lep': '81b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '1de3306f-6550-4f3b-ad99-c6ed380ba527'},
+    # Sheffield City Region LEP -> South Yorkshire Mayoral Combined Authority (SYMCA)
     {'lep': 'b7b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '33cb0c84-6d77-4aae-9931-1391b154b432'},
+    # York and North Yorkshire LEP -> York and North Yorkshire Combined Authority (YNYCA)
     {'lep': 'edb87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '5b5846ae-805e-4e27-a2c7-ad03ae3a48c7'},
+    # Hull & East Yorkshire LEP -> Hull & East Yorkshire
     {'lep': '67b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '881ebf0f-7e54-4dc2-a710-2592b8c2f3f3'},
+    # Cheshire & Warrington LEP -> Cheshire & Warrington
     {'lep': '43b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'ef9520d0-4ac6-4afc-a7a5-f52a84d722cd'},
+    # Coventry and Warwickshire LEP -> Coventry and Warwickshire
     {'lep': '47b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'fa7265d4-1b48-46f9-b1ad-4edb603a4b7a'},
+    # Black Country LEP -> The Black Country
     {'lep': '9f457ec7-0df1-e511-8ffa-e4115bead28a', 'idp': '6bf47e48-720e-4774-9f54-25d03e42ab8c'},
+    # Greater Birmingham and Solihull LEP -> Birmingham and Solihull
     {'lep': 'd722c64d-0af1-e511-8ffa-e4115bead28a', 'idp': 'bd5b1fc8-9f41-4f82-b01e-59b580405499'},
+    # Worcestershire LEP -> Worcestershire
     {'lep': 'e9b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '8efff1df-cc61-4f50-a45f-8a86a39255b2'},
+    # Greater Lincolnshire LEP -> Greater Lincolnshire
     {'lep': '5bb87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '7661d5c8-87cd-4f3d-a8d1-18537126d1d4'},
+    # Derby, Derbyshire, Nottingham and Nottinghamshire (D2N2) LEP -> Derbyshire & Nottinghamshire
     {'lep': '9bd5dc7b-0bf1-e511-8ffa-e4115bead28a', 'idp': '42848f9f-5672-453c-b80c-dd234f5a22a0'},
+    # Leicester and leicestershire LEP -> Leicester & Leicestershire
     {'lep': '83b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'c05199a7-7e71-44b2-9582-0a62bfa0a130'},
+    # The Marches LEP -> Shropshire, Telford and Herefordshire
     {'lep': '2d11f1d5-0df1-e511-8ffa-e4115bead28a', 'idp': 'e3e4ba66-563d-41e9-af8a-eaf4ee4463b5'},
+    # Stoke on Trent and Staffordshire LEP -> Stoke and Staffordshire
     {'lep': 'c9b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'e35991c5-45c2-426d-b5b9-18b5419d2582'},
+    # Cornwall and Isles of Scilly LEP -> Cornwall and Isles of Scilly
     {'lep': '4e37faaa-09f1-e511-8ffa-e4115bead28a', 'idp': '02015c5c-4143-4b6b-b93e-36ab22d365fc'},
+    # Dorset LEP -> Dorset
     {'lep': 'b8827a82-09f1-e511-8ffa-e4115bead28a', 'idp': 'b128bbd5-380c-4875-90fc-6c1551312943'},
+    # West of England LEP -> West of England Combined Authority (WECA)
     {'lep': 'e3b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'e7d21909-338f-480e-838f-23a1c04b4885'},
+    # GFirst LEP -> Gloucestershire
     {'lep': '688ea333-0af1-e511-8ffa-e4115bead28a', 'idp': '76b5619b-d08b-4527-a11a-850e1fc7eeff'},
+    # Swindon & Wiltshire LEP -> Swindon & Wiltshire
     {'lep': 'd3b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'b5f4d2e3-07aa-46d2-bb96-f479f8de12ca'},
+    # Coast to Capital LEP -> Sussex
     {'lep': '45b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '3ee9e0cb-136b-4b17-bb9e-ce6da411fc8a'},
+    # Oxfordshire LEP -> Oxfordshire
     {'lep': 'adb87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'dde9feb4-1656-4363-ab9a-c41d1f92442d'},
+    # Buckinghamshire LEP -> Buckinghamshire
     {'lep': '049b5f91-09f1-e511-8ffa-e4115bead28a', 'idp': 'ebd48659-e5b9-40a9-aa56-2051d4a0c78a'},
+    # Berkshire LEP -> Berkshire
     {'lep': 'd9b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '0026f106-d6cc-4327-9d7a-d0951d3c9168'},
+    # Hertfordshire LEP -> Hertfordshire
     {'lep': '63b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '624ceb13-f970-45e8-9e9a-358445558bb0'},
+    # Greater Cambridge and Greater Peterborough LEP -> Cambridge and Peterborough Combined Authority
     {'lep': '59b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'a557b7b7-8bf2-4c3d-9dbb-6d152b030fe3'},
+    # New Anglia LEP -> Norfolk and Suffolk
     {'lep': 'cdcc392e-0bf1-e511-8ffa-e4115bead28a', 'idp': 'a8ef4192-8f14-4208-be99-bd4545d6eed6'},
+    # South East Midlands LEP -> Northamptonshire, Bedforshire and Milton Keynes
     {'lep': 'c1b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'ba97d018-c353-4232-b90d-f09af0f7cfc0'},
 ]
 

--- a/datahub/dbmaintenance/management/commands/update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_delivery_partners.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
     for investment projects with an Actual land date values of 1st April 2024 onwards.
     """
 
-    help = 'Update Local Enterprice Partner (LEP) to Investment Delivery Partner (IDP) for investment projects with an Actual land date values of 1st April 2024 onwards'
+    help = 'One off command to update Local Enterprice Partner (LEP) to Investment Delivery Partner (IDP) for investment projects with an Actual land date values of 1st April 2024 onwards'
 
     log: dict
 
@@ -139,5 +139,9 @@ class Command(BaseCommand):
                             project.delivery_partners.remove(delivery_partner_mapping['lep'])
                             project.save()
                             self.log['leps']['deleted'] += 1
+                    else:
+                        self.log['idps']['errors'].append(
+                            f'Missing IDP {delivery_partner_mapping["idp"]} on Investment project {project.id}; LEP {delivery_partner_mapping["lep"]} has not been removed.',
+                        )
 
         logger.info(self.log)

--- a/datahub/dbmaintenance/management/commands/update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_delivery_partners.py
@@ -10,62 +10,39 @@ from datahub.investment.project.models import InvestmentProject
 logger = getLogger(__name__)
 
 delivery_partner_mappings = [
-    {"lep": "e96192bb-09f1-e511-8ffa-e4115bead28a",
-        "idp": "4d2d0351-ffaa-4a0d-986a-f13be4ec2198"},
-    {"lep": "9abd575e-0af1-e511-8ffa-e4115bead28a",
-        "idp": "182e76ca-868d-4ca4-a336-17a26719f786"},
-    {"lep": "87b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "dedd7553-63fe-41cc-874f-740d4cec8f97"},
-    {"lep": "7db87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "c49e39af-fd14-49d6-ae34-aa9a4a9da65f"},
-    {"lep": "6e85b4e3-0df1-e511-8ffa-e4115bead28a",
-        "idp": "58d8d795-fbb2-4ae5-aaa2-5c4415c78448"},
-    {"lep": "d5b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "b6e3d185-24ae-4b63-8c98-5717acf8e83e"},
-    {"lep": "81b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "1de3306f-6550-4f3b-ad99-c6ed380ba527"},
-    {"lep": "b7b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "33cb0c84-6d77-4aae-9931-1391b154b432"},
-    {"lep": "edb87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "5b5846ae-805e-4e27-a2c7-ad03ae3a48c7"},
-    {"lep": "67b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "881ebf0f-7e54-4dc2-a710-2592b8c2f3f3"},
-    {"lep": "43b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "ef9520d0-4ac6-4afc-a7a5-f52a84d722cd"},
-    {"lep": "47b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "fa7265d4-1b48-46f9-b1ad-4edb603a4b7a"},
-    {"lep": "9f457ec7-0df1-e511-8ffa-e4115bead28a",
-        "idp": "6bf47e48-720e-4774-9f54-25d03e42ab8c"},
-    {"lep": "e9b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "8efff1df-cc61-4f50-a45f-8a86a39255b2"},
-    {"lep": "83b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "c05199a7-7e71-44b2-9582-0a62bfa0a130"},
-    {"lep": "2d11f1d5-0df1-e511-8ffa-e4115bead28a",
-        "idp": "e3e4ba66-563d-41e9-af8a-eaf4ee4463b5"},
-    {"lep": "c9b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "e35991c5-45c2-426d-b5b9-18b5419d2582"},
-    {"lep": "4e37faaa-09f1-e511-8ffa-e4115bead28a",
-        "idp": "02015c5c-4143-4b6b-b93e-36ab22d365fc"},
-    {"lep": "b8827a82-09f1-e511-8ffa-e4115bead28a",
-        "idp": "b128bbd5-380c-4875-90fc-6c1551312943"},
-    {"lep": "e3b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "e7d21909-338f-480e-838f-23a1c04b4885"},
-    {"lep": "688ea333-0af1-e511-8ffa-e4115bead28a",
-        "idp": "76b5619b-d08b-4527-a11a-850e1fc7eeff"},
-    {"lep": "d3b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "b5f4d2e3-07aa-46d2-bb96-f479f8de12ca"},
-    {"lep": "adb87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "dde9feb4-1656-4363-ab9a-c41d1f92442d"},
-    {"lep": "049b5f91-09f1-e511-8ffa-e4115bead28a",
-        "idp": "ebd48659-e5b9-40a9-aa56-2051d4a0c78a"},
-    {"lep": "d9b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "0026f106-d6cc-4327-9d7a-d0951d3c9168"},
-    {"lep": "63b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "624ceb13-f970-45e8-9e9a-358445558bb0"},
-    {"lep": "59b87bf6-9f1a-e511-8e8f-441ea13961e2",
-        "idp": "a557b7b7-8bf2-4c3d-9dbb-6d152b030fe3"},
-    {"lep": "cdcc392e-0bf1-e511-8ffa-e4115bead28a",
-        "idp": "a8ef4192-8f14-4208-be99-bd4545d6eed6"},
+    {'lep': 'e96192bb-09f1-e511-8ffa-e4115bead28a', 'idp': '4d2d0351-ffaa-4a0d-986a-f13be4ec2198'},
+    {'lep': '9abd575e-0af1-e511-8ffa-e4115bead28a', 'idp': '182e76ca-868d-4ca4-a336-17a26719f786'},
+    {'lep': '87b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'dedd7553-63fe-41cc-874f-740d4cec8f97'},
+    {'lep': '7db87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'c49e39af-fd14-49d6-ae34-aa9a4a9da65f'},
+    {'lep': '6e85b4e3-0df1-e511-8ffa-e4115bead28a', 'idp': '58d8d795-fbb2-4ae5-aaa2-5c4415c78448'},
+    {'lep': 'd5b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'b6e3d185-24ae-4b63-8c98-5717acf8e83e'},
+    {'lep': '81b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '1de3306f-6550-4f3b-ad99-c6ed380ba527'},
+    {'lep': 'b7b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '33cb0c84-6d77-4aae-9931-1391b154b432'},
+    {'lep': 'edb87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '5b5846ae-805e-4e27-a2c7-ad03ae3a48c7'},
+    {'lep': '67b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '881ebf0f-7e54-4dc2-a710-2592b8c2f3f3'},
+    {'lep': '43b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'ef9520d0-4ac6-4afc-a7a5-f52a84d722cd'},
+    {'lep': '47b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'fa7265d4-1b48-46f9-b1ad-4edb603a4b7a'},
+    {'lep': '9f457ec7-0df1-e511-8ffa-e4115bead28a', 'idp': '6bf47e48-720e-4774-9f54-25d03e42ab8c'},
+    {'lep': 'd722c64d-0af1-e511-8ffa-e4115bead28a', 'idp': 'bd5b1fc8-9f41-4f82-b01e-59b580405499'},
+    {'lep': 'e9b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '8efff1df-cc61-4f50-a45f-8a86a39255b2'},
+    {'lep': '5bb87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '7661d5c8-87cd-4f3d-a8d1-18537126d1d4'},
+    {'lep': '9bd5dc7b-0bf1-e511-8ffa-e4115bead28a', 'idp': '42848f9f-5672-453c-b80c-dd234f5a22a0'},
+    {'lep': '83b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'c05199a7-7e71-44b2-9582-0a62bfa0a130'},
+    {'lep': '2d11f1d5-0df1-e511-8ffa-e4115bead28a', 'idp': 'e3e4ba66-563d-41e9-af8a-eaf4ee4463b5'},
+    {'lep': 'c9b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'e35991c5-45c2-426d-b5b9-18b5419d2582'},
+    {'lep': '4e37faaa-09f1-e511-8ffa-e4115bead28a', 'idp': '02015c5c-4143-4b6b-b93e-36ab22d365fc'},
+    {'lep': 'b8827a82-09f1-e511-8ffa-e4115bead28a', 'idp': 'b128bbd5-380c-4875-90fc-6c1551312943'},
+    {'lep': 'e3b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'e7d21909-338f-480e-838f-23a1c04b4885'},
+    {'lep': '688ea333-0af1-e511-8ffa-e4115bead28a', 'idp': '76b5619b-d08b-4527-a11a-850e1fc7eeff'},
+    {'lep': 'd3b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'b5f4d2e3-07aa-46d2-bb96-f479f8de12ca'},
+    {'lep': '45b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '3ee9e0cb-136b-4b17-bb9e-ce6da411fc8a'},
+    {'lep': 'adb87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'dde9feb4-1656-4363-ab9a-c41d1f92442d'},
+    {'lep': '049b5f91-09f1-e511-8ffa-e4115bead28a', 'idp': 'ebd48659-e5b9-40a9-aa56-2051d4a0c78a'},
+    {'lep': 'd9b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '0026f106-d6cc-4327-9d7a-d0951d3c9168'},
+    {'lep': '63b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': '624ceb13-f970-45e8-9e9a-358445558bb0'},
+    {'lep': '59b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'a557b7b7-8bf2-4c3d-9dbb-6d152b030fe3'},
+    {'lep': 'cdcc392e-0bf1-e511-8ffa-e4115bead28a', 'idp': 'a8ef4192-8f14-4208-be99-bd4545d6eed6'},
+    {'lep': 'c1b87bf6-9f1a-e511-8e8f-441ea13961e2', 'idp': 'ba97d018-c353-4232-b90d-f09af0f7cfc0'},
 ]
 
 
@@ -78,50 +55,56 @@ class Command(BaseCommand):
 
     help = 'Update Local Enterprice Partner (LEP) to Investment Delivery Partner (IDP) for investment projects with an Actual land date values of 1st April 2024 onwards'
 
+    log: dict
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.log = {
+            'projects': {'count': 0, 'errors': []},
+            'leps': {'investment_project_count': 0, 'to_delete': 0, 'deleted': 0, 'errors': []},
+            'idps': {'investment_project_count': 0, 'to_add': 0, 'added': 0, 'errors': []},
+        }
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            help='Simulate the command and only log expected changes without making changes.',
+        )
+        parser.add_argument(
+            '--delete',
+            action='store_true',
+            help='Delete LEPs that have a corresponding IDP.',
+        )
+
     def handle(self, *args, **options):
-        leps = [delivery_partner['lep']
-                for delivery_partner in delivery_partner_mappings]
+        is_simulation = options['simulate']
+        is_delete = options['delete']
 
-        projects = InvestmentProject.objects.filter(
-            actual_land_date__gte=datetime(2024, 4, 1, tzinfo=timezone.utc),
-            delivery_partners__in=leps,
-        ).prefetch_related('delivery_partners')
-
-        details = [
-            {
-                'id': project.id,
-                'name': project.name,
-                'delivery_partners': [{'id': delivery_partner.id, 'name': delivery_partner.name} for delivery_partner in project.delivery_partners.all()],
-            }
-            for project in projects
-        ]
-
-        logger.info(details)
-
-# list(map(lambda: details: logger.info(score_list.name), score_list))
-
-        for dpm in delivery_partner_mappings:
-            logger.info(dpm)
+        for delivery_partner_mapping in delivery_partner_mappings:
             projects = InvestmentProject.objects.filter(
-                actual_land_date__gte=datetime(
-                    2024, 4, 1, tzinfo=timezone.utc),
-                delivery_partners__in=[dpm['lep']],
+                actual_land_date__gte=datetime(2024, 4, 1, tzinfo=timezone.utc),
+                delivery_partners__in=[delivery_partner_mapping['lep']],
             ).prefetch_related('delivery_partners')
-            logger.info(projects.count())
+            self.log['leps']['investment_project_count'] += projects.count()
             for project in projects:
-                project.delivery_partners.add(dpm['idp'])
-                project.save()
-                # Check new IDP is added
-                logger.info(project.__dict__)
-                logger.info(project.id)
-                verify_project = InvestmentProject.objects.get(
-                    pk=project.id)
-                logger.info(dpm['idp'])
-                logger.info(list(verify_project.delivery_partners.all()))
-                if verify_project.delivery_partners.filter(pk=dpm['idp']).exists():
-                    logger.info(f'>>>>>>>>>> > Removing ${dpm["lep"]}')
-                    project.delivery_partners.remove(dpm['lep'])
+                project.delivery_partners.add(delivery_partner_mapping['idp'])
+                self.log['idps']['to_add'] += 1
+                if not is_simulation:
                     project.save()
+                    self.log['idps']['added'] += 1
 
+                if is_delete:
+                    # Check new IDP is added
+                    verify_project = InvestmentProject.objects.get(pk=project.id)
+                    if verify_project.delivery_partners.filter(
+                        pk=delivery_partner_mapping['idp'],
+                    ).exists():
+                        self.log['leps']['to_delete'] += 1
+                        if not is_simulation:
+                            project.delivery_partners.remove(delivery_partner_mapping['lep'])
+                            project.save()
+                            self.log['leps']['deleted'] += 1
 
-# If added remove existing LEP.
+        logger.info(self.log)

--- a/datahub/dbmaintenance/management/commands/update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_delivery_partners.py
@@ -1,0 +1,127 @@
+"""One off command to update LEPs to IDPs for Investment Projects."""
+
+from datetime import datetime, timezone
+from logging import getLogger
+
+from django.core.management import BaseCommand
+
+from datahub.investment.project.models import InvestmentProject
+
+logger = getLogger(__name__)
+
+delivery_partner_mappings = [
+    {"lep": "e96192bb-09f1-e511-8ffa-e4115bead28a",
+        "idp": "4d2d0351-ffaa-4a0d-986a-f13be4ec2198"},
+    {"lep": "9abd575e-0af1-e511-8ffa-e4115bead28a",
+        "idp": "182e76ca-868d-4ca4-a336-17a26719f786"},
+    {"lep": "87b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "dedd7553-63fe-41cc-874f-740d4cec8f97"},
+    {"lep": "7db87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "c49e39af-fd14-49d6-ae34-aa9a4a9da65f"},
+    {"lep": "6e85b4e3-0df1-e511-8ffa-e4115bead28a",
+        "idp": "58d8d795-fbb2-4ae5-aaa2-5c4415c78448"},
+    {"lep": "d5b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "b6e3d185-24ae-4b63-8c98-5717acf8e83e"},
+    {"lep": "81b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "1de3306f-6550-4f3b-ad99-c6ed380ba527"},
+    {"lep": "b7b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "33cb0c84-6d77-4aae-9931-1391b154b432"},
+    {"lep": "edb87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "5b5846ae-805e-4e27-a2c7-ad03ae3a48c7"},
+    {"lep": "67b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "881ebf0f-7e54-4dc2-a710-2592b8c2f3f3"},
+    {"lep": "43b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "ef9520d0-4ac6-4afc-a7a5-f52a84d722cd"},
+    {"lep": "47b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "fa7265d4-1b48-46f9-b1ad-4edb603a4b7a"},
+    {"lep": "9f457ec7-0df1-e511-8ffa-e4115bead28a",
+        "idp": "6bf47e48-720e-4774-9f54-25d03e42ab8c"},
+    {"lep": "e9b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "8efff1df-cc61-4f50-a45f-8a86a39255b2"},
+    {"lep": "83b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "c05199a7-7e71-44b2-9582-0a62bfa0a130"},
+    {"lep": "2d11f1d5-0df1-e511-8ffa-e4115bead28a",
+        "idp": "e3e4ba66-563d-41e9-af8a-eaf4ee4463b5"},
+    {"lep": "c9b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "e35991c5-45c2-426d-b5b9-18b5419d2582"},
+    {"lep": "4e37faaa-09f1-e511-8ffa-e4115bead28a",
+        "idp": "02015c5c-4143-4b6b-b93e-36ab22d365fc"},
+    {"lep": "b8827a82-09f1-e511-8ffa-e4115bead28a",
+        "idp": "b128bbd5-380c-4875-90fc-6c1551312943"},
+    {"lep": "e3b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "e7d21909-338f-480e-838f-23a1c04b4885"},
+    {"lep": "688ea333-0af1-e511-8ffa-e4115bead28a",
+        "idp": "76b5619b-d08b-4527-a11a-850e1fc7eeff"},
+    {"lep": "d3b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "b5f4d2e3-07aa-46d2-bb96-f479f8de12ca"},
+    {"lep": "adb87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "dde9feb4-1656-4363-ab9a-c41d1f92442d"},
+    {"lep": "049b5f91-09f1-e511-8ffa-e4115bead28a",
+        "idp": "ebd48659-e5b9-40a9-aa56-2051d4a0c78a"},
+    {"lep": "d9b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "0026f106-d6cc-4327-9d7a-d0951d3c9168"},
+    {"lep": "63b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "624ceb13-f970-45e8-9e9a-358445558bb0"},
+    {"lep": "59b87bf6-9f1a-e511-8e8f-441ea13961e2",
+        "idp": "a557b7b7-8bf2-4c3d-9dbb-6d152b030fe3"},
+    {"lep": "cdcc392e-0bf1-e511-8ffa-e4115bead28a",
+        "idp": "a8ef4192-8f14-4208-be99-bd4545d6eed6"},
+]
+
+
+class Command(BaseCommand):
+    """One off command to update LEPs to IDPs for Investment Projects.
+
+    Update Local Enterprice Partner (LEP) to Investment Delivery Partner (IDP)
+    for investment projects with an Actual land date values of 1st April 2024 onwards.
+    """
+
+    help = 'Update Local Enterprice Partner (LEP) to Investment Delivery Partner (IDP) for investment projects with an Actual land date values of 1st April 2024 onwards'
+
+    def handle(self, *args, **options):
+        leps = [delivery_partner['lep']
+                for delivery_partner in delivery_partner_mappings]
+
+        projects = InvestmentProject.objects.filter(
+            actual_land_date__gte=datetime(2024, 4, 1, tzinfo=timezone.utc),
+            delivery_partners__in=leps,
+        ).prefetch_related('delivery_partners')
+
+        details = [
+            {
+                'id': project.id,
+                'name': project.name,
+                'delivery_partners': [{'id': delivery_partner.id, 'name': delivery_partner.name} for delivery_partner in project.delivery_partners.all()],
+            }
+            for project in projects
+        ]
+
+        logger.info(details)
+
+# list(map(lambda: details: logger.info(score_list.name), score_list))
+
+        for dpm in delivery_partner_mappings:
+            logger.info(dpm)
+            projects = InvestmentProject.objects.filter(
+                actual_land_date__gte=datetime(
+                    2024, 4, 1, tzinfo=timezone.utc),
+                delivery_partners__in=[dpm['lep']],
+            ).prefetch_related('delivery_partners')
+            logger.info(projects.count())
+            for project in projects:
+                project.delivery_partners.add(dpm['idp'])
+                project.save()
+                # Check new IDP is added
+                logger.info(project.__dict__)
+                logger.info(project.id)
+                verify_project = InvestmentProject.objects.get(
+                    pk=project.id)
+                logger.info(dpm['idp'])
+                logger.info(list(verify_project.delivery_partners.all()))
+                if verify_project.delivery_partners.filter(pk=dpm['idp']).exists():
+                    logger.info(f'>>>>>>>>>> > Removing ${dpm["lep"]}')
+                    project.delivery_partners.remove(dpm['lep'])
+                    project.save()
+
+
+# If added remove existing LEP.

--- a/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
@@ -1,0 +1,106 @@
+from datetime import datetime, timezone
+from unittest import mock
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.db import DatabaseError
+from reversion.models import Version
+
+from datahub.company.models import Company, Contact
+from datahub.company.test.factories import (
+    CompanyFactory,
+    ContactFactory,
+)
+from datahub.interaction.models import Interaction
+from datahub.interaction.test.factories import CompanyInteractionFactory
+from datahub.investment.project.models import InvestmentDeliveryPartner, InvestmentProject
+from datahub.investment.project.test.factories import InvestmentProjectFactory, InvestmentDeliveryPartnerFactory
+
+
+@pytest.fixture
+def lep():
+    lep_id = 'e96192bb-09f1-e511-8ffa-e4115bead28a'
+    return InvestmentDeliveryPartner.objects.get(pk=lep_id)
+    return InvestmentDeliveryPartnerFactory(id=lep_id)
+
+
+@pytest.fixture
+def dpi():
+    dpi_id = '4d2d0351-ffaa-4a0d-986a-f13be4ec2198'
+    return InvestmentDeliveryPartnerFactory(id=dpi_id)
+
+
+def replace_with_fixtures(source, lep, dpi):
+    """Simple replacement as fixtures can't be used in @pytest.mark.parametrize
+    """
+    result = []
+    for value in source:
+        if value == 'lep':
+            result.append(lep)
+        if value == 'dpi':
+            result.append(dpi)
+    return result
+
+
+class TestUpdateInvestmentDeliveryPartnersCommand:
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        ('actual_land_date', 'delivery_partners', 'expected_partners'),
+        [
+            # Without actual land date
+            (None, ['lep'], ['lep']),
+            # Before 1st April 2024
+            (datetime(2024, 3, 1, tzinfo=timezone.utc), ['lep'], ['lep']),
+            # On 1st April 2024
+            (datetime(
+                2024, 4, 1, tzinfo=timezone.utc), ['lep'], ['dpi']),
+            # After 1st April 2024
+            (datetime(
+                2025, 4, 1, tzinfo=timezone.utc), ['lep'], ['dpi']),
+        ],
+    )
+    def test_actual_land_date(self, caplog, lep, dpi, actual_land_date, delivery_partners, expected_partners):
+        from pprint import pprint
+        delivery_partners = replace_with_fixtures(
+            delivery_partners, lep, dpi)
+        expected_partners = replace_with_fixtures(
+            expected_partners, lep, dpi)
+        pprint(actual_land_date)
+        pprint(delivery_partners)
+        pprint(expected_partners)
+
+        investment_project = InvestmentProjectFactory(
+            actual_land_date=actual_land_date, delivery_partners=delivery_partners)
+
+        call_command('update_investment_delivery_partners')
+
+        pprint(investment_project.__dict__)
+        stored_investment_project = InvestmentProject.objects.get(
+            pk=investment_project.id)
+        assert set([str(value.id) for value in stored_investment_project.delivery_partners.all(
+        )]) == set([str(expected_partner.id) for expected_partner in expected_partners])
+
+    def test_idp_added(self, test_base_stova_attendee, simulate, caplog):
+        """Test interactions created by Stova Attendees are removed and interactions not created by
+        stova are not removed.
+        """
+        s3_processor_mock = mock.Mock()
+        task = StovaAttendeeIngestionTask('dummy-prefix', s3_processor_mock)
+        data = test_base_stova_attendee
+        task._process_record(data)
+        data['id'] = 9876
+        task._process_record(data)
+        data['id'] = 8907
+        data['company_name'] = 'a new company'
+        task._process_record(data)
+        CompanyInteractionFactory.create_batch(5)
+
+        assert Interaction.objects.count() == 8
+
+        caplog.set_level('INFO')
+        call_command('remove_stova_relations', simulate=simulate)
+
+        log_text = caplog.text
+        assert 'There were 3 interactions deleted out of 3' in log_text
+        assert Interaction.objects.count() == 5

--- a/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
@@ -174,12 +174,12 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
         caplog: pytest.LogCaptureFixture,
         lep: InvestmentDeliveryPartner,
     ):
-        """Test idp doesn't exist."""
+        """Test lep doesn't exist."""
         mocker.patch(
             'datahub.dbmaintenance.management.commands.update_investment_delivery_partners.delivery_partner_mappings',
             new=[
                 {
-                    'lep': 'abcdef01-09f1-e511-8ffa-e4115bead28a',
+                    'lep': 'abcdef01-09f1-e511-8ffa-e4115bead28a',  # non existing UUID
                     'idp': '4d2d0351-ffaa-4a0d-986a-f13be4ec2198',
                 },
             ],

--- a/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
@@ -204,7 +204,7 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
         lep: InvestmentDeliveryPartner,
     ):
         """Test idp doesn't exist."""
-        idp_id = 'abcdef01-ffaa-4a0d-986a-f13be4ec2198'
+        idp_id = 'ef9520d0-4ac6-4afc-a7a5-f52a84d722cd'
         mocker.patch(
             'datahub.dbmaintenance.management.commands.update_investment_delivery_partners.delivery_partner_mappings',
             new=[
@@ -221,6 +221,7 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
             delivery_partners=[lep],
         )
         call_command('update_investment_delivery_partners', simulate=False, delete=True)
+
         message = (
             "{'projects': {'count': 0, 'errors': []}, 'leps': {'investment_project_count': 1, 'to_delete': 0, 'deleted': 0, 'errors': []}, 'idps': {'investment_project_count': 0, 'to_add': 1, 'added': 1, 'errors': ['Missing IDP "
             + str(idp_id)
@@ -231,3 +232,12 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
             + " has not been removed.']}}"
         )
         assert message in caplog.text
+
+        # Add missing idp to investment project to avoid post test issues causing IntegretyError in
+        # investment_investmentdeliverypartner test_case._post_teardown().
+        hack_idp = InvestmentDeliveryPartnerFactory(
+            id='ef9520d0-4ac6-4afc-a7a5-f52a84d722cd',
+            name='Hello world',
+        )
+        investment_project.delivery_partners.add(hack_idp)
+        investment_project.save()

--- a/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
@@ -14,7 +14,6 @@ from datahub.investment.project.test.factories import (
 def lep():
     lep_id = 'e96192bb-09f1-e511-8ffa-e4115bead28a'
     return InvestmentDeliveryPartner.objects.get(pk=lep_id)
-    return InvestmentDeliveryPartnerFactory(id=lep_id)
 
 
 @pytest.fixture
@@ -24,14 +23,14 @@ def dpi():
 
 
 def replace_with_fixtures(source, lep, dpi):
-    """Simple replacement as fixtures can't be used in @pytest.mark.parametrize.
-    """
+    """Simple replacement as fixtures can't be used in @pytest.mark.parametrize."""
     result = []
     for value in source:
-        if value == 'lep':
-            result.append(lep)
-        if value == 'dpi':
-            result.append(dpi)
+        match value:
+            case 'lep':
+                result.append(lep)
+            case 'dpi':
+                result.append(dpi)
     return result
 
 
@@ -45,25 +44,113 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
             # Before 1st April 2024
             (datetime(2024, 3, 1, tzinfo=timezone.utc), ['lep'], ['lep']),
             # On 1st April 2024
-            (datetime(
-                2024, 4, 1, tzinfo=timezone.utc), ['lep'], ['dpi']),
+            (datetime(2024, 4, 1, tzinfo=timezone.utc), ['lep'], ['dpi']),
             # After 1st April 2024
-            (datetime(
-                2025, 4, 1, tzinfo=timezone.utc), ['lep'], ['dpi']),
+            (datetime(2025, 4, 1, tzinfo=timezone.utc), ['lep'], ['dpi']),
         ],
     )
-    def test_actual_land_date(self, caplog, lep, dpi, actual_land_date, delivery_partners, expected_partners):
-        delivery_partners = replace_with_fixtures(
-            delivery_partners, lep, dpi)
-        expected_partners = replace_with_fixtures(
-            expected_partners, lep, dpi)
+    def test_actual_land_date(
+        self,
+        caplog,
+        lep,
+        dpi,
+        actual_land_date,
+        delivery_partners,
+        expected_partners,
+    ):
+        caplog.set_level('INFO')
+        delivery_partners = replace_with_fixtures(delivery_partners, lep, dpi)
+        expected_partners = replace_with_fixtures(expected_partners, lep, dpi)
 
         investment_project = InvestmentProjectFactory(
-            actual_land_date=actual_land_date, delivery_partners=delivery_partners)
+            actual_land_date=actual_land_date,
+            delivery_partners=delivery_partners,
+        )
 
-        call_command('update_investment_delivery_partners')
+        call_command('update_investment_delivery_partners', delete=True)
 
-        stored_investment_project = InvestmentProject.objects.get(
-            pk=investment_project.id)
-        assert set([str(value.id) for value in stored_investment_project.delivery_partners.all(
-        )]) == set([str(expected_partner.id) for expected_partner in expected_partners])
+        stored_investment_project = InvestmentProject.objects.get(pk=investment_project.id)
+        assert set(
+            [str(value.id) for value in stored_investment_project.delivery_partners.all()],
+        ) == set([str(expected_partner.id) for expected_partner in expected_partners])
+
+    @pytest.mark.django_db
+    def test_multiple_delivery_partners(self, caplog, lep, dpi):
+        """Test Investment Project with multiple delivery partners."""
+        caplog.set_level('INFO')
+
+        leps = [
+            lep,
+            InvestmentDeliveryPartner.objects.get(pk='9abd575e-0af1-e511-8ffa-e4115bead28a'),
+            InvestmentDeliveryPartner.objects.get(pk='87b87bf6-9f1a-e511-8e8f-441ea13961e2'),
+        ]
+
+        dpis = [
+            dpi,
+            InvestmentDeliveryPartnerFactory(id='182e76ca-868d-4ca4-a336-17a26719f786'),
+            InvestmentDeliveryPartnerFactory(id='dedd7553-63fe-41cc-874f-740d4cec8f97'),
+        ]
+
+        investment_project = InvestmentProjectFactory(
+            actual_land_date=datetime(2025, 4, 1, tzinfo=timezone.utc),
+            delivery_partners=leps,
+        )
+
+        call_command('update_investment_delivery_partners', simulate=False, delete=True)
+
+        stored_investment_project = InvestmentProject.objects.get(pk=investment_project.id)
+        assert set(
+            [str(value.id) for value in stored_investment_project.delivery_partners.all()],
+        ) == set([str(idp.id) for idp in dpis])
+
+    @pytest.mark.django_db
+    @pytest.mark.parametrize(
+        ('simulate', 'delete', 'caplog_text'),
+        [
+            (
+                False,
+                False,
+                "{'projects': {'count': 0, 'errors': []}, 'leps': {'investment_project_count': 3, 'to_delete': 0, 'deleted': 0, 'errors': []}, 'idps': {'investment_project_count': 0, 'to_add': 3, 'added': 3, 'errors': []}",
+            ),
+            (
+                True,
+                False,
+                "{'projects': {'count': 0, 'errors': []}, 'leps': {'investment_project_count': 3, 'to_delete': 0, 'deleted': 0, 'errors': []}, 'idps': {'investment_project_count': 0, 'to_add': 3, 'added': 0, 'errors': []}",
+            ),
+            (
+                False,
+                True,
+                "{'projects': {'count': 0, 'errors': []}, 'leps': {'investment_project_count': 3, 'to_delete': 3, 'deleted': 3, 'errors': []}, 'idps': {'investment_project_count': 0, 'to_add': 3, 'added': 3, 'errors': []}",
+            ),
+            (
+                True,
+                True,
+                "{'projects': {'count': 0, 'errors': []}, 'leps': {'investment_project_count': 3, 'to_delete': 3, 'deleted': 0, 'errors': []}, 'idps': {'investment_project_count': 0, 'to_add': 3, 'added': 0, 'errors': []}",
+            ),
+        ],
+    )
+    def test_arguments(self, caplog, lep, dpi, simulate, delete, caplog_text):
+        """Test simulate and delete arguments."""
+        caplog.set_level('INFO')
+
+        leps = [
+            lep,
+            InvestmentDeliveryPartner.objects.get(pk='9abd575e-0af1-e511-8ffa-e4115bead28a'),
+            InvestmentDeliveryPartner.objects.get(pk='87b87bf6-9f1a-e511-8e8f-441ea13961e2'),
+            InvestmentDeliveryPartner.objects.get(pk='14ee950e-0bf1-e511-8ffa-e4115bead28a'),
+        ]
+
+        dpis = [
+            dpi,
+            InvestmentDeliveryPartnerFactory(id='182e76ca-868d-4ca4-a336-17a26719f786'),
+            InvestmentDeliveryPartnerFactory(id='dedd7553-63fe-41cc-874f-740d4cec8f97'),
+        ]
+
+        investment_project = InvestmentProjectFactory(
+            actual_land_date=datetime(2025, 4, 1, tzinfo=timezone.utc),
+            delivery_partners=leps,
+        )
+
+        call_command('update_investment_delivery_partners', simulate=simulate, delete=delete)
+
+        assert caplog_text in caplog.text

--- a/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
@@ -140,13 +140,11 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
             InvestmentDeliveryPartner.objects.get(pk='14ee950e-0bf1-e511-8ffa-e4115bead28a'),
         ]
 
-        dpis = [
-            dpi,
-            InvestmentDeliveryPartnerFactory(id='182e76ca-868d-4ca4-a336-17a26719f786'),
-            InvestmentDeliveryPartnerFactory(id='dedd7553-63fe-41cc-874f-740d4cec8f97'),
-        ]
+        # dpis
+        InvestmentDeliveryPartnerFactory(id='182e76ca-868d-4ca4-a336-17a26719f786')
+        InvestmentDeliveryPartnerFactory(id='dedd7553-63fe-41cc-874f-740d4cec8f97')
 
-        investment_project = InvestmentProjectFactory(
+        InvestmentProjectFactory(
             actual_land_date=datetime(2025, 4, 1, tzinfo=timezone.utc),
             delivery_partners=leps,
         )

--- a/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
@@ -204,13 +204,13 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
         lep: InvestmentDeliveryPartner,
     ):
         """Test idp doesn't exist."""
-        idpId = 'abcdef01-ffaa-4a0d-986a-f13be4ec2198'
+        idp_id = 'abcdef01-ffaa-4a0d-986a-f13be4ec2198'
         mocker.patch(
             'datahub.dbmaintenance.management.commands.update_investment_delivery_partners.delivery_partner_mappings',
             new=[
                 {
                     'lep': lep.id,
-                    'idp': idpId,
+                    'idp': idp_id,
                 },
             ],
         )
@@ -223,7 +223,7 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
         call_command('update_investment_delivery_partners', simulate=False, delete=True)
         message = (
             "{'projects': {'count': 0, 'errors': []}, 'leps': {'investment_project_count': 1, 'to_delete': 0, 'deleted': 0, 'errors': []}, 'idps': {'investment_project_count': 0, 'to_add': 1, 'added': 1, 'errors': ['Missing IDP "
-            + str(idpId)
+            + str(idp_id)
             + ' on Investment project '
             + str(investment_project.id)
             + '; LEP '

--- a/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_delivery_partners.py
@@ -1,21 +1,13 @@
 from datetime import datetime, timezone
-from unittest import mock
-from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
-from django.db import DatabaseError
-from reversion.models import Version
 
-from datahub.company.models import Company, Contact
-from datahub.company.test.factories import (
-    CompanyFactory,
-    ContactFactory,
-)
-from datahub.interaction.models import Interaction
-from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.investment.project.models import InvestmentDeliveryPartner, InvestmentProject
-from datahub.investment.project.test.factories import InvestmentProjectFactory, InvestmentDeliveryPartnerFactory
+from datahub.investment.project.test.factories import (
+    InvestmentDeliveryPartnerFactory,
+    InvestmentProjectFactory,
+)
 
 
 @pytest.fixture
@@ -32,7 +24,7 @@ def dpi():
 
 
 def replace_with_fixtures(source, lep, dpi):
-    """Simple replacement as fixtures can't be used in @pytest.mark.parametrize
+    """Simple replacement as fixtures can't be used in @pytest.mark.parametrize.
     """
     result = []
     for value in source:
@@ -61,46 +53,17 @@ class TestUpdateInvestmentDeliveryPartnersCommand:
         ],
     )
     def test_actual_land_date(self, caplog, lep, dpi, actual_land_date, delivery_partners, expected_partners):
-        from pprint import pprint
         delivery_partners = replace_with_fixtures(
             delivery_partners, lep, dpi)
         expected_partners = replace_with_fixtures(
             expected_partners, lep, dpi)
-        pprint(actual_land_date)
-        pprint(delivery_partners)
-        pprint(expected_partners)
 
         investment_project = InvestmentProjectFactory(
             actual_land_date=actual_land_date, delivery_partners=delivery_partners)
 
         call_command('update_investment_delivery_partners')
 
-        pprint(investment_project.__dict__)
         stored_investment_project = InvestmentProject.objects.get(
             pk=investment_project.id)
         assert set([str(value.id) for value in stored_investment_project.delivery_partners.all(
         )]) == set([str(expected_partner.id) for expected_partner in expected_partners])
-
-    def test_idp_added(self, test_base_stova_attendee, simulate, caplog):
-        """Test interactions created by Stova Attendees are removed and interactions not created by
-        stova are not removed.
-        """
-        s3_processor_mock = mock.Mock()
-        task = StovaAttendeeIngestionTask('dummy-prefix', s3_processor_mock)
-        data = test_base_stova_attendee
-        task._process_record(data)
-        data['id'] = 9876
-        task._process_record(data)
-        data['id'] = 8907
-        data['company_name'] = 'a new company'
-        task._process_record(data)
-        CompanyInteractionFactory.create_batch(5)
-
-        assert Interaction.objects.count() == 8
-
-        caplog.set_level('INFO')
-        call_command('remove_stova_relations', simulate=simulate)
-
-        log_text = caplog.text
-        assert 'There were 3 interactions deleted out of 3' in log_text
-        assert Interaction.objects.count() == 5

--- a/datahub/investment/project/test/factories.py
+++ b/datahub/investment/project/test/factories.py
@@ -236,6 +236,15 @@ class InvestmentActivityFactory(factory.django.DjangoModelFactory):
         model = 'investment.InvestmentActivity'
 
 
+class InvestmentDeliveryPartnerFactory(factory.django.DjangoModelFactory):
+    """Investment Delivery Partner factory."""
+
+    name = factory.Faker('name')
+
+    class Meta:
+        model = 'investment.InvestmentDeliveryPartner'
+
+
 class GVAMultiplierFactory(factory.django.DjangoModelFactory):
     """GVA Multiplier factory."""
 


### PR DESCRIPTION
### Description of change

Command to change LEPs to IDPs.

Use `--simulate` to get summary output of changes without saving them.
Use `--delete` to delete LEPs that have new IDPs assigned to them.

The command will be run in two phases. First to add new IDPs to the Investment Projects. Once they've been verified as being correct the command will be run with --delete which will remove the LEPs of Investment Projects that have the new IDP assigned to it.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
