### PR TITLE
Move document bucket name to settings

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -37,6 +37,8 @@ TIME_ZONE = 'Etc/UTC'
 
 ADMIN_OAUTH2_ENABLED = env.bool('ADMIN_OAUTH2_ENABLED')
 
+ENVIRONMENT = env('ENVIRONMENT', default='')
+
 # If Django Admin OAuth2 authentication is enabled, we swap stock Django admin
 # with our own. We can only have either stock Django admin app or our OAuth2 admin app
 # enabled at a time.
@@ -670,6 +672,8 @@ DOCUMENT_BUCKETS = {
         'aws_region': env('REPORT_AWS_REGION', default=''),
     },
 }
+
+DOCUMENT_BUCKET_NAME = f'data-hub-documents{"-" + ENVIRONMENT if ENVIRONMENT else ""}'
 
 DIT_EMAIL_INGEST_BLOCKLIST = [
     email.lower() for email in env.list('DIT_EMAIL_INGEST_BLOCKLIST', default=[])

--- a/datahub/documents/models.py
+++ b/datahub/documents/models.py
@@ -1,7 +1,6 @@
 import uuid
 from logging import getLogger
 
-import environ
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -11,9 +10,6 @@ from django.utils.timezone import now
 from datahub.core.models import ArchivableModel, BaseModel
 from datahub.documents.tasks import schedule_virus_scan_document
 from datahub.documents.utils import sign_s3_url
-
-env = environ.Env()
-ENVIRONMENT = env('ENVIRONMENT', default='local')
 
 logger = getLogger(__name__)
 
@@ -230,7 +226,7 @@ class SharePointDocument(BaseModel, ArchivableModel):
 class UploadableDocument(AbstractEntityDocumentModel):
     """Model to represent an uploadable document."""
 
-    BUCKET = f'data-hub-documents{"-" + ENVIRONMENT if ENVIRONMENT else ""}'
+    BUCKET = settings.DOCUMENT_BUCKET_NAME
     USE_DEFAULT_CREDENTIALS = True
 
     title = models.CharField(max_length=settings.CHAR_FIELD_MAX_LENGTH, blank=True, default='')

--- a/sample.env
+++ b/sample.env
@@ -4,6 +4,7 @@ POSTGRES_URL=tcp://postgres:5432
 DEBUG=True
 DJANGO_SECRET_KEY=changeme
 DJANGO_SETTINGS_MODULE=config.settings.local
+ENVIRONMENT=local
 COV_TOKEN=${COV_TOKEN}
 OPENSEARCH_URL=http://opensearch:9200
 OPENSEARCH_INDEX_PREFIX=test_index


### PR DESCRIPTION
### Description of change

<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

In deployed environments, when attempting to upload documents, the document bucket name (in the upload URL) still has the suffix `-local` despite the `ENVIRONMENT` variable being used to populate this name. 

In an attempt to fix this, this PR moves the bucket name configuration to the settings file. This allows the bucket name to be evaluated when the settings are loaded, rather than at model instantiation.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
