### PR TITLE
Disable profiling panel in local config

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -20,6 +20,7 @@ if env.bool('DOCKER_DEV', True):
 
 DEBUG_TOOLBAR_CONFIG = {
     'DISABLE_PANELS': [
+        "debug_toolbar.panels.profiling.ProfilingPanel",
         'debug_toolbar.panels.redirects.RedirectsPanel',
     ],
     'SHOW_TEMPLATE_CONTEXT': True,

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -20,7 +20,8 @@ if env.bool('DOCKER_DEV', True):
 
 DEBUG_TOOLBAR_CONFIG = {
     'DISABLE_PANELS': [
-        "debug_toolbar.panels.profiling.ProfilingPanel",
+        #Python 3.12 does not allow concurrent requests with the profiling panel, see: https://django-debug-toolbar.readthedocs.io/en/latest/panels.html
+        "debug_toolbar.panels.profiling.ProfilingPanel", 
         'debug_toolbar.panels.redirects.RedirectsPanel',
     ],
     'SHOW_TEMPLATE_CONTEXT': True,


### PR DESCRIPTION
### Description of change

Disabled profiling panel in local config as this was causing an issue with the following error:
ValueError: Another profiling tool is already active

This problem is due to a change in Python 3.12 which does not allow concurrent requests with the profiling panel.

This panel gives profiling information for the processing of requests and shows all function calls made by the project.
More info here: https://django-debug-toolbar.readthedocs.io/en/latest/panels.html.


<!--
Enter a description of the changes in the PR here.
Include any context that will help reviewers understand the reason for these changes.
-->

### Checklist

* [ ] Has this branch been rebased on top of the current `main` branch?

  <details>
  <summary>Explanation</summary>
  
  The branch should not be stale or have conflicts at the time reviews are requested.
  
  </details>

* [ ] Is the CircleCI build passing?

### General points

<details>
<summary><strong>Other things to check</strong></summary><p></p>

* Make sure `fixtures/test_data.yaml` is maintained when updating models
* Consider the admin site when making changes to models
* Use select-/prefetch-related field lists in views and search apps, and update them when fields are added
* Make sure the README is updated e.g. when adding new environment variables

</details>

See [docs/CONTRIBUTING.md](https://github.com/uktrade/data-hub-api/blob/main/docs/CONTRIBUTING.md) for more guidelines.
