### PR TITLE
ci: set opensearch jvm heap size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,6 +53,7 @@ job_defaults: &job_defaults
     REDIS_BASE_URL: "redis://localhost:6379"
 
   working_directory: ~/app
+  resource_class: medium+
 
   docker:
     - image: <<parameters.python_image>>
@@ -62,6 +63,7 @@ job_defaults: &job_defaults
         discovery.type: single-node
         plugins.security.disabled: "true"
         http.port: 9200
+        OPENSEARCH_JAVA_OPTS: "-Xms2g -Xmx2g" # set jvm heap size for opensearch
 
     - image: <<parameters.postgres_image>>
       name: postgres


### PR DESCRIPTION
### Description of change

* we are getting oom error code 137 in our ci opensearch backing service
* opensearch jvm current has 1gb heap size (default)
* bumping up heap size actually made it worse if i didn't also bump underlying resource class because we hit the limit even faster when the jvm needs off-heap memory (metaspace, direct buffers, thread stacks)
* bump resource class to medium+
* bump jvm heap size to 2gb

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?
