### PR TITLE
Fix postcode data ingestion task

### DIFF
--- a/datahub/metadata/tasks.py
+++ b/datahub/metadata/tasks.py
@@ -3,6 +3,7 @@ import logging
 
 import smart_open
 
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.tasks import BaseObjectIdentificationTask, BaseObjectIngestionTask
 from datahub.metadata.constants import POSTCODE_DATA_PREFIX
@@ -13,7 +14,10 @@ logger = logging.getLogger(__name__)
 
 def postcode_data_identification_task() -> None:
     logger.info('Postcode data identification task started...')
-    identification_task = PostcodeDataIdentificationTask(prefix=POSTCODE_DATA_PREFIX)
+    identification_task = PostcodeDataIdentificationTask(
+        prefix=POSTCODE_DATA_PREFIX, 
+        job_timeout=THIRTY_MINUTES_IN_SECONDS
+    )
     identification_task.identify_new_objects(postcode_data_ingestion_task)
     logger.info('Postcode data identification task finished.')
 
@@ -40,12 +44,14 @@ class PostcodeDataIngestionTask(BaseObjectIngestionTask):
         object_key: str,
         s3_processor: S3ObjectProcessor,
     ) -> None:
+        logger.info('Starting PostcodeDataIngestionTask initialisation.')
         super().__init__(object_key, s3_processor)
         self._existing_ids = set(PostcodeData.objects.values_list('id', flat=True))
         self._fields_to_update = PostcodeDataIngestionTask._fields_to_update()
         self._to_create = []
         self._to_update = []
         self._to_delete = []
+        logger.info('Completed PostcodeDataIngestionTask initialisation.')
 
     def ingest_object(self) -> None:
         """Process all records in the object key specified when the class instance was created."""
@@ -54,6 +60,7 @@ class PostcodeDataIngestionTask(BaseObjectIngestionTask):
                 f's3://{self.s3_processor.bucket}/{self.object_key}',
                 transport_params={'client': self.s3_processor.s3_client},
             ) as s3_object:
+                logger.info('PostcodeDataIngestionTask: ingest_object.')
                 all_file_ids = set()
                 for line in s3_object:
                     jsn = json.loads(line)

--- a/datahub/metadata/tasks.py
+++ b/datahub/metadata/tasks.py
@@ -16,7 +16,7 @@ def postcode_data_identification_task() -> None:
     logger.info('Postcode data identification task started...')
     identification_task = PostcodeDataIdentificationTask(
         prefix=POSTCODE_DATA_PREFIX, 
-        job_timeout=THIRTY_MINUTES_IN_SECONDS
+        job_timeout=THIRTY_MINUTES_IN_SECONDS,
     )
     identification_task.identify_new_objects(postcode_data_ingestion_task)
     logger.info('Postcode data identification task finished.')

--- a/datahub/metadata/test/test_ingest_postcode_data.py
+++ b/datahub/metadata/test/test_ingest_postcode_data.py
@@ -8,7 +8,7 @@ from moto import mock_aws
 from sentry_sdk import init
 from sentry_sdk.transport import Transport
 
-from datahub.core.queues.constants import THREE_MINUTES_IN_SECONDS
+from datahub.core.queues.constants import THIRTY_MINUTES_IN_SECONDS
 from datahub.ingest.boto3 import S3ObjectProcessor
 from datahub.ingest.constants import (
     AWS_REGION,
@@ -98,7 +98,7 @@ def test_identification_task_schedules_ingestion_task(test_file_path, caplog):
         function_kwargs={
             'object_key': test_file_path,
         },
-        job_timeout=THREE_MINUTES_IN_SECONDS,
+        job_timeout=THIRTY_MINUTES_IN_SECONDS,
         queue_name='long-running',
         description=f'Ingest {test_file_path}',
     )


### PR DESCRIPTION
### Description of change

This PR adds extra logging to the postcode identification and ingestion tasks in order to debug. This also includes an added `job_timeout` to the identification task.

### Checklist

* [x] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [x] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
