### PR TITLE
fix: king's award ingestion - handle duplicate company number in datahub

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_kings_award_recipient.py
+++ b/datahub/dbmaintenance/management/commands/update_kings_award_recipient.py
@@ -39,10 +39,27 @@ class Command(CSVBaseCommand):
         year_expired = parse_int(row['year_expired'])
 
         try:
-            company = Company.objects.get(company_number=company_number)
+            company = Company.objects.get(company_number=company_number, archived=False)
         except Company.DoesNotExist:
+            companies = Company.objects.filter(company_number=company_number)
+            if companies.exists():
+                if companies.count() > 1:
+                    logger.warning(
+                        f'Skipping - Multiple archived companies with number {company_number} found.',
+                    )
+                    return
+                else:
+                    logger.warning(
+                        f'Company with number {company_number} exists but is archived, continuing.',
+                    )
+            else:
+                logger.warning(
+                    f'Skipping - Company with Companies House number {company_number} does not exist.',
+                )
+                return
+        except Company.MultipleObjectsReturned:
             logger.warning(
-                f'Skipping - Company with Companies House number {company_number} does not exist.',
+                f'Skipping - Multiple non-archived companies with number {company_number} found.',
             )
             return
 


### PR DESCRIPTION
### Description of change
* modified company lookup to filter for non-archived companies first
* added specific handling for multiple archived companies with the same number

when looking up a company by company number, we now first try to find a non-archived company:
* if no non-archived company is found, we check if there are archived companies with that number
* if multiple companies with the same number exist (either all archived or multiple non-archived), we log a clear warning and skip the row
* if only a single archived company exists, we log a warning but continue processing
* added tests for the above

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?