### PR TITLE
CPS-808: Validate that data submitted for Export Wins has been personally confirmed and by line manager

### DIFF
--- a/datahub/export_win/serializers.py
+++ b/datahub/export_win/serializers.py
@@ -50,6 +50,7 @@ from datahub.export_win.tasks import (
     update_customer_response_token_for_email_notification_id,
 )
 from datahub.export_win.validators import (
+    DataConfirmedValidator,
     DuplicateContributingAdviserValidator,
     DuplicateTeamMemberValidator,
     LeadOfficerAndContributingAdviserValidator,
@@ -315,6 +316,7 @@ class WinSerializer(ModelSerializer):
             LeadOfficerAndContributingAdviserValidator(),
             LeadOfficerAndTeamMemberValidator(),
             TeamMembersAndContributingAdvisersValidator(),
+            DataConfirmedValidator(),
         ]
 
     def create(self, validated_data):

--- a/datahub/export_win/validators.py
+++ b/datahub/export_win/validators.py
@@ -94,3 +94,23 @@ class TeamMembersAndContributingAdvisersValidator:
                 'A team member cannot also be a contributing adviser.',
                 code='team_member_as_contributing_adviser',
             )
+
+
+class DataConfirmedValidator:
+    """Validates that data has been personally confirmed by submitter and by their line manager."""
+
+    def __call__(self, data):
+        """Performs validation."""
+        is_personally_confirmed = data.get('is_personally_confirmed', False)
+        is_line_manager_confirmed = data.get('is_line_manager_confirmed', False)
+
+        if not is_personally_confirmed:
+            raise serializers.ValidationError(
+                'Export win data must be personally confirmed',
+                code='is_not_personally_confirmed',
+            )
+        if not is_line_manager_confirmed:
+            raise serializers.ValidationError(
+                'Export win data must be confirmed by line manager',
+                code='is_not_line_manager_confirmed',
+            )


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/CPS-808

### Description of change

Currently when you create a new Export Win, the form validates that the data has been confirmed by you personally and by your line manager:
![image](https://github.com/user-attachments/assets/8b37504b-1da1-44db-8fa8-c5882cdda337)

However, this is not currently validated on the backend, and if you update the Export Win record, those fields are incorrectly set back to false. This needs fixing on the frontend (https://github.com/uktrade/data-hub-frontend/pull/7733) but should also be validated on the backend which this PR adds.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
