### PR TITLE
ci: preserve off-heap memory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ job_defaults: &job_defaults
     REDIS_BASE_URL: "redis://localhost:6379"
 
   working_directory: ~/app
-  resource_class: medium+
+  resource_class: medium
 
   docker:
     - image: <<parameters.python_image>>
@@ -63,7 +63,7 @@ job_defaults: &job_defaults
         discovery.type: single-node
         plugins.security.disabled: "true"
         http.port: 9200
-        OPENSEARCH_JAVA_OPTS: "-Xms2g -Xmx2g" # set jvm heap size for opensearch
+        OPENSEARCH_JAVA_OPTS: "-Xms512m -Xmx512m"
 
     - image: <<parameters.postgres_image>>
       name: postgres


### PR DESCRIPTION
### Description of change

* the 137 oom error might be related to off-heap memory rather than heap memory, therefore the fix at https://github.com/uktrade/data-hub-api/pull/6083 might be unnecessarily using more resource when we only need to better manage off-heap memory

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?
* [ ] Is the CircleCI build passing?